### PR TITLE
Extract CopyToClipboardWithLog helper for the 5 selection-copy sites

### DIFF
--- a/internal/ui/center/model_input.go
+++ b/internal/ui/center/model_input.go
@@ -133,17 +133,12 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				}
 			}
 			tab.mu.Lock()
+			text := ""
 			if tab.Terminal != nil && tab.Terminal.HasSelection() {
-				text := tab.Terminal.SelectedText()
-				if text != "" {
-					if err := common.CopyToClipboard(text); err != nil {
-						logging.Error("Failed to copy to clipboard: %v", err)
-					} else {
-						logging.Info("Cmd+C copied %d chars to clipboard", len(text))
-					}
-				}
+				text = tab.Terminal.SelectedText()
 			}
 			tab.mu.Unlock()
+			common.CopyToClipboardWithLog(text, "Cmd+C clipboard")
 			return m, nil // Don't forward to terminal, don't clear selection
 		}
 

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -245,13 +245,7 @@ func (m *Model) updateWorkspaceDeleted(msg messages.WorkspaceDeleted) (*Model, t
 
 // updateTabSelectionResult handles tabSelectionResult.
 func (m *Model) updateTabSelectionResult(msg tabSelectionResult) (*Model, tea.Cmd) {
-	if msg.clipboard != "" {
-		if err := common.CopyToClipboard(msg.clipboard); err != nil {
-			logging.Error("Failed to copy to clipboard: %v", err)
-		} else {
-			logging.Info("Copied %d chars to clipboard", len(msg.clipboard))
-		}
-	}
+	common.CopyToClipboardWithLog(msg.clipboard, "clipboard")
 	return m, nil
 }
 

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -5,7 +5,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/diff"
 )
@@ -195,23 +194,18 @@ func (m *Model) updateMouseRelease(msg tea.MouseReleaseMsg) (*Model, tea.Cmd) {
 		}
 	}
 	tab.mu.Lock()
+	text := ""
 	if tab.Selection.Active {
 		if tab.Terminal != nil &&
 			(tab.Selection.StartX != tab.Selection.EndX ||
 				tab.Selection.StartLine != tab.Selection.EndLine) {
-			text := tab.Terminal.SelectedText()
-			if text != "" {
-				if err := common.CopyToClipboard(text); err != nil {
-					logging.Error("Failed to copy to clipboard: %v", err)
-				} else {
-					logging.Info("Copied %d chars to clipboard", len(text))
-				}
-			}
+			text = tab.Terminal.SelectedText()
 		}
 		tab.Selection.Active = false
 		tab.selectionScroll.Reset()
 	}
 	tab.mu.Unlock()
+	common.CopyToClipboardWithLog(text, "clipboard")
 	return m, common.SafeBatch(cmds...)
 }
 

--- a/internal/ui/common/clipboard.go
+++ b/internal/ui/common/clipboard.go
@@ -6,7 +6,24 @@ import (
 	"strings"
 
 	"github.com/atotto/clipboard"
+
+	"github.com/andyrewlee/amux/internal/logging"
 )
+
+// CopyToClipboardWithLog copies text to the clipboard (a no-op for empty text),
+// logging success or failure with label for context. It shells out to pbcopy on
+// macOS, so callers MUST NOT hold a tab/terminal mutex while calling it — capture
+// the text under the lock, release it, then call this.
+func CopyToClipboardWithLog(text, label string) {
+	if text == "" {
+		return
+	}
+	if err := CopyToClipboard(text); err != nil {
+		logging.Error("Failed to copy %s: %v", label, err)
+		return
+	}
+	logging.Info("Copied %d chars (%s)", len(text), label)
+}
 
 // CopyToClipboard writes text to the system clipboard with a macOS pbcopy fallback.
 func CopyToClipboard(text string) error {

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -5,7 +5,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -244,25 +243,20 @@ func (m *TerminalModel) handleMouseRelease(msg tea.MouseReleaseMsg) (*TerminalMo
 	}
 
 	ts.mu.Lock()
+	text := ""
 	if ts.Selection.Active {
 		// Only copy if selection spans more than a single point
 		if ts.VTerm != nil &&
 			(ts.Selection.StartX != ts.Selection.EndX ||
 				ts.Selection.StartLine != ts.Selection.EndLine) {
-			text := ts.VTerm.SelectedText()
-			if text != "" {
-				if err := common.CopyToClipboard(text); err != nil {
-					logging.Error("Failed to copy sidebar selection: %v", err)
-				} else {
-					logging.Info("Copied %d chars from sidebar", len(text))
-				}
-			}
+			text = ts.VTerm.SelectedText()
 			// Keep selection visible - don't clear it
 		}
 		ts.Selection.Active = false
 		ts.selectionScroll.Reset()
 	}
 	ts.mu.Unlock()
+	common.CopyToClipboardWithLog(text, "sidebar selection")
 
 	return m, nil
 }

--- a/internal/ui/sidebar/terminal_update.go
+++ b/internal/ui/sidebar/terminal_update.go
@@ -98,17 +98,12 @@ func (m *TerminalModel) Update(msg tea.Msg) (*TerminalModel, tea.Cmd) {
 		// Handle explicit Cmd+C to copy current selection
 		if isCopyKey {
 			ts.mu.Lock()
+			text := ""
 			if ts.VTerm != nil && ts.VTerm.HasSelection() {
-				text := ts.VTerm.SelectedText()
-				if text != "" {
-					if err := common.CopyToClipboard(text); err != nil {
-						logging.Error("Failed to copy to clipboard: %v", err)
-					} else {
-						logging.Info("Cmd+C copied %d chars from sidebar", len(text))
-					}
-				}
+				text = ts.VTerm.SelectedText()
 			}
 			ts.mu.Unlock()
+			common.CopyToClipboardWithLog(text, "Cmd+C sidebar")
 			return m, nil // Don't forward to terminal, don't clear selection
 		}
 


### PR DESCRIPTION
## What

Adds `common.CopyToClipboardWithLog(text, label)` and collapses the five duplicated clipboard-write + log blocks (center + sidebar selection handlers) to one call each, passing a per-site label.

## Why

The `CopyToClipboard(text)` + `Error`/`Info` log block was duplicated five times, varying only by the log string.

**Concurrency improvement (the reason this isn't a pure swap):** four of the five sites called `CopyToClipboard` *while holding* the tab/terminal mutex — shelling out to `pbcopy` under the lock, blocking any goroutine (e.g. the PTY actor) that needs that mutex for the `pbcopy` duration. Per the audit's risk note, the helper must run outside the lock. So each site now captures the selected text **under** the lock, releases it, then copies. The selection-state mutations (`Selection.Active = false`, `selectionScroll.Reset()`) and the span / `HasSelection` guards stay under the lock; only the external call moves out.

## Verification

- All five sites collapse to one `common.CopyToClipboardWithLog` call; no direct `common.CopyToClipboard(` callers remain in `internal/ui` (all route through the helper).
- Single-click zero-span still copies nothing (the span guard yields empty text → helper no-ops).
- `goimports` dropped the now-unused `logging` import from the two files where it became orphaned.
- `go build ./...`, `go test -race ./internal/ui/{common,center,sidebar}/...` pass; golangci-lint clean; center harness renders normally.

## Note for reviewers

This shortens lock hold time and removes a `pbcopy`-under-lock latent issue — a small, intentional behavior change beyond pure dedup. No import cycle (`common` already imports `internal/logging`).

---

⚠️ Stacked on #224. Duplication-extraction batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andyrewlee/amux/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->