### PR TITLE
Fix README: populate Configuration section and update Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/github/license/andyrewlee/amux?style=flat-square" alt="License" />
   </a>
-  <img src="https://img.shields.io/badge/Go-1.24.12-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go version" />
+  <img src="https://img.shields.io/badge/Go-1.26-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go version" />
   <a href="https://discord.gg/Dswc7KFPxs">
     <img src="https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" />
   </a>
@@ -72,10 +72,6 @@ Start with `internal/app/ARCHITECTURE.md` for lifecycle, PTY flow, tmux tagging,
 
 ## Configuration
 
-## Platform Support
-
-AMUX requires `tmux` and is supported on Linux/macOS. Windows is not supported.
-
 Create `.amux/workspaces.json` in your project to run setup commands for new workspaces:
 
 ```json
@@ -88,6 +84,10 @@ Create `.amux/workspaces.json` in your project to run setup commands for new wor
 ```
 
 Workspace metadata is stored in `~/.amux/workspaces-metadata/<workspace-id>/workspace.json`, and local worktree directories live under `~/.amux/workspaces/<project>/<workspace>`.
+
+## Platform Support
+
+AMUX requires `tmux` and is supported on Linux/macOS. Windows is not supported.
 
 ## Development
 


### PR DESCRIPTION
## What

Two README fixes:
1. The `## Configuration` heading was **empty** — its content (the `.amux/workspaces.json` example + metadata paths) was sitting under the unrelated `## Platform Support` heading, so the `#configuration` nav anchor landed on nothing. Config body moved up; Platform Support keeps only its single-line statement.
2. The Go badge read `Go-1.24.12`; updated to `Go-1.26` to match `go.mod` (`go 1.26.3`).

## Verification

- Configuration section is now non-empty; Platform Support retains only platform info; badge matches `go.mod`. Docs-only.

---

⚠️ Stacked on #230. Docs batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)