### PR TITLE
Extract common.ExtendSelection for the 6 selection-endpoint updates

### DIFF
--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -137,17 +137,7 @@ func (m *Model) updateMouseMotion(msg tea.MouseMotionMsg) (*Model, tea.Cmd) {
 			termY = termHeight - 1
 		}
 		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
-		startX := tab.Terminal.SelStartX()
-		startLine := tab.Terminal.SelStartLine()
-		if !tab.Terminal.HasSelection() {
-			startX = tab.Selection.StartX
-			startLine = tab.Selection.StartLine
-		}
-		tab.Selection.EndX = termX
-		tab.Selection.EndLine = absLine
-		tab.Terminal.SetSelection(startX, startLine, termX, absLine, true, false)
-		tab.Selection.StartX = startX
-		tab.Selection.StartLine = startLine
+		common.ExtendSelection(tab.Terminal, &tab.Selection, termX, absLine)
 
 		tab.selectionLastTermX = termX
 		if needTick, gen := tab.selectionScroll.NeedsTick(); needTick {
@@ -340,17 +330,7 @@ func (m *Model) updateSelectionScrollTick(msg selectionScrollTick) tea.Cmd {
 	}
 	absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
 	endX := tab.selectionLastTermX
-	startX := tab.Terminal.SelStartX()
-	startLine := tab.Terminal.SelStartLine()
-	if !tab.Terminal.HasSelection() {
-		startX = tab.Selection.StartX
-		startLine = tab.Selection.StartLine
-	}
-	tab.Selection.EndX = endX
-	tab.Selection.EndLine = absLine
-	tab.Terminal.SetSelection(startX, startLine, endX, absLine, true, false)
-	tab.Selection.StartX = startX
-	tab.Selection.StartLine = startLine
+	common.ExtendSelection(tab.Terminal, &tab.Selection, endX, absLine)
 
 	tab.mu.Unlock()
 	tabID := msg.TabID

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -269,17 +269,7 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 		}
 
 		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
-		startX := tab.Terminal.SelStartX()
-		startLine := tab.Terminal.SelStartLine()
-		if !tab.Terminal.HasSelection() {
-			startX = tab.Selection.StartX
-			startLine = tab.Selection.StartLine
-		}
-		tab.Selection.EndX = termX
-		tab.Selection.EndLine = absLine
-		tab.Terminal.SetSelection(startX, startLine, termX, absLine, true, false)
-		tab.Selection.StartX = startX
-		tab.Selection.StartLine = startLine
+		common.ExtendSelection(tab.Terminal, &tab.Selection, termX, absLine)
 
 		tab.selectionLastTermX = termX
 		if needTick, gen := tab.selectionScroll.NeedsTick(); needTick && m.msgSink != nil {
@@ -328,17 +318,7 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 		}
 		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
 		endX := tab.selectionLastTermX
-		startX := tab.Terminal.SelStartX()
-		startLine := tab.Terminal.SelStartLine()
-		if !tab.Terminal.HasSelection() {
-			startX = tab.Selection.StartX
-			startLine = tab.Selection.StartLine
-		}
-		tab.Selection.EndX = endX
-		tab.Selection.EndLine = absLine
-		tab.Terminal.SetSelection(startX, startLine, endX, absLine, true, false)
-		tab.Selection.StartX = startX
-		tab.Selection.StartLine = startLine
+		common.ExtendSelection(tab.Terminal, &tab.Selection, endX, absLine)
 
 		tab.mu.Unlock()
 		if m.msgSink != nil {

--- a/internal/ui/common/selection.go
+++ b/internal/ui/common/selection.go
@@ -1,5 +1,7 @@
 package common
 
+import "github.com/andyrewlee/amux/internal/vterm"
+
 // SelectionState tracks mouse selection state for copy/paste.
 type SelectionState struct {
 	Active    bool // Selection in progress (mouse button down)?
@@ -7,4 +9,23 @@ type SelectionState struct {
 	StartLine int  // Start row (absolute line number, 0 = first scrollback line)
 	EndX      int  // End column
 	EndLine   int  // End row (absolute line number)
+}
+
+// ExtendSelection moves the far endpoint of an in-progress selection to
+// (endX, endAbsLine). The anchor is read from the live vterm selection, falling
+// back to sel's stored start when the vterm has no selection yet, then written
+// back to sel so the two stay in sync. This block is order-sensitive; callers
+// must hold the owning tab/terminal mutex. It performs no I/O.
+func ExtendSelection(v *vterm.VTerm, sel *SelectionState, endX, endAbsLine int) {
+	startX := v.SelStartX()
+	startLine := v.SelStartLine()
+	if !v.HasSelection() {
+		startX = sel.StartX
+		startLine = sel.StartLine
+	}
+	sel.EndX = endX
+	sel.EndLine = endAbsLine
+	v.SetSelection(startX, startLine, endX, endAbsLine, true, false)
+	sel.StartX = startX
+	sel.StartLine = startLine
 }

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -192,20 +192,7 @@ func (m *TerminalModel) handleMouseMotion(msg tea.MouseMotionMsg) (*TerminalMode
 
 		// Convert to absolute line and update selection
 		absLine := ts.VTerm.ScreenYToAbsoluteLine(termY)
-		startX := ts.VTerm.SelStartX()
-		startLine := ts.VTerm.SelStartLine()
-		if !ts.VTerm.HasSelection() {
-			startX = ts.Selection.StartX
-			startLine = ts.Selection.StartLine
-		}
-		ts.Selection.EndX = termX
-		ts.Selection.EndLine = absLine
-		ts.VTerm.SetSelection(
-			startX, startLine,
-			termX, absLine, true, false,
-		)
-		ts.Selection.StartX = startX
-		ts.Selection.StartLine = startLine
+		common.ExtendSelection(ts.VTerm, &ts.Selection, termX, absLine)
 
 		// Store last X for tick-based endpoint updates
 		ts.selectionLastTermX = termX
@@ -289,17 +276,7 @@ func (m *TerminalModel) handleSelectionScrollTick(msg SidebarSelectionScrollTick
 	}
 	absLine := ts.VTerm.ScreenYToAbsoluteLine(edgeY)
 	endX := ts.selectionLastTermX
-	startX := ts.VTerm.SelStartX()
-	startLine := ts.VTerm.SelStartLine()
-	if !ts.VTerm.HasSelection() {
-		startX = ts.Selection.StartX
-		startLine = ts.Selection.StartLine
-	}
-	ts.Selection.EndX = endX
-	ts.Selection.EndLine = absLine
-	ts.VTerm.SetSelection(startX, startLine, endX, absLine, true, false)
-	ts.Selection.StartX = startX
-	ts.Selection.StartLine = startLine
+	common.ExtendSelection(ts.VTerm, &ts.Selection, endX, absLine)
 
 	ts.mu.Unlock()
 


### PR DESCRIPTION
## What

Adds `common.ExtendSelection(v, sel, endX, endAbsLine)` and collapses the six copy-pasted selection-endpoint blocks (center mouse-drag + auto-scroll, sidebar mouse-drag + auto-scroll) to one call each. Net −42 lines.

## Why

The order-sensitive block — read the anchor from the live vterm selection, fall back to the stored start when the vterm reports no selection, `SetSelection`, then write the anchor back to the state struct — appeared **six** times. The fallback branch is exactly the kind of subtle logic that drifts when edited in one place but not the others.

## Safety

The helper touches only the `*vterm.VTerm` and the `*SelectionState` (no I/O), so it stays **under the caller's existing tab/terminal mutex** — unlike the clipboard helper, nothing moves outside the lock. `common` gains a `vterm` import; no cycle (`vterm` doesn't import `common`).

The two read-only render-normalization sites (`model_scrolled_history.go`, compositor snapshot) use a different shape (they read `SelEndX`/`SelEndLine` and swap for ordering) and are explicitly left untouched.

## Verification

- `ExtendSelection`: 1 definition + 6 call sites; excluded normalization site untouched.
- `go build ./...`, `go test -race ./internal/ui/{common,center,sidebar}/...` pass (selection + scroll-tick suites included); gofumpt + golangci-lint clean.

---

⚠️ Stacked on #226. Duplication-extraction batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)