### PR TITLE
Fix terminal state after Codex agent exit

### DIFF
--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -66,8 +66,10 @@ func (m *AgentManager) CreateAgent(wt *data.Worktree, agentType AgentType, rows,
 		shell = "/bin/bash"
 	}
 
-	// Execute agent, then reset terminal state (RIS), print message, and drop to shell
-	fullCommand := fmt.Sprintf("%s; printf '\\033c'; echo 'Agent exited. Dropping to shell...'; export TERM=xterm-256color; exec %s", assistantCfg.Command, shell)
+	// Execute agent, then reset terminal state and drop to shell
+	// Reset sequence: stty sane (terminal modes), exit alt screen, show cursor, reset attrs, RIS
+	// Use -l flag to start login shell so .zshrc/.bashrc are loaded
+	fullCommand := fmt.Sprintf("%s; stty sane; printf '\\033[?1049l\\033[?25h\\033[0m\\033c'; echo 'Agent exited. Dropping to shell...'; export TERM=xterm-256color; exec %s -l", assistantCfg.Command, shell)
 
 	term, err := NewWithSize(fullCommand, wt.Root, env, rows, cols)
 	if err != nil {


### PR DESCRIPTION
- Add stty sane to reset terminal modes (echo, canonical, etc.)
- Add escape sequences to exit alternate screen and show cursor
- Start shell as login shell (-l) to load .zshrc/.bashrc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
