### PR TITLE
Add a thin CLAUDE.md pointing at AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md) for the full conventions (tech stack, entry points,
+lint-driven workflow, release process). It is the source of truth.
+
+Most load-bearing rule: **never commit or push unless the user explicitly asks.**


### PR DESCRIPTION
## What

Adds a 5-line tracked `CLAUDE.md` at the repo root that points to `AGENTS.md` and restates the never-commit/push rule.

## Why

Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`, so Claude-driven sessions started without the project's conventions (never commit/push, `make devcheck`, gofumpt baseline, strict-lint ratcheting, harness verification). It's a plain file (not a symlink or copy) referencing `AGENTS.md` as the source of truth, so the two can't drift.

## Verification

- `CLAUDE.md` is a regular tracked file referencing `AGENTS.md` and restating the never-commit rule; `.gitignore` doesn't exclude it.

---

⚠️ Stacked on #231. Docs batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)