### PR TITLE
Combine Unstaged and Untracked sections in sidebar

### DIFF
--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -213,10 +213,9 @@ func (m *Model) rebuildDisplayList() {
 			unstagedCount++
 		}
 	}
-	untrackedCount := 0
 	for i := range m.gitStatus.Untracked {
 		if matchesFilter(&m.gitStatus.Untracked[i]) {
-			untrackedCount++
+			unstagedCount++
 		}
 	}
 
@@ -236,7 +235,7 @@ func (m *Model) rebuildDisplayList() {
 		}
 	}
 
-	// Add Unstaged section
+	// Add Unstaged section (includes both modified and untracked files)
 	if unstagedCount > 0 {
 		m.displayItems = append(m.displayItems, displayItem{
 			isHeader: true,
@@ -250,14 +249,6 @@ func (m *Model) rebuildDisplayList() {
 				})
 			}
 		}
-	}
-
-	// Add Untracked section
-	if untrackedCount > 0 {
-		m.displayItems = append(m.displayItems, displayItem{
-			isHeader: true,
-			header:   "Untracked (" + strconv.Itoa(untrackedCount) + ")",
-		})
 		for i := range m.gitStatus.Untracked {
 			if matchesFilter(&m.gitStatus.Untracked[i]) {
 				m.displayItems = append(m.displayItems, displayItem{


### PR DESCRIPTION
Merge the separate "Unstaged" and "Untracked" sections into a single "Unstaged" section, matching the behavior of tools like SourceTree and GitKraken.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
