### PR TITLE
fix: show visible cursor in focused terminal panes

### DIFF
--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -634,6 +634,7 @@ func (m *Model) View() string {
 		tab := tabs[activeIdx]
 		tab.mu.Lock()
 		if tab.Terminal != nil {
+			tab.Terminal.ShowCursor = m.focused
 			b.WriteString(tab.Terminal.Render())
 
 			// Show scroll indicator if scrolled

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -429,6 +429,7 @@ func (m *TerminalModel) View() string {
 		b.WriteString(placeholder)
 	} else {
 		ts.mu.Lock()
+		ts.VTerm.ShowCursor = m.focused
 		content := ts.VTerm.Render()
 		isScrolled := ts.VTerm.IsScrolled()
 		var scrollInfo string

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -51,6 +51,12 @@ type VTerm struct {
 	selStartX, selStartY int
 	selEndX, selEndY     int
 
+	// Cursor visibility (controlled externally when pane is focused)
+	ShowCursor     bool
+	lastShowCursor bool
+	lastCursorX    int
+	lastCursorY    int
+
 	// Synchronized output (DEC mode 2026)
 	syncActive        bool
 	syncScreen        [][]Cell


### PR DESCRIPTION
- Add ShowCursor field to VTerm to control cursor visibility
- Render cursor as reverse-video block at cursor position
- Invalidate render cache when cursor state or position changes
- Set ShowCursor based on pane focus in center and sidebar terminals