### PR TITLE
Remove unused logging.WithError and Updater.Version helpers

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -172,13 +172,6 @@ func Error(format string, args ...any) {
 	log(LevelError, format, args...)
 }
 
-// WithError logs an error with context
-func WithError(err error, context string) {
-	if err != nil {
-		log(LevelError, "%s: %v", context, err)
-	}
-}
-
 // Close closes the log file
 func Close() error {
 	if defaultLogger != nil && defaultLogger.writer != nil {

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -168,8 +168,3 @@ func (u *Updater) Upgrade(release *Release) error {
 	logging.Info("Upgrade complete: %s", release.TagName)
 	return nil
 }
-
-// Version returns the current version.
-func (u *Updater) Version() string {
-	return u.version
-}


### PR DESCRIPTION
## What

Deletes two dead exported helpers:

- `logging.WithError(err, context)` (`logger.go`)
- `(*Updater).Version()` (`updater.go`)

## Why

`WithError` had no callers — all error logging routes through `Error`/`Warn`. `(*Updater).Version()` had no callers either.

## Verification

- Each had only its own definition in `grep -rn` across `internal/`/`cmd/`.
- **Not** touched: the `internal/update` `Version` *value type* and its methods (`ParseVersion`/`String`/`Compare`/`LessThan`) — those are used (`updater.go` calls `ParseVersion`). Distinct from VTerm/Terminal `.Version()`.
- The `Updater.version` field is still read by the update-check logic (5 sites), so it isn't orphaned.
- `go build ./...`, `go test ./internal/logging/... ./internal/update/...` pass; golangci-lint clean.

---

⚠️ Stacked on #219. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->