### PR TITLE
Add visual indicators for active coding agents

### DIFF
--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -138,6 +138,9 @@ type Model struct {
 	offsetX         int // X offset from screen left (dashboard width)
 	showKeymapHints bool
 
+	// Animation
+	spinnerFrame int // Current frame for activity spinner animation
+
 	// Config
 	config  *config.Config
 	styles  common.Styles
@@ -485,6 +488,11 @@ func (m *Model) Close() {
 	if m.agentManager != nil {
 		m.agentManager.CloseAll()
 	}
+}
+
+// TickSpinner advances the spinner animation frame.
+func (m *Model) TickSpinner() {
+	m.spinnerFrame++
 }
 
 // screenToTerminal converts screen coordinates to terminal coordinates

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -26,6 +26,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		status := ""
 		statusText := ""
 		dirty := false
+		working := false
 		main := m.getMainWorktree(row.Project)
 		if main != nil {
 			if m.deletingWorktrees[main.Root] {
@@ -34,6 +35,9 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			} else if m.loadingStatus[main.Root] {
 				frame := common.SpinnerFrame(m.spinnerFrame)
 				statusText = m.styles.StatusPending.Render(frame)
+			} else if m.activeWorktrees[main.Root] {
+				// Active agents - color change only, no spinner
+				working = true
 			} else if s, ok := m.statusCache[main.Root]; ok && !s.Clean {
 				dirty = true
 			}
@@ -52,7 +56,10 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		} else if m.isProjectActive(row.Project) {
 			style = m.styles.ActiveWorktree.PaddingLeft(0)
 		}
-		if dirty {
+		// Working color takes priority over dirty color
+		if working {
+			style = style.Foreground(common.ColorPrimary).Bold(true)
+		} else if dirty {
 			style = style.Foreground(common.ColorSecondary)
 		}
 
@@ -88,6 +95,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		status := ""
 		statusText := ""
 		dirty := false
+		working := false
 
 		// Check deletion state first
 		if m.deletingWorktrees[row.Worktree.Root] {
@@ -100,6 +108,9 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			// Show spinner while loading
 			frame := common.SpinnerFrame(m.spinnerFrame)
 			statusText = m.styles.StatusPending.Render(frame)
+		} else if m.activeWorktrees[row.Worktree.Root] {
+			// Active agents - color change only, no spinner
+			working = true
 		} else if s, ok := m.statusCache[row.Worktree.Root]; ok && !s.Clean {
 			dirty = true
 		}
@@ -114,7 +125,10 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		} else if row.Worktree.Root == m.activeRoot {
 			style = m.styles.ActiveWorktree
 		}
-		if dirty {
+		// Working color takes priority over dirty color
+		if working {
+			style = style.Foreground(common.ColorPrimary).Bold(true)
+		} else if dirty {
 			style = style.Foreground(common.ColorSecondary)
 		}
 		// Reserve space for delete icon to keep status aligned

--- a/internal/ui/dashboard/dashboard_state.go
+++ b/internal/ui/dashboard/dashboard_state.go
@@ -13,7 +13,7 @@ import (
 // tickSpinner returns a command that ticks the spinner
 func (m *Model) tickSpinner() tea.Cmd {
 	return common.SafeTick(spinnerInterval, func(t time.Time) tea.Msg {
-		return spinnerTickMsg{}
+		return SpinnerTickMsg{}
 	})
 }
 
@@ -22,11 +22,16 @@ func (m *Model) startSpinnerIfNeeded() tea.Cmd {
 	if m.spinnerActive {
 		return nil
 	}
-	if len(m.loadingStatus) == 0 && len(m.creatingWorktrees) == 0 && len(m.deletingWorktrees) == 0 {
+	if len(m.loadingStatus) == 0 && len(m.creatingWorktrees) == 0 && len(m.deletingWorktrees) == 0 && len(m.activeWorktrees) == 0 {
 		return nil
 	}
 	m.spinnerActive = true
 	return m.tickSpinner()
+}
+
+// StartSpinnerIfNeeded is the public version for external callers.
+func (m *Model) StartSpinnerIfNeeded() tea.Cmd {
+	return m.startSpinnerIfNeeded()
 }
 
 // SetWorktreeCreating marks a worktree as creating (or clears it).

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -13,8 +13,8 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
-// spinnerTickMsg is sent to update the spinner animation
-type spinnerTickMsg struct{}
+// SpinnerTickMsg is sent to update the spinner animation
+type SpinnerTickMsg struct{}
 
 // spinnerInterval is how often the spinner updates
 const spinnerInterval = 80 * time.Millisecond
@@ -82,6 +82,9 @@ type Model struct {
 	spinnerFrame      int                       // Current spinner animation frame
 	spinnerActive     bool                      // Whether spinner ticks are active
 
+	// Agent activity state
+	activeWorktrees map[string]bool // Worktrees with active agents (synced from center)
+
 	// Styles
 	styles common.Styles
 }
@@ -95,10 +98,16 @@ func New() *Model {
 		loadingStatus:     make(map[string]bool),
 		creatingWorktrees: make(map[string]*data.Worktree),
 		deletingWorktrees: make(map[string]bool),
+		activeWorktrees:   make(map[string]bool),
 		cursor:            0,
 		focused:           true,
 		styles:            common.DefaultStyles(),
 	}
+}
+
+// SetActiveWorktrees updates the set of worktrees with active agents.
+func (m *Model) SetActiveWorktrees(active map[string]bool) {
+	m.activeWorktrees = active
 }
 
 // SetCanFocusRight controls whether focus-right hints should be shown.
@@ -266,9 +275,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			}
 		}
 
-	case spinnerTickMsg:
-		// Advance spinner frame if we have loading items
-		if len(m.loadingStatus) > 0 || len(m.creatingWorktrees) > 0 || len(m.deletingWorktrees) > 0 {
+	case SpinnerTickMsg:
+		// Advance spinner frame if we have loading items or active agents
+		if len(m.loadingStatus) > 0 || len(m.creatingWorktrees) > 0 || len(m.deletingWorktrees) > 0 || len(m.activeWorktrees) > 0 {
 			m.spinnerFrame++
 			cmds = append(cmds, m.tickSpinner())
 		} else {


### PR DESCRIPTION
Show when agents are actively working (producing output) via:
- Primary color + bold text in worktree list (left pane)
- Primary color + bold text in tab bar (center pane)

Activity is detected when an agent has produced output within the last 2 seconds. The colored dot on agent tabs remains as a brand color indicator only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/107">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
