### PR TITLE
Fix dashboard dirty indicator out of sync with sidebar

### DIFF
--- a/internal/app/app_input_messages.go
+++ b/internal/app/app_input_messages.go
@@ -77,6 +77,7 @@ func (a *App) handleWorkspacePreviewed(msg messages.WorkspacePreviewed) []tea.Cm
 			a.sidebar.SetGitStatus(cached)
 		} else {
 			a.sidebar.SetGitStatus(nil)
+			a.dashboard.InvalidateStatus(msg.Workspace.Root)
 		}
 	} else {
 		a.sidebar.SetGitStatus(nil)
@@ -416,6 +417,7 @@ func (a *App) handleGitStatusTick() []tea.Cmd {
 func (a *App) handleFileWatcherEvent(msg messages.FileWatcherEvent) []tea.Cmd {
 	// File changed, invalidate cache and refresh
 	a.statusManager.Invalidate(msg.Root)
+	a.dashboard.InvalidateStatus(msg.Root)
 	return []tea.Cmd{
 		a.requestGitStatus(msg.Root),
 		a.startFileWatcher(),

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -110,6 +110,15 @@ func (m *Model) SetActiveWorkspaces(active map[string]bool) {
 	m.activeWorkspaces = active
 }
 
+// InvalidateStatus removes a workspace's cached status.
+// This should be called when git status is invalidated externally (e.g., file watcher events)
+// to keep the dashboard cache in sync with the StatusManager cache.
+func (m *Model) InvalidateStatus(root string) {
+	delete(m.statusCache, root)
+	// Mark as loading so UI shows spinner instead of stale state
+	m.loadingStatus[root] = true
+}
+
 // SetCanFocusRight controls whether focus-right hints should be shown.
 func (m *Model) SetCanFocusRight(can bool) {
 	m.canFocusRight = can


### PR DESCRIPTION
The dashboard maintains its own statusCache separate from the StatusManager cache. When git status was invalidated (e.g., after git rebase), only the StatusManager cache was cleared, leaving the dashboard with stale data showing a dirty indicator while the sidebar showed no files.

Add InvalidateStatus method to dashboard that clears its local cache and marks the workspace as loading. Call this method from:
- handleFileWatcherEvent: when file changes trigger status refresh
- handleWorkspacePreviewed: when there's a cache miss in StatusManager
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/113">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
