### PR TITLE
Run setup scripts asynchronously during worktree creation

### DIFF
--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -260,6 +260,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.WorktreeCreated:
 		cmds = append(cmds, a.handleWorktreeCreated(msg)...)
 
+	case messages.WorktreeSetupComplete:
+		if cmd := a.handleWorktreeSetupComplete(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case messages.WorktreeCreateFailed:
 		if cmd := a.handleWorktreeCreateFailed(msg); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/app/app_input_messages.go
+++ b/internal/app/app_input_messages.go
@@ -287,9 +287,21 @@ func (a *App) handleWorktreeCreated(msg messages.WorktreeCreated) []tea.Cmd {
 		if cmd := a.dashboard.SetWorktreeCreating(msg.Worktree, false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		// Run setup scripts asynchronously
+		if msg.Meta != nil {
+			cmds = append(cmds, a.runSetupAsync(msg.Worktree, msg.Meta))
+		}
 	}
 	cmds = append(cmds, a.loadProjects())
 	return cmds
+}
+
+// handleWorktreeSetupComplete handles the WorktreeSetupComplete message.
+func (a *App) handleWorktreeSetupComplete(msg messages.WorktreeSetupComplete) tea.Cmd {
+	if msg.Err != nil {
+		return a.toast.ShowWarning(fmt.Sprintf("Setup failed for %s: %v", msg.Worktree.Name, msg.Err))
+	}
+	return nil
 }
 
 // handleWorktreeCreateFailed handles the WorktreeCreateFailed message.

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -194,16 +194,18 @@ func (a *App) createWorktree(project *data.Project, name, base string) tea.Cmd {
 			}
 		}
 
-		// Run setup scripts from .amux/worktrees.json
-		if err := a.scripts.RunSetup(wt, meta); err != nil {
-			// Don't fail worktree creation, just log the error
-			return messages.WorktreeCreatedWithWarning{
-				Worktree: wt,
-				Warning:  fmt.Sprintf("setup failed: %v", err),
-			}
-		}
+		// Return immediately with metadata for async setup
+		return messages.WorktreeCreated{Worktree: wt, Meta: meta}
+	}
+}
 
-		return messages.WorktreeCreated{Worktree: wt}
+// runSetupAsync runs setup scripts asynchronously and returns a WorktreeSetupComplete message
+func (a *App) runSetupAsync(wt *data.Worktree, meta *data.Metadata) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.scripts.RunSetup(wt, meta); err != nil {
+			return messages.WorktreeSetupComplete{Worktree: wt, Err: err}
+		}
+		return messages.WorktreeSetupComplete{Worktree: wt}
 	}
 }
 

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -36,6 +36,13 @@ type WorktreePreviewed struct {
 // WorktreeCreated is sent when a new worktree is created
 type WorktreeCreated struct {
 	Worktree *data.Worktree
+	Meta     *data.Metadata // For async setup
+}
+
+// WorktreeSetupComplete is sent when async setup scripts finish
+type WorktreeSetupComplete struct {
+	Worktree *data.Worktree
+	Err      error
 }
 
 // WorktreeCreateFailed is sent when a worktree creation fails


### PR DESCRIPTION
The "Creating" spinner was showing for ~10 seconds even though the worktree was usable much sooner. This was because setup scripts ran synchronously before returning WorktreeCreated.

Now the worktree creation returns immediately after metadata is saved, and setup scripts run in a background command. If setup fails, a warning toast is shown instead of blocking the UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/101">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
