### PR TITLE
Enable bodyclose linter in base and strict configs

### DIFF
--- a/.golangci.strict.yml
+++ b/.golangci.strict.yml
@@ -6,6 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - bodyclose
     - copyloopvar
     - depguard
     - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - bodyclose
     - copyloopvar
     - depguard
     - errcheck


### PR DESCRIPTION
## What

Adds `bodyclose` to `linters.enable` in both `.golangci.yml` (base) and `.golangci.strict.yml`. No source changes.

## Why

The project makes outbound HTTP calls (`internal/update/github.go` has three `httpClient.Do(req)` sites) where a missed `resp.Body.Close()` leaks connections — and nothing guarded against it. `bodyclose` reports **zero** issues on the current tree, so it's free regression insurance. Mirrored in strict so the ratchet stays a superset of base.

## Verification

- Ran `bodyclose` standalone on `./...` → exit 0 (clean).
- Full-tree base `golangci-lint run` (what pre-commit runs) passes with bodyclose enabled.

---

⚠️ Stacked on #232. Tooling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)