### PR TITLE
Fix file picker tab completion bug

### DIFF
--- a/internal/ui/common/filepicker_navigation.go
+++ b/internal/ui/common/filepicker_navigation.go
@@ -295,16 +295,21 @@ func (fp *FilePicker) handleOpenFromInput() bool {
 }
 
 func (fp *FilePicker) handleAutocomplete() {
-	if fp.cursor > 0 && len(fp.filteredIdx) > 0 {
-		entry := fp.entries[fp.filteredIdx[fp.cursor-1]]
+	if fp.cursor >= 0 && len(fp.filteredIdx) > 0 && fp.cursor < len(fp.filteredIdx) {
+		entry := fp.entries[fp.filteredIdx[fp.cursor]]
 		if entry.IsDir() {
-			fp.input.SetValue(entry.Name() + "/")
-			if fp.handleOpenFromInput() {
-				return
-			}
+			// Navigate directly into the directory (like Enter does)
+			newPath := filepath.Join(fp.currentPath, entry.Name())
+			fp.currentPath = newPath
+			fp.input.SetValue(fp.inputBasePath())
+			fp.input.CursorEnd()
+			fp.loadDirectory()
 		} else {
 			fp.input.SetValue(entry.Name())
+			fp.applyFilter()
 		}
-		fp.applyFilter()
+		return
 	}
+	// Fallback: try to navigate from typed path
+	fp.handleOpenFromInput()
 }

--- a/internal/ui/common/filepicker_render.go
+++ b/internal/ui/common/filepicker_render.go
@@ -224,7 +224,7 @@ func (fp *FilePicker) helpLines(width int) []string {
 		fp.helpItem("enter", "open/select"),
 		fp.helpItem("esc", "cancel"),
 		fp.helpItem("↑/↓", "move"),
-		fp.helpItem("tab", "autocomplete"),
+		fp.helpItem("tab", "enter folder"),
 		fp.helpItem("backspace", "parent"),
 		fp.helpItem("ctrl+h", "hidden"),
 	}


### PR DESCRIPTION
Tab wasn't working when the first item was selected because handleAutocomplete() used cursor > 0 instead of cursor >= 0, and used wrong index (cursor-1 instead of cursor).