### PR TITLE
Remove circle dot indicator from file tabs

### DIFF
--- a/internal/ui/center/model_render.go
+++ b/internal/ui/center/model_render.go
@@ -180,12 +180,18 @@ func (m *Model) renderTabBar() string {
 			name = tab.Assistant
 		}
 
-		// Add status indicator
+		// Add status indicator only for agent tabs (not file viewers)
 		var indicator string
-		if tab.Running {
-			indicator = common.Icons.Running + " "
-		} else {
-			indicator = common.Icons.Idle + " "
+		isAgent := tab.Assistant == "claude" || tab.Assistant == "codex" ||
+			tab.Assistant == "gemini" || tab.Assistant == "amp" ||
+			tab.Assistant == "opencode" || tab.Assistant == "droid" ||
+			tab.Assistant == "cursor"
+		if isAgent {
+			if tab.Running {
+				indicator = common.Icons.Running + " "
+			} else {
+				indicator = common.Icons.Idle + " "
+			}
 		}
 
 		// Get agent-specific color


### PR DESCRIPTION
File tabs (vim, diff, viewer) no longer show the running/idle indicator (● / ○) that is intended only for coding agent tabs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
