### PR TITLE
Fix dashboard clicks not working on lower sidebar items

### DIFF
--- a/internal/ui/dashboard/click_test.go
+++ b/internal/ui/dashboard/click_test.go
@@ -208,78 +208,6 @@ func TestMouseClickOnRows(t *testing.T) {
 	}
 }
 
-func TestToolbarClick(t *testing.T) {
-	m := setupClickTestModel()
-
-	// Force View to calculate toolbarY
-	_ = m.View()
-
-	// The toolbar should be at the bottom of the content area
-	// With showKeymapHints=false, toolbar is rendered without help lines below
-	// Toolbar buttons are: [Help] [Monitor] [Settings] on a single row
-
-	// Get toolbar Y position (set during View())
-	// We need to add border offset (1) to get screen Y
-	toolbarScreenY := m.toolbarY + 1 // +1 for top border
-
-	tests := []struct {
-		name        string
-		screenX     int
-		screenY     int
-		wantMsgType string
-	}{
-		{
-			name:        "click Help button",
-			screenX:     3, // [?H] starts near the left
-			screenY:     toolbarScreenY,
-			wantMsgType: "ToggleHelp",
-		},
-		{
-			name:        "click Monitor button",
-			screenX:     8, // [◆M] is after [?H] with gap
-			screenY:     toolbarScreenY,
-			wantMsgType: "ToggleMonitor",
-		},
-		{
-			name:        "click Settings button",
-			screenX:     13, // [⚙S] is after [▤M] with gap
-			screenY:     toolbarScreenY,
-			wantMsgType: "ShowSettingsDialog",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Reset state
-			m.toolbarFocused = false
-			m.toolbarIndex = 0
-
-			cmd := m.handleToolbarClick(tt.screenX, tt.screenY)
-			if cmd == nil {
-				t.Fatalf("expected command from toolbar click at (%d, %d), got nil (toolbarY=%d)",
-					tt.screenX, tt.screenY, m.toolbarY)
-			}
-
-			msg := cmd()
-			gotType := ""
-			switch msg.(type) {
-			case messages.ToggleHelp:
-				gotType = "ToggleHelp"
-			case messages.ToggleMonitor:
-				gotType = "ToggleMonitor"
-			case messages.ShowSettingsDialog:
-				gotType = "ShowSettingsDialog"
-			default:
-				gotType = "unknown"
-			}
-
-			if gotType != tt.wantMsgType {
-				t.Errorf("toolbar click message type = %s, want %s", gotType, tt.wantMsgType)
-			}
-		})
-	}
-}
-
 func TestRowClickWithScrollOffset(t *testing.T) {
 	m := New()
 	m.SetSize(30, 10) // Small height to force scrolling
@@ -341,117 +269,78 @@ func TestClickOutsideContentArea(t *testing.T) {
 	}
 }
 
-func TestToolbarYCalculation(t *testing.T) {
-	// Test that toolbarY is correctly calculated for different content sizes
+// TestClickLowerRowsWithKeymapHintsHidden is a regression test for a bug where
+// clicks on lower items in the sidebar failed when showKeymapHints was false.
+// The bug was in rowIndexAt() which didn't account for showKeymapHints when
+// calculating the clickable area, causing it to subtract help height even when
+// help wasn't being rendered.
+func TestClickLowerRowsWithKeymapHintsHidden(t *testing.T) {
+	m := New()
+	m.SetSize(30, 12) // Height chosen so visible rows are affected by help height bug
+	m.showKeymapHints = false
 
-	t.Run("few rows - toolbar pushed to bottom", func(t *testing.T) {
-		m := New()
-		m.SetSize(30, 20)
-		m.showKeymapHints = false
-		m.SetProjects([]data.Project{{
-			Name: "test",
-			Path: "/test",
+	// Create projects to have rows that fill the visible area
+	projects := []data.Project{}
+	for i := 0; i < 3; i++ {
+		projects = append(projects, data.Project{
+			Name: "proj" + string(rune('A'+i)),
+			Path: "/proj" + string(rune('A'+i)),
 			Workspaces: []data.Workspace{
-				{Name: "main", Branch: "main", Root: "/test"},
+				{Name: "main", Branch: "main", Repo: "/proj", Root: "/proj" + string(rune('A'+i))},
 			},
-		}})
-
-		_ = m.View()
-
-		// With few rows, toolbar should be near the bottom
-		// innerHeight = 20 - 2 = 18
-		// toolbarHeight = 1 (single row of buttons)
-		// targetHeight = 18 - 1 = 17
-		// Toolbar should be at or near targetHeight
-		if m.toolbarY < 5 {
-			t.Errorf("toolbarY = %d, expected it to be pushed toward bottom (>= 5)", m.toolbarY)
-		}
-	})
-
-	t.Run("many rows - toolbar follows content", func(t *testing.T) {
-		m := New()
-		m.SetSize(30, 10) // Small height
-		m.showKeymapHints = false
-
-		// Create many projects
-		projects := []data.Project{}
-		for i := 0; i < 20; i++ {
-			projects = append(projects, data.Project{
-				Name: "proj" + string(rune('A'+i)),
-				Path: "/proj",
-				Workspaces: []data.Workspace{
-					{Name: "main", Branch: "main", Root: "/proj"},
-				},
-			})
-		}
-		m.SetProjects(projects)
-
-		_ = m.View()
-
-		// Toolbar should still be clickable
-		if m.toolbarY < 0 {
-			t.Errorf("toolbarY = %d, should be non-negative", m.toolbarY)
-		}
-	})
-}
-
-func TestDeleteButtonClick(t *testing.T) {
-	m := setupClickTestModel()
-
-	// Select a workspace row to make Delete button visible
-	m.cursor = 3 // Workspace row
+		})
+	}
+	m.SetProjects(projects)
 	_ = m.View()
 
-	// Find the Delete button position
-	// Toolbar items when workspace selected: Help, Monitor, Settings, Delete
-	// [?H] [◆M] [⚙S] [Delete]
-	toolbarScreenY := m.toolbarY + 1
+	// With height=12, innerHeight = 10 (minus 2 for borders)
+	// Toolbar takes 1 line, leaving 9 lines for content
+	// Help lines (when shown) would be ~3 lines
+	// Without the fix, rowIndexAt() would subtract ~3 lines from clickable area
+	//
+	// Row layout:
+	// 0: Home
+	// 1: Spacer
+	// 2: projA (project)
+	// 3: + New (create)
+	// 4: Spacer
+	// 5: projB (project)
+	// 6: + New (create)
+	// 7: Spacer
+	// 8: projC (project)
+	// 9: + New (create)
 
-	// Delete should be on same row, after Settings
-	cmd := m.handleToolbarClick(12, toolbarScreenY) // Same row, right side
-	if cmd != nil {
-		msg := cmd()
-		if _, ok := msg.(messages.ShowDeleteWorkspaceDialog); ok {
-			// Success - Delete button was clicked
-			return
+	// Calculate visible height to find rows near the bottom
+	visibleHeight := m.visibleHeight()
+
+	// Try to click on rows that would be in the bottom portion of visible area
+	// These would fail without the fix because help height was incorrectly subtracted
+	for rowIdx := 0; rowIdx < len(m.rows) && rowIdx < visibleHeight; rowIdx++ {
+		screenY := rowIdx + 1 // +1 for top border
+
+		idx, ok := m.rowIndexAt(5, screenY)
+		if !ok {
+			t.Errorf("row %d at screenY=%d should be clickable, got ok=false", rowIdx, screenY)
+			continue
+		}
+		if idx != rowIdx {
+			t.Errorf("click at screenY=%d should map to row %d, got %d", screenY, rowIdx, idx)
 		}
 	}
 
-	// Try alternative position - the exact X depends on button width
-	for x := 8; x < 20; x++ {
-		cmd := m.handleToolbarClick(x, toolbarScreenY+1)
-		if cmd != nil {
-			msg := cmd()
-			if _, ok := msg.(messages.ShowDeleteWorkspaceDialog); ok {
-				return // Found it
-			}
+	// Specifically test the last visible row - this is where the bug manifests
+	lastVisibleRow := visibleHeight - 1
+	if lastVisibleRow >= len(m.rows) {
+		lastVisibleRow = len(m.rows) - 1
+	}
+	if lastVisibleRow >= 0 {
+		screenY := lastVisibleRow + 1
+		idx, ok := m.rowIndexAt(5, screenY)
+		if !ok {
+			t.Errorf("last visible row %d at screenY=%d should be clickable, got ok=false", lastVisibleRow, screenY)
+		}
+		if ok && idx != lastVisibleRow {
+			t.Errorf("click at screenY=%d should map to row %d, got %d", screenY, lastVisibleRow, idx)
 		}
 	}
-
-	t.Log("Note: Delete button click test may need coordinate adjustment based on actual button layout")
-}
-
-func TestRemoveButtonClickOnProject(t *testing.T) {
-	m := setupClickTestModel()
-
-	// Select a project row to make Remove button visible
-	m.cursor = 2 // Project row
-	_ = m.View()
-
-	// Toolbar items when project selected: Help, Monitor, Settings, Remove
-	// [?H] [◆M] [⚙S] [Remove]
-	toolbarScreenY := m.toolbarY + 1
-
-	// Try to find Remove button on same row
-	for x := 8; x < 20; x++ {
-		cmd := m.handleToolbarClick(x, toolbarScreenY)
-		if cmd != nil {
-			msg := cmd()
-			if _, ok := msg.(messages.ShowRemoveProjectDialog); ok {
-				return // Found it
-			}
-		}
-	}
-
-	t.Log("Note: Remove button click test may need coordinate adjustment based on actual button layout")
 }

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -80,8 +80,7 @@ func (m *Model) rowIndexAt(screenX, screenY int) (int, bool) {
 	}
 
 	headerHeight := 0
-	helpLines := m.helpLines(contentWidth)
-	helpHeight := len(helpLines)
+	helpHeight := m.helpLineCount()
 	toolbarHeight := m.toolbarHeight()
 	rowAreaHeight := innerHeight - headerHeight - toolbarHeight - helpHeight
 	if rowAreaHeight < 1 {

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -169,6 +169,20 @@ func (m *Model) helpItem(key, desc string) string {
 	return common.RenderHelpItem(m.styles, key, desc)
 }
 
+// helpLineCount returns the number of help lines that will be displayed.
+// This encapsulates the showKeymapHints check to avoid bugs where callers
+// forget to check it.
+func (m *Model) helpLineCount() int {
+	if !m.showKeymapHints {
+		return 0
+	}
+	contentWidth := m.width - 3
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	return len(m.helpLines(contentWidth))
+}
+
 func (m *Model) helpLines(contentWidth int) []string {
 	items := []string{
 		m.helpItem("k/↑", "up"),

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -325,16 +325,7 @@ func (m *Model) View() string {
 		innerHeight = 0
 	}
 	headerHeight := 0
-	// Calculate help height based on content width (pane width minus border and padding)
-	contentWidth := m.width - 3
-	if contentWidth < 1 {
-		contentWidth = 1
-	}
-	helpLines := m.helpLines(contentWidth)
-	if !m.showKeymapHints {
-		helpLines = nil
-	}
-	helpHeight := len(helpLines)
+	helpHeight := m.helpLineCount()
 	toolbarHeight := m.toolbarHeight()
 	visibleHeight := innerHeight - headerHeight - toolbarHeight - helpHeight
 	if visibleHeight < 1 {
@@ -382,9 +373,16 @@ func (m *Model) View() string {
 	b.WriteString(toolbar)
 
 	// Help lines
-	if len(helpLines) > 0 {
-		b.WriteString("\n")
-		b.WriteString(strings.Join(helpLines, "\n"))
+	if m.showKeymapHints {
+		contentWidth := m.width - 3
+		if contentWidth < 1 {
+			contentWidth = 1
+		}
+		helpLines := m.helpLines(contentWidth)
+		if len(helpLines) > 0 {
+			b.WriteString("\n")
+			b.WriteString(strings.Join(helpLines, "\n"))
+		}
 	}
 
 	// Return raw content - buildBorderedPane in app.go handles truncation
@@ -425,15 +423,7 @@ func (m *Model) visibleHeight() int {
 		innerHeight = 0
 	}
 	headerHeight := 0
-	contentWidth := m.width - 3
-	if contentWidth < 1 {
-		contentWidth = 1
-	}
-	helpLines := m.helpLines(contentWidth)
-	if !m.showKeymapHints {
-		helpLines = nil
-	}
-	helpHeight := len(helpLines)
+	helpHeight := m.helpLineCount()
 	toolbarHeight := m.toolbarHeight()
 	visibleHeight := innerHeight - headerHeight - toolbarHeight - helpHeight
 	if visibleHeight < 1 {

--- a/internal/ui/dashboard/toolbar_click_test.go
+++ b/internal/ui/dashboard/toolbar_click_test.go
@@ -1,0 +1,195 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+func TestToolbarClick(t *testing.T) {
+	m := setupClickTestModel()
+
+	// Force View to calculate toolbarY
+	_ = m.View()
+
+	// The toolbar should be at the bottom of the content area
+	// With showKeymapHints=false, toolbar is rendered without help lines below
+	// Toolbar buttons are: [Help] [Monitor] [Settings] on a single row
+
+	// Get toolbar Y position (set during View())
+	// We need to add border offset (1) to get screen Y
+	toolbarScreenY := m.toolbarY + 1 // +1 for top border
+
+	tests := []struct {
+		name        string
+		screenX     int
+		screenY     int
+		wantMsgType string
+	}{
+		{
+			name:        "click Help button",
+			screenX:     3, // [?H] starts near the left
+			screenY:     toolbarScreenY,
+			wantMsgType: "ToggleHelp",
+		},
+		{
+			name:        "click Monitor button",
+			screenX:     8, // [◆M] is after [?H] with gap
+			screenY:     toolbarScreenY,
+			wantMsgType: "ToggleMonitor",
+		},
+		{
+			name:        "click Settings button",
+			screenX:     13, // [⚙S] is after [▤M] with gap
+			screenY:     toolbarScreenY,
+			wantMsgType: "ShowSettingsDialog",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset state
+			m.toolbarFocused = false
+			m.toolbarIndex = 0
+
+			cmd := m.handleToolbarClick(tt.screenX, tt.screenY)
+			if cmd == nil {
+				t.Fatalf("expected command from toolbar click at (%d, %d), got nil (toolbarY=%d)",
+					tt.screenX, tt.screenY, m.toolbarY)
+			}
+
+			msg := cmd()
+			gotType := ""
+			switch msg.(type) {
+			case messages.ToggleHelp:
+				gotType = "ToggleHelp"
+			case messages.ToggleMonitor:
+				gotType = "ToggleMonitor"
+			case messages.ShowSettingsDialog:
+				gotType = "ShowSettingsDialog"
+			default:
+				gotType = "unknown"
+			}
+
+			if gotType != tt.wantMsgType {
+				t.Errorf("toolbar click message type = %s, want %s", gotType, tt.wantMsgType)
+			}
+		})
+	}
+}
+
+func TestToolbarYCalculation(t *testing.T) {
+	// Test that toolbarY is correctly calculated for different content sizes
+
+	t.Run("few rows - toolbar pushed to bottom", func(t *testing.T) {
+		m := New()
+		m.SetSize(30, 20)
+		m.showKeymapHints = false
+		m.SetProjects([]data.Project{{
+			Name: "test",
+			Path: "/test",
+			Workspaces: []data.Workspace{
+				{Name: "main", Branch: "main", Root: "/test"},
+			},
+		}})
+
+		_ = m.View()
+
+		// With few rows, toolbar should be near the bottom
+		// innerHeight = 20 - 2 = 18
+		// toolbarHeight = 1 (single row of buttons)
+		// targetHeight = 18 - 1 = 17
+		// Toolbar should be at or near targetHeight
+		if m.toolbarY < 5 {
+			t.Errorf("toolbarY = %d, expected it to be pushed toward bottom (>= 5)", m.toolbarY)
+		}
+	})
+
+	t.Run("many rows - toolbar follows content", func(t *testing.T) {
+		m := New()
+		m.SetSize(30, 10) // Small height
+		m.showKeymapHints = false
+
+		// Create many projects
+		projects := []data.Project{}
+		for i := 0; i < 20; i++ {
+			projects = append(projects, data.Project{
+				Name: "proj" + string(rune('A'+i)),
+				Path: "/proj",
+				Workspaces: []data.Workspace{
+					{Name: "main", Branch: "main", Root: "/proj"},
+				},
+			})
+		}
+		m.SetProjects(projects)
+
+		_ = m.View()
+
+		// Toolbar should still be clickable
+		if m.toolbarY < 0 {
+			t.Errorf("toolbarY = %d, should be non-negative", m.toolbarY)
+		}
+	})
+}
+
+func TestDeleteButtonClick(t *testing.T) {
+	m := setupClickTestModel()
+
+	// Select a workspace row to make Delete button visible
+	m.cursor = 3 // Workspace row
+	_ = m.View()
+
+	// Find the Delete button position
+	// Toolbar items when workspace selected: Help, Monitor, Settings, Delete
+	// [?H] [◆M] [⚙S] [Delete]
+	toolbarScreenY := m.toolbarY + 1
+
+	// Delete should be on same row, after Settings
+	cmd := m.handleToolbarClick(12, toolbarScreenY) // Same row, right side
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(messages.ShowDeleteWorkspaceDialog); ok {
+			// Success - Delete button was clicked
+			return
+		}
+	}
+
+	// Try alternative position - the exact X depends on button width
+	for x := 8; x < 20; x++ {
+		cmd := m.handleToolbarClick(x, toolbarScreenY+1)
+		if cmd != nil {
+			msg := cmd()
+			if _, ok := msg.(messages.ShowDeleteWorkspaceDialog); ok {
+				return // Found it
+			}
+		}
+	}
+
+	t.Log("Note: Delete button click test may need coordinate adjustment based on actual button layout")
+}
+
+func TestRemoveButtonClickOnProject(t *testing.T) {
+	m := setupClickTestModel()
+
+	// Select a project row to make Remove button visible
+	m.cursor = 2 // Project row
+	_ = m.View()
+
+	// Toolbar items when project selected: Help, Monitor, Settings, Remove
+	// [?H] [◆M] [⚙S] [Remove]
+	toolbarScreenY := m.toolbarY + 1
+
+	// Try to find Remove button on same row
+	for x := 8; x < 20; x++ {
+		cmd := m.handleToolbarClick(x, toolbarScreenY)
+		if cmd != nil {
+			msg := cmd()
+			if _, ok := msg.(messages.ShowRemoveProjectDialog); ok {
+				return // Found it
+			}
+		}
+	}
+
+	t.Log("Note: Remove button click test may need coordinate adjustment based on actual button layout")
+}


### PR DESCRIPTION
rowIndexAt() was not checking showKeymapHints when calculating the clickable area, but View() and visibleHeight() did check it. This caused clicks on lower items to fail bounds checks when keymap hints were hidden (the default).

Added regression test and split toolbar tests to separate file to stay under 500-line limit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/126">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
