### PR TITLE
Fix typing delay in amp coding agent on first prompt

### DIFF
--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -129,7 +129,10 @@ func (m *TerminalModel) flushTiming() (time.Duration, time.Duration) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 
-	if ts.VTerm != nil && (ts.VTerm.AltScreen || ts.VTerm.SyncActive()) {
+	// Only use slower Alt timing for true AltScreen mode (full-screen TUIs like vim).
+	// SyncActive (DEC 2026) already handles partial updates via screen snapshots,
+	// so we don't need slower flush timing - it just makes streaming text feel laggy.
+	if ts.VTerm != nil && ts.VTerm.AltScreen {
 		return ptyFlushQuietAlt, ptyFlushMaxAlt
 	}
 	return ptyFlushQuiet, ptyFlushMaxInterval


### PR DESCRIPTION
Two changes to improve streaming text responsiveness:

1. Reduced PTY flush intervals from 12/50ms to 4/16ms for normal mode and 30/120ms to 8/32ms for alt screen mode. The original values were too conservative and made streaming text appear laggy.

2. Only use slower Alt timing for true AltScreen mode (full-screen TUIs like vim). SyncActive (DEC 2026) already handles partial updates via screen snapshots, so slower flush timing is unnecessary.

Fixes: amux-fgb