### PR TITLE
Strip unused UV-buffer render path from internal/e2e/render.go

### DIFF
--- a/internal/e2e/render.go
+++ b/internal/e2e/render.go
@@ -3,65 +3,8 @@ package e2e
 import (
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
-	uv "github.com/charmbracelet/ultraviolet"
-	"github.com/charmbracelet/x/ansi"
-
 	"github.com/andyrewlee/amux/internal/vterm"
 )
-
-const (
-	syncBegin = "\x1b[?2026h"
-	syncEnd   = "\x1b[?2026l"
-)
-
-// RenderViewToBuffer renders a tea.View into a UV buffer for inspection.
-func RenderViewToBuffer(view tea.View, width, height int) *uv.Buffer {
-	if width <= 0 {
-		width = 1
-	}
-	if height <= 0 {
-		height = 1
-	}
-	content := view.Content
-	if content != "" {
-		content = strings.ReplaceAll(content, syncBegin, "")
-		content = strings.ReplaceAll(content, syncEnd, "")
-		content = normalizeSnapshotContent(content)
-	}
-	buf := uv.NewBuffer(width, height)
-	styled := uv.NewStyledString(content)
-	screen := bufferScreen{Buffer: buf}
-	styled.Draw(screen, uv.Rect(0, 0, width, height))
-	return screen.Buffer
-}
-
-// BufferToASCII converts a UV buffer to ASCII text. Trailing spaces are trimmed.
-func BufferToASCII(buf *uv.Buffer) string {
-	if buf == nil {
-		return ""
-	}
-	lines := make([]string, 0, len(buf.Lines))
-	for _, line := range buf.Lines {
-		var b strings.Builder
-		for _, cell := range line {
-			if cell.Width == 0 {
-				continue
-			}
-			content := cell.Content
-			if content == "" {
-				content = " "
-			}
-			if !isASCII(content) {
-				b.WriteByte('?')
-				continue
-			}
-			b.WriteString(content)
-		}
-		lines = append(lines, strings.TrimRight(b.String(), " "))
-	}
-	return strings.Join(lines, "\n")
-}
 
 // CellsToASCII converts a vterm screen buffer to ASCII text.
 func CellsToASCII(screen [][]vterm.Cell) string {
@@ -88,33 +31,4 @@ func CellsToASCII(screen [][]vterm.Cell) string {
 		lines = append(lines, strings.TrimRight(b.String(), " "))
 	}
 	return strings.Join(lines, "\n")
-}
-
-func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] > 0x7f {
-			return false
-		}
-	}
-	return true
-}
-
-func normalizeSnapshotContent(s string) string {
-	if s == "" {
-		return s
-	}
-	return strings.Map(func(r rune) rune {
-		if r > 0x7f {
-			return '?'
-		}
-		return r
-	}, s)
-}
-
-type bufferScreen struct {
-	*uv.Buffer
-}
-
-func (b bufferScreen) WidthMethod() uv.WidthMethod {
-	return ansi.GraphemeWidth
 }


### PR DESCRIPTION
## What

Removes the dead UV-buffer rendering path from `internal/e2e/render.go`, leaving only the live `CellsToASCII` (used by `e2e/pty.go`). The file goes 121 → 34 lines.

Deleted: `RenderViewToBuffer`, `BufferToASCII`, `isASCII`, `normalizeSnapshotContent`, the `bufferScreen` type + `WidthMethod`, and the `syncBegin`/`syncEnd` consts — plus the now-unused `tea`, `ultraviolet`, and `ansi` imports.

## Why

Two parallel render paths existed but only `CellsToASCII` had a caller. The UV path was the sole consumer of the three heavy imports and had zero references anywhere in the e2e package or its tests.

## Verification

- Each removed symbol had 0 references outside `render.go`; `CellsToASCII` had exactly 1 (pty.go).
- No other e2e file imports `ultraviolet`/`bubbletea`/`x/ansi`.
- `go build ./...`, `go vet`, and `go test ./internal/e2e/` (real tmux) pass; gofumpt + goimports + golangci-lint clean.

---

⚠️ Stacked on #222. Final PR of the dead-code batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->