### PR TITLE
Simplify spinner to only trigger on create/delete operations

### DIFF
--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -32,9 +32,6 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			if m.deletingWorkspaces[main.Root] {
 				frame := common.SpinnerFrame(m.spinnerFrame)
 				statusText = m.styles.StatusPending.Render(frame + " deleting")
-			} else if m.loadingStatus[main.Root] {
-				frame := common.SpinnerFrame(m.spinnerFrame)
-				statusText = m.styles.StatusPending.Render(frame)
 			} else if m.activeWorkspaces[main.Root] {
 				// Active agents - color change only, no spinner
 				working = true
@@ -104,10 +101,6 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		} else if _, ok := m.creatingWorkspaces[row.Workspace.Root]; ok {
 			frame := common.SpinnerFrame(m.spinnerFrame)
 			statusText = m.styles.StatusPending.Render(frame + " creating")
-		} else if m.loadingStatus[row.Workspace.Root] {
-			// Show spinner while loading
-			frame := common.SpinnerFrame(m.spinnerFrame)
-			statusText = m.styles.StatusPending.Render(frame)
 		} else if m.activeWorkspaces[row.Workspace.Root] {
 			// Active agents - color change only, no spinner
 			working = true

--- a/internal/ui/dashboard/dashboard_state.go
+++ b/internal/ui/dashboard/dashboard_state.go
@@ -22,7 +22,7 @@ func (m *Model) startSpinnerIfNeeded() tea.Cmd {
 	if m.spinnerActive {
 		return nil
 	}
-	if len(m.loadingStatus) == 0 && len(m.creatingWorkspaces) == 0 && len(m.deletingWorkspaces) == 0 && len(m.activeWorkspaces) == 0 {
+	if len(m.creatingWorkspaces) == 0 && len(m.deletingWorkspaces) == 0 {
 		return nil
 	}
 	m.spinnerActive = true


### PR DESCRIPTION
Remove loadingStatus tracking entirely — git status refreshes no longer show spinners, fixing unwanted spinners during workspace navigation. Spinner now only activates for user-initiated create and delete operations. Add TestSpinnerOnlyForCreateDelete to verify the invariant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/117">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
