### PR TITLE
Fix Option+Arrow keys not being forwarded to terminal

### DIFF
--- a/internal/ui/common/keys.go
+++ b/internal/ui/common/keys.go
@@ -20,12 +20,24 @@ func KeyToBytes(msg tea.KeyMsg) []byte {
 	case tea.KeyEsc:
 		return []byte{0x1b}
 	case tea.KeyUp:
+		if msg.Alt {
+			return []byte{0x1b, '[', '1', ';', '3', 'A'}
+		}
 		return []byte{0x1b, '[', 'A'}
 	case tea.KeyDown:
+		if msg.Alt {
+			return []byte{0x1b, '[', '1', ';', '3', 'B'}
+		}
 		return []byte{0x1b, '[', 'B'}
 	case tea.KeyRight:
+		if msg.Alt {
+			return []byte{0x1b, '[', '1', ';', '3', 'C'}
+		}
 		return []byte{0x1b, '[', 'C'}
 	case tea.KeyLeft:
+		if msg.Alt {
+			return []byte{0x1b, '[', '1', ';', '3', 'D'}
+		}
 		return []byte{0x1b, '[', 'D'}
 	case tea.KeyHome:
 		return []byte{0x1b, '[', 'H'}


### PR DESCRIPTION
The KeyToBytes function was ignoring the Alt modifier on arrow keys, causing Option+Up/Down/Left/Right to be sent as regular arrow keys.

Added proper Alt-modified escape sequences:
- Alt+Up: ESC[1;3A
- Alt+Down: ESC[1;3B
- Alt+Right: ESC[1;3C
- Alt+Left: ESC[1;3D