### PR TITLE
e2e: wait for real process exit in PTYSession

### DIFF
--- a/internal/e2e/pty.go
+++ b/internal/e2e/pty.go
@@ -165,7 +165,7 @@ func (s *PTYSession) readLoop() {
 
 func (s *PTYSession) waitLoop() {
 	defer close(s.procDone)
-	_, err := s.cmd.Process.Wait()
+	err := s.cmd.Wait()
 	s.waitMu.Lock()
 	s.waitErr = err
 	s.waitMu.Unlock()
@@ -252,6 +252,7 @@ func (s *PTYSession) WaitForAbsent(substr string, timeout time.Duration) error {
 }
 
 func (s *PTYSession) WaitForExit(timeout time.Duration) error {
+	// WaitForExit reports process termination. PTY drain/EOF may lag behind.
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {


### PR DESCRIPTION
## Summary

Describe the change and intended behavior.

## Quality Checklist

- [ ] Ran `make devcheck` locally.
- [ ] Ran `make lint-strict-new` locally for changed code.
- [ ] If UI/rendering changed, ran `make harness-presets`.
- [ ] If tmux/e2e changed, ran `go test ./internal/tmux ./internal/e2e`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
