### PR TITLE
Send CSI u sequence for Shift+Enter

### DIFF
--- a/internal/ui/common/keys.go
+++ b/internal/ui/common/keys.go
@@ -1,10 +1,15 @@
 package common
 
-import tea "charm.land/bubbletea/v2"
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/logging"
+)
 
 // KeyToBytes converts a key press message to bytes for the terminal.
 func KeyToBytes(msg tea.KeyPressMsg) []byte {
 	key := msg.Key()
+	logging.Debug("KeyToBytes: code=%d mod=%d str=%q", key.Code, key.Mod, msg.String())
 
 	if key.Mod&tea.ModCtrl != 0 {
 		switch key.Code {


### PR DESCRIPTION
Shift+Enter now sends ESC[13;2u (kitty keyboard protocol) instead of plain CR. This allows apps like Claude Code to distinguish Shift+Enter from Enter and insert a new line instead of submitting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/125">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
