### PR TITLE
Add a go.mod/go.sum tidy check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Tidy check
+        run: |
+          set -euo pipefail
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
       - name: Test
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Adds a `Tidy check` step to the CI `test` job (between Vet and Test) that runs `go mod tidy` and fails on any `go.mod`/`go.sum` diff.

```yaml
- name: Tidy check
  run: |
    set -euo pipefail
    go mod tidy
    git diff --exit-code go.mod go.sum
```

## Why

CI ran lint/test/vet/govulncheck but never verified the module graph was tidy. `goreleaser` only runs `go mod tidy` at **release** time, so an untidy `go.mod`/`go.sum` could sit on `main` undetected until a release silently changed the dependency set. The step reuses the job's Go (`go-version-file: go.mod`) so tidy output is toolchain-consistent.

## Verification

- Confirmed the tree is already tidy: `go mod tidy` produces no diff, so the guard is zero-friction on current `main`.
- Ran the step's exact commands locally → exit 0.
- `actionlint .github/workflows/ci.yml` → clean.

---

⚠️ Top of the stack — based on #215. Final PR of the suggested-first maintainability series from an automated audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->