### PR TITLE
Add package doc comments to the remaining internal packages

### DIFF
--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,3 @@
+// Package config loads and represents amux configuration: assistant
+// definitions, UI settings, and resolved on-disk paths.
+package config

--- a/internal/data/doc.go
+++ b/internal/data/doc.go
@@ -1,0 +1,3 @@
+// Package data persists workspace records to disk via WorkspaceStore, using
+// atomic JSON reads/writes keyed by workspace ID plus per-repo lookup.
+package data

--- a/internal/git/doc.go
+++ b/internal/git/doc.go
@@ -1,0 +1,4 @@
+// Package git wraps the git CLI for amux's worktree-per-workspace model:
+// creating and removing worktrees and branches, computing diffs, and watching
+// the working tree for changes.
+package git

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,0 +1,4 @@
+// Package logging is amux's file-based logger. Internal packages route
+// diagnostics through it (Debug/Info/Warn/Error) instead of writing to
+// stdout/stderr, which is reserved for the CLI entrypoints.
+package logging

--- a/internal/messages/doc.go
+++ b/internal/messages/doc.go
@@ -1,0 +1,4 @@
+// Package messages defines the shared Bubble Tea message vocabulary exchanged
+// between the app message pump and the UI panes: user intents, lifecycle
+// events, and cross-pane notifications. See internal/app/MESSAGE_FLOW.md.
+package messages

--- a/internal/perf/doc.go
+++ b/internal/perf/doc.go
@@ -1,0 +1,4 @@
+// Package perf is lightweight, opt-in instrumentation: named counters (Count)
+// and timers (Record/Time) that flush to a log for the headless harness and the
+// perf baselines. It is disabled by default in production.
+package perf

--- a/internal/process/doc.go
+++ b/internal/process/doc.go
@@ -1,0 +1,4 @@
+// Package process provides cross-platform process-group teardown: it kills a
+// process together with its descendants (KillProcessGroup) so agent process
+// trees do not survive the tmux session that launched them.
+package process

--- a/internal/safego/doc.go
+++ b/internal/safego/doc.go
@@ -1,0 +1,4 @@
+// Package safego provides panic-safe goroutine helpers (Go, Run) with a
+// pluggable PanicHandler, so background work can never crash the TUI on an
+// otherwise-unrecovered panic.
+package safego

--- a/internal/supervisor/doc.go
+++ b/internal/supervisor/doc.go
@@ -1,0 +1,4 @@
+// Package supervisor runs named background workers under a restart/backoff
+// policy and surfaces fatal worker errors through a pluggable error handler
+// instead of letting an unrecovered failure take down the app.
+package supervisor

--- a/internal/ui/common/doc.go
+++ b/internal/ui/common/doc.go
@@ -1,0 +1,5 @@
+// Package common holds UI building blocks shared across panes: theming
+// (colors, styles, icons), widgets (dialogs, file picker, toasts), text
+// selection, and the low-level PTY/tmux plumbing used by the center and sidebar
+// terminals.
+package common

--- a/internal/ui/dashboard/doc.go
+++ b/internal/ui/dashboard/doc.go
@@ -1,0 +1,3 @@
+// Package dashboard implements the dashboard pane: the project and workspace
+// tree with keyboard and mouse navigation plus a toolbar for workspace actions.
+package dashboard

--- a/internal/ui/diff/doc.go
+++ b/internal/ui/diff/doc.go
@@ -1,0 +1,3 @@
+// Package diff implements the diff viewer shown in a center tab, rendering a
+// git change as scrollable, syntax-aware output.
+package diff

--- a/internal/ui/layout/doc.go
+++ b/internal/ui/layout/doc.go
@@ -1,0 +1,3 @@
+// Package layout computes pane geometry: it tracks the layout mode and divides
+// the terminal into the dashboard, center, and sidebar regions (Manager).
+package layout

--- a/internal/ui/sidebar/doc.go
+++ b/internal/ui/sidebar/doc.go
@@ -1,0 +1,3 @@
+// Package sidebar implements the sidebar pane: the workspace file tree plus an
+// embedded tmux-backed terminal with its own PTY I/O and text selection.
+package sidebar

--- a/internal/update/doc.go
+++ b/internal/update/doc.go
@@ -1,0 +1,4 @@
+// Package update implements self-update: it compares the running version
+// against GitHub releases and downloads, checksum-verifies, and installs a
+// newer binary, skipping Homebrew and go-install builds.
+package update

--- a/internal/validation/doc.go
+++ b/internal/validation/doc.go
@@ -1,0 +1,4 @@
+// Package validation guards untrusted input before it reaches git or the
+// filesystem: it sanitizes strings and validates assistant names, base refs,
+// project paths, and workspace names.
+package validation


### PR DESCRIPTION
## What

Adds a `doc.go` with a `// Package …` synopsis to the 16 remaining undocumented packages: `process`, `supervisor`, `safego`, `validation`, `config`, `data`, `git`, `update`, `perf`, `logging`, `messages`, and `ui/{common,dashboard,diff,layout,sidebar}`.

## Why

Several are small single-responsibility packages whose purpose isn't obvious from the name (`safego` = panic-safe goroutines, `supervisor` = restart/backoff, `validation` = input guards, `messages` = the Bubble Tea message taxonomy) — the highest-leverage-per-line docs in the repo.

## Verification

- `go doc ./internal/<pkg>` now renders a `Package …` synopsis for all 16.
- Docs only; `go build ./...`, `go vet ./...`, full-tree golangci-lint clean; gofumpt clean.

---

⚠️ Stacked on #234. Docs batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)