### PR TITLE
Delete unused vterm LoadPaneCaptureWithCursor wrapper

### DIFF
--- a/internal/vterm/pane_capture_modes_test.go
+++ b/internal/vterm/pane_capture_modes_test.go
@@ -355,7 +355,7 @@ func TestLoadPaneCaptureWithCursor_PreservesExistingAltScreenStateWhenModesUnkno
 	vt.enterAltScreen()
 	vt.Write([]byte("tui"))
 
-	vt.LoadPaneCaptureWithCursor([]byte("one\ntwo\nthree"), 0, 2, true)
+	vt.LoadPaneCaptureWithCursorAndModes([]byte("one\ntwo\nthree"), 0, 2, true, PaneModeState{PreserveExistingState: true})
 
 	if !vt.AltScreen {
 		t.Fatal("expected capture without pane modes to preserve existing alt-screen state")

--- a/internal/vterm/prepend_scrollback_test.go
+++ b/internal/vterm/prepend_scrollback_test.go
@@ -305,7 +305,7 @@ func TestLoadPaneCapture_RestoresCursorFromCaptureWhenMetadataUnavailable(t *tes
 func TestLoadPaneCaptureWithCursor_RestoresExplicitCursor(t *testing.T) {
 	vt := New(20, 2)
 
-	vt.LoadPaneCaptureWithCursor([]byte("history\nscreen one\nscreen two\n"), 5, 1, true)
+	vt.LoadPaneCaptureWithCursorAndModes([]byte("history\nscreen one\nscreen two\n"), 5, 1, true, PaneModeState{PreserveExistingState: true})
 
 	if vt.CursorX != 5 || vt.CursorY != 1 {
 		t.Fatalf("expected explicit pane cursor to be restored, got (%d,%d)", vt.CursorX, vt.CursorY)
@@ -348,7 +348,7 @@ func TestLoadPaneCapture_EmptyCaptureClearsFrameAndParserState(t *testing.T) {
 	vt.Write([]byte("stale"))
 	vt.Write([]byte("\x1b["))
 
-	vt.LoadPaneCaptureWithCursor(nil, 3, 0, true)
+	vt.LoadPaneCaptureWithCursorAndModes(nil, 3, 0, true, PaneModeState{PreserveExistingState: true})
 
 	if len(vt.Scrollback) != 0 {
 		t.Fatalf("expected empty authoritative snapshot to clear scrollback, got %d lines", len(vt.Scrollback))
@@ -384,7 +384,7 @@ func TestLoadPaneCapture_EmptyCaptureClearsAltScreenScrollback(t *testing.T) {
 	vt.enterAltScreen()
 	vt.Write([]byte("stale"))
 
-	vt.LoadPaneCaptureWithCursor(nil, 0, 0, true)
+	vt.LoadPaneCaptureWithCursorAndModes(nil, 0, 0, true, PaneModeState{PreserveExistingState: true})
 
 	if len(vt.Scrollback) != 0 {
 		t.Fatalf("expected empty authoritative snapshot to clear stale alt-screen scrollback, got %d lines", len(vt.Scrollback))

--- a/internal/vterm/vterm_scroll.go
+++ b/internal/vterm/vterm_scroll.go
@@ -309,13 +309,6 @@ func (v *VTerm) LoadPaneCapture(data []byte) {
 	v.LoadPaneCaptureWithCursorAndModes(data, 0, 0, false, PaneModeState{PreserveExistingState: true})
 }
 
-// LoadPaneCaptureWithCursor replaces the terminal screen + scrollback with a
-// full tmux pane capture and applies a separately captured tmux cursor position
-// when one is available.
-func (v *VTerm) LoadPaneCaptureWithCursor(data []byte, cursorX, cursorY int, hasCursor bool) {
-	v.LoadPaneCaptureWithCursorAndModes(data, cursorX, cursorY, hasCursor, PaneModeState{PreserveExistingState: true})
-}
-
 // LoadPaneCaptureWithCursorAndModes replaces the terminal screen + scrollback
 // with a full tmux pane capture and applies the accompanying tmux VT mode state
 // when one is available.


### PR DESCRIPTION
## What

Removes the middle of three telescoping pane-capture loaders, `(*VTerm).LoadPaneCaptureWithCursor`, and repoints its four test sites at the real entry point.

## Why

`LoadPaneCaptureWithCursor` had **no production callers** — only vterm's own tests. It was a thin forward to `LoadPaneCaptureWithCursorAndModes(data, x, y, has, PaneModeState{PreserveExistingState: true})`. The other two loaders stay: `LoadPaneCapture` (used by other packages' tests) and `LoadPaneCaptureWithCursorAndModes` (the production entry point, `session_restore.go`).

## Verification

- The four test sites (`prepend_scrollback_test.go:308/351/387`, `pane_capture_modes_test.go:358`) now call `LoadPaneCaptureWithCursorAndModes` with the exact `PaneModeState` the wrapper supplied — behavior-preserving.
- `grep` confirms no `LoadPaneCaptureWithCursor` (non-`AndModes`) references remain.
- `go build ./...`, `go test -race ./internal/vterm/` pass; gofumpt + golangci-lint clean.

---

⚠️ Stacked on #220. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->