### PR TITLE
Fix monitor mode input not working with project filters

### DIFF
--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -167,7 +167,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		// Handle paste in monitor mode - forward to selected tile
 		if a.monitorMode && a.focusedPane == messages.PaneMonitor {
-			tabs := a.center.MonitorTabs()
+			tabs := a.filterMonitorTabs(a.center.MonitorTabs())
 			if len(tabs) > 0 {
 				idx := a.center.MonitorSelectedIndex(len(tabs))
 				if cmd := a.center.HandleMonitorInput(tabs[idx].ID, msg); cmd != nil {

--- a/internal/app/app_monitor.go
+++ b/internal/app/app_monitor.go
@@ -217,7 +217,7 @@ func (a *App) handleMonitorInput(msg tea.KeyPressMsg) tea.Cmd {
 	// All keys -> Forward to selected tile's PTY
 
 	// Forward all other keys to selected tile's PTY
-	tabs := a.center.MonitorTabs()
+	tabs := a.filterMonitorTabs(a.center.MonitorTabs())
 	if len(tabs) == 0 {
 		return nil
 	}

--- a/internal/app/app_monitor_grid.go
+++ b/internal/app/app_monitor_grid.go
@@ -344,7 +344,7 @@ func (a *App) monitorFilterHit(x, y int) (string, bool) {
 }
 
 func (a *App) selectMonitorTile(paneX, paneY int) (int, bool) {
-	tabs := a.center.MonitorTabs()
+	tabs := a.filterMonitorTabs(a.center.MonitorTabs())
 	count := len(tabs)
 	if count == 0 {
 		return -1, false


### PR DESCRIPTION
Apply filterMonitorTabs() in input handlers to match the filtered view rendered by renderMonitorGrid(). Previously, clicking/typing went to wrong tiles when a project filter was active due to index mismatch.