### PR TITLE
Delete dead theme/style helpers

### DIFF
--- a/internal/ui/common/colors.go
+++ b/internal/ui/common/colors.go
@@ -34,10 +34,8 @@ func ColorInfo() color.Color      { return themePtr.Load().Colors.Info }
 func ColorSurface0() color.Color { return themePtr.Load().Colors.Surface0 }
 func ColorSurface1() color.Color { return themePtr.Load().Colors.Surface1 }
 func ColorSurface2() color.Color { return themePtr.Load().Colors.Surface2 }
-func ColorSurface3() color.Color { return themePtr.Load().Colors.Surface3 }
 
 func ColorSelection() color.Color { return themePtr.Load().Colors.Selection }
-func ColorHighlight() color.Color { return themePtr.Load().Colors.Highlight }
 
 // Agent colors remain constant across themes for brand recognition.
 var (

--- a/internal/ui/common/icons.go
+++ b/internal/ui/common/icons.go
@@ -84,27 +84,3 @@ var Icons = struct {
 func SpinnerFrame(frame int) string {
 	return Icons.Spinner[frame%len(Icons.Spinner)]
 }
-
-// FileStatusIcon returns an icon and description for git file status
-func FileStatusIcon(status string) (icon, desc string) {
-	switch status {
-	case "M":
-		return "M", "modified"
-	case "A":
-		return "A", "added"
-	case "D":
-		return "D", "deleted"
-	case "R":
-		return "R", "renamed"
-	case "C":
-		return "C", "copied"
-	case "U":
-		return "U", "unmerged"
-	case "??":
-		return "A", "new file"
-	case "!!":
-		return "!", "ignored"
-	default:
-		return "?", "unknown"
-	}
-}

--- a/internal/ui/common/styles.go
+++ b/internal/ui/common/styles.go
@@ -314,16 +314,3 @@ func DefaultStyles() Styles {
 			Foreground(ColorBackground()),
 	}
 }
-
-// RenderHelpBar renders a help bar with the given key-description pairs
-func RenderHelpBar(s Styles, items []struct{ Key, Desc string }, width int) string {
-	var parts []string
-	for _, item := range items {
-		key := s.HelpKey.Render(item.Key)
-		desc := s.HelpDesc.Render(item.Desc)
-		parts = append(parts, key+":"+desc)
-	}
-
-	joined := lipgloss.JoinHorizontal(lipgloss.Center, parts...)
-	return s.Help.Width(width).Render(joined)
-}


### PR DESCRIPTION
## What

Removes four exported helpers in `internal/ui/common` that had **zero callers**:

- `ColorSurface3()` / `ColorHighlight()` accessors (`colors.go`)
- `FileStatusIcon()` (`icons.go`)
- `RenderHelpBar()` (`styles.go`) — which baked in an awkward inline `[]struct{ Key, Desc string }` param no caller exercised

## Why

Pure dead surface. The `Surface0/1/2` accessors *are* used, but `Surface3`/`Highlight` never were.

## Verification

- Each symbol had only its own definition in `grep -rn` across `internal/` and `cmd/`.
- **Kept** the underlying `Theme.Colors.Surface3`/`Highlight` struct fields — they define the theme shape and are populated per variant (`theme.go`, `theme_light.go`, `theme_dark.go`).
- No orphaned imports (`lipgloss` still has 121 uses in `styles.go`); `gofumpt`/`goimports` clean.
- `go build ./...`, `go test ./internal/ui/common/` pass; golangci-lint clean.

---

⚠️ Stacked on #218. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->