### PR TITLE
Improve file tab reuse and workspace rebind handling

### DIFF
--- a/internal/app/app_input_messages_center.go
+++ b/internal/app/app_input_messages_center.go
@@ -12,8 +12,7 @@ func (a *App) handleOpenDiff(msg messages.OpenDiff) tea.Cmd {
 	logging.Info("Opening diff: change=%v", msg.Change)
 	newCenter, cmd := a.center.Update(msg)
 	a.center = newCenter
-	a.focusPane(messages.PaneCenter)
-	return cmd
+	return tea.Batch(cmd, a.focusPane(messages.PaneCenter))
 }
 
 // handleLaunchAgent handles the LaunchAgent message.
@@ -28,6 +27,9 @@ func (a *App) handleLaunchAgent(msg messages.LaunchAgent) tea.Cmd {
 func (a *App) handleTabCreated(msg messages.TabCreated) tea.Cmd {
 	logging.Info("Tab created: %s", msg.Name)
 	cmd := a.center.StartPTYReaders()
-	a.focusPane(messages.PaneCenter)
-	return cmd
+	if a.center != nil && a.center.HasDiffViewer() {
+		a.setFocusedPane(messages.PaneCenter)
+		return cmd
+	}
+	return tea.Batch(cmd, a.focusPane(messages.PaneCenter))
 }

--- a/internal/app/app_input_messages_center.go
+++ b/internal/app/app_input_messages_center.go
@@ -12,6 +12,7 @@ func (a *App) handleOpenDiff(msg messages.OpenDiff) tea.Cmd {
 	logging.Info("Opening diff: change=%v", msg.Change)
 	newCenter, cmd := a.center.Update(msg)
 	a.center = newCenter
+	a.focusPane(messages.PaneCenter)
 	return cmd
 }
 

--- a/internal/app/app_input_open_diff_test.go
+++ b/internal/app/app_input_open_diff_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/diff"
+)
+
+func TestOpenDiff_ReusesExistingChangedFileTab(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo")
+	wsID := string(ws.ID())
+
+	centerModel := center.New(&config.Config{})
+	centerModel.SetWorkspace(ws)
+	centerModel.AddTab(&center.Tab{
+		ID:        center.TabID("tab-chat"),
+		Name:      "claude",
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+	})
+	centerModel.AddTab(&center.Tab{
+		ID:         center.TabID("tab-diff"),
+		Name:       "Diff: main.go",
+		Assistant:  "diff",
+		Workspace:  ws,
+		DiffViewer: diff.New(ws, &git.Change{Path: "main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, 80, 24),
+	})
+	centerModel.SelectTab(0)
+
+	app := &App{
+		activeWorkspace: ws,
+		center:          centerModel,
+		focusedPane:     messages.PaneSidebar,
+	}
+
+	_, cmd := app.Update(messages.OpenDiff{
+		Change:    &git.Change{Path: "./main.go", Kind: git.ChangeModified},
+		Mode:      git.DiffModeUnstaged,
+		Workspace: ws,
+	})
+	if cmd == nil {
+		t.Fatal("expected command when opening an already-open changed file")
+	}
+
+	tabs, activeIdx := app.center.GetTabsInfoForWorkspace(wsID)
+	if len(tabs) != 2 {
+		t.Fatalf("expected changed-file click to reuse existing diff tab, got %d tabs", len(tabs))
+	}
+	if activeIdx != 1 {
+		t.Fatalf("expected existing diff tab to become active immediately, got index %d", activeIdx)
+	}
+	if app.focusedPane != messages.PaneCenter {
+		t.Fatalf("expected center focus after opening diff, got %v", app.focusedPane)
+	}
+
+	msg := cmd()
+	switch typed := msg.(type) {
+	case tea.BatchMsg:
+		for _, subcmd := range typed {
+			if subcmd == nil {
+				continue
+			}
+			submsg := subcmd()
+			if submsg == nil {
+				continue
+			}
+			if _, followup := app.Update(submsg); followup != nil {
+				_ = followup()
+			}
+		}
+	default:
+		if _, followup := app.Update(typed); followup != nil {
+			_ = followup()
+		}
+	}
+
+	tabs, activeIdx = app.center.GetTabsInfoForWorkspace(wsID)
+	if len(tabs) != 2 {
+		t.Fatalf("expected no duplicate diff tab after follow-up updates, got %d tabs", len(tabs))
+	}
+	if activeIdx != 1 {
+		t.Fatalf("expected reused diff tab to stay active, got index %d", activeIdx)
+	}
+}

--- a/internal/ui/center/model_tabs_diff_reuse_test.go
+++ b/internal/ui/center/model_tabs_diff_reuse_test.go
@@ -1,0 +1,156 @@
+package center
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/diff"
+)
+
+func TestCreateDiffTab_ReusesExistingTabForSamePathAndMode(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	m.SetWorkspace(ws)
+
+	m.tabsByWorkspace[wsID] = []*Tab{
+		{
+			ID:        TabID("tab-chat"),
+			Name:      "claude",
+			Assistant: "claude",
+			Workspace: ws,
+			Running:   true,
+		},
+		{
+			ID:         TabID("tab-diff"),
+			Name:       "Diff: main.go",
+			Assistant:  "diff",
+			Workspace:  ws,
+			DiffViewer: diff.New(ws, &git.Change{Path: "main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, 80, 24),
+		},
+	}
+	m.activeTabByWorkspace[wsID] = 0
+
+	cmd := m.createDiffTab(&git.Change{Path: "./main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, ws)
+	if cmd == nil {
+		t.Fatal("expected reuse command for existing diff tab")
+	}
+	if got := len(m.tabsByWorkspace[wsID]); got != 2 {
+		t.Fatalf("expected existing diff tab reuse, got %d tabs", got)
+	}
+	if got := m.activeTabByWorkspace[wsID]; got != 1 {
+		t.Fatalf("expected existing diff tab to become active, got index %d", got)
+	}
+
+	msg := cmd()
+	sawSelection := false
+	sawReload := false
+
+	switch typed := msg.(type) {
+	case tea.BatchMsg:
+		for _, subcmd := range typed {
+			if subcmd == nil {
+				continue
+			}
+			switch submsg := subcmd().(type) {
+			case messages.TabSelectionChanged:
+				sawSelection = true
+				if submsg.WorkspaceID != wsID || submsg.ActiveIndex != 1 {
+					t.Fatalf("unexpected selection payload: %+v", submsg)
+				}
+			default:
+				if strings.HasSuffix(fmt.Sprintf("%T", submsg), ".diffLoaded") {
+					sawReload = true
+				}
+			}
+		}
+	default:
+		t.Fatalf("expected batched reuse command, got %T", typed)
+	}
+
+	if !sawSelection {
+		t.Fatal("expected tab selection change for reused diff tab")
+	}
+	if !sawReload {
+		t.Fatal("expected reused diff tab to reload its diff")
+	}
+}
+
+func TestReuseDiffTab_RefreshesChangeKindBeforeReload(t *testing.T) {
+	repo := t.TempDir()
+	mustRunGit(t, repo, "init", "-b", "main")
+	mustRunGit(t, repo, "config", "user.name", "Test")
+	mustRunGit(t, repo, "config", "user.email", "test@example.com")
+
+	filePath := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(filePath, []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write untracked file: %v", err)
+	}
+
+	ws := data.NewWorkspace("ws", "ws", "main", repo, repo)
+	wsID := string(ws.ID())
+	m := newTestModel()
+	m.SetWorkspace(ws)
+
+	dv := diff.New(ws, &git.Change{Path: "main.go", Kind: git.ChangeUntracked}, git.DiffModeUnstaged, 80, 24)
+	m.tabsByWorkspace[wsID] = []*Tab{
+		{
+			ID:         TabID("tab-diff"),
+			Name:       "Diff: main.go",
+			Assistant:  "diff",
+			Workspace:  ws,
+			DiffViewer: dv,
+		},
+	}
+	m.activeTabByWorkspace[wsID] = 0
+
+	mustRunGit(t, repo, "add", "main.go")
+	mustRunGit(t, repo, "commit", "-m", "track main.go")
+	if err := os.WriteFile(filePath, []byte("package main\n\nfunc main() { println(\"hi\") }\n"), 0o644); err != nil {
+		t.Fatalf("write tracked modification: %v", err)
+	}
+
+	cmd := m.createDiffTab(&git.Change{Path: "main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, ws)
+	if cmd == nil {
+		t.Fatal("expected reuse command for tracked modification")
+	}
+
+	msg := cmd()
+	switch typed := msg.(type) {
+	case tea.BatchMsg:
+		for _, subcmd := range typed {
+			if subcmd == nil {
+				continue
+			}
+			submsg := subcmd()
+			updatedDV, _ := dv.Update(submsg)
+			dv = updatedDV
+		}
+	default:
+		updatedDV, _ := dv.Update(typed)
+		dv = updatedDV
+	}
+
+	rendered := dv.View()
+	if strings.Contains(rendered, "/dev/null") {
+		t.Fatalf("expected tracked diff reload, got stale untracked diff:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "--- a/main.go") {
+		t.Fatalf("expected tracked diff header after reuse, got:\n%s", rendered)
+	}
+}
+
+func mustRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if _, err := git.RunGit(dir, args...); err != nil {
+		t.Fatalf("git %s failed: %v", strings.Join(args, " "), err)
+	}
+}

--- a/internal/ui/center/model_tabs_viewer.go
+++ b/internal/ui/center/model_tabs_viewer.go
@@ -73,12 +73,58 @@ func (m *Model) createVimTab(filePath string, ws *data.Workspace) tea.Cmd {
 	}
 }
 
+func (m *Model) findOpenDiffTab(ws *data.Workspace, changePath string, mode git.DiffMode) (int, *Tab) {
+	if ws == nil {
+		return -1, nil
+	}
+	wsID := string(ws.ID())
+	for idx, tab := range m.tabsByWorkspace[wsID] {
+		if tab == nil || tab.isClosed() {
+			continue
+		}
+		tab.mu.Lock()
+		dv := tab.DiffViewer
+		tab.mu.Unlock()
+		if dv != nil && dv.MatchesSource(changePath, mode) {
+			return idx, tab
+		}
+	}
+	return -1, nil
+}
+
+func (m *Model) reuseDiffTab(ws *data.Workspace, idx int, tab *Tab, change *git.Change, mode git.DiffMode) tea.Cmd {
+	if ws == nil || tab == nil {
+		return nil
+	}
+	wsID := string(ws.ID())
+	activeChanged := m.activeTabByWorkspace[wsID] != idx
+	m.setActiveTabIdxForWorkspace(wsID, idx)
+
+	var cmds []tea.Cmd
+	tab.mu.Lock()
+	dv := tab.DiffViewer
+	tab.mu.Unlock()
+	if dv != nil {
+		dv.ResetSource(ws, change, mode)
+		cmds = append(cmds, dv.Init())
+	}
+	if m.workspaceID() == wsID {
+		cmds = append(cmds, m.tabSelectionChangedCmd(activeChanged))
+	}
+	return common.SafeBatch(cmds...)
+}
+
 // createDiffTab creates a new native diff viewer tab (no PTY)
 func (m *Model) createDiffTab(change *git.Change, mode git.DiffMode, ws *data.Workspace) tea.Cmd {
 	if ws == nil {
 		return func() tea.Msg {
 			return messages.Error{Err: errors.New("no workspace selected"), Context: "creating diff viewer"}
 		}
+	}
+
+	if idx, tab := m.findOpenDiffTab(ws, change.Path, mode); tab != nil {
+		logging.Info("Reusing diff tab: path=%s mode=%d workspace=%s", change.Path, mode, ws.Name)
+		return m.reuseDiffTab(ws, idx, tab, change, mode)
 	}
 
 	logging.Info("Creating diff tab: path=%s mode=%d workspace=%s", change.Path, mode, ws.Name)

--- a/internal/ui/diff/model.go
+++ b/internal/ui/diff/model.go
@@ -1,6 +1,8 @@
 package diff
 
 import (
+	"path/filepath"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
@@ -17,6 +19,7 @@ type Model struct {
 	change    *git.Change
 	diff      *git.DiffResult
 	mode      git.DiffMode
+	loadID    uint64
 
 	// State
 	loading bool
@@ -36,8 +39,9 @@ type Model struct {
 
 // diffLoaded is sent when the diff has been loaded
 type diffLoaded struct {
-	diff *git.DiffResult
-	err  error
+	diff   *git.DiffResult
+	err    error
+	loadID uint64
 }
 
 // New creates a new diff viewer model
@@ -58,15 +62,44 @@ func (m *Model) Init() tea.Cmd {
 	return m.loadDiff()
 }
 
+func normalizeSourcePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+// MatchesSource reports whether the viewer is already showing the same diff target.
+func (m *Model) MatchesSource(changePath string, mode git.DiffMode) bool {
+	if m == nil || m.change == nil {
+		return false
+	}
+	return normalizeSourcePath(m.change.Path) == normalizeSourcePath(changePath) && m.mode == mode
+}
+
+// ResetSource updates the diff target before a reload while preserving viewer UI state.
+func (m *Model) ResetSource(ws *data.Workspace, change *git.Change, mode git.DiffMode) {
+	m.workspace = ws
+	m.change = change
+	m.mode = mode
+	m.loading = true
+	m.err = nil
+	m.diff = nil
+	m.scroll = 0
+	m.hunkIdx = 0
+}
+
 // loadDiff returns a command that loads the diff asynchronously
 func (m *Model) loadDiff() tea.Cmd {
 	ws := m.workspace
 	change := m.change
 	mode := m.mode
+	m.loadID++
+	loadID := m.loadID
 
 	return func() tea.Msg {
 		if ws == nil || change == nil {
-			return diffLoaded{err: nil, diff: &git.DiffResult{Empty: true}}
+			return diffLoaded{err: nil, diff: &git.DiffResult{Empty: true}, loadID: loadID}
 		}
 
 		var diff *git.DiffResult
@@ -81,7 +114,7 @@ func (m *Model) loadDiff() tea.Cmd {
 			diff, err = git.GetFileDiff(ws.Root, change.Path, mode)
 		}
 
-		return diffLoaded{diff: diff, err: err}
+		return diffLoaded{diff: diff, err: err, loadID: loadID}
 	}
 }
 
@@ -89,11 +122,15 @@ func (m *Model) loadDiff() tea.Cmd {
 func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case diffLoaded:
+		if msg.loadID != m.loadID {
+			return m, nil
+		}
 		m.loading = false
 		if msg.err != nil {
 			m.err = msg.err
 			return m, nil
 		}
+		m.err = nil
 		m.diff = msg.diff
 		return m, nil
 

--- a/internal/ui/diff/model_test.go
+++ b/internal/ui/diff/model_test.go
@@ -3,6 +3,7 @@ package diff
 import (
 	"testing"
 
+	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
 )
 
@@ -84,5 +85,65 @@ func TestHunkNavigation(t *testing.T) {
 	m.prevHunk()
 	if m.scroll != 8 || m.hunkIdx != 2 {
 		t.Fatalf("expected wrap to last hunk at 8, idx 2, got scroll=%d idx=%d", m.scroll, m.hunkIdx)
+	}
+}
+
+func TestResetSource_ResetsScrollState(t *testing.T) {
+	ws := data.NewWorkspace("ws", "ws", "main", "/repo", "/repo")
+	m := &Model{
+		workspace: ws,
+		change:    &git.Change{Path: "before.go", Kind: git.ChangeModified},
+		mode:      git.DiffModeUnstaged,
+		diff:      &git.DiffResult{Lines: make([]git.DiffLine, 20)},
+		loading:   false,
+		scroll:    12,
+		hunkIdx:   3,
+		err:       nil,
+	}
+
+	m.ResetSource(ws, &git.Change{Path: "after.go", Kind: git.ChangeModified}, git.DiffModeStaged)
+
+	if !m.loading {
+		t.Fatal("expected reset source to mark model loading")
+	}
+	if m.scroll != 0 {
+		t.Fatalf("expected scroll reset to 0, got %d", m.scroll)
+	}
+	if m.hunkIdx != 0 {
+		t.Fatalf("expected hunk index reset to 0, got %d", m.hunkIdx)
+	}
+	if m.diff != nil {
+		t.Fatal("expected previous diff content to be cleared")
+	}
+	if m.change == nil || m.change.Path != "after.go" {
+		t.Fatalf("expected source change to update, got %+v", m.change)
+	}
+	if m.mode != git.DiffModeStaged {
+		t.Fatalf("expected mode update to staged, got %v", m.mode)
+	}
+}
+
+func TestDiffLoaded_IgnoresStaleLoadCompletion(t *testing.T) {
+	m := &Model{
+		loadID:  2,
+		loading: true,
+	}
+	staleDiff := &git.DiffResult{Path: "stale.go"}
+	currentDiff := &git.DiffResult{Path: "current.go"}
+
+	updated, _ := m.Update(diffLoaded{loadID: 1, diff: staleDiff})
+	if !updated.loading {
+		t.Fatal("expected stale load to keep current load in progress")
+	}
+	if updated.diff != nil {
+		t.Fatalf("expected stale load to be ignored, got %+v", updated.diff)
+	}
+
+	updated, _ = updated.Update(diffLoaded{loadID: 2, diff: currentDiff})
+	if updated.loading {
+		t.Fatal("expected current load to finish")
+	}
+	if updated.diff != currentDiff {
+		t.Fatalf("expected current diff to win, got %+v", updated.diff)
 	}
 }


### PR DESCRIPTION
## Summary

Describe the change and intended behavior.

## Quality Checklist

- [ ] Ran `make devcheck` locally.
- [ ] Ran `make lint-strict-new` locally for changed code.
- [ ] If UI/rendering changed, ran `make harness-presets`.
- [ ] If tmux/e2e changed, ran `go test ./internal/tmux ./internal/e2e`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
