### PR TITLE
Show total lines added/removed in Changes tab header

### DIFF
--- a/internal/ui/sidebar/model_view.go
+++ b/internal/ui/sidebar/model_view.go
@@ -83,9 +83,21 @@ func (m *Model) renderChanges() string {
 		return b.String()
 	}
 
-	// Show file count
+	// Show file count and line stats
 	total := m.gitStatus.GetDirtyCount()
 	b.WriteString(m.styles.Muted.Render(strconv.Itoa(total) + " changed files"))
+	if m.gitStatus.TotalAdded > 0 || m.gitStatus.TotalDeleted > 0 {
+		b.WriteString(" ")
+		if m.gitStatus.TotalAdded > 0 {
+			b.WriteString(m.styles.StatusAdded.Render("+" + strconv.Itoa(m.gitStatus.TotalAdded)))
+		}
+		if m.gitStatus.TotalAdded > 0 && m.gitStatus.TotalDeleted > 0 {
+			b.WriteString(m.styles.Muted.Render(" "))
+		}
+		if m.gitStatus.TotalDeleted > 0 {
+			b.WriteString(m.styles.StatusDeleted.Render("-" + strconv.Itoa(m.gitStatus.TotalDeleted)))
+		}
+	}
 	b.WriteString("\n")
 
 	visibleHeight := m.visibleHeight()


### PR DESCRIPTION
Display colored +N/-N line stats next to the file count in the sidebar Changes tab by running git diff --numstat for both staged and unstaged changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/146">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
