### PR TITLE
fix(ui): align cursor with input in agent filter dialog

### DIFF
--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -454,7 +454,7 @@ func (d *Dialog) Cursor() *tea.Cursor {
 		return nil
 	}
 
-	c.Y += lipgloss.Height(prefix.String())
+	c.Y += lipgloss.Height(prefix.String()) - 1
 
 	// Account for border + padding (Border=1, Padding=(1,2)).
 	c.X += 3
@@ -523,22 +523,22 @@ func (d *Dialog) renderLines() []string {
 		Foreground(ColorPrimary).
 		MarginBottom(1)
 	appendLines(titleStyle.Render(d.title))
-	appendBlank(2)
+	appendBlank(1)
 
 	switch d.dtype {
 	case DialogInput:
 		appendLines(d.input.View())
-		appendBlank(2)
+		appendBlank(1)
 		line := d.renderInputButtonsLine(len(lines))
 		lines = append(lines, line)
 	case DialogConfirm:
 		appendLines(d.message)
-		appendBlank(2)
+		appendBlank(1)
 		lines = append(lines, d.renderOptionsLines(len(lines))...)
 	case DialogSelect:
 		if d.message != "" {
 			appendLines(d.message)
-			appendBlank(2)
+			appendBlank(1)
 		}
 		lines = append(lines, d.renderOptionsLines(len(lines))...)
 	}

--- a/internal/ui/common/dialog_test.go
+++ b/internal/ui/common/dialog_test.go
@@ -37,7 +37,7 @@ func TestDialogCursorPositionInput(t *testing.T) {
 	prefix := titleStyle.Render(d.title) + "\n\n"
 
 	expectedX := inputCursor.X + 3
-	expectedY := inputCursor.Y + lipgloss.Height(prefix) + 2
+	expectedY := inputCursor.Y + lipgloss.Height(prefix) + 1
 
 	if c.X != expectedX || c.Y != expectedY {
 		t.Fatalf("unexpected cursor position: got (%d,%d), want (%d,%d)", c.X, c.Y, expectedX, expectedY)
@@ -70,7 +70,7 @@ func TestDialogCursorPositionFilter(t *testing.T) {
 	}
 
 	expectedX := inputCursor.X + 3
-	expectedY := inputCursor.Y + lipgloss.Height(prefix) + 2
+	expectedY := inputCursor.Y + lipgloss.Height(prefix) + 1
 
 	if c.X != expectedX || c.Y != expectedY {
 		t.Fatalf("unexpected cursor position: got (%d,%d), want (%d,%d)", c.X, c.Y, expectedX, expectedY)


### PR DESCRIPTION
- Reduces vertical whitespace in dialogs by changing appendBlank(2) to appendBlank(1).
- Fixes off-by-one error in cursor vertical position calculation caused by trailing newline in prefix string.
- Updates tests to reflect correct cursor positioning.