### PR TITLE
Add runTmux helper to collapse duplicated exit-1-suppressing blocks

### DIFF
--- a/internal/tmux/activity.go
+++ b/internal/tmux/activity.go
@@ -171,28 +171,12 @@ func ActiveAgentSessionsByActivity(window time.Duration, opts Options) ([]Sessio
 // Called once at startup and when the tmux server name changes,
 // rather than on every activity scan.
 func SetMonitorActivityOn(opts Options) error {
-	cmd, cancel := tmuxCommand(opts, "set-option", "-g", "monitor-activity", "on")
-	defer cancel()
-	if err := cmd.Run(); err != nil {
-		if isExitCode1(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return runTmux(opts, "set-option", "-g", "monitor-activity", "on")
 }
 
 // SetStatusOff disables the tmux status line globally for the server.
 func SetStatusOff(opts Options) error {
-	cmd, cancel := tmuxCommand(opts, "set-option", "-g", "status", "off")
-	defer cancel()
-	if err := cmd.Run(); err != nil {
-		if isExitCode1(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return runTmux(opts, "set-option", "-g", "status", "off")
 }
 
 // ContentHash returns a fast hash of the content for change detection.

--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -287,7 +287,7 @@ func ResizePaneToSize(sessionName string, cols, rows int, opts Options) error {
 	if !exists {
 		return nil
 	}
-	cmd, cancel := tmuxCommand(
+	return runTmux(
 		opts,
 		"resize-window",
 		"-t",
@@ -297,14 +297,6 @@ func ResizePaneToSize(sessionName string, cols, rows int, opts Options) error {
 		"-y",
 		strconv.Itoa(rows),
 	)
-	defer cancel()
-	if err := cmd.Run(); err != nil {
-		if isExitCode1(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
 }
 
 // CapturePane captures the scrollback history of a tmux pane (excluding the

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -181,6 +181,21 @@ func tmuxCommand(opts Options, args ...string) (*exec.Cmd, context.CancelFunc) {
 	return cmd, cancel
 }
 
+// runTmux runs a fire-and-forget tmux command, treating tmux's exit code 1
+// ("not found": no session/server) as success. Use for mutations where a
+// missing target should not surface as an error.
+func runTmux(opts Options, args ...string) error {
+	cmd, cancel := tmuxCommand(opts, args...)
+	defer cancel()
+	if err := cmd.Run(); err != nil {
+		if isExitCode1(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func hasSession(sessionName string, opts Options) (bool, error) {
 	cmd, cancel := tmuxCommand(opts, "has-session", "-t", sessionTarget(sessionName))
 	defer cancel()
@@ -234,15 +249,7 @@ func KillSession(sessionName string, opts Options) error {
 			_ = process.KillProcessGroup(pid, process.KillOptions{})
 		}
 	}
-	cmd, cancel := tmuxCommand(opts, "kill-session", "-t", sessionTarget(sessionName))
-	defer cancel()
-	if err := cmd.Run(); err != nil {
-		if isExitCode1(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return runTmux(opts, "kill-session", "-t", sessionTarget(sessionName))
 }
 
 // panePIDs returns the PID of each pane's initial process in the given session.


### PR DESCRIPTION
## What

Adds `runTmux(opts, args...)` next to `tmuxCommand` and rewrites four fire-and-forget tmux mutation sites to one call each:

- `SetMonitorActivityOn` / `SetStatusOff` (`activity.go`)
- `ResizePaneToSize` tail (`capture.go`)
- `KillSession` tail (`tmux.go`)

## Why

`SetMonitorActivityOn` and `SetStatusOff` were byte-identical except for the arg list, and the resize/kill tails repeated the same `tmuxCommand → defer cancel → Run → isExitCode1 ? nil : err` boilerplate. The helper encodes the "tmux exit code 1 means the target is gone → treat as success" convention in one place. Net −17 lines.

## Scope guardrails

Left untouched (different contracts): `hasSession`/`hasLivePane` (return `bool, error`), `send.go` (no exit-1 suppression), and any `cmd.Output()`/`CombinedOutput()` sites. `ResizePaneToSize` keeps its `hasSession` precheck; `KillSession` keeps its `EnsureAvailable` + pane-tree-kill logic.

## Verification

- `runTmux`: 1 definition + 4 call sites.
- `go build ./...`, `go vet`, `go test ./internal/tmux/` (real tmux) pass; gofumpt + golangci-lint clean.

---

⚠️ Stacked on #223. First of the duplication-extraction batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->