### PR TITLE
Use visible PTY output for tab activity state

### DIFF
--- a/internal/ui/center/model_activity_test.go
+++ b/internal/ui/center/model_activity_test.go
@@ -32,10 +32,10 @@ func TestIsTabActiveChatOnly(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	activeChat := &Tab{
-		Assistant:    "claude",
-		Workspace:    ws,
-		Running:      true,
-		lastOutputAt: now.Add(-1 * time.Second),
+		Assistant:         "claude",
+		Workspace:         ws,
+		Running:           true,
+		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 	m.tabsByWorkspace[string(ws.ID())] = []*Tab{activeChat}
 
@@ -50,21 +50,21 @@ func TestIsTabActiveIgnoresDetachedAndNonChat(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	nonChat := &Tab{
-		Assistant:    "vim",
-		Workspace:    ws,
-		Running:      true,
-		lastOutputAt: now.Add(-1 * time.Second),
+		Assistant:         "vim",
+		Workspace:         ws,
+		Running:           true,
+		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 	if m.IsTabActive(nonChat) {
 		t.Fatalf("expected non-chat tab to be inactive even with output")
 	}
 
 	detached := &Tab{
-		Assistant:    "claude",
-		Workspace:    ws,
-		Running:      true,
-		Detached:     true,
-		lastOutputAt: now.Add(-1 * time.Second),
+		Assistant:         "claude",
+		Workspace:         ws,
+		Running:           true,
+		Detached:          true,
+		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 	if m.IsTabActive(detached) {
 		t.Fatalf("expected detached chat tab to be inactive")
@@ -79,16 +79,16 @@ func TestGetActiveWorkspaceIDsChatOnly(t *testing.T) {
 	ws2 := newTestWorkspace("ws2", "/repo/ws2")
 
 	activeChat := &Tab{
-		Assistant:    "claude",
-		Workspace:    ws1,
-		Running:      true,
-		lastOutputAt: now.Add(-1 * time.Second),
+		Assistant:         "claude",
+		Workspace:         ws1,
+		Running:           true,
+		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 	viewer := &Tab{
-		Assistant:    "viewer",
-		Workspace:    ws2,
-		Running:      true,
-		lastOutputAt: now.Add(-1 * time.Second),
+		Assistant:         "viewer",
+		Workspace:         ws2,
+		Running:           true,
+		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 
 	m.tabsByWorkspace[string(ws1.ID())] = []*Tab{activeChat}
@@ -106,12 +106,29 @@ func TestIsTabActiveIdle(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	idle := &Tab{
-		Assistant:    "claude",
-		Workspace:    ws,
-		Running:      true,
-		lastOutputAt: now.Add(-3 * time.Second),
+		Assistant:         "claude",
+		Workspace:         ws,
+		Running:           true,
+		lastVisibleOutput: now.Add(-3 * time.Second),
 	}
 	if m.IsTabActive(idle) {
 		t.Fatalf("expected idle chat tab to be inactive")
+	}
+}
+
+func TestIsTabActiveUsesVisibleOutputOnly(t *testing.T) {
+	m := newTestModel()
+	now := time.Now()
+
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{
+		Assistant:         "claude",
+		Workspace:         ws,
+		Running:           true,
+		lastOutputAt:      now.Add(-1 * time.Second),
+		lastVisibleOutput: time.Time{},
+	}
+	if m.IsTabActive(tab) {
+		t.Fatal("expected tab with no visible output timestamp to be inactive")
 	}
 }

--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -132,6 +132,9 @@ func TestUpdatePTYOutput_DoesNotTagControlOnlyOutput(t *testing.T) {
 	if !tab.lastActivityTagAt.IsZero() {
 		t.Fatalf("expected lastActivityTagAt to remain zero for control-only output, got %v", tab.lastActivityTagAt)
 	}
+	if !tab.lastVisibleOutput.IsZero() {
+		t.Fatalf("expected lastVisibleOutput to remain zero for control-only output, got %v", tab.lastVisibleOutput)
+	}
 }
 
 func TestUpdatePTYOutput_TagsVisibleOutput(t *testing.T) {
@@ -156,6 +159,12 @@ func TestUpdatePTYOutput_TagsVisibleOutput(t *testing.T) {
 		Data:        []byte("visible output"),
 	})
 
+	if tab.lastVisibleOutput.IsZero() {
+		t.Fatalf("expected lastVisibleOutput to be set for visible output")
+	}
+	if tab.lastVisibleOutput.Sub(before) <= 0 {
+		t.Fatalf("expected lastVisibleOutput to move forward, before=%v after=%v", before, tab.lastVisibleOutput)
+	}
 	if !tab.lastActivityTagAt.After(before) {
 		t.Fatalf("expected lastActivityTagAt to move forward, before=%v after=%v", before, tab.lastActivityTagAt)
 	}

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -59,11 +59,11 @@ func (m *Model) IsTabActive(tab *Tab) bool {
 	if tab.Detached || !tab.Running {
 		return false
 	}
-	// Check buffered output or recent output timestamp
-	if tab.flushScheduled || len(tab.pendingOutput) > 0 {
+	// Check buffered output or recent visible output.
+	if len(tab.pendingOutput) > 0 {
 		return true
 	}
-	return !tab.lastOutputAt.IsZero() && time.Since(tab.lastOutputAt) < 2*time.Second
+	return !tab.lastVisibleOutput.IsZero() && time.Since(tab.lastVisibleOutput) < 2*time.Second
 }
 
 // HasActiveAgentsInWorkspace returns whether any tab in a workspace is actively outputting.

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -53,6 +53,7 @@ type Tab struct {
 	pendingOutput     []byte
 	flushScheduled    bool
 	lastOutputAt      time.Time
+	lastVisibleOutput time.Time
 	lastActivityTagAt time.Time
 	activityANSIState ansiActivityState
 	lastInputTagAt    time.Time


### PR DESCRIPTION
## Summary

Describe the change and intended behavior.

## Quality Checklist

- [ ] Ran `make devcheck` locally.
- [ ] Ran `make lint-strict-new` locally for changed code.
- [ ] If UI/rendering changed, ran `make harness-presets`.
- [ ] If tmux/e2e changed, ran `go test ./internal/tmux ./internal/e2e`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
