### PR TITLE
fix: show workspaces as active immediately on new instance startup

### DIFF
--- a/internal/tmux/activity.go
+++ b/internal/tmux/activity.go
@@ -142,7 +142,10 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 		return "", false
 	}
 	startLine := -lines
-	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", exactTarget(sessionName), "-S", strconv.Itoa(startLine))
+	// Use plain session name instead of exactTarget because capture-pane
+	// expects a pane target, and the "=" prefix for exact session matching
+	// is not recognized in pane-target context (tmux 3.6+).
+	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionName, "-S", strconv.Itoa(startLine))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Two issues prevented workspaces with running agents from showing the active color when a new amux instance started:

1. CapturePaneTail used exactTarget() ("=" prefix) for capture-pane, but capture-pane expects a pane target where "=" is not recognized (tmux 3.6+), causing every capture to fail silently.

2. Hysteresis initialized new sessions at score=0, requiring multiple scan cycles before reaching the active threshold. Now sessions start at the threshold so they appear active on first detection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
