### PR TITLE
Rename git.GitError to git.Error to drop package-name stutter

### DIFF
--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -42,7 +42,7 @@ func RunGitCtx(ctx context.Context, dir string, args ...string) (string, error) 
 		}
 		// Include stderr in error for debugging
 		if stderr.Len() > 0 {
-			return "", &GitError{
+			return "", &Error{
 				Command: strings.Join(args, " "),
 				Stderr:  stderr.String(),
 				Err:     err,
@@ -54,18 +54,18 @@ func RunGitCtx(ctx context.Context, dir string, args ...string) (string, error) 
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-// GitError wraps git command errors with additional context
-type GitError struct {
+// Error wraps git command errors with additional context
+type Error struct {
 	Command string
 	Stderr  string
 	Err     error
 }
 
-func (e *GitError) Error() string {
+func (e *Error) Error() string {
 	return "git " + e.Command + ": " + e.Stderr
 }
 
-func (e *GitError) Unwrap() error {
+func (e *Error) Unwrap() error {
 	return e.Err
 }
 
@@ -114,7 +114,7 @@ func RunGitAllowFailureCtx(ctx context.Context, dir string, args ...string) (str
 	// Only return error if there's actual stderr output indicating a problem
 	// and no stdout (which would indicate the command worked but returned non-zero)
 	if stderr.Len() > 0 && stdout.Len() == 0 {
-		return "", &GitError{
+		return "", &Error{
 			Command: strings.Join(args, " "),
 			Stderr:  stderr.String(),
 			Err:     err,
@@ -144,7 +144,7 @@ func RunGitRawCtx(ctx context.Context, dir string, args ...string) ([]byte, erro
 			return nil, ctxErr
 		}
 		if stderr.Len() > 0 {
-			return nil, &GitError{
+			return nil, &Error{
 				Command: strings.Join(args, " "),
 				Stderr:  stderr.String(),
 				Err:     err,


### PR DESCRIPTION
## What

Renames the exported error type `git.GitError` → `git.Error`.

## Why

`git.GitError` / `*git.GitError` stutters; idiomatic Go drops the package prefix (`exec.Error`, `os.PathError`). The type is entirely package-internal — never named outside `operations.go` — so this is a mechanical rename of the type decl, two method receivers, three struct literals, and the doc comment. The `Error()` method satisfying the `error` interface is untouched, and there is no existing `Error` type in package `git` to collide with.

## Verification

- `grep -rn GitError .` → none.
- `go build ./...`, `go test ./internal/git/` pass; golangci-lint (errorlint/staticcheck) clean.

---

⚠️ Stacked on #227. API-naming cleanup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)