### PR TITLE
Drop redundant installSupervisorErrorHandler call in SetMsgSender

### DIFF
--- a/internal/app/app_msgpump.go
+++ b/internal/app/app_msgpump.go
@@ -28,7 +28,6 @@ func (a *App) SetMsgSender(send func(tea.Msg)) {
 			err := fmt.Errorf("background panic in %s: %v", name, recovered)
 			a.enqueueExternalMsg(messages.Error{Err: err, Context: errorContext(errorServiceApp, "background")})
 		})
-		a.installSupervisorErrorHandler()
 		if a.supervisor != nil {
 			a.supervisor.Start("app.external_msgs", a.runExternalMsgs)
 			return


### PR DESCRIPTION
## What

Removes the second `a.installSupervisorErrorHandler()` call (inside `SetMsgSender`), keeping the one in `App.New()`.

## Why

`installSupervisorErrorHandler` was called twice:
1. `app_init.go:128` — during `App.New()`, right after `supervisor.New`, before any `Start` or worker goroutine.
2. `app_msgpump.go:31` — inside `SetMsgSender`, re-installing a byte-for-byte identical closure.

`SetErrorHandler` just sets a field, so the second call is dead work.

## Not a concurrency fix

There was no data race: `New()` → `SetMsgSender` run in order on the single main goroutine, and `supervisor.Start` reads `onError` synchronously before spawning workers. This is pure dead-code removal — **no mutex or `-race` test added** for it.

## Verification

- Exactly one call site remains (`app_init.go:128`).
- `go build ./...`, `go test -race ./internal/app/... ./internal/supervisor/...` pass; golangci-lint clean.

---

⚠️ Stacked on #221. Dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->