### PR TITLE
Fix tmux session prefix matching causing cross-tab kills

### DIFF
--- a/internal/tmux/activity.go
+++ b/internal/tmux/activity.go
@@ -142,7 +142,7 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 		return "", false
 	}
 	startLine := -lines
-	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionName, "-S", strconv.Itoa(startLine))
+	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", exactTarget(sessionName), "-S", strconv.Itoa(startLine))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -11,7 +11,7 @@ func SessionHasClients(sessionName string, opts Options) (bool, error) {
 	if sessionName == "" {
 		return false, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "list-clients", "-t", sessionName, "-F", "#{client_name}")
+	cmd, cancel := tmuxCommand(opts, "list-clients", "-t", exactTarget(sessionName), "-F", "#{client_name}")
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -30,7 +30,7 @@ func SessionCreatedAt(sessionName string, opts Options) (int64, error) {
 	if sessionName == "" {
 		return 0, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "display-message", "-p", "-t", sessionName, "#{session_created}")
+	cmd, cancel := tmuxCommand(opts, "display-message", "-p", "-t", exactTarget(sessionName), "#{session_created}")
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/tmux/command.go
+++ b/internal/tmux/command.go
@@ -24,6 +24,7 @@ func ClientCommandWithTagsAttach(sessionName, workDir, command string, opts Opti
 func clientCommand(sessionName, workDir, command string, opts Options, tags SessionTags, detachExisting bool) string {
 	base := tmuxBase(opts)
 	session := shellQuote(sessionName)
+	exactSession := shellQuote("=" + sessionName)
 	dir := shellQuote(workDir)
 	cmd := shellQuote(command)
 
@@ -37,27 +38,27 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 
 	var settings strings.Builder
 	// Disable tmux prefix for this session only (not global) to make it transparent
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix None 2>/dev/null; ", base, session))
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix2 None 2>/dev/null; ", base, session))
+	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix None 2>/dev/null; ", base, exactSession))
+	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix2 None 2>/dev/null; ", base, exactSession))
 	if opts.HideStatus {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s status off 2>/dev/null; ", base, session))
+		settings.WriteString(fmt.Sprintf("%s set-option -t %s status off 2>/dev/null; ", base, exactSession))
 	}
 	if opts.DisableMouse {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s mouse off 2>/dev/null; ", base, session))
+		settings.WriteString(fmt.Sprintf("%s set-option -t %s mouse off 2>/dev/null; ", base, exactSession))
 	}
 	if opts.DefaultTerminal != "" {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s default-terminal %s 2>/dev/null; ", base, session, shellQuote(opts.DefaultTerminal)))
+		settings.WriteString(fmt.Sprintf("%s set-option -t %s default-terminal %s 2>/dev/null; ", base, exactSession, shellQuote(opts.DefaultTerminal)))
 	}
 	// Ensure activity timestamps update for window_activity-based tracking.
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s -w monitor-activity on 2>/dev/null; ", base, session))
-	appendSessionTags(&settings, base, session, tags)
+	settings.WriteString(fmt.Sprintf("%s set-option -t %s -w monitor-activity on 2>/dev/null; ", base, exactSession))
+	appendSessionTags(&settings, base, exactSession, tags)
 
 	// Attach to the session, optionally detaching other clients.
 	attachFlag := "-t"
 	if detachExisting {
 		attachFlag = "-dt"
 	}
-	attach := fmt.Sprintf("%s attach %s %s", base, attachFlag, session)
+	attach := fmt.Sprintf("%s attach %s %s", base, attachFlag, exactSession)
 
 	return fmt.Sprintf("%s && %s%s", create, settings.String(), attach)
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -143,11 +143,11 @@ func TestClientCommandWithOptions(t *testing.T) {
 		t.Error("Command should use atomic new-session -Ads")
 	}
 
-	// Should disable prefix per-session (not globally)
-	if !strings.Contains(cmd, "set-option -t 'test-session' prefix None") {
+	// Should disable prefix per-session (not globally) with exact-match target
+	if !strings.Contains(cmd, "set-option -t '=test-session' prefix None") {
 		t.Error("Command should disable prefix for session")
 	}
-	if !strings.Contains(cmd, "set-option -t 'test-session' prefix2 None") {
+	if !strings.Contains(cmd, "set-option -t '=test-session' prefix2 None") {
 		t.Error("Command should disable prefix2 for session")
 	}
 


### PR DESCRIPTION
Use tmux's =sessionName exact-match syntax for all -t (target) arguments to prevent prefix fallback from targeting the wrong session (e.g., kill-session -t amux-ws-tab-1 hitting amux-ws-tab-10).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/156">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
