### PR TITLE
Dedup containsSGRParam into vterm.ContainsSGRParam

### DIFF
--- a/internal/ui/compositor/canvas_test.go
+++ b/internal/ui/compositor/canvas_test.go
@@ -1,7 +1,6 @@
 package compositor
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestCanvasRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
 	}
 
 	out := canvas.Render()
-	if containsSGRParam(out, 4) {
+	if vterm.ContainsSGRParam(out, 4) {
 		t.Fatalf("expected no underline SGR for blank cells, got %q", out)
 	}
 }
@@ -212,28 +211,4 @@ func makeLine(text string, width int) []vterm.Cell {
 		line[i] = vterm.Cell{Rune: r, Width: 1}
 	}
 	return line
-}
-
-func containsSGRParam(s string, target int) bool {
-	targetStr := strconv.Itoa(target)
-	for i := 0; i < len(s); i++ {
-		if s[i] != 0x1b || i+1 >= len(s) || s[i+1] != '[' {
-			continue
-		}
-		j := i + 2
-		for j < len(s) && s[j] != 'm' {
-			j++
-		}
-		if j >= len(s) {
-			break
-		}
-		params := strings.Split(s[i+2:j], ";")
-		for _, param := range params {
-			if param == targetStr {
-				return true
-			}
-		}
-		i = j
-	}
-	return false
 }

--- a/internal/vterm/sgr_scan.go
+++ b/internal/vterm/sgr_scan.go
@@ -1,0 +1,33 @@
+package vterm
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ContainsSGRParam reports whether s contains an SGR escape sequence (CSI ... m)
+// carrying the given numeric parameter. vterm owns ANSI/SGR scanning, so tests
+// in any package that renders via vterm can share this instead of re-deriving it.
+func ContainsSGRParam(s string, target int) bool {
+	targetStr := strconv.Itoa(target)
+	for i := 0; i < len(s); i++ {
+		if s[i] != 0x1b || i+1 >= len(s) || s[i+1] != '[' {
+			continue
+		}
+		j := i + 2
+		for j < len(s) && s[j] != 'm' {
+			j++
+		}
+		if j >= len(s) {
+			break
+		}
+		params := strings.Split(s[i+2:j], ";")
+		for _, param := range params {
+			if param == targetStr {
+				return true
+			}
+		}
+		i = j
+	}
+	return false
+}

--- a/internal/vterm/vterm_render_test.go
+++ b/internal/vterm/vterm_render_test.go
@@ -1,7 +1,6 @@
 package vterm
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -12,7 +11,7 @@ func TestRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
 	vt.Write([]byte("     "))
 
 	out := vt.Render()
-	if containsSGRParam(out, 4) {
+	if ContainsSGRParam(out, 4) {
 		t.Fatalf("expected no underline SGR for blank cells, got %q", out)
 	}
 }
@@ -32,31 +31,7 @@ func TestRenderKeepsUnderlineForText(t *testing.T) {
 	vt.Write([]byte("A "))
 
 	out := vt.Render()
-	if !containsSGRParam(out, 4) {
+	if !ContainsSGRParam(out, 4) {
 		t.Fatalf("expected underline SGR for text, got %q", out)
 	}
-}
-
-func containsSGRParam(s string, target int) bool {
-	targetStr := strconv.Itoa(target)
-	for i := 0; i < len(s); i++ {
-		if s[i] != 0x1b || i+1 >= len(s) || s[i+1] != '[' {
-			continue
-		}
-		j := i + 2
-		for j < len(s) && s[j] != 'm' {
-			j++
-		}
-		if j >= len(s) {
-			break
-		}
-		params := strings.Split(s[i+2:j], ";")
-		for _, param := range params {
-			if param == targetStr {
-				return true
-			}
-		}
-		i = j
-	}
-	return false
 }


### PR DESCRIPTION
## What

Moves the duplicated `containsSGRParam` test helper into a non-test file `internal/vterm/sgr_scan.go` as the exported `ContainsSGRParam`, and deletes both local copies (vterm + compositor test files).

## Why

The identical SGR-scanning helper was copy-pasted into two test files; a bug fixed in one would silently persist in the other. vterm owns ANSI/SGR scanning (`sgr.go`, `csi.go`) and compositor already imports vterm, so it's the natural home. A `_test.go` helper can't be shared cross-package, hence the production file (it has legitimate cross-package test utility).

## Verification

- `grep` confirms no local `containsSGRParam` defs remain; exactly one `ContainsSGRParam` in vterm.
- Call sites updated (`ContainsSGRParam` in vterm tests, `vterm.ContainsSGRParam` in compositor); orphaned `strconv` imports dropped by goimports.
- `go build ./...`, `go test ./internal/vterm/ ./internal/ui/compositor/` pass; golangci-lint clean.

---

⚠️ Stacked on #228 (the abandoned Style-methods PR was dropped — it conflicted with the complexity ratchet). Duplication-extraction batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)