### PR TITLE
Close RunPTYReader's msgCh exactly once via a single deferred close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andyrewlee/amux
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.0.0

--- a/internal/ui/common/pty_reader.go
+++ b/internal/ui/common/pty_reader.go
@@ -30,17 +30,17 @@ type PTYMsgFactory struct {
 
 // RunPTYReader reads from r, buffers bytes, sends Output messages via msgCh
 // on ticker ticks or when MaxPendingBytes is hit. Sends Stopped on error.
-// Closes msgCh on exit.
+// msgCh is closed exactly once, by this goroutine, on every return path
+// (including panic) via the deferred close below, so ForwardPTYMsgs never
+// blocks on a channel that will not close.
 func RunPTYReader(
 	r io.Reader, msgCh chan tea.Msg, cancel <-chan struct{},
 	heartbeat *int64, cfg PTYReaderConfig, factory PTYMsgFactory,
 ) {
-	// Ensure msgCh is always closed even if we panic, so forwardPTYMsgs doesn't block forever.
-	// The inner recover() catches double-close panics from existing close(msgCh) calls.
-	defer func() {
-		defer func() { _ = recover() }()
-		close(msgCh)
-	}()
+	// This goroutine is the sole owner of msgCh, so close it once on return.
+	// A deferred close runs during panic unwinding too, which unblocks
+	// ForwardPTYMsgs before the panic propagates to safego.Run (which logs it).
+	defer close(msgCh)
 
 	if r == nil {
 		return
@@ -112,7 +112,6 @@ func RunPTYReader(
 	for {
 		select {
 		case <-cancel:
-			close(msgCh)
 			return
 		case err := <-errCh:
 			beat()
@@ -122,7 +121,6 @@ func RunPTYReader(
 			if !ok {
 				if len(pending) > 0 {
 					if !SendPTYMsg(msgCh, cancel, factory.Output(pending)) {
-						close(msgCh)
 						return
 					}
 				}
@@ -130,14 +128,12 @@ func RunPTYReader(
 					stoppedErr = io.EOF
 				}
 				SendPTYMsg(msgCh, cancel, factory.Stopped(stoppedErr))
-				close(msgCh)
 				return
 			}
 			pending = append(pending, data...)
 			startFlushTicker()
 			if len(pending) >= cfg.MaxPendingBytes {
 				if !SendPTYMsg(msgCh, cancel, factory.Output(pending)) {
-					close(msgCh)
 					return
 				}
 				pending = nil
@@ -147,14 +143,12 @@ func RunPTYReader(
 			}
 			if stoppedErr != nil && len(pending) == 0 {
 				SendPTYMsg(msgCh, cancel, factory.Stopped(stoppedErr))
-				close(msgCh)
 				return
 			}
 		case <-flushTick:
 			beat()
 			if len(pending) > 0 {
 				if !SendPTYMsg(msgCh, cancel, factory.Output(pending)) {
-					close(msgCh)
 					return
 				}
 				pending = nil
@@ -164,7 +158,6 @@ func RunPTYReader(
 			}
 			if stoppedErr != nil {
 				SendPTYMsg(msgCh, cancel, factory.Stopped(stoppedErr))
-				close(msgCh)
 				return
 			}
 		case <-heartbeatTicker.C:

--- a/internal/ui/common/pty_reader_test.go
+++ b/internal/ui/common/pty_reader_test.go
@@ -1,0 +1,203 @@
+package common
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// scriptedReader drives RunPTYReader through deterministic exit paths: it
+// returns each chunk in order, then (optionally blocking on block) returns
+// finalErr, defaulting to io.EOF.
+type scriptedReader struct {
+	chunks   [][]byte
+	idx      int
+	block    <-chan struct{}
+	finalErr error
+}
+
+func (s *scriptedReader) Read(p []byte) (int, error) {
+	if s.idx < len(s.chunks) {
+		n := copy(p, s.chunks[s.idx])
+		s.idx++
+		return n, nil
+	}
+	if s.block != nil {
+		<-s.block
+	}
+	if s.finalErr != nil {
+		return 0, s.finalErr
+	}
+	return 0, io.EOF
+}
+
+type testOutputMsg struct{ data []byte }
+
+type testStoppedMsg struct{ err error }
+
+type collectedPTY struct {
+	outputs []testOutputMsg
+	stops   []testStoppedMsg
+}
+
+func (c collectedPTY) outputBytes() []byte {
+	var b []byte
+	for _, o := range c.outputs {
+		b = append(b, o.data...)
+	}
+	return b
+}
+
+// runReaderAndForward wires RunPTYReader to ForwardPTYMsgs over an unbuffered
+// msgCh (so ForwardPTYMsgs is forced to drain), runs both to completion, and
+// fails if either fails to return within the timeout. ForwardPTYMsgs only
+// returns when msgCh is closed, so a clean return proves msgCh was closed
+// exactly once: a missing close would hang, a double close would panic (there
+// is no longer a recover() to swallow it).
+func runReaderAndForward(t *testing.T, r io.Reader, cancel <-chan struct{}, cfg PTYReaderConfig) collectedPTY {
+	t.Helper()
+
+	msgCh := make(chan tea.Msg)
+	var hb int64
+	factory := PTYMsgFactory{
+		Output: func(data []byte) tea.Msg {
+			cp := make([]byte, len(data))
+			copy(cp, data)
+			return testOutputMsg{data: cp}
+		},
+		Stopped: func(err error) tea.Msg { return testStoppedMsg{err: err} },
+	}
+	merger := OutputMerger{
+		ExtractData: func(msg tea.Msg) ([]byte, bool) {
+			o, ok := msg.(testOutputMsg)
+			if !ok {
+				return nil, false
+			}
+			return o.data, true
+		},
+		CanMerge:   func(_, _ tea.Msg) bool { return true },
+		Build:      func(_ tea.Msg, data []byte) tea.Msg { return testOutputMsg{data: data} },
+		MaxPending: 1 << 20,
+	}
+
+	var mu sync.Mutex
+	var got collectedPTY
+	forwardDone := make(chan struct{})
+	go func() {
+		ForwardPTYMsgs(msgCh, func(m tea.Msg) {
+			mu.Lock()
+			defer mu.Unlock()
+			switch v := m.(type) {
+			case testOutputMsg:
+				got.outputs = append(got.outputs, v)
+			case testStoppedMsg:
+				got.stops = append(got.stops, v)
+			}
+		}, merger)
+		close(forwardDone)
+	}()
+
+	readerDone := make(chan struct{})
+	go func() {
+		RunPTYReader(r, msgCh, cancel, &hb, cfg, factory)
+		close(readerDone)
+	}()
+
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunPTYReader did not return within 2s (msgCh likely never closed)")
+	}
+	select {
+	case <-forwardDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ForwardPTYMsgs did not return within 2s (msgCh not closed exactly once)")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	return got
+}
+
+func baseReaderCfg() PTYReaderConfig {
+	return PTYReaderConfig{
+		Label:           "test",
+		ReadBufferSize:  4096,
+		ReadQueueSize:   8,
+		FrameInterval:   10 * time.Millisecond,
+		MaxPendingBytes: 1 << 20,
+	}
+}
+
+func TestRunPTYReaderClosesOnceOnEOF(t *testing.T) {
+	cancel := make(chan struct{})
+	got := runReaderAndForward(t, &scriptedReader{chunks: [][]byte{[]byte("hello")}}, cancel, baseReaderCfg())
+
+	if string(got.outputBytes()) != "hello" {
+		t.Fatalf("output = %q, want %q", got.outputBytes(), "hello")
+	}
+	if len(got.stops) != 1 {
+		t.Fatalf("got %d Stopped msgs, want 1", len(got.stops))
+	}
+	if got.stops[0].err != io.EOF {
+		t.Fatalf("Stopped err = %v, want io.EOF", got.stops[0].err)
+	}
+}
+
+func TestRunPTYReaderClosesOnceOnError(t *testing.T) {
+	cancel := make(chan struct{})
+	got := runReaderAndForward(t, &scriptedReader{finalErr: errors.New("boom")}, cancel, baseReaderCfg())
+
+	// The terminal error may be the read error or io.EOF depending on whether
+	// the err channel or the closed data channel is observed first; both are
+	// non-nil. The contract under test is exactly-once close, asserted by
+	// runReaderAndForward returning rather than hanging or panicking.
+	if len(got.stops) != 1 {
+		t.Fatalf("got %d Stopped msgs, want 1", len(got.stops))
+	}
+	if got.stops[0].err == nil {
+		t.Fatal("Stopped err = nil, want non-nil")
+	}
+}
+
+func TestRunPTYReaderFlushesOnMaxPending(t *testing.T) {
+	cfg := baseReaderCfg()
+	cfg.FrameInterval = time.Hour // never tick: isolate the max-pending flush path
+	cfg.MaxPendingBytes = 4
+	cancel := make(chan struct{})
+
+	got := runReaderAndForward(t, &scriptedReader{chunks: [][]byte{[]byte("ABCDEFGH")}}, cancel, cfg)
+
+	if string(got.outputBytes()) != "ABCDEFGH" {
+		t.Fatalf("output = %q, want ABCDEFGH (max-pending flush)", got.outputBytes())
+	}
+	if len(got.stops) != 1 || got.stops[0].err != io.EOF {
+		t.Fatalf("stops = %+v, want exactly one io.EOF", got.stops)
+	}
+}
+
+func TestRunPTYReaderClosesOnceOnCancel(t *testing.T) {
+	cancel := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release) // unblock the leaked read goroutine after the test
+
+	// No chunks: the read goroutine blocks on release (not cancel), so closing
+	// cancel exercises the loop's cancel path deterministically without racing
+	// an EOF from the reader.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(cancel)
+	}()
+	got := runReaderAndForward(t, &scriptedReader{block: release}, cancel, baseReaderCfg())
+
+	if len(got.outputs) != 0 {
+		t.Fatalf("got %d outputs on cancel, want 0", len(got.outputs))
+	}
+	if len(got.stops) != 0 {
+		t.Fatalf("got %d Stopped msgs on cancel, want 0 (cancel path sends no Stopped)", len(got.stops))
+	}
+}


### PR DESCRIPTION
## What

Replaces the `recover()`-wrapped deferred close + seven explicit `close(msgCh)` calls in `RunPTYReader` with a single `defer close(msgCh)`, and adds `pty_reader_test.go` covering every exit path.

## Why

The old code registered:

```go
defer func() {
    defer func() { _ = recover() }()
    close(msgCh)
}()
```

…**and** called `close(msgCh)` explicitly on 7 return paths. Since the defer always runs, each explicit close was immediately followed by a deferred double-close that only survived via the inner `recover()`. That is panic-recovery as normal control flow — the exact anti-pattern "close exactly once, by the owner" exists to avoid — and it silently swallowed any genuine double-close bug.

Now the spawning goroutine is the sole owner and closes once on every return (including panic unwinding, which still unblocks `ForwardPTYMsgs` before the panic propagates to `safego.Run`, which logs it). A real double-close would now panic loudly instead of being hidden.

## Verification

- `grep -c 'close(msgCh)' internal/ui/common/pty_reader.go` → **1**.
- New tests drive cancel / EOF / error / max-pending-flush and assert exactly-once close + non-blocking drain (a double-close now panics with no recover to swallow it).
- `go test -race ./internal/ui/common/... ./internal/ui/center/... ./internal/ui/sidebar/...` pass; golangci-lint clean.
- Both callers (`center/model_pty_lifecycle.go`, `sidebar/terminal_pty_lifecycle.go`) create `msgCh` fresh per reader and range until close — behavior-preserving.

---

⚠️ Stacked on #212 — review/merge that first. Part of the maintainability series from an automated audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->