### PR TITLE
Add a root ARCHITECTURE.md package map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,8 +15,13 @@ boundaries and command discipline between the app pump and the panes, see
 
 ## Dependency direction
 
-Dependencies point downward; the UI never reaches the OS directly — it goes
-through the tmux/pty/git/data layers.
+Dependencies point downward. Most UI code reaches OS and process boundaries
+through the tmux/pty/git/data layers. UI packages may still own
+interaction-local adapters when the behavior is part of a widget boundary, such
+as clipboard writes and file-picker filesystem reads in `internal/ui/common`, PTY
+tracing in `internal/ui/center`, and shell plumbing in the sidebar terminal.
+Shared process, persistence, git, tmux, and PTY behavior belongs in the lower
+layers.
 
 ```
             cmd/amux            cmd/amux-harness

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# Architecture
+
+amux is a terminal UI (Bubble Tea v2) for running and orchestrating coding
+agents. Each agent runs in its own tmux session hosted in a pseudo-terminal;
+amux parses that terminal output with a built-in emulator, composes it with the
+surrounding UI, and renders the result. Two binaries share the `internal`
+packages: `cmd/amux` (the interactive app) and `cmd/amux-harness` (a headless
+renderer used for deterministic perf and render testing).
+
+For the runtime detail of the app package — lifecycle, PTY flow, tmux activity
+tagging, and persistence invariants — see
+[internal/app/ARCHITECTURE.md](internal/app/ARCHITECTURE.md). For the message
+boundaries and command discipline between the app pump and the panes, see
+[internal/app/MESSAGE_FLOW.md](internal/app/MESSAGE_FLOW.md).
+
+## Dependency direction
+
+Dependencies point downward; the UI never reaches the OS directly — it goes
+through the tmux/pty/git/data layers.
+
+```
+            cmd/amux            cmd/amux-harness
+                \                   /
+                 v                 v
+              internal/app  (message pump, services, tmux-activity lease)
+                 |  \
+                 |   `-- internal/ui/{dashboard, center, sidebar, diff}
+                 |              |
+                 |              v
+                 |       internal/ui/{compositor, layout, common}
+                 v              |
+   internal/{tmux, pty, git,    v
+     data, update, config,  internal/vterm   (terminal emulator)
+     supervisor, process}
+                 \              /
+                  v            v
+        internal/{safego, perf, logging, messages, validation}
+```
+
+## Packages
+
+The table is hand-maintained; keep it in sync when adding or moving a package.
+
+| Package | Responsibility | Entry points |
+|---------|----------------|--------------|
+| `cmd/amux` | App entrypoint: flag parsing, terminal setup, tmux socket janitor | `main.go` |
+| `cmd/amux-harness` | Headless render/perf harness (no TTY) for CI and local profiling | `main.go` |
+| `internal/app` | Bubble Tea root: message pump, services, layout, tmux-activity leader lease | `app_core.go`, `app_init.go` |
+| `internal/app/activity` | Agent-activity detection logic and per-session lease state | `logic.go`, `types.go` |
+| `internal/ui/center` | Center pane: agent tab strip, per-tab PTY I/O, diff viewer, selection | `model.go`, `tab_actor.go` |
+| `internal/ui/sidebar` | Sidebar pane: workspace file tree + embedded tmux terminal | `terminal.go` |
+| `internal/ui/dashboard` | Dashboard pane: project/workspace tree and toolbar | `model.go` |
+| `internal/ui/diff` | Scrollable, syntax-aware git diff viewer (a center tab) | `model.go` |
+| `internal/ui/compositor` | Composes vterm snapshots + UI layers into a frame; delta ANSI | `canvas.go` |
+| `internal/ui/layout` | Pane geometry and layout modes | `manager.go` |
+| `internal/ui/common` | Shared theming, widgets, selection, PTY/tmux plumbing | `theme.go`, `pty_reader.go` |
+| `internal/vterm` | Terminal emulator: ANSI/VT parsing → cell grid + scrollback → ANSI | `vterm.go` |
+| `internal/tmux` | tmux CLI wrapper: sessions, capture, resize, activity tags | `tmux.go` |
+| `internal/pty` | Pseudo-terminals backing hosted agents (Agent, Terminal) | `agent.go` |
+| `internal/git` | git worktree-per-workspace model: worktrees, branches, diff, watcher | `operations.go`, `workspace.go` |
+| `internal/data` | Workspace record persistence (atomic JSON via WorkspaceStore) | `workspace_store.go` |
+| `internal/update` | Self-update: version check, download, verify, install | `updater.go` |
+| `internal/config` | Configuration: assistants, UI settings, resolved paths | `config.go` |
+| `internal/supervisor` | Named background workers with restart/backoff and error surfacing | `supervisor.go` |
+| `internal/process` | Cross-platform process-group teardown (kill agent process trees) | `treekill_unix.go` |
+| `internal/safego` | Panic-safe goroutine helpers with a pluggable panic handler | `safego.go` |
+| `internal/perf` | Opt-in counters/timers for the harness and perf baselines | `perf.go` |
+| `internal/logging` | File-based logger; the output channel for internal packages | `logger.go` |
+| `internal/messages` | Shared Bubble Tea message vocabulary between pump and panes | `messages.go` |
+| `internal/validation` | Input/path guards (assistant, base ref, project path, workspace) | `validation.go` |
+| `internal/e2e` | PTY-driven end-to-end tests exercising the real binary | (tests) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Pull requests are CI-gated (automated). For local confidence before opening a PR
 
 Architecture references:
 
+- `ARCHITECTURE.md` (repo-level package map and dependency direction)
 - `internal/app/ARCHITECTURE.md`
 - `internal/app/MESSAGE_FLOW.md`
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each workspace tracks a repo checkout and its metadata. For local workflows, wor
 
 ## Architecture quick tour
 
-Start with `internal/app/ARCHITECTURE.md` for lifecycle, PTY flow, tmux tagging, and persistence invariants. Message boundaries and command discipline are documented in `internal/app/MESSAGE_FLOW.md`.
+Start with [`ARCHITECTURE.md`](ARCHITECTURE.md) for the repo-level package map and dependency direction. Then `internal/app/ARCHITECTURE.md` covers lifecycle, PTY flow, tmux tagging, and persistence invariants, and `internal/app/MESSAGE_FLOW.md` documents message boundaries and command discipline.
 
 ## Features
 


### PR DESCRIPTION
## What

Adds a repo-level `ARCHITECTURE.md` and points `README.md` + `CONTRIBUTING.md` at it ahead of the two app-scoped docs.

Contents: a one-paragraph system overview, an ASCII dependency-direction sketch (cmd → app → ui/* → compositor/vterm, with tmux/pty/git/data below), links to `internal/app/ARCHITECTURE.md` and `MESSAGE_FLOW.md`, and a hand-maintained package table — one row per `go list ./...` package with its job and key entry-point file.

## Why

The only architecture docs were under `internal/app/` and described just that package's runtime. Nothing told a newcomer or agent what each of the 26 packages does or the dependency direction.

## Verification

- Every `go list ./...` package (24 internal + 2 cmd) has a table row (checked programmatically); cited entry-point files all exist.
- Markdown-only; relative links resolve.

---

⚠️ Stacked on #235. Docs batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)