### PR TITLE
Add a strict-on-changed complexity ratchet (funlen, gocyclo, nestif)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,4 +118,4 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           install-mode: goinstall
           verify: false
-          args: --config=.golangci.strict.yml --new-from-rev=${{ github.event.pull_request.base.sha }} --timeout=10m
+          args: --config=.golangci.strict.yml --enable=funlen --enable=gocyclo --enable=nestif --new-from-rev=${{ github.event.pull_request.base.sha }} --timeout=10m

--- a/.golangci.strict.yml
+++ b/.golangci.strict.yml
@@ -11,8 +11,6 @@ linters:
     - errcheck
     - errorlint
     - forbidigo
-    - funlen
-    - gocyclo
     - gofmt
     - gofumpt
     - govet
@@ -20,7 +18,6 @@ linters:
     - goimports
     - ineffassign
     - misspell
-    - nestif
     - nolintlint
     - perfsprint
     - revive

--- a/.golangci.strict.yml
+++ b/.golangci.strict.yml
@@ -11,6 +11,8 @@ linters:
     - errcheck
     - errorlint
     - forbidigo
+    - funlen
+    - gocyclo
     - gofmt
     - gofumpt
     - govet
@@ -18,6 +20,7 @@ linters:
     - goimports
     - ineffassign
     - misspell
+    - nestif
     - nolintlint
     - perfsprint
     - revive
@@ -53,6 +56,11 @@ linters-settings:
         msg: Use internal/logging for internal packages; stdout/stderr output is reserved for CLI entrypoints.
       - p: ^log\.(Print|Printf|Println|Fatal|Fatalf|Fatalln|Panic|Panicf|Panicln)$
         msg: Use internal/logging and explicit error returns instead of stdlib log side effects.
+  funlen:
+    lines: 120
+    statements: 60
+  gocyclo:
+    min-complexity: 30
   gofumpt:
     extra-rules: true
   goimports:
@@ -65,6 +73,8 @@ linters-settings:
       - unusedwrite
   misspell:
     locale: US
+  nestif:
+    min-complexity: 5
   nolintlint:
     require-explanation: true
     require-specific: true
@@ -116,4 +126,8 @@ issues:
       path: ^cmd/
     - linters:
         - forbidigo
+      path: _test\.go
+    # Table-driven tests legitimately exceed the function-length budget.
+    - linters:
+        - funlen
       path: _test\.go

--- a/LINTING.md
+++ b/LINTING.md
@@ -39,9 +39,10 @@ CI runs this strict profile for pull requests only, ratcheted to changed code vi
 
 ### Complexity ratchet
 
-The strict profile also gates function-level complexity. The 500-line file
-guard does nothing about oversized or deeply-nested *functions* inside
-sub-500-line files, so the strict profile adds:
+The changed-code strict ratchet also gates function-level complexity. The
+500-line file guard does nothing about oversized or deeply-nested *functions*
+inside sub-500-line files, so `make lint-strict-new` and the PR-only
+`lint-strict-pr` job enable:
 
 - `funlen` — `lines: 120`, `statements: 60` (excluded on `_test.go`, where
   table-driven tests legitimately run long)
@@ -49,10 +50,11 @@ sub-500-line files, so the strict profile adds:
 - `nestif` — `min-complexity: 5` (deeply nested `if` blocks; a different shape
   than `gocyclo` — a linear nested-`if` chain trips `nestif` but not `gocyclo`)
 
-Because the strict profile only runs `--new-from-rev`, every existing offender
-is grandfathered: these linters never fail on legacy code and only prevent
-*new* functions from exceeding the budget (and gently nudge ongoing
-decompositions). They are intentionally absent from baseline `.golangci.yml`.
+Because these complexity linters only run with `--new` or `--new-from-rev`,
+every existing offender is grandfathered: they never fail on legacy code and
+only prevent *new* functions from exceeding the budget (and gently nudge
+ongoing decompositions). They are intentionally absent from baseline
+`.golangci.yml` and from full-tree `make lint-strict`.
 
 ## Phase 3: Baseline Promotion + Escalation
 

--- a/LINTING.md
+++ b/LINTING.md
@@ -37,6 +37,23 @@ make lint-strict-new BASE=origin/main
 
 CI runs this strict profile for pull requests only, ratcheted to changed code via `--new-from-rev=<base-sha>`.
 
+### Complexity ratchet
+
+The strict profile also gates function-level complexity. The 500-line file
+guard does nothing about oversized or deeply-nested *functions* inside
+sub-500-line files, so the strict profile adds:
+
+- `funlen` — `lines: 120`, `statements: 60` (excluded on `_test.go`, where
+  table-driven tests legitimately run long)
+- `gocyclo` — `min-complexity: 30` (high-branching functions)
+- `nestif` — `min-complexity: 5` (deeply nested `if` blocks; a different shape
+  than `gocyclo` — a linear nested-`if` chain trips `nestif` but not `gocyclo`)
+
+Because the strict profile only runs `--new-from-rev`, every existing offender
+is grandfathered: these linters never fail on legacy code and only prevent
+*new* functions from exceeding the budget (and gently nudge ongoing
+decompositions). They are intentionally absent from baseline `.golangci.yml`.
+
 ## Phase 3: Baseline Promotion + Escalation
 
 Phase 3 promotes additional low-noise rules into baseline `.golangci.yml`:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ HARNESS_WIDTH ?= 160
 HARNESS_HEIGHT ?= 48
 HARNESS_SCROLLBACK_FRAMES ?= 600
 GOFUMPT ?= go run mvdan.cc/gofumpt@v0.9.2
+STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 
 .PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-file-length fmt fmt-check vet clean run dev devcheck help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets
 
@@ -52,10 +53,10 @@ lint-strict-new:
 	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint is required (install: https://golangci-lint.run/welcome/install/)"; exit 1)
 	@if [ -n "$(BASE)" ]; then \
 		echo "Running strict lint against changes since $(BASE)"; \
-		golangci-lint run -c .golangci.strict.yml --new-from-rev "$(BASE)" --timeout=10m; \
+		golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$(BASE)" --timeout=10m; \
 	else \
 		echo "Running strict lint on current unstaged/staged changes (--new)"; \
-		golangci-lint run -c .golangci.strict.yml --new --timeout=10m; \
+		golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m; \
 	fi
 
 lint-ci-parity: # CACHE_ROOT defaults to a gitignored local directory (/.cache/).
@@ -69,11 +70,11 @@ lint-ci-parity: # CACHE_ROOT defaults to a gitignored local directory (/.cache/)
 		BASE=$$(git merge-base HEAD "$$BASE_REF"); \
 		echo "Running CI-parity strict lint against changes since $$BASE_REF ($$BASE)"; \
 		OUTPUT=$$(mktemp); trap 'rm -f "$$OUTPUT"' EXIT INT TERM; \
-		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml --new-from-rev "$$BASE" --timeout=10m >"$$OUTPUT" 2>&1; then \
+		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m >"$$OUTPUT" 2>&1; then \
 				cat "$$OUTPUT"; \
 				if grep -q "no go files to analyze" "$$OUTPUT"; then \
 					echo "golangci-lint test loader failed locally; retrying with --tests=false"; \
-					if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml --new-from-rev "$$BASE" --timeout=10m --tests=false; then \
+					if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m --tests=false; then \
 						exit 1; \
 					fi; \
 				else \
@@ -84,11 +85,11 @@ lint-ci-parity: # CACHE_ROOT defaults to a gitignored local directory (/.cache/)
 	else \
 		echo "Base ref $$BASE_REF not found; falling back to strict lint on current unstaged/staged changes"; \
 		OUTPUT=$$(mktemp); trap 'rm -f "$$OUTPUT"' EXIT INT TERM; \
-		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml --new --timeout=10m >"$$OUTPUT" 2>&1; then \
+		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m >"$$OUTPUT" 2>&1; then \
 			cat "$$OUTPUT"; \
 			if grep -q "no go files to analyze" "$$OUTPUT"; then \
 				echo "golangci-lint test loader failed locally; retrying with --tests=false"; \
-				if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml --new --timeout=10m --tests=false; then \
+				if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m --tests=false; then \
 					exit 1; \
 				fi; \
 			else \


### PR DESCRIPTION
## What

Adds `funlen`, `gocyclo`, and `nestif` to **`.golangci.strict.yml` only** (the PR-ratcheted profile), with thresholds documented in `LINTING.md`. Merges the two tooling tickets (funlen + nestif/gocyclo) into one "strict complexity ratchet" PR.

| Linter | Threshold | Gates |
|---|---|---|
| `funlen` | `lines: 120`, `statements: 60` | oversized functions (excluded on `_test.go`) |
| `gocyclo` | `min-complexity: 30` | high-branching functions |
| `nestif` | `min-complexity: 5` | deeply nested `if` blocks |

## Why

The 500-line **file** guard does nothing about 200–370 line **functions** (`Model.Update`, `handleTabEvent`, `viewLayerBased`) inside sub-500 files. Because the strict profile runs with `--new-from-rev`, every existing offender is **grandfathered** — these linters never fail legacy code; they only stop *new* oversized/over-nested functions and nudge the ongoing decompositions. Base `.golangci.yml` is untouched, so the full-tree gate never fails on legacy code.

`gocyclo` and `nestif` catch different shapes: a linear nested-`if` chain trips `nestif` but not `gocyclo`.

## Verification

- `make lint-ci-parity` (the pre-push / `lint-strict-pr` command, `--new-from-rev=origin/main`) passes on the full stack — **no new issues**, confirming grandfathering and that PR #213/#214's changed code clears the new budgets.
- Sanity-checked that the ratchet *engages*: a deliberately 5-deep nested new function trips `nestif` (`complexity: 10`).
- Base full-tree `golangci-lint` unaffected; `make devcheck` clean.

---

⚠️ Stacked on #214. Part of the maintainability series from an automated audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->