### PR TITLE
Delete dead Canvas.DrawBorder and RenderTerminal* wrappers

### DIFF
--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -109,40 +109,6 @@ func (c *Canvas) DrawText(x, y int, text string, style vterm.Style) {
 	}
 }
 
-// DrawBorder draws a single or double line border.
-func (c *Canvas) DrawBorder(x, y, w, h int, style vterm.Style, focused bool) {
-	if w < 2 || h < 2 {
-		return
-	}
-
-	var tl, tr, bl, br, hline, vline rune
-	if focused {
-		tl, tr, bl, br = '╔', '╗', '╚', '╝'
-		hline, vline = '═', '║'
-	} else {
-		tl, tr, bl, br = '┌', '┐', '└', '┘'
-		hline, vline = '─', '│'
-	}
-
-	// Corners
-	c.SetCell(x, y, vterm.Cell{Rune: tl, Width: 1, Style: style})
-	c.SetCell(x+w-1, y, vterm.Cell{Rune: tr, Width: 1, Style: style})
-	c.SetCell(x, y+h-1, vterm.Cell{Rune: bl, Width: 1, Style: style})
-	c.SetCell(x+w-1, y+h-1, vterm.Cell{Rune: br, Width: 1, Style: style})
-
-	// Horizontal lines
-	for cx := x + 1; cx < x+w-1; cx++ {
-		c.SetCell(cx, y, vterm.Cell{Rune: hline, Width: 1, Style: style})
-		c.SetCell(cx, y+h-1, vterm.Cell{Rune: hline, Width: 1, Style: style})
-	}
-
-	// Vertical lines
-	for cy := y + 1; cy < y+h-1; cy++ {
-		c.SetCell(x, cy, vterm.Cell{Rune: vline, Width: 1, Style: style})
-		c.SetCell(x+w-1, cy, vterm.Cell{Rune: vline, Width: 1, Style: style})
-	}
-}
-
 // CursorState holds cursor position and visibility for DrawScreen.
 type CursorState struct {
 	X, Y    int
@@ -271,11 +237,6 @@ func (c *Canvas) Render() string {
 	return b.String()
 }
 
-// RenderTerminal renders a vterm into a canvas and returns the ANSI string.
-func RenderTerminal(term *vterm.VTerm, width, height int, showCursor bool, fg, bg vterm.Color) string {
-	return RenderTerminalWithCanvas(nil, term, width, height, showCursor, fg, bg)
-}
-
 // RenderSnapshotWithCanvas renders a vterm snapshot into a reusable canvas.
 func RenderSnapshotWithCanvas(canvas *Canvas, snap *VTermSnapshot, width, height int, fg, bg vterm.Color) string {
 	if snap == nil {
@@ -318,15 +279,6 @@ func RenderSnapshotWithCanvas(canvas *Canvas, snap *VTermSnapshot, width, height
 		},
 	)
 	return canvas.Render()
-}
-
-// RenderTerminalWithCanvas renders a vterm into a reusable canvas.
-func RenderTerminalWithCanvas(canvas *Canvas, term *vterm.VTerm, width, height int, showCursor bool, fg, bg vterm.Color) string {
-	if term == nil || width <= 0 || height <= 0 {
-		return ""
-	}
-	snap := NewVTermSnapshot(term, showCursor)
-	return RenderSnapshotWithCanvas(canvas, snap, width, height, fg, bg)
 }
 
 // HexColor converts a #RRGGBB string to a vterm.Color.

--- a/internal/ui/compositor/canvas_test.go
+++ b/internal/ui/compositor/canvas_test.go
@@ -43,7 +43,7 @@ func TestCanvasRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
 	}
 }
 
-func TestRenderTerminalWithCanvasClampsOffscreenSelection(t *testing.T) {
+func TestRenderSnapshotWithCanvasClampsOffscreenSelection(t *testing.T) {
 	width, height := 5, 3
 	term := vterm.New(width, height)
 	term.Scrollback = [][]vterm.Cell{
@@ -61,7 +61,7 @@ func TestRenderTerminalWithCanvasClampsOffscreenSelection(t *testing.T) {
 	term.SetSelection(2, 1, 3, 6, true, false)
 
 	canvas := NewCanvas(width, height)
-	RenderTerminalWithCanvas(canvas, term, width, height, false, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
+	RenderSnapshotWithCanvas(canvas, NewVTermSnapshot(term, false), width, height, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
 
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
@@ -72,7 +72,7 @@ func TestRenderTerminalWithCanvasClampsOffscreenSelection(t *testing.T) {
 	}
 }
 
-func TestRenderTerminalWithCanvasClampsStartAboveViewport(t *testing.T) {
+func TestRenderSnapshotWithCanvasClampsStartAboveViewport(t *testing.T) {
 	width, height := 5, 3
 	term := vterm.New(width, height)
 	term.Scrollback = [][]vterm.Cell{
@@ -90,7 +90,7 @@ func TestRenderTerminalWithCanvasClampsStartAboveViewport(t *testing.T) {
 	term.SetSelection(3, 1, 1, 4, true, false)
 
 	canvas := NewCanvas(width, height)
-	RenderTerminalWithCanvas(canvas, term, width, height, false, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
+	RenderSnapshotWithCanvas(canvas, NewVTermSnapshot(term, false), width, height, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
 
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
@@ -116,7 +116,7 @@ func TestRenderTerminalWithCanvasClampsStartAboveViewport(t *testing.T) {
 	}
 }
 
-func TestRenderTerminalWithCanvasClampsEndBelowViewport(t *testing.T) {
+func TestRenderSnapshotWithCanvasClampsEndBelowViewport(t *testing.T) {
 	width, height := 5, 3
 	term := vterm.New(width, height)
 	term.Scrollback = [][]vterm.Cell{
@@ -134,7 +134,7 @@ func TestRenderTerminalWithCanvasClampsEndBelowViewport(t *testing.T) {
 	term.SetSelection(2, 3, 1, 6, true, false)
 
 	canvas := NewCanvas(width, height)
-	RenderTerminalWithCanvas(canvas, term, width, height, false, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
+	RenderSnapshotWithCanvas(canvas, NewVTermSnapshot(term, false), width, height, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
 
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
@@ -156,7 +156,7 @@ func TestRenderTerminalWithCanvasClampsEndBelowViewport(t *testing.T) {
 	}
 }
 
-func TestRenderTerminalWithCanvasReverseSelectionAnchor(t *testing.T) {
+func TestRenderSnapshotWithCanvasReverseSelectionAnchor(t *testing.T) {
 	width, height := 5, 3
 	term := vterm.New(width, height)
 	term.Scrollback = [][]vterm.Cell{
@@ -174,7 +174,7 @@ func TestRenderTerminalWithCanvasReverseSelectionAnchor(t *testing.T) {
 	term.SetSelection(4, 5, 1, 3, true, false)
 
 	canvas := NewCanvas(width, height)
-	RenderTerminalWithCanvas(canvas, term, width, height, false, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
+	RenderSnapshotWithCanvas(canvas, NewVTermSnapshot(term, false), width, height, vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault})
 
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {


### PR DESCRIPTION
## What

Removes three unused symbols from the compositor render package and repoints the affected tests at the live API.

- `Canvas.DrawBorder` — ~30-line box-drawing routine, **zero references** anywhere.
- `RenderTerminal` — thin wrapper forwarding to `RenderTerminalWithCanvas(nil, ...)`, **zero callers**.
- `RenderTerminalWithCanvas` — **no production callers**; only `canvas_test.go` used it.

The only production render path is `RenderSnapshotWithCanvas` (`center/model_render.go`). The four `canvas_test.go` sites now call it directly — they already passed `showCursor=false` + default fg/bg, so test semantics are identical — and the tests are renamed `TestRenderSnapshotWithCanvas*`.

## Verification

- `grep -rn 'RenderTerminal(' internal/` → none; `RenderTerminalWithCanvas`/`DrawBorder` → none.
- `go build ./...`, `go vet`, `go test -race ./internal/ui/compositor/` pass; golangci-lint clean; `canvas.go` 295 lines.

---

⚠️ Stacked on #216. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->