### PR TITLE
Fix agent send --enter not submitting

### DIFF
--- a/internal/tmux/send.go
+++ b/internal/tmux/send.go
@@ -1,5 +1,13 @@
 package tmux
 
+import "time"
+
+// sendKeysEnterDelay is the pause between delivering text and pressing Enter.
+// Some coding agents (e.g. Codex, Cline) drop an Enter keystroke that arrives
+// in the same event-loop tick as a burst of text input. A short delay ensures
+// the agent has processed the text before Enter arrives.
+const sendKeysEnterDelay = 50 * time.Millisecond
+
 // SendKeys sends text to a tmux session via send-keys.
 // If enter is true, an Enter key is sent after the text.
 // Uses plain session name (not exactTarget) because send-keys expects a
@@ -20,6 +28,7 @@ func SendKeys(sessionName, text string, enter bool, opts Options) error {
 	}
 
 	if enter {
+		time.Sleep(sendKeysEnterDelay)
 		enterCmd, enterCancel := tmuxCommand(opts, "send-keys", "-t", sessionName, "Enter")
 		defer enterCancel()
 		return enterCmd.Run()

--- a/internal/tmux/send_test.go
+++ b/internal/tmux/send_test.go
@@ -1,7 +1,9 @@
 package tmux
 
 import (
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestSendKeysEmptySession(t *testing.T) {
@@ -25,5 +27,74 @@ func TestSendInterruptEmptySession(t *testing.T) {
 	err := SendInterrupt("", DefaultOptions())
 	if err != nil {
 		t.Errorf("expected nil error for empty session interrupt, got %v", err)
+	}
+}
+
+func TestSendKeysEnterDelayBounds(t *testing.T) {
+	// Guard against accidental zero or absurd delay values.
+	if sendKeysEnterDelay < 10*time.Millisecond {
+		t.Fatalf("sendKeysEnterDelay too small (%v), Enter will be dropped by some coding agents", sendKeysEnterDelay)
+	}
+	if sendKeysEnterDelay > 1*time.Second {
+		t.Fatalf("sendKeysEnterDelay too large (%v), will degrade interactive feel", sendKeysEnterDelay)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests (require real tmux)
+// ---------------------------------------------------------------------------
+
+func TestSendKeysEnterDelay_IsApplied(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	createSession(t, opts, "delay-test", "sleep 300")
+	time.Sleep(100 * time.Millisecond)
+
+	// Sending without enter should be fast.
+	startNoEnter := time.Now()
+	if err := SendKeys("delay-test", "hello", false, opts); err != nil {
+		t.Fatalf("SendKeys(enter=false): %v", err)
+	}
+	noEnterDur := time.Since(startNoEnter)
+
+	// Sending with enter should take at least sendKeysEnterDelay longer.
+	startEnter := time.Now()
+	if err := SendKeys("delay-test", "world", true, opts); err != nil {
+		t.Fatalf("SendKeys(enter=true): %v", err)
+	}
+	enterDur := time.Since(startEnter)
+
+	margin := sendKeysEnterDelay / 2 // allow some jitter
+	if enterDur < noEnterDur+margin {
+		t.Fatalf("enter=true (%v) should take at least %v longer than enter=false (%v)",
+			enterDur, margin, noEnterDur)
+	}
+}
+
+func TestSendKeysDeliversTextAndEnter(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	// Run cat so typed text + Enter produces a visible echo line.
+	createSession(t, opts, "echo-test", "cat")
+	time.Sleep(100 * time.Millisecond)
+
+	if err := SendKeys("echo-test", "ping", true, opts); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	// cat echoes each character as typed, then on Enter it reads the line
+	// and writes it back. Allow time for the round-trip.
+	time.Sleep(200 * time.Millisecond)
+
+	text, ok := CapturePaneTail("echo-test", 10, opts)
+	if !ok {
+		t.Fatal("CapturePaneTail failed")
+	}
+
+	// We expect "ping" to appear at least twice in the capture:
+	// once as the typed input line, once as cat's echo output.
+	if count := strings.Count(text, "ping"); count < 2 {
+		t.Fatalf("expected 'ping' at least twice (typed + echo), got %d in:\n%s", count, text)
 	}
 }


### PR DESCRIPTION
Codex (Ink/React TUI) drops an Enter keystroke that arrives in the same event-loop tick as a burst of text input. Add a 50ms delay between delivering text and pressing Enter in SendKeys.

Verified against live Codex sessions:
- Old binary (0ms delay): 5 rapid sends → 0/5 submitted
- New binary (50ms delay): 5 rapid sends → 5/5 submitted
- Claude/Gemini unaffected (work with or without delay)

See tmux/tmux#1778 for prior art: tmux maintainer confirmed the application can eat keystrokes that arrive before it is ready, and the fix is a timing delay.

## Summary

Describe the change and intended behavior.

## Quality Checklist

- [ ] Ran `make devcheck` locally.
- [ ] Ran `make lint-strict-new` locally for changed code.
- [ ] If UI/rendering changed, ran `make harness-presets`.
- [ ] If tmux/e2e changed, ran `go test ./internal/tmux ./internal/e2e`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
