### PR TITLE
Add Dependabot config for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      # The Charm stack moves fast and spans two module prefixes; batch it
+      # into a single PR so updates don't arrive piecemeal.
+      charm:
+        patterns:
+          - "charm.land/*"
+          - "github.com/charmbracelet/*"
+      # Everything else (minor/patch) in one follow-up PR.
+      go-modules:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "charm.land/*"
+          - "github.com/charmbracelet/*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` with weekly update PRs for `github-actions` and `gomod`.

## Why

No Dependabot config existed; all Actions are pinned to mutable major tags (`checkout@v4`, `setup-go@v5`, `golangci-lint-action@v6`, `goreleaser-action@v6`), and `govulncheck` catches CVEs but doesn't propose upgrades.

The Charm stack moves fast and spans **two** module prefixes, so the `charm` group batches both `charm.land/*` and `github.com/charmbracelet/*` (incl. the `ultraviolet` pseudo-version) into one PR; everything else lands in a second grouped PR.

## Verification

- YAML parses cleanly.
- Both Charm prefixes are in the group patterns, so update PRs actually consolidate rather than arriving piecemeal.

---

⚠️ Stacked on #229. Tooling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)