### PR TITLE
Reduce scroll amount from half-page to quarter-page

### DIFF
--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -165,7 +165,7 @@ func (m *Model) HandleMonitorInput(tabID TabID, msg tea.Msg) tea.Cmd {
 		case msg.Key().Code == tea.KeyPgUp:
 			tab.mu.Lock()
 			if tab.Terminal != nil {
-				tab.Terminal.ScrollView(tab.Terminal.Height / 2)
+				tab.Terminal.ScrollView(tab.Terminal.Height / 4)
 			}
 			tab.mu.Unlock()
 			return nil
@@ -173,7 +173,7 @@ func (m *Model) HandleMonitorInput(tabID TabID, msg tea.Msg) tea.Cmd {
 		case msg.Key().Code == tea.KeyPgDown:
 			tab.mu.Lock()
 			if tab.Terminal != nil {
-				tab.Terminal.ScrollView(-tab.Terminal.Height / 2)
+				tab.Terminal.ScrollView(-tab.Terminal.Height / 4)
 			}
 			tab.mu.Unlock()
 			return nil
@@ -181,7 +181,7 @@ func (m *Model) HandleMonitorInput(tabID TabID, msg tea.Msg) tea.Cmd {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+u"))):
 			tab.mu.Lock()
 			if tab.Terminal != nil {
-				tab.Terminal.ScrollView(tab.Terminal.Height / 2)
+				tab.Terminal.ScrollView(tab.Terminal.Height / 4)
 			}
 			tab.mu.Unlock()
 			return nil
@@ -189,7 +189,7 @@ func (m *Model) HandleMonitorInput(tabID TabID, msg tea.Msg) tea.Cmd {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+d"))):
 			tab.mu.Lock()
 			if tab.Terminal != nil {
-				tab.Terminal.ScrollView(-tab.Terminal.Height / 2)
+				tab.Terminal.ScrollView(-tab.Terminal.Height / 4)
 			}
 			tab.mu.Unlock()
 			return nil
@@ -834,7 +834,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				case tea.KeyPgUp:
 					tab.mu.Lock()
 					if tab.Terminal != nil {
-						tab.Terminal.ScrollView(tab.Terminal.Height / 2)
+						tab.Terminal.ScrollView(tab.Terminal.Height / 4)
 					}
 					tab.mu.Unlock()
 					return m, nil
@@ -842,7 +842,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				case tea.KeyPgDown:
 					tab.mu.Lock()
 					if tab.Terminal != nil {
-						tab.Terminal.ScrollView(-tab.Terminal.Height / 2)
+						tab.Terminal.ScrollView(-tab.Terminal.Height / 4)
 					}
 					tab.mu.Unlock()
 					return m, nil
@@ -1224,8 +1224,8 @@ func (m *Model) helpLines(contentWidth int) []string {
 			m.helpItem("C-Spc n", "next"),
 			m.helpItem("C-Spc 1-9", "jump tab"),
 			m.helpItem("C-Spc [", "copy"),
-			m.helpItem("PgUp", "half up"),
-			m.helpItem("PgDn", "half down"),
+			m.helpItem("PgUp", "scroll up"),
+			m.helpItem("PgDn", "scroll down"),
 		)
 		if m.CopyModeActive() {
 			items = append(items,
@@ -1974,24 +1974,24 @@ func (m *Model) handleCopyModeKey(tab *Tab, msg tea.KeyPressMsg) tea.Cmd {
 		tab.mu.Unlock()
 		return nil
 
-	// Scroll up half page
+	// Scroll up quarter page
 	case msg.Key().Code == tea.KeyPgUp:
 		fallthrough
 	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+u"))):
 		tab.mu.Lock()
 		if tab.Terminal != nil {
-			tab.Terminal.ScrollView(tab.Terminal.Height / 2)
+			tab.Terminal.ScrollView(tab.Terminal.Height / 4)
 		}
 		tab.mu.Unlock()
 		return nil
 
-	// Scroll down half page
+	// Scroll down quarter page
 	case msg.Key().Code == tea.KeyPgDown:
 		fallthrough
 	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+d"))):
 		tab.mu.Lock()
 		if tab.Terminal != nil {
-			tab.Terminal.ScrollView(-tab.Terminal.Height / 2)
+			tab.Terminal.ScrollView(-tab.Terminal.Height / 4)
 		}
 		tab.mu.Unlock()
 		return nil


### PR DESCRIPTION
Scrolling by half the terminal height was too aggressive, making it hard to read content when scrolling up or down. This reduces the scroll amount to quarter-page for smoother, more controllable scrolling.