### PR TITLE
Fix home screen button click detection offset

### DIFF
--- a/internal/app/app_view_content.go
+++ b/internal/app/app_view_content.go
@@ -101,7 +101,7 @@ func (a *App) renderWelcome() string {
 
 	// Center the content in the pane
 	width := a.layout.CenterWidth() - 4 // Account for borders/padding
-	height := a.layout.Height() - 4
+	height := a.layout.Height() - 2
 
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, content)
 }


### PR DESCRIPTION
lipgloss.Place centers each line independently based on that line's width. The buttons line is narrower than the logo, so it gets more left padding. Fixed by calculating offsetX per-line using each line's visual width instead of the max content width.

Also fixed height calculation (Height-4 to Height-2) to account for 0 vertical padding in the center pane style.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
