### PR TITLE
Fix wheel routing and scrolled history viewport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andyrewlee/amux
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/bubbles/v2 v2.0.0

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -56,7 +56,7 @@ func handleOverlayInput[T interface {
 		*cmds = append(*cmds, cmd)
 	}
 	switch msg.(type) {
-	case tea.KeyPressMsg, tea.MouseClickMsg:
+	case tea.KeyPressMsg, tea.MouseClickMsg, tea.MouseWheelMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg:
 		return updated, true
 	case tea.PasteMsg:
 		return updated, consumePaste

--- a/internal/app/app_input_dialogs_test.go
+++ b/internal/app/app_input_dialogs_test.go
@@ -1,9 +1,15 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
 type overlayStub struct {
@@ -44,5 +50,79 @@ func TestHandleOverlayInput_VisibleOverlayConsumesKey(t *testing.T) {
 	}
 	if !updated.updated {
 		t.Fatal("expected visible overlay to receive Update")
+	}
+}
+
+func TestHandleOverlayInput_VisibleOverlayConsumesWheel(t *testing.T) {
+	overlay := &overlayStub{visible: true}
+	cmds := make([]tea.Cmd, 0, 1)
+
+	updated, consumed := handleOverlayInput(overlay, tea.MouseWheelMsg{Button: tea.MouseWheelDown}, &cmds, true)
+	if !consumed {
+		t.Fatal("expected wheel input to be consumed for visible overlay")
+	}
+	if !updated.updated {
+		t.Fatal("expected visible overlay to receive wheel Update")
+	}
+}
+
+func TestHandleOverlayInput_VisibleOverlayConsumesMotion(t *testing.T) {
+	overlay := &overlayStub{visible: true}
+	cmds := make([]tea.Cmd, 0, 1)
+
+	updated, consumed := handleOverlayInput(overlay, tea.MouseMotionMsg{Button: tea.MouseLeft}, &cmds, true)
+	if !consumed {
+		t.Fatal("expected motion input to be consumed for visible overlay")
+	}
+	if !updated.updated {
+		t.Fatal("expected visible overlay to receive motion Update")
+	}
+}
+
+func TestHandleOverlayInput_VisibleOverlayConsumesRelease(t *testing.T) {
+	overlay := &overlayStub{visible: true}
+	cmds := make([]tea.Cmd, 0, 1)
+
+	updated, consumed := handleOverlayInput(overlay, tea.MouseReleaseMsg{Button: tea.MouseLeft}, &cmds, true)
+	if !consumed {
+		t.Fatal("expected release input to be consumed for visible overlay")
+	}
+	if !updated.updated {
+		t.Fatal("expected visible overlay to receive release Update")
+	}
+}
+
+func TestAppUpdate_FilePickerVisibleConsumesWheel(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{
+		Mode:   HarnessCenter,
+		Width:  120,
+		Height: 40,
+		Tabs:   1,
+	})
+	if err != nil {
+		t.Fatalf("harness init: %v", err)
+	}
+
+	tmp := t.TempDir()
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if err := os.Mkdir(filepath.Join(tmp, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	h.app.filePicker = common.NewFilePicker(DialogAddProject, tmp, true)
+	h.app.filePicker.SetSize(h.app.width, h.app.height)
+	h.app.filePicker.Show()
+
+	before := ansi.Strip(h.app.filePicker.View())
+	if !strings.Contains(before, "> alpha/") {
+		t.Fatalf("expected initial file picker selection on alpha, got %q", before)
+	}
+
+	h.app.update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	after := ansi.Strip(h.app.filePicker.View())
+	if !strings.Contains(after, "> beta/") {
+		t.Fatalf("expected wheel input to move file picker selection to beta, got %q", after)
 	}
 }

--- a/internal/app/app_input_mouse.go
+++ b/internal/app/app_input_mouse.go
@@ -97,23 +97,31 @@ func (a *App) routeMouseWheel(msg tea.MouseWheelMsg) tea.Cmd {
 		return nil
 	}
 
+	if (a.dialog != nil && a.dialog.Visible()) ||
+		(a.filePicker != nil && a.filePicker.Visible()) ||
+		(a.settingsDialog != nil && a.settingsDialog.Visible()) ||
+		a.err != nil ||
+		a.toastCoversPoint(msg.X, msg.Y) {
+		// Modal, error, and toast overlays should block background scrolling.
+		return nil
+	}
+
 	targetPane := a.focusedPane
-	// Modal overlays and toast overlays do not consume wheel today, so preserve
-	// focused-pane routing instead of hit-testing obscured panes beneath them.
-	if !a.overlayVisible() && !a.toastCoversPoint(msg.X, msg.Y) {
-		// Route wheel input by pointer target when possible so hovered panes
-		// scroll without requiring a prior click. Fall back to keyboard focus
-		// when the pointer is outside interactive pane geometry.
-		hoverPane, hasTarget := a.paneForPoint(msg.X, msg.Y)
-		if hasTarget {
-			// Dashboard wheel handling activates rows, so do not retarget passive
-			// hover wheel input into it from another pane.
-			if hoverPane != messages.PaneDashboard || a.focusedPane == messages.PaneDashboard {
-				if a.canRetargetWheelToPane(hoverPane) {
-					targetPane = hoverPane
-				}
-			}
+	// Route wheel input by pointer target when possible so hovered panes scroll
+	// without requiring a prior click. If the pointer is over another pane that
+	// cannot handle wheel input, consume the event instead of scrolling the
+	// previously focused pane behind it.
+	hoverPane, hasTarget := a.paneForPoint(msg.X, msg.Y)
+	if hasTarget && hoverPane != a.focusedPane {
+		// Dashboard wheel handling activates rows, so do not retarget passive
+		// hover wheel input into it from another pane.
+		if hoverPane == messages.PaneDashboard {
+			return nil
 		}
+		if !a.canRetargetWheelToPane(hoverPane) {
+			return nil
+		}
+		targetPane = hoverPane
 	}
 
 	var focusCmd tea.Cmd

--- a/internal/app/app_input_mouse_helpers_test.go
+++ b/internal/app/app_input_mouse_helpers_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+)
+
+func newScrollableCenterWheelHarness(t *testing.T) (*App, *center.Tab) {
+	t.Helper()
+
+	h, err := NewHarness(HarnessOptions{
+		Mode:    HarnessCenter,
+		Tabs:    1,
+		Width:   140,
+		Height:  40,
+		HotTabs: 0,
+	})
+	if err != nil {
+		t.Fatalf("harness init: %v", err)
+	}
+	if h.app == nil || len(h.tabs) != 1 || h.tabs[0] == nil || h.tabs[0].Terminal == nil {
+		t.Fatal("expected harness center tab terminal")
+	}
+
+	tab := h.tabs[0]
+	for i := 0; i < 80; i++ {
+		tab.WriteToTerminal([]byte(fmt.Sprintf("line %d\n", i)))
+	}
+	tab.Terminal.ScrollView(12)
+	offset, _ := tab.Terminal.GetScrollInfo()
+	if offset == 0 {
+		t.Fatal("expected center terminal to start scrolled into history")
+	}
+
+	if cmd := h.app.focusPane(messages.PaneCenter); cmd != nil {
+		t.Fatal("expected scroll harness focus to be synchronous")
+	}
+	return h.app, tab
+}

--- a/internal/app/app_input_mouse_test.go
+++ b/internal/app/app_input_mouse_test.go
@@ -181,6 +181,29 @@ func TestRouteMouseWheel_PrefixPaletteConsumesWheel(t *testing.T) {
 	}
 }
 
+func TestRouteMouseWheel_PrefixModeOutsidePaletteStillScrollsFocusedPane(t *testing.T) {
+	app, tab := newScrollableCenterWheelHarness(t)
+	app.prefixActive = true
+
+	l := app.layout
+	x := l.LeftGutter() + l.DashboardWidth() + l.GapX() + 3
+	y := l.TopGutter() + 2
+	if app.prefixPaletteContainsPoint(x, y) {
+		t.Fatal("expected wheel point to be outside prefix palette")
+	}
+
+	before, _ := tab.Terminal.GetScrollInfo()
+	app.routeMouseWheel(tea.MouseWheelMsg{
+		Button: tea.MouseWheelDown,
+		X:      x,
+		Y:      y,
+	})
+	after, _ := tab.Terminal.GetScrollInfo()
+	if after >= before {
+		t.Fatalf("expected prefix mode wheel outside palette to scroll focused center pane, before=%d after=%d", before, after)
+	}
+}
+
 func TestRouteMouseWheel_FocusesHoveredSidebarAndScrollsChanges(t *testing.T) {
 	l := layout.NewManager()
 	l.Resize(140, 40)
@@ -263,6 +286,25 @@ func TestRouteMouseWheel_HoverSidebarTerminalSkipsFocusSideEffects(t *testing.T)
 	}
 }
 
+func TestRouteMouseWheel_HoverSidebarTerminalDoesNotScrollFocusedCenter(t *testing.T) {
+	app, tab := newScrollableCenterWheelHarness(t)
+
+	l := app.layout
+	sidebarStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX() + l.CenterWidth() + l.GapX()
+	topPaneHeight, _ := sidebarPaneHeights(l.Height())
+
+	before, _ := tab.Terminal.GetScrollInfo()
+	app.routeMouseWheel(tea.MouseWheelMsg{
+		Button: tea.MouseWheelDown,
+		X:      sidebarStartX + 3,
+		Y:      l.TopGutter() + topPaneHeight + 2,
+	})
+	after, _ := tab.Terminal.GetScrollInfo()
+	if after != before {
+		t.Fatalf("expected hovered empty sidebar terminal to leave center scroll unchanged, before=%d after=%d", before, after)
+	}
+}
+
 func TestRouteMouseWheel_HoverCenterPreservesDetachedReattach(t *testing.T) {
 	l := layout.NewManager()
 	l.Resize(140, 40)
@@ -310,18 +352,10 @@ func TestRouteMouseWheel_HoverCenterPreservesDetachedReattach(t *testing.T) {
 }
 
 func TestRouteMouseWheel_HoverDashboardDoesNotRetargetFromFocusedPane(t *testing.T) {
-	l := layout.NewManager()
-	l.Resize(140, 40)
+	app, tab := newScrollableCenterWheelHarness(t)
+	l := app.layout
 
-	app := &App{
-		layout:          l,
-		dashboard:       dashboard.New(),
-		center:          center.New(&config.Config{}),
-		sidebar:         sidebar.NewTabbedSidebar(),
-		sidebarTerminal: sidebar.NewTerminalModel(),
-	}
-	app.updateLayout()
-	app.focusPane(messages.PaneCenter)
+	before, _ := tab.Terminal.GetScrollInfo()
 
 	cmd := app.routeMouseWheel(tea.MouseWheelMsg{
 		Button: tea.MouseWheelDown,
@@ -333,6 +367,10 @@ func TestRouteMouseWheel_HoverDashboardDoesNotRetargetFromFocusedPane(t *testing
 	}
 	if app.focusedPane != messages.PaneCenter {
 		t.Fatalf("expected focus to remain center, got %v", app.focusedPane)
+	}
+	after, _ := tab.Terminal.GetScrollInfo()
+	if after != before {
+		t.Fatalf("expected dashboard hover wheel to leave center scroll unchanged, before=%d after=%d", before, after)
 	}
 }
 
@@ -362,66 +400,30 @@ func TestRouteMouseWheel_HoverEmptyCenterDoesNotStealFocus(t *testing.T) {
 }
 
 func TestRouteMouseWheel_DialogOverlayPreventsRetarget(t *testing.T) {
-	l := layout.NewManager()
-	l.Resize(140, 40)
-
-	app := &App{
-		layout:          l,
-		dashboard:       dashboard.New(),
-		center:          center.New(&config.Config{}),
-		sidebar:         sidebar.NewTabbedSidebar(),
-		sidebarTerminal: sidebar.NewTerminalModel(),
-		dialog:          common.NewConfirmDialog("quit", "Quit", "Confirm?"),
-	}
+	app, tab := newScrollableCenterWheelHarness(t)
+	l := app.layout
+	app.dialog = common.NewConfirmDialog("quit", "Quit", "Confirm?")
 	app.dialog.Show()
-	app.updateLayout()
-	app.focusPane(messages.PaneDashboard)
 
 	centerStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX()
+	before, _ := tab.Terminal.GetScrollInfo()
 	_ = app.routeMouseWheel(tea.MouseWheelMsg{
 		Button: tea.MouseWheelDown,
 		X:      centerStartX + 3,
 		Y:      l.TopGutter() + 2,
 	})
-	if app.focusedPane != messages.PaneDashboard {
-		t.Fatalf("expected dialog overlay to preserve dashboard focus, got %v", app.focusedPane)
+	if app.focusedPane != messages.PaneCenter {
+		t.Fatalf("expected dialog overlay to preserve center focus, got %v", app.focusedPane)
+	}
+	after, _ := tab.Terminal.GetScrollInfo()
+	if after != before {
+		t.Fatalf("expected dialog overlay to block background scrolling, before=%d after=%d", before, after)
 	}
 }
 
 func TestRouteMouseWheel_ToastOverlayPreventsRetarget(t *testing.T) {
-	l := layout.NewManager()
-	l.Resize(140, 40)
-
-	cfg := &config.Config{
-		Assistants: map[string]config.AssistantConfig{
-			"codex": {Command: "codex"},
-		},
-	}
-	centerModel := center.New(cfg)
-	app := &App{
-		width:           140,
-		height:          40,
-		layout:          l,
-		dashboard:       dashboard.New(),
-		center:          centerModel,
-		sidebar:         sidebar.NewTabbedSidebar(),
-		sidebarTerminal: sidebar.NewTerminalModel(),
-		toast:           common.NewToastModel(),
-	}
-	app.updateLayout()
-
-	ws := data.NewWorkspace("feature", "feature", "main", "/tmp/repo", "/tmp/repo/feature")
-	ws.OpenTabs = []data.TabInfo{{
-		Assistant:   "codex",
-		Name:        "Codex",
-		SessionName: "amux-test-toast-detached",
-		Status:      "detached",
-	}}
-	centerModel.SetWorkspace(ws)
-	if cmd := centerModel.RestoreTabsFromWorkspace(ws); cmd != nil {
-		t.Fatal("expected detached tab restore to be synchronous")
-	}
-	app.focusPane(messages.PaneDashboard)
+	app, tab := newScrollableCenterWheelHarness(t)
+	l := app.layout
 
 	_ = app.toast.ShowInfo(strings.Repeat("toast ", 12))
 	toastView := app.toast.View()
@@ -452,6 +454,7 @@ func TestRouteMouseWheel_ToastOverlayPreventsRetarget(t *testing.T) {
 		t.Fatal("expected toast height to be positive")
 	}
 
+	before, _ := tab.Terminal.GetScrollInfo()
 	cmd := app.routeMouseWheel(tea.MouseWheelMsg{
 		Button: tea.MouseWheelDown,
 		X:      x,
@@ -460,7 +463,11 @@ func TestRouteMouseWheel_ToastOverlayPreventsRetarget(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected toast-covered wheel input to avoid retarget side effects")
 	}
-	if app.focusedPane != messages.PaneDashboard {
-		t.Fatalf("expected toast overlay to preserve dashboard focus, got %v", app.focusedPane)
+	if app.focusedPane != messages.PaneCenter {
+		t.Fatalf("expected toast overlay to preserve center focus, got %v", app.focusedPane)
+	}
+	after, _ := tab.Terminal.GetScrollInfo()
+	if after != before {
+		t.Fatalf("expected toast overlay to block background scrolling, before=%d after=%d", before, after)
 	}
 }

--- a/internal/ui/center/model_input.go
+++ b/internal/ui/center/model_input.go
@@ -259,7 +259,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 					}
 					tab.mu.Lock()
 					if tab.Terminal != nil {
-						tab.Terminal.ScrollView(tab.Terminal.Height / 4)
+						m.scrollTerminalViewLocked(tab, common.ScrollDeltaForHeight(tab.Terminal.Height, 4))
 					}
 					tab.mu.Unlock()
 					return m, nil
@@ -278,7 +278,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 					}
 					tab.mu.Lock()
 					if tab.Terminal != nil {
-						tab.Terminal.ScrollView(-tab.Terminal.Height / 4)
+						m.scrollTerminalViewLocked(tab, -common.ScrollDeltaForHeight(tab.Terminal.Height, 4))
 					}
 					tab.mu.Unlock()
 					return m, nil
@@ -297,7 +297,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				if !sent {
 					tab.mu.Lock()
 					if tab.Terminal != nil && tab.Terminal.IsScrolled() {
-						tab.Terminal.ScrollViewToBottom()
+						m.scrollTerminalToBottomLocked(tab)
 					}
 					tab.mu.Unlock()
 				}

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -63,7 +63,11 @@ func (m *Model) updateMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 	tab.Selection = common.SelectionState{}
 	tab.selectionScroll.Reset()
 	if inBounds && tab.Terminal != nil {
-		absLine := tab.Terminal.ScreenYToAbsoluteLine(termY)
+		absLine, ok := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
+		if !ok {
+			tab.mu.Unlock()
+			return m, common.SafeBatch(cmds...)
+		}
 		tab.Selection = common.SelectionState{
 			Active:    true,
 			StartX:    termX,
@@ -127,13 +131,13 @@ func (m *Model) updateMouseMotion(msg tea.MouseMotionMsg) (*Model, tea.Cmd) {
 		tab.selectionScroll.SetDirection(termY, termHeight)
 
 		if termY < 0 {
-			tab.Terminal.ScrollView(1)
+			m.scrollTerminalViewLocked(tab, 1)
 			termY = 0
 		} else if termY >= termHeight {
-			tab.Terminal.ScrollView(-1)
+			m.scrollTerminalViewLocked(tab, -1)
 			termY = termHeight - 1
 		}
-		absLine := tab.Terminal.ScreenYToAbsoluteLine(termY)
+		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
 		startX := tab.Terminal.SelStartX()
 		startLine := tab.Terminal.SelStartLine()
 		if !tab.Terminal.HasSelection() {
@@ -260,9 +264,9 @@ func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 		tab.mu.Lock()
 		if tab.Terminal != nil {
 			if msg.Button == tea.MouseWheelUp {
-				tab.Terminal.ScrollView(delta)
+				m.scrollTerminalViewLocked(tab, delta)
 			} else if msg.Button == tea.MouseWheelDown {
-				tab.Terminal.ScrollView(-delta)
+				m.scrollTerminalViewLocked(tab, -delta)
 			}
 		}
 		tab.mu.Unlock()
@@ -333,14 +337,14 @@ func (m *Model) updateSelectionScrollTick(msg selectionScrollTick) tea.Cmd {
 		tab.mu.Unlock()
 		return nil
 	}
-	tab.Terminal.ScrollView(tab.selectionScroll.ScrollDir)
+	m.scrollTerminalViewLocked(tab, tab.selectionScroll.ScrollDir)
 
 	// Update selection endpoint to viewport edge
 	edgeY := 0
 	if tab.selectionScroll.ScrollDir < 0 {
 		edgeY = tab.Terminal.Height - 1
 	}
-	absLine := tab.Terminal.ScreenYToAbsoluteLine(edgeY)
+	absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
 	endX := tab.selectionLastTermX
 	startX := tab.Terminal.SelStartX()
 	startLine := tab.Terminal.SelStartLine()

--- a/internal/ui/center/model_input_test.go
+++ b/internal/ui/center/model_input_test.go
@@ -6,6 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/vterm"
 )
 
 func TestUpdatePasteWithoutAttachedTerminalDoesNotTagActivity(t *testing.T) {
@@ -105,5 +106,70 @@ func TestUpdateQueuedKeyInputDoesNotStampLocalInputWindow(t *testing.T) {
 	}
 	if !tab.lastPromptInputAt.IsZero() {
 		t.Fatal("expected queued key input not to stamp prompt-input window before PTY write")
+	}
+}
+
+func TestUpdateKeyPgUpScrollsOneLineOnShortTerminal(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	term := vterm.New(80, 3)
+	for i := 0; i < 10; i++ {
+		term.Write([]byte("line\n"))
+	}
+	tab := &Tab{
+		ID:        TabID("tab-short-page-scroll"),
+		Assistant: "claude",
+		Workspace: ws,
+		Terminal:  term,
+		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.workspace = ws
+	m.focused = true
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
+
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 1 {
+		t.Fatalf("expected PgUp on a short terminal to scroll by 1 line, got %d", offset)
+	}
+}
+
+func TestTabActorScrollPageScrollsOneLineOnShortTerminal(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	term := vterm.New(80, 3)
+	for i := 0; i < 10; i++ {
+		term.Write([]byte("line\n"))
+	}
+	tab := &Tab{
+		ID:        TabID("tab-short-page-scroll-actor"),
+		Assistant: "claude",
+		Workspace: ws,
+		Terminal:  term,
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.workspace = ws
+	m.focused = true
+
+	m.handleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: wsID,
+		tabID:       tab.ID,
+		kind:        tabEventScrollPage,
+		scrollPage:  1,
+	})
+
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 1 {
+		t.Fatalf("expected actor page scroll on a short terminal to scroll by 1 line, got %d", offset)
 	}
 }

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -336,6 +336,7 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 	}
 
 	if isChat {
+		applyScrolledChatHistoryViewLocked(tab.Terminal, snap)
 		liveCursorX, liveCursorY := snap.CursorX, snap.CursorY
 		appOwnsCursor := showCursor &&
 			!tab.Terminal.AltScreen &&

--- a/internal/ui/center/model_render.go
+++ b/internal/ui/center/model_render.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/vterm"
 )
 
 // formatScrollPos formats the scroll position for display
@@ -44,8 +46,22 @@ func (m *Model) View() string {
 			// Keep cursor state in sync at render time too; Focus/Blur also set
 			// this eagerly to avoid stale frames during fast pane switches.
 			tab.Terminal.ShowCursor = m.focused
-			// Use VTerm.Render() directly - it uses dirty line caching and delta styles
-			b.WriteString(tab.Terminal.Render())
+			snap := compositor.NewVTermSnapshot(tab.Terminal, m.focused)
+			if snap != nil {
+				if m.isChatTabLocked(tab) {
+					applyScrolledChatHistoryViewLocked(tab.Terminal, snap)
+				}
+				b.WriteString(compositor.RenderSnapshotWithCanvas(
+					nil,
+					snap,
+					snap.Width,
+					snap.Height,
+					vterm.Color{Type: vterm.ColorDefault},
+					vterm.Color{Type: vterm.ColorDefault},
+				))
+			} else {
+				b.WriteString(tab.Terminal.Render())
+			}
 
 			if status := m.terminalStatusLineLocked(tab); status != "" {
 				b.WriteString("\n" + status)
@@ -258,7 +274,7 @@ func (m *Model) terminalStatusLineLocked(tab *Tab) string {
 		return ""
 	}
 	if tab.Terminal.IsScrolled() {
-		offset, total := tab.Terminal.GetScrollInfo()
+		offset, total := m.displayedScrollInfoLocked(tab)
 		scrollStyle := lipgloss.NewStyle().
 			Bold(true).
 			Foreground(common.ColorBackground()).

--- a/internal/ui/center/model_scrolled_history.go
+++ b/internal/ui/center/model_scrolled_history.go
@@ -1,0 +1,273 @@
+package center
+
+import (
+	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func scrolledChatHistoryScrollbackLen(term *vterm.VTerm) int {
+	if term == nil {
+		return 0
+	}
+	_, scrollbackLen := term.RenderBuffers()
+	if scrollbackLen > len(term.Scrollback) {
+		scrollbackLen = len(term.Scrollback)
+	}
+	return scrollbackLen
+}
+
+func scrolledChatHistoryMaxViewOffset(term *vterm.VTerm) int {
+	if term == nil || term.AltScreen {
+		return 0
+	}
+	scrollbackLen := scrolledChatHistoryScrollbackLen(term)
+	if scrollbackLen <= 0 {
+		return 0
+	}
+	height := term.Height
+	if height <= 0 {
+		height = 1
+	}
+	maxOffset := scrollbackLen - height + 1
+	if maxOffset < 1 {
+		maxOffset = 1
+	}
+	return maxOffset
+}
+
+func scrolledChatHistoryEffectiveViewOffset(term *vterm.VTerm) int {
+	if term == nil {
+		return 0
+	}
+	offset := term.ViewOffset
+	maxOffset := scrolledChatHistoryMaxViewOffset(term)
+	if maxOffset > 0 && offset > maxOffset {
+		offset = maxOffset
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return offset
+}
+
+func scrolledChatHistoryVisibleRange(term *vterm.VTerm, height int) (startLine, endLine int, ok bool) {
+	if term == nil || term.ViewOffset <= 0 || term.AltScreen {
+		return 0, 0, false
+	}
+	if height <= 0 {
+		height = term.Height
+	}
+	if height <= 0 {
+		return 0, 0, false
+	}
+	scrollbackLen := scrolledChatHistoryScrollbackLen(term)
+	if scrollbackLen <= 0 {
+		return 0, 0, false
+	}
+
+	viewOffset := scrolledChatHistoryEffectiveViewOffset(term)
+	startLine = scrollbackLen - height - viewOffset + 1
+	if startLine < 0 {
+		startLine = 0
+	}
+	endLine = startLine + height - 1
+	if maxEnd := scrollbackLen - 1; endLine > maxEnd {
+		endLine = maxEnd
+	}
+	return startLine, endLine, true
+}
+
+func scrolledChatHistoryScreenYToAbsoluteLine(term *vterm.VTerm, screenY int) (int, bool) {
+	if term == nil {
+		return 0, false
+	}
+	startLine, endLine, ok := scrolledChatHistoryVisibleRange(term, term.Height)
+	if !ok {
+		return term.ScreenYToAbsoluteLine(screenY), true
+	}
+	if screenY < 0 {
+		screenY = 0
+	} else if screenY >= term.Height {
+		screenY = term.Height - 1
+	}
+	visibleRows := endLine - startLine + 1
+	if visibleRows <= 0 {
+		return 0, false
+	}
+	absLine := startLine + screenY
+	if absLine > endLine {
+		return endLine, false
+	}
+	return absLine, true
+}
+
+func (m *Model) displayedScreenYToAbsoluteLineLocked(tab *Tab, screenY int) (int, bool) {
+	if tab == nil || tab.Terminal == nil {
+		return 0, false
+	}
+	if m != nil && m.isChatTabLocked(tab) {
+		return scrolledChatHistoryScreenYToAbsoluteLine(tab.Terminal, screenY)
+	}
+	return tab.Terminal.ScreenYToAbsoluteLine(screenY), true
+}
+
+func (m *Model) clampScrolledChatHistoryViewOffsetLocked(tab *Tab) {
+	if m == nil || tab == nil || tab.Terminal == nil || !m.isChatTabLocked(tab) {
+		return
+	}
+	if tab.Terminal.ViewOffset <= 0 {
+		return
+	}
+	maxOffset := scrolledChatHistoryMaxViewOffset(tab.Terminal)
+	if maxOffset == 0 {
+		tab.Terminal.ScrollViewToBottom()
+		return
+	}
+	if tab.Terminal.ViewOffset > maxOffset {
+		tab.Terminal.ScrollViewTo(maxOffset)
+	}
+}
+
+func (m *Model) scrollTerminalViewLocked(tab *Tab, delta int) {
+	if tab == nil || tab.Terminal == nil || delta == 0 {
+		return
+	}
+	m.clampScrolledChatHistoryViewOffsetLocked(tab)
+	tab.Terminal.ScrollView(delta)
+	m.clampScrolledChatHistoryViewOffsetLocked(tab)
+}
+
+func (m *Model) scrollTerminalToBottomLocked(tab *Tab) {
+	if tab == nil || tab.Terminal == nil {
+		return
+	}
+	tab.Terminal.ScrollViewToBottom()
+}
+
+func (m *Model) scrollTerminalToTopLocked(tab *Tab) {
+	if tab == nil || tab.Terminal == nil {
+		return
+	}
+	if m != nil && m.isChatTabLocked(tab) {
+		maxOffset := scrolledChatHistoryMaxViewOffset(tab.Terminal)
+		if maxOffset > 0 {
+			tab.Terminal.ScrollViewTo(maxOffset)
+			return
+		}
+	}
+	tab.Terminal.ScrollViewToTop()
+}
+
+func (m *Model) displayedScrollInfoLocked(tab *Tab) (offset, maxOffset int) {
+	if tab == nil || tab.Terminal == nil {
+		return 0, 0
+	}
+	if m != nil && m.isChatTabLocked(tab) && tab.Terminal.ViewOffset > 0 {
+		maxOffset = scrolledChatHistoryMaxViewOffset(tab.Terminal)
+		if maxOffset == 0 {
+			return 0, 0
+		}
+		offset = scrolledChatHistoryEffectiveViewOffset(tab.Terminal)
+		return offset, maxOffset
+	}
+	return tab.Terminal.GetScrollInfo()
+}
+
+// applyScrolledChatHistoryViewLocked replaces a scrolled chat snapshot with a
+// history-only view so the live prompt/output region does not appear mixed into
+// the middle of scrollback while the user is reading older content.
+//
+// Caller must hold tab.mu.
+func applyScrolledChatHistoryViewLocked(term *vterm.VTerm, snap *compositor.VTermSnapshot) {
+	if term == nil || snap == nil || snap.ViewOffset <= 0 || term.AltScreen {
+		return
+	}
+
+	width := snap.Width
+	height := snap.Height
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	startLine, _, ok := scrolledChatHistoryVisibleRange(term, height)
+	if !ok {
+		return
+	}
+	scrollbackLen := scrolledChatHistoryScrollbackLen(term)
+
+	screen := make([][]vterm.Cell, height)
+	for i := 0; i < height; i++ {
+		line := vterm.MakeBlankLine(width)
+		lineIdx := startLine + i
+		if lineIdx >= 0 && lineIdx < scrollbackLen {
+			copy(line, term.Scrollback[lineIdx])
+		}
+		screen[i] = line
+	}
+	snap.Screen = screen
+	rebaseScrolledChatSelection(term, snap, startLine)
+}
+
+func rebaseScrolledChatSelection(term *vterm.VTerm, snap *compositor.VTermSnapshot, startLine int) {
+	if term == nil || snap == nil || !snap.SelActive {
+		return
+	}
+
+	width := snap.Width
+	height := snap.Height
+	scrollbackLen := scrolledChatHistoryScrollbackLen(term)
+	if width <= 0 || height <= 0 || scrollbackLen <= 0 {
+		snap.SelActive = false
+		return
+	}
+
+	startAbs := term.SelStartLine()
+	endAbs := term.SelEndLine()
+	startX := term.SelStartX()
+	endX := term.SelEndX()
+
+	if startAbs > endAbs || (startAbs == endAbs && startX > endX) {
+		startAbs, endAbs = endAbs, startAbs
+		startX, endX = endX, startX
+	}
+
+	visibleEnd := startLine + height - 1
+	if _, endLine, ok := scrolledChatHistoryVisibleRange(term, height); ok {
+		visibleEnd = endLine
+	}
+
+	if endAbs < startLine || startAbs > visibleEnd {
+		snap.SelActive = false
+		return
+	}
+
+	if startAbs < startLine {
+		snap.SelStartY = 0
+		startX = 0
+	} else {
+		snap.SelStartY = startAbs - startLine
+	}
+
+	if endAbs > visibleEnd {
+		snap.SelEndY = visibleEnd - startLine
+		endX = width - 1
+	} else {
+		snap.SelEndY = endAbs - startLine
+	}
+
+	if startX < 0 {
+		startX = 0
+	}
+	if startX >= width {
+		startX = width - 1
+	}
+	if endX < 0 {
+		endX = 0
+	}
+	if endX >= width {
+		endX = width - 1
+	}
+
+	snap.SelStartX = startX
+	snap.SelEndX = endX
+}

--- a/internal/ui/center/model_scrolled_history_test.go
+++ b/internal/ui/center/model_scrolled_history_test.go
@@ -1,0 +1,352 @@
+package center
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func TestTerminalLayerUsesHistoryOnlyViewWhenChatTabIsScrolled(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+
+	term.ScrollView(1)
+	layer := m.TerminalLayer()
+	if layer == nil || layer.Snap == nil {
+		t.Fatal("expected terminal layer snapshot")
+	}
+
+	lines := snapshotLines(layer.Snap.Screen)
+	if strings.Join(lines, "\n") != "old0\nold1\nold2\nold3" {
+		t.Fatalf("expected scrolled chat view to render history only, got %q", lines)
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "prompt") || strings.Contains(line, "reply") {
+			t.Fatalf("expected scrolled history to hide live prompt/output rows, got %q", lines)
+		}
+	}
+}
+
+func TestMouseSelectionOnScrolledChatUsesVisibleHistoryLines(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+	m.SetSize(40, 10)
+	m.SetOffset(0)
+	term.ScrollView(1)
+
+	tm := m.terminalMetrics()
+	startX := tm.ContentStartX
+	startY := tm.ContentStartY
+	endX := startX + term.Width - 1
+	endY := startY + 1
+
+	_, _ = m.Update(tea.MouseClickMsg{X: startX, Y: startY, Button: tea.MouseLeft})
+	_, _ = m.Update(tea.MouseMotionMsg{X: endX, Y: endY, Button: tea.MouseLeft})
+
+	tab.mu.Lock()
+	got := tab.Terminal.SelectedText()
+	tab.mu.Unlock()
+
+	if got != "old0\nold1" {
+		t.Fatalf("expected scrolled chat selection to follow visible history, got %q", got)
+	}
+}
+
+func TestTabActorSelectionOnScrolledChatUsesVisibleHistoryLines(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+	term.ScrollView(1)
+	workspaceID := string(tab.Workspace.ID())
+
+	m.handleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: workspaceID,
+		tabID:       tab.ID,
+		kind:        tabEventSelectionStart,
+		termX:       0,
+		termY:       0,
+		inBounds:    true,
+	})
+	m.handleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: workspaceID,
+		tabID:       tab.ID,
+		kind:        tabEventSelectionUpdate,
+		termX:       term.Width - 1,
+		termY:       1,
+	})
+
+	tab.mu.Lock()
+	got := tab.Terminal.SelectedText()
+	tab.mu.Unlock()
+
+	if got != "old0\nold1" {
+		t.Fatalf("expected tab actor scrolled chat selection to follow visible history, got %q", got)
+	}
+}
+
+func TestCenterViewUsesHistoryOnlyRenderWhenChatTabIsScrolled(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	tab.Terminal.ScrollView(1)
+	m.showKeymapHints = false
+	m.SetSize(40, 10)
+	m.SetOffset(0)
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "old0") {
+		t.Fatalf("expected scrolled center view to include history rows, got %q", view)
+	}
+	if strings.Contains(view, "> prompt") || strings.Contains(view, "reply1") || strings.Contains(view, "reply2") {
+		t.Fatalf("expected scrolled center view to hide live prompt/output rows, got %q", view)
+	}
+}
+
+func TestTerminalLayerUsesFrozenHistoryViewDuringSyncOutput(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+	term.ScrollView(1)
+
+	before := layerLines(t, m)
+
+	term.Write([]byte("\x1b[?2026h"))
+	if !term.SyncActive() {
+		t.Fatal("expected synchronized output mode to be active")
+	}
+	term.Write([]byte("reply3\nreply4\nreply5\n"))
+
+	during := layerLines(t, m)
+	if strings.Join(during, "\n") != strings.Join(before, "\n") {
+		t.Fatalf("expected scrolled chat layer to stay frozen during sync, before=%q during=%q", before, during)
+	}
+
+	term.Write([]byte("\x1b[?2026l"))
+	after := layerLines(t, m)
+	if strings.Join(after, "\n") != strings.Join(before, "\n") {
+		t.Fatalf("expected scrolled chat layer to preserve anchor after sync, before=%q after=%q", before, after)
+	}
+}
+
+func TestMouseSelectionOnScrolledChatUsesFrozenHistoryDuringSyncOutput(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+	m.SetSize(40, 10)
+	m.SetOffset(0)
+	term.ScrollView(1)
+
+	term.Write([]byte("\x1b[?2026h"))
+	if !term.SyncActive() {
+		t.Fatal("expected synchronized output mode to be active")
+	}
+	term.Write([]byte("reply3\nreply4\nreply5\n"))
+
+	tm := m.terminalMetrics()
+	startX := tm.ContentStartX
+	startY := tm.ContentStartY
+	endX := startX + term.Width - 1
+	endY := startY + 1
+
+	_, _ = m.Update(tea.MouseClickMsg{X: startX, Y: startY, Button: tea.MouseLeft})
+	_, _ = m.Update(tea.MouseMotionMsg{X: endX, Y: endY, Button: tea.MouseLeft})
+
+	tab.mu.Lock()
+	got := tab.Terminal.SelectedText()
+	tab.mu.Unlock()
+
+	if got != "old0\nold1" {
+		t.Fatalf("expected scrolled chat selection to follow frozen history during sync, got %q", got)
+	}
+}
+
+func TestScrolledChatHistoryScreenYToAbsoluteLineRejectsPaddedRows(t *testing.T) {
+	_, tab := setupScrolledChatHistoryModelWithBuffers(
+		[]string{"old0", "old1"},
+		[]string{"old2", "> prompt", "reply1", "reply2"},
+	)
+	tab.Terminal.ScrollView(1)
+
+	if absLine, ok := scrolledChatHistoryScreenYToAbsoluteLine(tab.Terminal, 1); !ok || absLine != 1 {
+		t.Fatalf("expected last real history row to map to line 1, got line=%d ok=%v", absLine, ok)
+	}
+	if absLine, ok := scrolledChatHistoryScreenYToAbsoluteLine(tab.Terminal, 2); ok || absLine != 1 {
+		t.Fatalf("expected padded history row to be invalid and clamp to line 1, got line=%d ok=%v", absLine, ok)
+	}
+}
+
+func TestMouseSelectionOnScrolledChatIgnoresPaddedHistoryRows(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModelWithBuffers(
+		[]string{"old0", "old1"},
+		[]string{"old2", "> prompt", "reply1", "reply2"},
+	)
+	term := tab.Terminal
+	term.ScrollView(1)
+
+	tm := m.terminalMetrics()
+	startX := tm.ContentStartX
+	startY := tm.ContentStartY + 2
+	endX := startX + term.Width - 1
+	endY := startY + 1
+
+	_, _ = m.Update(tea.MouseClickMsg{X: startX, Y: startY, Button: tea.MouseLeft})
+	_, _ = m.Update(tea.MouseMotionMsg{X: endX, Y: endY, Button: tea.MouseLeft})
+
+	tab.mu.Lock()
+	active := tab.Selection.Active
+	hasSelection := tab.Terminal.HasSelection()
+	tab.mu.Unlock()
+
+	if active || hasSelection {
+		t.Fatalf("expected padded history rows to avoid starting a selection, active=%v hasSelection=%v", active, hasSelection)
+	}
+}
+
+func TestTabActorSelectionOnScrolledChatIgnoresPaddedHistoryRows(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModelWithBuffers(
+		[]string{"old0", "old1"},
+		[]string{"old2", "> prompt", "reply1", "reply2"},
+	)
+	term := tab.Terminal
+	term.ScrollView(1)
+	workspaceID := string(tab.Workspace.ID())
+
+	m.handleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: workspaceID,
+		tabID:       tab.ID,
+		kind:        tabEventSelectionStart,
+		termX:       0,
+		termY:       2,
+		inBounds:    true,
+	})
+	m.handleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: workspaceID,
+		tabID:       tab.ID,
+		kind:        tabEventSelectionUpdate,
+		termX:       term.Width - 1,
+		termY:       3,
+	})
+
+	tab.mu.Lock()
+	active := tab.Selection.Active
+	hasSelection := tab.Terminal.HasSelection()
+	tab.mu.Unlock()
+
+	if active || hasSelection {
+		t.Fatalf("expected padded history rows to avoid starting an actor selection, active=%v hasSelection=%v", active, hasSelection)
+	}
+}
+
+func TestChatHistoryScrollStopsAtLastDistinctFrame(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModelWithBuffers(
+		[]string{"old0", "old1", "old2", "old3", "old4"},
+		[]string{"old5", "> prompt", "reply1", "reply2"},
+	)
+	m.showKeymapHints = false
+
+	tab.mu.Lock()
+	for i := 0; i < 6; i++ {
+		m.scrollTerminalViewLocked(tab, 1)
+	}
+	offset, maxOffset := m.displayedScrollInfoLocked(tab)
+	tab.mu.Unlock()
+	if offset != 2 || maxOffset != 2 {
+		t.Fatalf("expected chat history scroll to clamp at 2/2, got %d/%d", offset, maxOffset)
+	}
+
+	lines := layerLines(t, m)
+	if strings.Join(lines, "\n") != "old0\nold1\nold2\nold3" {
+		t.Fatalf("expected top history frame after repeated wheel-up, got %q", lines)
+	}
+
+	status := ansi.Strip(m.ActiveTerminalStatusLine())
+	if !strings.Contains(status, "2/2 lines up") {
+		t.Fatalf("expected capped chat scroll status, got %q", status)
+	}
+}
+
+func setupScrolledChatHistoryModel() (*Model, *Tab) {
+	return setupScrolledChatHistoryModelWithBuffers(
+		[]string{"old0", "old1", "old2", "old3"},
+		[]string{"old4", "> prompt", "reply1", "reply2"},
+	)
+}
+
+func setupScrolledChatHistoryModelWithBuffers(scrollbackLines, screenLines []string) (*Model, *Tab) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	term := vterm.New(20, 4)
+	term.Scrollback = make([][]vterm.Cell, 0, len(scrollbackLines))
+	for _, line := range scrollbackLines {
+		term.Scrollback = append(term.Scrollback, testHistoryLine(term.Width, line))
+	}
+	term.Screen = make([][]vterm.Cell, term.Height)
+	for i := 0; i < term.Height; i++ {
+		text := ""
+		if i < len(screenLines) {
+			text = screenLines[i]
+		}
+		term.Screen[i] = testHistoryLine(term.Width, text)
+	}
+
+	tab := &Tab{
+		ID:        TabID("tab-chat-scrolled-history-only"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.SetWorkspace(ws)
+	m.Focus()
+	return m, tab
+}
+
+func testHistoryLine(width int, text string) []vterm.Cell {
+	line := vterm.MakeBlankLine(width)
+	for i, r := range text {
+		if i >= width {
+			break
+		}
+		cell := line[i]
+		cell.Rune = r
+		if cell.Width == 0 {
+			cell.Width = 1
+		}
+		line[i] = cell
+	}
+	return line
+}
+
+func snapshotLines(screen [][]vterm.Cell) []string {
+	lines := make([]string, 0, len(screen))
+	for _, row := range screen {
+		var b strings.Builder
+		for _, cell := range row {
+			if cell.Width == 0 {
+				continue
+			}
+			if cell.Rune == 0 {
+				b.WriteRune(' ')
+			} else {
+				b.WriteRune(cell.Rune)
+			}
+		}
+		lines = append(lines, strings.TrimRight(b.String(), " "))
+	}
+	return lines
+}
+
+func layerLines(t *testing.T, m *Model) []string {
+	t.Helper()
+	layer := m.TerminalLayer()
+	if layer == nil || layer.Snap == nil {
+		t.Fatal("expected terminal layer snapshot")
+	}
+	return snapshotLines(layer.Snap.Screen)
+}

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -223,7 +223,11 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 		tab.Selection = common.SelectionState{}
 		tab.selectionScroll.Reset()
 		if ev.inBounds && tab.Terminal != nil {
-			absLine := tab.Terminal.ScreenYToAbsoluteLine(ev.termY)
+			absLine, ok := m.displayedScreenYToAbsoluteLineLocked(tab, ev.termY)
+			if !ok {
+				tab.mu.Unlock()
+				return
+			}
 			tab.Selection = common.SelectionState{
 				Active:    true,
 				StartX:    ev.termX,
@@ -256,14 +260,14 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 		tab.selectionScroll.SetDirection(termY, termHeight)
 
 		if termY < 0 {
-			tab.Terminal.ScrollView(1)
+			m.scrollTerminalViewLocked(tab, 1)
 			termY = 0
 		} else if termY >= termHeight {
-			tab.Terminal.ScrollView(-1)
+			m.scrollTerminalViewLocked(tab, -1)
 			termY = termHeight - 1
 		}
 
-		absLine := tab.Terminal.ScreenYToAbsoluteLine(termY)
+		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
 		startX := tab.Terminal.SelStartX()
 		startLine := tab.Terminal.SelStartLine()
 		if !tab.Terminal.HasSelection() {
@@ -305,7 +309,7 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 	case tabEventScrollBy:
 		tab.mu.Lock()
 		if tab.Terminal != nil && ev.delta != 0 {
-			tab.Terminal.ScrollView(ev.delta)
+			m.scrollTerminalViewLocked(tab, ev.delta)
 		}
 		tab.mu.Unlock()
 	case tabEventSelectionScrollTick:
@@ -314,14 +318,14 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 			tab.mu.Unlock()
 			return
 		}
-		tab.Terminal.ScrollView(tab.selectionScroll.ScrollDir)
+		m.scrollTerminalViewLocked(tab, tab.selectionScroll.ScrollDir)
 
 		// Update selection endpoint to viewport edge
 		edgeY := 0
 		if tab.selectionScroll.ScrollDir < 0 {
 			edgeY = tab.Terminal.Height - 1
 		}
-		absLine := tab.Terminal.ScreenYToAbsoluteLine(edgeY)
+		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
 		endX := tab.selectionLastTermX
 		startX := tab.Terminal.SelStartX()
 		startLine := tab.Terminal.SelStartLine()
@@ -346,23 +350,20 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 	case tabEventScrollToBottom:
 		tab.mu.Lock()
 		if tab.Terminal != nil && tab.Terminal.IsScrolled() {
-			tab.Terminal.ScrollViewToBottom()
+			m.scrollTerminalToBottomLocked(tab)
 		}
 		tab.mu.Unlock()
 	case tabEventScrollPage:
 		tab.mu.Lock()
 		if tab.Terminal != nil && ev.scrollPage != 0 {
-			delta := tab.Terminal.Height / 4
-			if delta < 1 {
-				delta = 1
-			}
-			tab.Terminal.ScrollView(delta * ev.scrollPage)
+			delta := common.ScrollDeltaForHeight(tab.Terminal.Height, 4)
+			m.scrollTerminalViewLocked(tab, delta*ev.scrollPage)
 		}
 		tab.mu.Unlock()
 	case tabEventScrollToTop:
 		tab.mu.Lock()
 		if tab.Terminal != nil {
-			tab.Terminal.ScrollViewToTop()
+			m.scrollTerminalToTopLocked(tab)
 		}
 		tab.mu.Unlock()
 	case tabEventDiffInput:

--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -276,9 +276,18 @@ func RenderTerminal(term *vterm.VTerm, width, height int, showCursor bool, fg, b
 	return RenderTerminalWithCanvas(nil, term, width, height, showCursor, fg, bg)
 }
 
-// RenderTerminalWithCanvas renders a vterm into a reusable canvas.
-func RenderTerminalWithCanvas(canvas *Canvas, term *vterm.VTerm, width, height int, showCursor bool, fg, bg vterm.Color) string {
-	if term == nil || width <= 0 || height <= 0 {
+// RenderSnapshotWithCanvas renders a vterm snapshot into a reusable canvas.
+func RenderSnapshotWithCanvas(canvas *Canvas, snap *VTermSnapshot, width, height int, fg, bg vterm.Color) string {
+	if snap == nil {
+		return ""
+	}
+	if width <= 0 || width > snap.Width {
+		width = snap.Width
+	}
+	if height <= 0 || height > snap.Height {
+		height = snap.Height
+	}
+	if width <= 0 || height <= 0 {
 		return ""
 	}
 
@@ -288,77 +297,36 @@ func RenderTerminalWithCanvas(canvas *Canvas, term *vterm.VTerm, width, height i
 		canvas.Resize(width, height)
 	}
 	canvas.Fill(vterm.Style{Fg: fg, Bg: bg})
-	screen := term.VisibleScreen()
-
-	// Get selection state and convert to screen coordinates.
-	selActive := term.SelActive()
-	selStartX := 0
-	selStartY := 0
-	selEndX := 0
-	selEndY := 0
-
-	if selActive {
-		startLine := term.SelStartLine()
-		endLine := term.SelEndLine()
-		startX := term.SelStartX()
-		endX := term.SelEndX()
-
-		// Normalize so start is before end.
-		if startLine > endLine || (startLine == endLine && startX > endX) {
-			startLine, endLine = endLine, startLine
-			startX, endX = endX, startX
-		}
-
-		visibleStartLine := term.ScreenYToAbsoluteLine(0)
-		visibleEndLine := term.ScreenYToAbsoluteLine(height - 1)
-
-		// If selection is entirely outside viewport, disable selection rendering.
-		if endLine < visibleStartLine || startLine > visibleEndLine {
-			selActive = false
-		} else {
-			if startLine < visibleStartLine {
-				selStartY = 0
-				startX = 0
-			} else {
-				selStartY = startLine - visibleStartLine
-			}
-
-			if endLine > visibleEndLine {
-				selEndY = height - 1
-				endX = width - 1
-			} else {
-				selEndY = endLine - visibleStartLine
-			}
-
-			if startX < 0 {
-				startX = 0
-			}
-			if startX >= width {
-				startX = width - 1
-			}
-			if endX < 0 {
-				endX = 0
-			}
-			if endX >= width {
-				endX = width - 1
-			}
-
-			selStartX = startX
-			selEndX = endX
-		}
-	}
-
 	canvas.DrawScreen(
 		0,
 		0,
 		width,
 		height,
-		screen,
-		CursorState{X: term.CursorX, Y: term.CursorY, Visible: showCursor},
-		term.ViewOffset,
-		SelectionRegion{Active: selActive, StartX: selStartX, StartY: selStartY, EndX: selEndX, EndY: selEndY},
+		snap.Screen,
+		CursorState{
+			X:       snap.CursorX,
+			Y:       snap.CursorY,
+			Visible: snap.ShowCursor && !snap.CursorHidden,
+		},
+		snap.ViewOffset,
+		SelectionRegion{
+			Active: snap.SelActive,
+			StartX: snap.SelStartX,
+			StartY: snap.SelStartY,
+			EndX:   snap.SelEndX,
+			EndY:   snap.SelEndY,
+		},
 	)
 	return canvas.Render()
+}
+
+// RenderTerminalWithCanvas renders a vterm into a reusable canvas.
+func RenderTerminalWithCanvas(canvas *Canvas, term *vterm.VTerm, width, height int, showCursor bool, fg, bg vterm.Color) string {
+	if term == nil || width <= 0 || height <= 0 {
+		return ""
+	}
+	snap := NewVTermSnapshot(term, showCursor)
+	return RenderSnapshotWithCanvas(canvas, snap, width, height, fg, bg)
 }
 
 // HexColor converts a #RRGGBB string to a vterm.Color.

--- a/internal/ui/diff/model.go
+++ b/internal/ui/diff/model.go
@@ -159,9 +159,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("k", "up"))):
 			m.scrollUp(1)
 		case key.Matches(msg, key.NewBinding(key.WithKeys("pgdown", "ctrl+d"))):
-			m.scrollDown(m.visibleHeight() / 2)
+			m.scrollDown(common.ScrollDeltaForHeight(m.visibleHeight(), 2))
 		case key.Matches(msg, key.NewBinding(key.WithKeys("pgup", "ctrl+u"))):
-			m.scrollUp(m.visibleHeight() / 2)
+			m.scrollUp(common.ScrollDeltaForHeight(m.visibleHeight(), 2))
 		case key.Matches(msg, key.NewBinding(key.WithKeys("g", "home"))):
 			m.scroll = 0
 		case key.Matches(msg, key.NewBinding(key.WithKeys("G", "end"))):

--- a/internal/ui/diff/model_test.go
+++ b/internal/ui/diff/model_test.go
@@ -3,6 +3,8 @@ package diff
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
 )
@@ -145,5 +147,20 @@ func TestDiffLoaded_IgnoresStaleLoadCompletion(t *testing.T) {
 	}
 	if updated.diff != currentDiff {
 		t.Fatalf("expected current diff to win, got %+v", updated.diff)
+	}
+}
+
+func TestPageScrollUsesMinimumOneLine(t *testing.T) {
+	m := newModelWithDiff(4, 10, nil)
+	m.focused = true
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	if m.scroll != 1 {
+		t.Fatalf("expected PgDown on a short diff to scroll by 1 line, got %d", m.scroll)
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	if m.scroll != 0 {
+		t.Fatalf("expected PgUp on a short diff to scroll back to 0, got %d", m.scroll)
 	}
 }

--- a/internal/ui/sidebar/terminal_update.go
+++ b/internal/ui/sidebar/terminal_update.go
@@ -117,7 +117,7 @@ func (m *TerminalModel) Update(msg tea.Msg) (*TerminalModel, tea.Cmd) {
 		case tea.KeyPgUp:
 			ts.mu.Lock()
 			if ts.VTerm != nil {
-				ts.VTerm.ScrollView(ts.VTerm.Height / 2)
+				ts.VTerm.ScrollView(common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
 			}
 			ts.mu.Unlock()
 			return m, nil
@@ -125,7 +125,7 @@ func (m *TerminalModel) Update(msg tea.Msg) (*TerminalModel, tea.Cmd) {
 		case tea.KeyPgDown:
 			ts.mu.Lock()
 			if ts.VTerm != nil {
-				ts.VTerm.ScrollView(-ts.VTerm.Height / 2)
+				ts.VTerm.ScrollView(-common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
 			}
 			ts.mu.Unlock()
 			return m, nil

--- a/internal/ui/sidebar/terminal_update_test.go
+++ b/internal/ui/sidebar/terminal_update_test.go
@@ -1,0 +1,44 @@
+package sidebar
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func TestUpdateKeyPgUpScrollsOneLineOnShortTerminal(t *testing.T) {
+	ws := &data.Workspace{Name: "ws", Repo: "/repo/ws", Root: "/repo/ws"}
+	term := vterm.New(80, 1)
+	for i := 0; i < 10; i++ {
+		term.Write([]byte("line\n"))
+	}
+
+	state := &TerminalState{
+		VTerm:    term,
+		Terminal: &appPty.Terminal{},
+	}
+	tab := &TerminalTab{
+		ID:    generateTerminalTabID(),
+		Name:  "Terminal 1",
+		State: state,
+	}
+
+	m := NewTerminalModel()
+	m.workspace = ws
+	m.focused = true
+	m.tabsByWorkspace[string(ws.ID())] = []*TerminalTab{tab}
+	m.activeTabByWorkspace[string(ws.ID())] = 0
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
+
+	state.mu.Lock()
+	offset, _ := state.VTerm.GetScrollInfo()
+	state.mu.Unlock()
+	if offset != 1 {
+		t.Fatalf("expected PgUp on a short sidebar terminal to scroll by 1 line, got %d", offset)
+	}
+}

--- a/internal/vterm/alt_screen_capture.go
+++ b/internal/vterm/alt_screen_capture.go
@@ -20,13 +20,7 @@ func (v *VTerm) captureScreenToScrollback() {
 	v.clearPendingRestoredAltScreenCapture()
 	if matched, dedupRemoved := v.matchesTrackedAltScreenCapture(lines); matched {
 		if oldViewOffset > 0 {
-			v.ViewOffset = oldViewOffset + pendingAdded - dedupRemoved
-			if v.ViewOffset < 0 {
-				v.ViewOffset = 0
-			}
-			if v.ViewOffset > len(v.Scrollback) {
-				v.ViewOffset = len(v.Scrollback)
-			}
+			v.adjustAnchoredViewOffset(pendingAdded - dedupRemoved)
 		}
 		v.trimScrollback()
 		return
@@ -40,13 +34,7 @@ func (v *VTerm) captureScreenToScrollback() {
 		if oldViewOffset <= 0 {
 			return
 		}
-		v.ViewOffset = oldViewOffset + pendingAdded - removed
-		if v.ViewOffset < 0 {
-			v.ViewOffset = 0
-		}
-		if v.ViewOffset > len(v.Scrollback) {
-			v.ViewOffset = len(v.Scrollback)
-		}
+		v.adjustAnchoredViewOffset(pendingAdded - removed)
 	}
 
 	// Dedup: skip if these lines match the tail of scrollback
@@ -74,13 +62,7 @@ func (v *VTerm) captureScreenToScrollback() {
 	v.altScreenCaptureDropLen = added
 	v.altScreenCaptureTracked = true
 	if oldViewOffset > 0 {
-		v.ViewOffset = oldViewOffset + pendingAdded - removed + added
-		if v.ViewOffset < 0 {
-			v.ViewOffset = 0
-		}
-		if v.ViewOffset > len(v.Scrollback) {
-			v.ViewOffset = len(v.Scrollback)
-		}
+		v.adjustAnchoredViewOffset(pendingAdded - removed + added)
 	}
 	v.trimScrollback()
 }

--- a/internal/vterm/scroll.go
+++ b/internal/vterm/scroll.go
@@ -36,12 +36,7 @@ func (v *VTerm) scrollUp(n int) {
 				v.invalidateAltScreenCapture()
 			}
 		}
-		if added > 0 && v.ViewOffset > 0 {
-			v.ViewOffset += added
-			if v.ViewOffset > len(v.Scrollback) {
-				v.ViewOffset = len(v.Scrollback)
-			}
-		}
+		v.anchorViewOffsetForAddedLines(added)
 		v.trimScrollback()
 	}
 

--- a/internal/vterm/search.go
+++ b/internal/vterm/search.go
@@ -54,15 +54,16 @@ func (v *VTerm) Search(query string) []int {
 
 // ScrollToLine scrolls view to show the given line index (in combined buffer)
 func (v *VTerm) ScrollToLine(lineIdx int) {
-	totalLines := len(v.Scrollback) + len(v.Screen)
+	screen, scrollbackLen := v.RenderBuffers()
+	totalLines := scrollbackLen + len(screen)
 
 	// Calculate ViewOffset to center this line
 	targetOffset := totalLines - lineIdx - v.Height/2
 	if targetOffset < 0 {
 		targetOffset = 0
 	}
-	if targetOffset > len(v.Scrollback) {
-		targetOffset = len(v.Scrollback)
+	if targetOffset > scrollbackLen {
+		targetOffset = scrollbackLen
 	}
 
 	v.ViewOffset = targetOffset

--- a/internal/vterm/sync.go
+++ b/internal/vterm/sync.go
@@ -13,6 +13,8 @@ func (v *VTerm) setSynchronizedOutput(active bool) {
 		v.syncActive = true
 		v.syncScreen = copyScreen(v.Screen)
 		v.syncScrollbackLen = len(v.Scrollback)
+		v.syncViewOffsetDelta = 0
+		v.syncPreserveViewport = v.ViewOffset > 0
 		v.invalidateRenderCache()
 		return
 	}
@@ -23,9 +25,16 @@ func (v *VTerm) setSynchronizedOutput(active bool) {
 	v.syncActive = false
 	v.syncScreen = nil
 	v.syncScrollbackLen = 0
+	if v.syncPreserveViewport && v.syncViewOffsetDelta != 0 {
+		v.ViewOffset += v.syncViewOffsetDelta
+	}
+	v.syncViewOffsetDelta = 0
+	v.syncPreserveViewport = false
 	if v.syncDeferTrim {
 		v.syncDeferTrim = false
 		v.trimScrollback()
+	} else {
+		v.clampViewOffsetToCurrentMax()
 	}
 	v.invalidateRenderCache()
 }

--- a/internal/vterm/sync_mapping_test.go
+++ b/internal/vterm/sync_mapping_test.go
@@ -28,3 +28,106 @@ func TestSelectionMappingUsesSyncBuffers(t *testing.T) {
 		t.Fatalf("expected abs line 4 to be off-screen with sync buffers, got %d", got)
 	}
 }
+
+func TestSyncScrollClampsToFrozenScrollback(t *testing.T) {
+	vt := New(5, 2)
+	vt.Scrollback = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+	vt.Screen = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+
+	vt.setSynchronizedOutput(true)
+
+	// Grow live scrollback after sync begins; frozen history should remain at 2.
+	vt.Scrollback = append(vt.Scrollback, MakeBlankLine(5), MakeBlankLine(5))
+
+	vt.ScrollViewToTop()
+	if offset, maxOffset := vt.GetScrollInfo(); offset != 2 || maxOffset != 2 {
+		t.Fatalf("expected sync scroll top to clamp to frozen max 2, got offset=%d max=%d", offset, maxOffset)
+	}
+
+	vt.ScrollToLine(0)
+	if offset, maxOffset := vt.GetScrollInfo(); offset != 2 || maxOffset != 2 {
+		t.Fatalf("expected ScrollToLine to respect frozen sync buffers, got offset=%d max=%d", offset, maxOffset)
+	}
+}
+
+func TestSyncScrollbackGrowthDoesNotShiftAnchoredView(t *testing.T) {
+	vt := New(5, 2)
+	vt.Scrollback = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+	vt.Screen = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+	vt.ViewOffset = 1
+
+	vt.setSynchronizedOutput(true)
+
+	beforeLine := vt.ScreenYToAbsoluteLine(0)
+	vt.scrollUp(1)
+
+	if got := vt.ScreenYToAbsoluteLine(0); got != beforeLine {
+		t.Fatalf("expected sync mapping to stay anchored while frozen, got %d want %d", got, beforeLine)
+	}
+
+	vt.setSynchronizedOutput(false)
+
+	if got := vt.ScreenYToAbsoluteLine(0); got != beforeLine {
+		t.Fatalf("expected sync exit to preserve anchored line %d, got %d", beforeLine, got)
+	}
+	if offset, maxOffset := vt.GetScrollInfo(); offset != 2 || maxOffset != 4 {
+		t.Fatalf("expected sync exit to preserve live offset 2 with max 4, got offset=%d max=%d", offset, maxOffset)
+	}
+}
+
+func TestSyncOutputKeepsLiveBottomWhenViewportNeverScrolled(t *testing.T) {
+	vt := New(5, 2)
+	vt.Scrollback = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+	vt.Screen = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+
+	vt.setSynchronizedOutput(true)
+	vt.scrollUp(1)
+	vt.setSynchronizedOutput(false)
+
+	if offset, maxOffset := vt.GetScrollInfo(); offset != 0 || maxOffset != 4 {
+		t.Fatalf("expected live-follow viewport to remain at bottom after sync, got offset=%d max=%d", offset, maxOffset)
+	}
+}
+
+func TestSyncOutputDoesNotRestoreHistoryAfterUserReturnsToBottom(t *testing.T) {
+	vt := New(5, 2)
+	vt.Scrollback = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+	vt.Screen = [][]Cell{
+		MakeBlankLine(5),
+		MakeBlankLine(5),
+	}
+
+	vt.setSynchronizedOutput(true)
+	vt.ScrollView(1)
+	vt.scrollUp(1)
+	vt.ScrollViewToBottom()
+	vt.setSynchronizedOutput(false)
+
+	if offset, maxOffset := vt.GetScrollInfo(); offset != 0 || maxOffset != 4 {
+		t.Fatalf("expected viewport to stay at bottom after sync exit, got offset=%d max=%d", offset, maxOffset)
+	}
+}

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -95,6 +95,12 @@ type VTerm struct {
 	syncScreen        [][]Cell
 	syncScrollbackLen int
 	syncDeferTrim     bool
+	// syncViewOffsetDelta tracks the net hidden scrollback growth/shrink that
+	// occurred while sync output was freezing the visible viewport.
+	syncViewOffsetDelta int
+	// syncPreserveViewport keeps the frozen viewport anchored when the user was
+	// already scrolled or interacted with scrollback during sync output.
+	syncPreserveViewport bool
 
 	// Render cache for live screen (ViewOffset == 0)
 	renderCache    []string
@@ -177,12 +183,7 @@ func (v *VTerm) resize(width, height int, revealHistoryOnGrow bool) {
 			if added > 0 {
 				v.invalidateAltScreenCapture()
 			}
-			if added > 0 && v.ViewOffset > 0 {
-				v.ViewOffset += added
-				if v.ViewOffset > len(v.Scrollback) {
-					v.ViewOffset = len(v.Scrollback)
-				}
-			}
+			v.anchorViewOffsetForAddedLines(added)
 			v.trimScrollback()
 		}
 	}
@@ -348,7 +349,5 @@ func (v *VTerm) trimScrollback() {
 		v.shiftSelectionAfterTrim(trimmed)
 	}
 	// Clamp ViewOffset after trim to prevent stale offsets
-	if v.ViewOffset > len(v.Scrollback) {
-		v.ViewOffset = len(v.Scrollback)
-	}
+	v.clampViewOffsetToCurrentMax()
 }

--- a/internal/vterm/vterm_scroll.go
+++ b/internal/vterm/vterm_scroll.go
@@ -54,17 +54,63 @@ func (v *VTerm) AbsoluteLineToScreenY(absLine int) int {
 	return screenY
 }
 
-// ScrollView scrolls the view by delta lines (positive = up into history)
-func (v *VTerm) ScrollView(delta int) {
-	oldOffset := v.ViewOffset
-	v.ViewOffset += delta
-	maxOffset := len(v.Scrollback)
+func (v *VTerm) currentMaxViewOffset() int {
+	if v == nil {
+		return 0
+	}
+	_, scrollbackLen := v.RenderBuffers()
+	return scrollbackLen
+}
+
+func (v *VTerm) clampViewOffsetToCurrentMax() {
+	if v == nil {
+		return
+	}
+	maxOffset := v.currentMaxViewOffset()
 	if v.ViewOffset > maxOffset {
 		v.ViewOffset = maxOffset
 	}
 	if v.ViewOffset < 0 {
 		v.ViewOffset = 0
 	}
+}
+
+func (v *VTerm) noteSyncViewportInteraction(oldOffset int) {
+	if v == nil || !v.syncActive {
+		return
+	}
+	_ = oldOffset
+	v.syncPreserveViewport = v.ViewOffset > 0
+}
+
+func (v *VTerm) adjustAnchoredViewOffset(delta int) {
+	if v == nil || delta == 0 {
+		return
+	}
+	if v.syncActive {
+		v.syncViewOffsetDelta += delta
+		return
+	}
+	if v.ViewOffset <= 0 {
+		return
+	}
+	v.ViewOffset += delta
+	v.clampViewOffsetToCurrentMax()
+}
+
+func (v *VTerm) anchorViewOffsetForAddedLines(added int) {
+	if v == nil || added <= 0 {
+		return
+	}
+	v.adjustAnchoredViewOffset(added)
+}
+
+// ScrollView scrolls the view by delta lines (positive = up into history)
+func (v *VTerm) ScrollView(delta int) {
+	oldOffset := v.ViewOffset
+	v.ViewOffset += delta
+	v.clampViewOffsetToCurrentMax()
+	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -74,13 +120,8 @@ func (v *VTerm) ScrollView(delta int) {
 func (v *VTerm) ScrollViewTo(offset int) {
 	oldOffset := v.ViewOffset
 	v.ViewOffset = offset
-	maxOffset := len(v.Scrollback)
-	if v.ViewOffset > maxOffset {
-		v.ViewOffset = maxOffset
-	}
-	if v.ViewOffset < 0 {
-		v.ViewOffset = 0
-	}
+	v.clampViewOffsetToCurrentMax()
+	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -89,7 +130,8 @@ func (v *VTerm) ScrollViewTo(offset int) {
 // ScrollViewToTop scrolls to oldest content
 func (v *VTerm) ScrollViewToTop() {
 	oldOffset := v.ViewOffset
-	v.ViewOffset = len(v.Scrollback)
+	v.ViewOffset = v.currentMaxViewOffset()
+	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -99,6 +141,7 @@ func (v *VTerm) ScrollViewToTop() {
 func (v *VTerm) ScrollViewToBottom() {
 	oldOffset := v.ViewOffset
 	v.ViewOffset = 0
+	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -111,7 +154,7 @@ func (v *VTerm) IsScrolled() bool {
 
 // GetScrollInfo returns (current offset, max offset)
 func (v *VTerm) GetScrollInfo() (int, int) {
-	return v.ViewOffset, len(v.Scrollback)
+	return v.ViewOffset, v.currentMaxViewOffset()
 }
 
 // PrependScrollback parses captured scrollback content (with ANSI escapes) and
@@ -191,12 +234,7 @@ func (v *VTerm) AppendScrollbackDelta(data []byte) {
 	}
 	if added > 0 {
 		v.invalidateTrackedAltScreenCapture()
-		if v.ViewOffset > 0 {
-			v.ViewOffset += added
-			if v.ViewOffset > len(v.Scrollback) {
-				v.ViewOffset = len(v.Scrollback)
-			}
-		}
+		v.anchorViewOffsetForAddedLines(added)
 	}
 	v.trimScrollback()
 }
@@ -259,12 +297,7 @@ func (v *VTerm) AppendScrollbackDeltaWithSize(data []byte, width, height, visibl
 	}
 	if added > 0 {
 		v.invalidateTrackedAltScreenCapture()
-		if v.ViewOffset > 0 {
-			v.ViewOffset += added
-			if v.ViewOffset > len(v.Scrollback) {
-				v.ViewOffset = len(v.Scrollback)
-			}
-		}
+		v.anchorViewOffsetForAddedLines(added)
 	}
 	v.trimScrollback()
 }


### PR DESCRIPTION
## What changed

This PR fixes two related terminal interaction paths:

- mouse wheel routing now follows the hovered pane and modal overlays consume wheel/motion/release input instead of leaking events to the focused pane behind them
- scrolled chat tabs render a history-only viewport, keep selection coordinates aligned with the visible history rows, and preserve the viewport anchor while synchronized output is active

It also makes short page-scroll targets move by at least one line in center terminals, sidebar terminals, and diff views.

Finally, it bumps the Go patch directive from `1.26.2` to `1.26.3` so CI runs govulncheck on the standard-library version that fixes GO-2026-4971 and GO-2026-4918.

## Why

Wheel input previously fell back to the focused pane when the hovered pane could not consume the event, which could scroll hidden or unrelated content. Chat scrollback also mixed live prompt/output rows into older history when scrolled, and synchronized output could shift the anchored viewport while the user was reading history.

The PR was rebased onto latest `origin/main`; the only rebase conflict was in `internal/ui/diff/model_test.go`, where both sides had added tests. The resolution keeps both sets.

## User impact

- wheel scrolling tracks pointer location more consistently
- dialogs, file pickers, settings, error overlays, and toast-covered areas block background wheel input
- chat history scrolling shows stable historical frames without live rows interleaved
- mouse selection while scrolled maps to the rows the user can actually see
- PgUp/PgDown on very short views still moves one line
- CI govulncheck uses Go `1.26.3` and no longer reports the fixed standard-library vulnerabilities

## Validation

- `make devcheck`
- `make harness-presets`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...`
- pre-push hook: CI-parity strict lint, headless center harness, and `go test ./internal/e2e`
