### PR TITLE
Preserve active text color when row is selected

### DIFF
--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -6,6 +6,15 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
+// applyDirtyForeground sets the dirty color (ColorSecondary) on a row style
+// when the row is dirty but not active and not selected.
+func applyDirtyForeground(style lipgloss.Style, dirty, active, selected bool) lipgloss.Style {
+	if dirty && !active && !selected {
+		return style.Foreground(common.ColorSecondary)
+	}
+	return style
+}
+
 // renderRow renders a single dashboard row
 func (m *Model) renderRow(row Row, selected bool) string {
 	switch row.Type {
@@ -55,10 +64,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		} else if m.isProjectActive(row.Project) {
 			style = m.styles.ActiveWorkspace.PaddingLeft(0)
 		}
-		// Dirty color takes priority for project headers.
-		if dirty && !m.isProjectActive(row.Project) {
-			style = style.Foreground(common.ColorSecondary)
-		}
+		style = applyDirtyForeground(style, dirty, m.isProjectActive(row.Project), selected)
 
 		// Reserve space for delete icon to keep status aligned
 		deleteSlot := "   "
@@ -121,10 +127,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		} else if working {
 			style = m.styles.ActiveWorkspace
 		}
-		// Dirty color takes priority for inactive workspaces.
-		if !working && !selected && dirty {
-			style = style.Foreground(common.ColorSecondary)
-		}
+		style = applyDirtyForeground(style, dirty, working, selected)
 		// Reserve space for delete icon to keep status aligned
 		deleteSlot := "   "
 		deleteSlotWidth := 3


### PR DESCRIPTION
When a row is both active (has running agents) and selected (cursor highlight), keep the ColorPrimary foreground instead of replacing it with ColorForeground. Applies to home, project, and workspace rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
