### PR TITLE
Add a GOOS=windows cross-compile smoke step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Windows cross-compile
+        run: GOOS=windows GOARCH=amd64 go build ./...
+
       - name: Tidy check
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Adds one step to the `test` job (after Vet, on the existing ubuntu runner): `GOOS=windows GOARCH=amd64 go build ./...`.

## Why

Six paired `*_windows.go`/`*_unix.go` files exist (registry locking, atomic replace, tree-kill, stop-error mapping, both `main` entrypoints), but CI never compiled the `windows` build tag. The Windows half compiles cleanly today, yet a future shared-API edit could break the tag-gated files unnoticed. `go build ./...` (not vet) is used so both `cmd` entrypoints' `main_windows.go` compile.

## Verification

- `GOOS=windows GOARCH=amd64 go build ./...` passes locally today.
- `actionlint` clean. Compile-hygiene only — README still states Windows is unsupported.

---

⚠️ Stacked on #238. Tooling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)