### PR TITLE
Fix error modal right border being cut off

### DIFF
--- a/internal/app/app_view.go
+++ b/internal/app/app_view.go
@@ -411,7 +411,7 @@ func (a *App) renderErrorOverlay() string {
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#f7768e")).
 		Padding(1, 2).
-		MaxWidth(60)
+		Width(56)
 	return errStyle.Render("Error: " + a.err.Error() + "\n\nPress any key to dismiss.")
 }
 


### PR DESCRIPTION
Change MaxWidth(60) to Width(56) to match the pattern used by other dialogs. MaxWidth constrains total width which can cause border rendering issues, while Width sets explicit content width with border added around it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
