### PR TITLE
Fix mouse click handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -272,11 +272,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-		// Don't process other keys while dialog is open
+		// Don't process other input while dialog is open
 		if _, ok := msg.(tea.KeyPressMsg); ok {
 			return a, tea.Batch(cmds...)
 		}
 		if _, ok := msg.(tea.PasteMsg); ok {
+			return a, tea.Batch(cmds...)
+		}
+		if _, ok := msg.(tea.MouseClickMsg); ok {
 			return a, tea.Batch(cmds...)
 		}
 	}
@@ -289,11 +292,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-		// Don't process other keys while file picker is open
+		// Don't process other input while file picker is open
 		if _, ok := msg.(tea.KeyPressMsg); ok {
 			return a, tea.Batch(cmds...)
 		}
 		if _, ok := msg.(tea.PasteMsg); ok {
+			return a, tea.Batch(cmds...)
+		}
+		if _, ok := msg.(tea.MouseClickMsg); ok {
 			return a, tea.Batch(cmds...)
 		}
 	}
@@ -1954,6 +1960,20 @@ func (a *App) handleWelcomeClick(localX, localY int) tea.Cmd {
 		region.Y += offsetY
 		if region.Contains(localX, localY) {
 			return func() tea.Msg { return messages.ShowAddProjectDialog{} }
+		}
+	}
+
+	// Help toggle button
+	helpLabel := "[?] Hide keymap"
+	if !a.config.UI.ShowKeymapHints {
+		helpLabel = "[?] Show keymap"
+	}
+	helpToggleBtn := a.styles.TabPlus.Render(helpLabel)
+	if region, ok := findButtonRegion(lines, helpToggleBtn); ok {
+		region.X += offsetX
+		region.Y += offsetY
+		if region.Contains(localX, localY) {
+			return func() tea.Msg { return messages.ToggleKeymapHints{} }
 		}
 	}
 

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -1309,15 +1309,19 @@ func (m *Model) renderTabBar() string {
 }
 
 func (m *Model) handleTabBarClick(msg tea.MouseClickMsg) tea.Cmd {
-	if msg.Y != 0 {
+	// Tab bar is at screen Y=1 due to the pane's top border (Y=0 is the border itself)
+	const borderTop = 1
+	if msg.Y != borderTop {
 		return nil
 	}
 	localX := msg.X - m.offsetX
 	if localX < 0 {
 		return nil
 	}
+	// Convert screen Y to local Y within tab bar content (all tab hits are at Y=0)
+	localY := msg.Y - borderTop
 	for _, hit := range m.tabHits {
-		if hit.region.Contains(localX, msg.Y) {
+		if hit.region.Contains(localX, localY) {
 			switch hit.kind {
 			case tabHitPlus:
 				return func() tea.Msg { return messages.ShowSelectAssistantDialog{} }


### PR DESCRIPTION
- Fix tab bar click Y-coordinate bug: tab bar is at Y=1 due to pane border, not Y=0. Also convert screen Y to local Y for hit detection.
- Add click handler for welcome screen help toggle button
- Add early return for MouseClickMsg in dialog and file picker handlers to prevent clicks from falling through to panes underneath