### PR TITLE
fix: cleanup in-memory state when deleting worktree

### DIFF
--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -145,6 +145,20 @@ func (m *AgentManager) CloseAll() {
 	m.agents = make(map[data.WorktreeID][]*Agent)
 }
 
+// CloseWorktreeAgents closes and removes all agents for a specific worktree
+func (m *AgentManager) CloseWorktreeAgents(wt *data.Worktree) {
+	if wt == nil {
+		return
+	}
+	wtID := wt.ID()
+	for _, agent := range m.agents[wtID] {
+		if agent.Terminal != nil {
+			agent.Terminal.Close()
+		}
+	}
+	delete(m.agents, wtID)
+}
+
 // SendInterrupt sends an interrupt to an agent
 func (m *AgentManager) SendInterrupt(agent *Agent) error {
 	if agent.Terminal == nil {

--- a/internal/pty/agent_test.go
+++ b/internal/pty/agent_test.go
@@ -68,3 +68,42 @@ func TestAgentManagerSendInterrupt(t *testing.T) {
 		t.Fatalf("SendInterrupt() error = %v", err)
 	}
 }
+
+func TestAgentManagerCloseWorktreeAgents(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+
+	mgr := NewAgentManager(cfg)
+	wt1 := &data.Worktree{Name: "wt1", Repo: "/tmp", Root: "/tmp/wt1"}
+	wt2 := &data.Worktree{Name: "wt2", Repo: "/tmp", Root: "/tmp/wt2"}
+
+	// Directly populate agents map to test cleanup without creating real terminals
+	mgr.agents[wt1.ID()] = []*Agent{
+		{Type: AgentCodex, Worktree: wt1},
+		{Type: AgentClaude, Worktree: wt1},
+	}
+	mgr.agents[wt2.ID()] = []*Agent{
+		{Type: AgentCodex, Worktree: wt2},
+	}
+
+	if len(mgr.agents[wt1.ID()]) != 2 {
+		t.Fatalf("expected 2 agents for wt1, got %d", len(mgr.agents[wt1.ID()]))
+	}
+	if len(mgr.agents[wt2.ID()]) != 1 {
+		t.Fatalf("expected 1 agent for wt2, got %d", len(mgr.agents[wt2.ID()]))
+	}
+
+	mgr.CloseWorktreeAgents(wt1)
+
+	if _, exists := mgr.agents[wt1.ID()]; exists {
+		t.Fatalf("expected wt1 agents to be deleted from map")
+	}
+	if len(mgr.agents[wt2.ID()]) != 1 {
+		t.Fatalf("expected wt2 agents unchanged, got %d", len(mgr.agents[wt2.ID()]))
+	}
+
+	// Should not panic on nil
+	mgr.CloseWorktreeAgents(nil)
+}

--- a/internal/ui/center/monitor_tabs_test.go
+++ b/internal/ui/center/monitor_tabs_test.go
@@ -53,3 +53,38 @@ func TestMonitorTabsIncludesAllTabs(t *testing.T) {
 		t.Fatalf("unexpected monitor tab order: %+v", tabs)
 	}
 }
+
+func TestCleanupWorktree(t *testing.T) {
+	wtA := &data.Worktree{Name: "alpha", Repo: "/repoA", Root: "/repoA/alpha"}
+	wtB := &data.Worktree{Name: "beta", Repo: "/repoB", Root: "/repoB/beta"}
+
+	model := &Model{
+		tabsByWorktree: map[string][]*Tab{
+			string(wtA.ID()): {
+				{ID: "tab-1", Worktree: wtA, Assistant: "codex", Name: "codex"},
+			},
+			string(wtB.ID()): {
+				{ID: "tab-2", Worktree: wtB, Assistant: "claude", Name: "claude"},
+			},
+		},
+		activeTabByWorktree: map[string]int{
+			string(wtA.ID()): 0,
+			string(wtB.ID()): 0,
+		},
+	}
+
+	model.CleanupWorktree(wtA)
+
+	if _, exists := model.tabsByWorktree[string(wtA.ID())]; exists {
+		t.Fatalf("expected wtA tabs to be deleted")
+	}
+	if _, exists := model.activeTabByWorktree[string(wtA.ID())]; exists {
+		t.Fatalf("expected wtA active tab index to be deleted")
+	}
+
+	if len(model.tabsByWorktree[string(wtB.ID())]) != 1 {
+		t.Fatalf("expected wtB tabs to remain unchanged")
+	}
+
+	model.CleanupWorktree(nil)
+}

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -405,6 +405,17 @@ func (m *TerminalModel) Update(msg tea.Msg) (*TerminalModel, tea.Cmd) {
 	case SidebarTerminalCreated:
 		cmd := m.HandleTerminalCreated(msg.WorktreeID, msg.Terminal)
 		cmds = append(cmds, cmd)
+
+	case messages.WorktreeDeleted:
+		if msg.Worktree != nil {
+			wtID := string(msg.Worktree.ID())
+			if ts := m.terminals[wtID]; ts != nil {
+				if ts.Terminal != nil {
+					ts.Terminal.Close()
+				}
+				delete(m.terminals, wtID)
+			}
+		}
 	}
 
 	return m, tea.Batch(cmds...)


### PR DESCRIPTION
When deleting a worktree and recreating one with the same name, the old tabs would persist because WorktreeID is a hash of repo+root path. The in-memory maps (tabsByWorktree, agents, terminals) were not being cleaned up on deletion.

Changes:
- Add CloseWorktreeAgents() to AgentManager to close and remove agents
- Add CleanupWorktree() to center Model to remove tabs, close trace files
- Handle WorktreeDeleted message in center Model and sidebar TerminalModel
- Add tests for cleanup methods