### PR TITLE
Add listTmux helper to encode the exit-1-means-empty read convention once

### DIFF
--- a/internal/tmux/activity.go
+++ b/internal/tmux/activity.go
@@ -25,17 +25,12 @@ func sessionLatestActivitySeconds(sessionName string, opts Options) (int64, erro
 	if err := EnsureAvailable(); err != nil {
 		return 0, err
 	}
-	cmd, cancel := tmuxCommand(opts, "list-windows", "-t", sessionTarget(sessionName), "-F", "#{window_activity}")
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-windows", "-t", sessionTarget(sessionName), "-F", "#{window_activity}")
 	if err != nil {
-		if isExitCode1(err) {
-			return 0, nil
-		}
 		return 0, err
 	}
 	var latest int64
-	for _, line := range parseOutputLines(output) {
+	for _, line := range lines {
 		activityRaw := strings.TrimSpace(line)
 		if activityRaw == "" {
 			continue
@@ -90,18 +85,13 @@ func ActiveAgentSessionsByActivity(window time.Duration, opts Options) ([]Sessio
 	}
 	applyWindow := window > 0
 	format := "#{session_name}\t#{window_activity}\t#{@amux}\t#{@amux_workspace}\t#{@amux_tab}\t#{@amux_type}"
-	cmd, cancel := tmuxCommand(opts, "list-windows", "-a", "-F", format)
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-windows", "-a", "-F", format)
 	if err != nil {
-		if isExitCode1(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	now := time.Now()
 	latest := make(map[string]SessionActivity)
-	for _, line := range parseOutputLines(output) {
+	for _, line := range lines {
 		parts := strings.Split(line, "\t")
 		if len(parts) < 6 {
 			continue

--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -53,23 +53,11 @@ func SessionClientCount(sessionName string, opts Options) (int, error) {
 	if !exists {
 		return 0, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "list-clients", "-t", sessionTarget(sessionName), "-F", "#{client_name}")
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-clients", "-t", sessionTarget(sessionName), "-F", "#{client_name}")
 	if err != nil {
-		if isExitCode1(err) {
-			return 0, nil
-		}
 		return 0, err
 	}
-	count := 0
-	for _, line := range parseOutputLines(output) {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		count++
-	}
-	return count, nil
+	return len(lines), nil
 }
 
 // SessionCreatedAt returns the tmux session creation timestamp (unix seconds).

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -106,17 +106,12 @@ func AllSessionStates(opts Options) (map[string]SessionState, error) {
 	if err := EnsureAvailable(); err != nil {
 		return nil, err
 	}
-	cmd, cancel := tmuxCommand(opts, "list-panes", "-a", "-F", "#{session_name}\t#{pane_dead}")
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-panes", "-a", "-F", "#{session_name}\t#{pane_dead}")
 	if err != nil {
-		if isExitCode1(err) {
-			return map[string]SessionState{}, nil
-		}
 		return nil, err
 	}
 	states := make(map[string]SessionState)
-	for _, line := range parseOutputLines(output) {
+	for _, line := range lines {
 		parts := strings.SplitN(line, "\t", 2)
 		if len(parts) != 2 {
 			continue
@@ -196,6 +191,24 @@ func runTmux(opts Options, args ...string) error {
 	return nil
 }
 
+// listTmux runs a tmux read command and returns its non-empty output lines.
+// tmux's exit code 1 ("not found": no session/server) yields an empty result
+// with no error, encoding the exit-1-means-empty convention (see errors.go)
+// once instead of at every read site. Callers keep their own availability
+// gating (EnsureAvailable / hasSession) and any per-line parsing.
+func listTmux(opts Options, args ...string) ([]string, error) {
+	cmd, cancel := tmuxCommand(opts, args...)
+	defer cancel()
+	output, err := cmd.Output()
+	if err != nil {
+		if isExitCode1(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseOutputLines(output), nil
+}
+
 func hasSession(sessionName string, opts Options) (bool, error) {
 	cmd, cancel := tmuxCommand(opts, "has-session", "-t", sessionTarget(sessionName))
 	defer cancel()
@@ -216,18 +229,12 @@ func hasLivePane(sessionName string, opts Options) (bool, error) {
 	if !exists {
 		return false, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_dead}")
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_dead}")
 	if err != nil {
-		if isExitCode1(err) {
-			return false, nil
-		}
 		return false, err
 	}
-	lines := strings.Fields(string(output))
 	for _, line := range lines {
-		if strings.TrimSpace(line) == "0" {
+		if line == "0" {
 			return true, nil
 		}
 	}
@@ -262,17 +269,12 @@ func panePIDs(sessionName string, opts Options) ([]int, error) {
 	if !exists {
 		return nil, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "list-panes", "-s", "-t", sessionTarget(sessionName), "-F", "#{pane_pid}")
-	defer cancel()
-	output, err := cmd.Output()
+	lines, err := listTmux(opts, "list-panes", "-s", "-t", sessionTarget(sessionName), "-F", "#{pane_pid}")
 	if err != nil {
-		if isExitCode1(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	var pids []int
-	for _, field := range strings.Fields(string(output)) {
+	for _, field := range lines {
 		if pid, err := strconv.Atoi(field); err == nil && pid > 0 {
 			pids = append(pids, pid)
 		}

--- a/internal/tmux/tmux_sessions.go
+++ b/internal/tmux/tmux_sessions.go
@@ -7,16 +7,7 @@ func ListSessions(opts Options) ([]string, error) {
 	if err := EnsureAvailable(); err != nil {
 		return nil, err
 	}
-	cmd, cancel := tmuxCommand(opts, "list-sessions", "-F", "#{session_name}")
-	defer cancel()
-	output, err := cmd.Output()
-	if err != nil {
-		if isExitCode1(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return parseOutputLines(output), nil
+	return listTmux(opts, "list-sessions", "-F", "#{session_name}")
 }
 
 // KillSessionsWithPrefix kills all sessions with a matching name prefix.


### PR DESCRIPTION
## What

Adds `listTmux(opts, args...) ([]string, error)` and converts seven tmux read functions to it: `ListSessions`, `SessionClientCount`, `sessionLatestActivitySeconds`, `AllSessionStates`, `ActiveAgentSessionsByActivity`, `hasLivePane`, `panePIDs`. Net −29 lines.

## Why

All seven repeated `cmd.Output()` → `isExitCode1 ? empty : err`, re-encoding the "tmux exit 1 means no session/server → treat as empty" invariant (documented once in `errors.go`) at every call site. The helper owns that convention; a function that forgets the exit-1 branch can no longer silently surface "no session" as a hard error.

## Scope guardrails

- Each caller keeps its **own** availability gating: `EnsureAvailable`-gated (ListSessions, AllSessionStates, the two activity fns) and `hasSession`-gated (SessionClientCount, hasLivePane, panePIDs) stay exactly as they were — `EnsureAvailable` is **not** baked into the helper.
- `parseOutputLines` ≡ `strings.Fields` for the single-column numeric callers, so `hasLivePane`/`panePIDs` keep their `== "0"` / `Atoi` filtering at the call site.
- The non-fitting reads (`SessionTagValue`, `SessionCreatedAt`, tag-matching variants) are left untouched.

## Verification

- `listTmux`: 1 definition + 7 call sites.
- `go build ./...`, `go vet`, `go test ./internal/tmux/` (real tmux, incl. no-server exit-1 cases) pass; gofumpt + golangci-lint clean.

---

⚠️ Stacked on #225. Duplication-extraction batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)