### PR TITLE
feat: add support for Droid agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Agent orchestrator made for developers to run parallel coding agents using git w
 
 Here are some reasons why you would use amux over others:
 * Use coding agents directly (i.e. Claude Code, Codex CLI). There's no new coding agent, wrapper, or SDK involved.
-* Supports all of the major coding agents: Claude Code, Codex CLI, Gemini CLI, Amp, OpenCode.
+* Supports all of the major coding agents: Claude Code, Codex CLI, Gemini CLI, Amp, OpenCode, Droid.
 * Navigate with keyboard only using vim inspired shortcuts.
 * Run it on the terminal.
 * Open source.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,11 @@ func DefaultConfig() (*Config, error) {
 				InterruptCount:   1,
 				InterruptDelayMs: 0,
 			},
+			"droid": {
+				Command:          "droid",
+				InterruptCount:   1,
+				InterruptDelayMs: 0,
+			},
 		},
 	}, nil
 }

--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -18,6 +18,7 @@ const (
 	AgentGemini   AgentType = "gemini"
 	AgentAmp      AgentType = "amp"
 	AgentOpencode AgentType = "opencode"
+	AgentDroid    AgentType = "droid"
 )
 
 // Agent represents a running AI agent instance

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -778,6 +778,8 @@ func (m *Model) renderTabBar() string {
 			agentStyle = m.styles.AgentAmp
 		case "opencode":
 			agentStyle = m.styles.AgentOpencode
+		case "droid":
+			agentStyle = m.styles.AgentDroid
 		default:
 			agentStyle = m.styles.AgentTerm
 		}

--- a/internal/ui/common/colors.go
+++ b/internal/ui/common/colors.go
@@ -26,6 +26,7 @@ var (
 	ColorGemini   = lipgloss.Color("#61afef") // Blue
 	ColorAmp      = lipgloss.Color("#c678dd") // Purple (Sourcegraph)
 	ColorOpencode = lipgloss.Color("#56b6c2") // Cyan (SST)
+	ColorDroid    = lipgloss.Color("#ff6b6b") // Red/coral (Factory)
 
 	// Surface colors for layering
 	ColorSurface0 = lipgloss.Color("#1a1b26") // Base background
@@ -51,6 +52,8 @@ func AgentColor(agent string) lipgloss.Color {
 		return ColorAmp
 	case "opencode":
 		return ColorOpencode
+	case "droid":
+		return ColorDroid
 	default:
 		return ColorPrimary
 	}

--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -108,6 +108,7 @@ func DefaultAgentOptions() []AgentOption {
 		{ID: "gemini", Name: "gemini", Desc: "Google Gemini"},
 		{ID: "amp", Name: "amp", Desc: "Sourcegraph Amp"},
 		{ID: "opencode", Name: "opencode", Desc: "SST OpenCode"},
+		{ID: "droid", Name: "droid", Desc: "Factory Droid"},
 	}
 }
 
@@ -409,6 +410,8 @@ func (d *Dialog) renderOptions() string {
 				colorStyle = lipgloss.NewStyle().Foreground(ColorAmp)
 			case "opencode":
 				colorStyle = lipgloss.NewStyle().Foreground(ColorOpencode)
+			case "droid":
+				colorStyle = lipgloss.NewStyle().Foreground(ColorDroid)
 			default:
 				colorStyle = lipgloss.NewStyle().Foreground(ColorForeground)
 			}

--- a/internal/ui/common/styles.go
+++ b/internal/ui/common/styles.go
@@ -49,6 +49,7 @@ type Styles struct {
 	AgentGemini   lipgloss.Style
 	AgentAmp      lipgloss.Style
 	AgentOpencode lipgloss.Style
+	AgentDroid    lipgloss.Style
 	AgentTerm     lipgloss.Style
 
 	// Sidebar
@@ -216,6 +217,9 @@ func DefaultStyles() Styles {
 
 		AgentOpencode: lipgloss.NewStyle().
 			Foreground(ColorOpencode),
+
+		AgentDroid: lipgloss.NewStyle().
+			Foreground(ColorDroid),
 
 		AgentTerm: lipgloss.NewStyle().
 			Foreground(ColorForeground),

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -120,6 +120,7 @@ func ValidateAssistant(assistant string) error {
 		"gemini":   true,
 		"amp":      true,
 		"opencode": true,
+		"droid":    true,
 		"term":     true,
 	}
 


### PR DESCRIPTION
Add Droid as a supported coding agent alongside Claude, Codex, Gemini, Amp, and OpenCode. This includes:
- Default configuration in config.go
- Agent type constant in pty/agent.go
- Color scheme and styling in UI components
- Validation support
- Documentation update in README.md