### PR TITLE
Add package doc comments to the five core packages

### DIFF
--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -1,3 +1,6 @@
+// Package pty manages the pseudo-terminals that back hosted agents: it spawns
+// agent processes (Agent) attached to a PTY (Terminal), sizes them, and
+// streams their byte output to the UI for parsing by internal/vterm.
 package pty
 
 import (

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,3 +1,8 @@
+// Package tmux is a thin wrapper over the tmux CLI used to host agent
+// sessions: it creates and kills sessions, captures pane contents and
+// scrollback, resizes windows, and reads/writes the @amux_* activity tags
+// that coordinate detection and reattach across amux instances. tmux exit
+// code 1 ("not found") is treated as an empty/absent result, not an error.
 package tmux
 
 import (

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -1,3 +1,8 @@
+// Package center implements the center-pane Bubble Tea model: the agent tab
+// strip, per-tab PTY I/O and flushing, the diff viewer, and mouse/keyboard
+// text selection. It is the largest UI subsystem; tab work is serialized
+// through a per-model actor (see tab_actor.go) and output is parsed by
+// internal/vterm.
 package center
 
 import (

--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -1,3 +1,7 @@
+// Package compositor composes vterm snapshots and UI layers into a single
+// rendered frame. A Canvas holds the working cell grid and is reused across
+// frames; snapshot rendering (RenderSnapshotWithCanvas) and delta-aware ANSI
+// emission keep redraws cheap on the hot render path.
 package compositor
 
 import (

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -1,3 +1,7 @@
+// Package vterm is a terminal emulator: it parses a stream of ANSI/VT escape
+// sequences into a cell grid plus scrollback and renders that state back to
+// ANSI. It is the source of truth for what a hosted agent's terminal looks
+// like, feeding the compositor and the center/sidebar UI models.
 package vterm
 
 const MaxScrollback = 10000


### PR DESCRIPTION
## What

Adds a `// Package …` synopsis to a canonical file in each of the five most load-bearing packages: `vterm`, `tmux`, `pty`, `compositor`, `center`.

## Why

`go doc` on each jumped straight from the import line to a const/type list — no orientation for a newcomer or an agent. Each comment states the package's purpose, key types/entry points, and relation to the render/PTY pipeline, following the `internal/app/activity` precedent (the one package that already had a real doc comment).

## Verification

- `go doc ./internal/{vterm,tmux,pty,ui/compositor,ui/center}` now renders a `Package …` synopsis.
- Docs only; `go build ./...`, `go vet`, gofumpt + golangci-lint clean.

---

⚠️ Stacked on #233. Docs batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)