### PR TITLE
Fix stale UI after worktree deletion

### DIFF
--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -209,11 +209,9 @@ func (a *App) createWorktree(project *data.Project, name, base string) tea.Cmd {
 
 // deleteWorktree deletes a git worktree
 func (a *App) deleteWorktree(project *data.Project, wt *data.Worktree) tea.Cmd {
-	// Check if we need to clear active worktree before running async
-	clearActive := a.activeWorktree != nil && a.activeWorktree.Root == wt.Root
-	if clearActive {
-		a.activeWorktree = nil
-		a.showWelcome = true
+	// Clear UI components if deleting the active worktree
+	if a.activeWorktree != nil && a.activeWorktree.Root == wt.Root {
+		a.goHome()
 	}
 
 	return func() tea.Msg {


### PR DESCRIPTION
Call goHome() instead of manually clearing activeWorktree and showWelcome when deleting the active worktree. This ensures all UI components (center, sidebar, sidebarTerminal) are properly cleared, matching the pattern used by removeProject().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/100">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
