### PR TITLE
Remove unadopted non-ctx git wrappers RunGitAllowFailure and RunGitRaw

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -86,7 +86,7 @@ func GetFileDiff(repoPath, path string, mode DiffMode) (*DiffResult, error) {
 func GetUntrackedFileContent(repoPath, path string) (*DiffResult, error) {
 	fullPath := repoPath + "/" + path
 
-	// Use RunGitAllowFailure since --no-index returns exit code 1 when differences exist
+	// Use RunGitAllowFailureCtx since --no-index returns exit code 1 when differences exist
 	ctx, cancel := context.WithTimeout(context.Background(), diffTimeout)
 	defer cancel()
 	output, err := RunGitAllowFailureCtx(ctx, repoPath, "diff", "--no-index", "--no-color", "--", "/dev/null", fullPath)

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -90,12 +90,6 @@ func GetRemoteURL(path, remote string) (string, error) {
 	return RunGitCtx(context.Background(), path, "remote", "get-url", remote)
 }
 
-// RunGitAllowFailure executes git and returns stdout even if exit code is non-zero.
-// Use for commands like `git diff --no-index` which return 1 when differences exist.
-func RunGitAllowFailure(dir string, args ...string) (string, error) {
-	return RunGitAllowFailureCtx(context.Background(), dir, args...)
-}
-
 // RunGitAllowFailureCtx executes git and returns stdout even if exit code is non-zero.
 // Use for commands like `git diff --no-index` which return 1 when differences exist.
 func RunGitAllowFailureCtx(ctx context.Context, dir string, args ...string) (string, error) {
@@ -128,12 +122,6 @@ func RunGitAllowFailureCtx(ctx context.Context, dir string, args ...string) (str
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
-}
-
-// RunGitRaw executes a git command and returns raw bytes without trimming.
-// Use this for commands with -z output that use NUL separators.
-func RunGitRaw(dir string, args ...string) ([]byte, error) {
-	return RunGitRawCtx(context.Background(), dir, args...)
 }
 
 // RunGitRawCtx executes a git command and returns raw bytes without trimming.


### PR DESCRIPTION
## What

Deletes `RunGitAllowFailure` and `RunGitRaw` from `internal/git/operations.go` and fixes a stale comment in `diff.go`.

## Why

Both were context-free shims that just called their `*Ctx` counterpart with `context.Background()`. The codebase standardized on the `*Ctx` variants, and these two had **zero references** anywhere (production or tests). `RunGitAllowFailureCtx` / `RunGitRawCtx` remain.

`diff.go:89`'s comment ("Use `RunGitAllowFailure`…") was already stale — the call below it uses `RunGitAllowFailureCtx` — so it's updated to match.

## Verification

- `grep` for `RunGitAllowFailure(` / `RunGitRaw(` (excluding `*Ctx`) → none.
- `RunGit` (plain, non-ctx) left untouched — still referenced by `workspace_integration_test.go` and `model_tabs_diff_reuse_test.go`.
- `context` import remains used (`RunGit`/`RunGitCtx`). `go build ./...`, `go test -race ./internal/git/` pass; golangci-lint clean.

---

⚠️ Stacked on #217. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->