### PR TITLE
Fix bottom projects unclickable after delete+add in same session

### DIFF
--- a/internal/ui/dashboard/dashboard_state.go
+++ b/internal/ui/dashboard/dashboard_state.go
@@ -111,6 +111,22 @@ func (m *Model) rebuildRows() {
 			m.cursor = prev
 		}
 	}
+
+	m.clampScrollOffset()
+}
+
+// clampScrollOffset ensures scrollOffset stays within valid bounds.
+func (m *Model) clampScrollOffset() {
+	maxOffset := len(m.rows) - m.visibleHeight()
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.scrollOffset > maxOffset {
+		m.scrollOffset = maxOffset
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
 }
 
 func (m *Model) sortedWorkspaces(project *data.Project) []*data.Workspace {

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -290,8 +290,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		}
 
 	case messages.ProjectsLoaded:
-		m.projects = msg.Projects
-		m.rebuildRows()
+		m.SetProjects(msg.Projects)
 
 	case messages.GitStatusResult:
 		if msg.Err == nil {
@@ -412,8 +411,14 @@ func (m *Model) Focused() bool {
 
 // SetProjects sets the projects list
 func (m *Model) SetProjects(projects []data.Project) {
+	prevCursor := m.cursor
+	prevOffset := m.scrollOffset
 	m.projects = projects
 	m.rebuildRows()
+	if m.cursor == prevCursor {
+		m.scrollOffset = prevOffset
+		m.clampScrollOffset()
+	}
 }
 
 // visibleHeight returns the number of visible rows in the dashboard


### PR DESCRIPTION
Add clampScrollOffset() to rebuildRows() so scrollOffset stays valid when the row count changes. SetProjects() now preserves scroll position on refresh and clamps it on structural changes, preventing rowIndexAt() from failing to map bottom screen positions to rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/128">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
