### PR TITLE
Route tab_actor tmux-tag write through safego.Go

### DIFF
--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/perf"
+	"github.com/andyrewlee/amux/internal/safego"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
@@ -449,9 +450,9 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 			opts := m.getTmuxOptions()
 			sessionName := tagSessionName
 			timestamp := strconv.FormatInt(tagTimestamp, 10)
-			go func() {
+			safego.Go("center.tmux_tag_write", func() {
 				_ = tmux.SetSessionTagValue(sessionName, tmux.TagLastOutputAt, timestamp, opts)
-			}()
+			})
 		}
 		if requestFlush && m.msgSink != nil {
 			m.msgSink(PTYFlush{WorkspaceID: ev.workspaceID, TabID: ev.tabID, CatchUp: ev.catchUp})


### PR DESCRIPTION
## What

Wraps the bare `go func()` in `handleTabEvent` (`tab_actor.go:452`) with `safego.Go("center.tmux_tag_write", ...)`.

## Why

This was the **only** goroutine under `internal/ui` that bypassed `safego.Go`. A panic inside it would propagate with no `recover()` and crash the TUI — defeating the app-wide `safego.SetPanicHandler` (`app_msgpump.go:24`) — and because it was unlabelled it was invisible in the SIGUSR1 goroutine dump (`cmd/amux/main.go`) and in `safego` panic logs.

`SetSessionTagValue` is a thin `os/exec` wrapper so a crash is unlikely; the value here is **consistency + observability**.

## Verification

- `grep -rn 'go func' internal/ui --include='*.go' | grep -v '_test.go'` → nothing.
- No behavior change: the write is already throttled 1/sec/tab via `activityTagThrottle`.
- `go build ./...`, `go test -race ./internal/ui/center/...` pass; golangci-lint clean.

---

⚠️ Stacked on #213. Part of the maintainability series from an automated audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->