### PR TITLE
Fix tab ordering across multiple instances

### DIFF
--- a/internal/data/workspace.go
+++ b/internal/data/workspace.go
@@ -34,6 +34,7 @@ type TabInfo struct {
 	Name        string `json:"name"`
 	SessionName string `json:"session_name,omitempty"`
 	Status      string `json:"status,omitempty"`
+	CreatedAt   int64  `json:"created_at,omitempty"`
 }
 
 // ScriptsConfig holds the setup/run/archive script commands

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -86,6 +86,8 @@ type Tab struct {
 	cachedShowCursor bool
 	monitorSnapAt    time.Time
 	monitorDirty     bool
+
+	createdAt int64 // Unix timestamp for ordering; persisted in workspace.json
 }
 
 func (t *Tab) isClosed() bool {

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -50,7 +50,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 	}
 	if tab.Terminal != nil {
 		tab.Terminal.AllowAltScreenScrollback = true
-		if createdTerminal {
+		if createdTerminal || len(tab.Terminal.Scrollback) == 0 {
 			tab.Terminal.PrependScrollback(msg.ScrollbackCapture)
 		}
 	}

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -182,6 +182,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 		Terminal:     term,
 		Running:      true, // Agent/viewer starts running
 		monitorDirty: true,
+		createdAt:    time.Now().Unix(),
 	}
 
 	// Set up response writer for terminal queries (DSR, DA, etc.)
@@ -422,6 +423,7 @@ func (m *Model) GetTabsInfo() ([]data.TabInfo, int) {
 			Name:        tab.Name,
 			SessionName: sessionName,
 			Status:      status,
+			CreatedAt:   tab.createdAt,
 		})
 	}
 	return result, m.getActiveTabIdx()
@@ -454,6 +456,7 @@ func (m *Model) GetTabsInfoForWorkspace(wsID string) ([]data.TabInfo, int) {
 			Name:        tab.Name,
 			SessionName: sessionName,
 			Status:      status,
+			CreatedAt:   tab.createdAt,
 		})
 	}
 	return result, m.activeTabByWorkspace[wsID]

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -1,0 +1,170 @@
+package center
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
+	tm := m.terminalMetrics()
+	termWidth := tm.Width
+	termHeight := tm.Height
+	if termWidth < 1 {
+		termWidth = 80
+	}
+	if termHeight < 1 {
+		termHeight = 24
+	}
+	displayName := strings.TrimSpace(info.Name)
+	if displayName == "" {
+		displayName = strings.TrimSpace(info.Assistant)
+	}
+	if displayName == "" {
+		displayName = "Terminal"
+	}
+	term := vterm.New(termWidth, termHeight)
+	term.AllowAltScreenScrollback = true
+	ca := info.CreatedAt
+	if ca == 0 {
+		ca = time.Now().Unix()
+	}
+	tab := &Tab{
+		ID:          generateTabID(),
+		Name:        displayName,
+		Assistant:   info.Assistant,
+		Workspace:   ws,
+		SessionName: info.SessionName,
+		Detached:    true,
+		Running:     false,
+		Terminal:    term,
+		createdAt:   ca,
+	}
+	wsID := string(ws.ID())
+	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
+}
+
+// addPlaceholderTab synchronously creates a placeholder tab in the correct slice
+// position. The tab starts detached and non-running; an async reattach upgrades
+// it in-place (by TabID) without changing slice order.
+func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID, string) {
+	tm := m.terminalMetrics()
+	termWidth := tm.Width
+	termHeight := tm.Height
+	if termWidth < 1 {
+		termWidth = 80
+	}
+	if termHeight < 1 {
+		termHeight = 24
+	}
+	displayName := strings.TrimSpace(info.Name)
+	if displayName == "" {
+		displayName = strings.TrimSpace(info.Assistant)
+	}
+	if displayName == "" {
+		displayName = "Terminal"
+	}
+	term := vterm.New(termWidth, termHeight)
+	term.AllowAltScreenScrollback = true
+	tabID := generateTabID()
+	sessionName := strings.TrimSpace(info.SessionName)
+	if sessionName == "" {
+		sessionName = tmux.SessionName("amux", string(ws.ID()), string(tabID))
+	}
+	ca := info.CreatedAt
+	if ca == 0 {
+		ca = time.Now().Unix()
+	}
+	tab := &Tab{
+		ID:          tabID,
+		Name:        displayName,
+		Assistant:   info.Assistant,
+		Workspace:   ws,
+		SessionName: sessionName,
+		Detached:    true,
+		Running:     false,
+		Terminal:    term,
+		createdAt:   ca,
+	}
+	wsID := string(ws.ID())
+	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
+	return tabID, sessionName
+}
+
+// reattachToSession returns a tea.Cmd that asynchronously connects a placeholder
+// tab to its tmux session. On success it produces ptyTabReattachResult which
+// updates the tab in-place (by TabID). On failure it produces ptyTabReattachFailed.
+func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant string, sessionName string) tea.Cmd {
+	tm := m.terminalMetrics()
+	termWidth := tm.Width
+	termHeight := tm.Height
+	opts := m.getTmuxOptions()
+	return func() tea.Msg {
+		state, err := tmux.SessionStateFor(sessionName, opts)
+		if err != nil {
+			return ptyTabReattachFailed{
+				WorkspaceID: string(ws.ID()),
+				TabID:       tabID,
+				Err:         err,
+				Action:      "reattach",
+			}
+		}
+		if !state.Exists || !state.HasLivePane {
+			return ptyTabReattachFailed{
+				WorkspaceID: string(ws.ID()),
+				TabID:       tabID,
+				Err:         fmt.Errorf("tmux session ended"),
+				Stopped:     true,
+				Action:      "reattach",
+			}
+		}
+		tags := tmux.SessionTags{
+			WorkspaceID: string(ws.ID()),
+			TabID:       string(tabID),
+			Type:        "agent",
+			Assistant:   assistant,
+		}
+		agent, err := m.agentManager.CreateAgentWithTags(ws, appPty.AgentType(assistant), sessionName, uint16(termHeight), uint16(termWidth), tags)
+		if err != nil {
+			return ptyTabReattachFailed{
+				WorkspaceID: string(ws.ID()),
+				TabID:       tabID,
+				Err:         err,
+				Action:      "reattach",
+			}
+		}
+		scrollback, _ := tmux.CapturePane(sessionName, opts)
+		return ptyTabReattachResult{
+			WorkspaceID:       string(ws.ID()),
+			TabID:             tabID,
+			Agent:             agent,
+			Rows:              termHeight,
+			Cols:              termWidth,
+			ScrollbackCapture: scrollback,
+		}
+	}
+}
+
+// safeBatch wraps commands in a batch, handling nil commands gracefully.
+func safeBatch(cmds ...tea.Cmd) tea.Cmd {
+	var valid []tea.Cmd
+	for _, cmd := range cmds {
+		if cmd != nil {
+			valid = append(valid, cmd)
+		}
+	}
+	if len(valid) == 0 {
+		return nil
+	}
+	if len(valid) == 1 {
+		return valid[0]
+	}
+	return tea.Batch(valid...)
+}


### PR DESCRIPTION
Pre-create tabs as placeholders synchronously in persisted order, then attach to tmux sessions asynchronously via the existing reattach pattern. This ensures tabs always appear in the same order regardless of which goroutine completes first.

- Add addPlaceholderTab() and reattachToSession() helpers
- Replace createAgentTabWithSession in RestoreTabsFromWorkspace/AddTabsFromWorkspace
- Sort discovered tmux tabs by @amux_created_at timestamp
- Persist CreatedAt in TabInfo for stable ordering across restarts
- Fix scrollback prepend for placeholder tabs on reattach
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/143">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
