### PR TITLE
Add a minimal macOS CI job for darwin build + unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,29 @@ jobs:
           install-mode: goinstall
           verify: false
           args: --config=.golangci.strict.yml --enable=funlen --enable=gocyclo --enable=nestif --new-from-rev=${{ github.event.pull_request.base.sha }} --timeout=10m
+
+  macos-build:
+    # Minimal darwin coverage on push to main only (macOS minutes are ~10x
+    # linux). Proves the released darwin binary compiles and exercises the
+    # darwin-only pbcopy path in internal/ui/common. Race/lint/govulncheck/
+    # harness are host-independent and already run on linux.
+    if: github.event_name == 'push'
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: |
+          set -euo pipefail
+          pkgs=$(go list ./... | grep -v '/internal/e2e$' | grep -v '/internal/tmux$')
+          go test $pkgs


### PR DESCRIPTION
## What

Adds a single `macos-build` job (macos-14) that runs `go build ./...` + the non-tmux/non-e2e unit tests, gated to **push-to-main only** (`if: github.event_name == 'push'`).

## Why

CI ran only on ubuntu, yet amux ships darwin release binaries and the maintainer develops on macOS. The one genuinely darwin-only runtime path — the `pbcopy` fallback in `common/clipboard.go` — had zero CI coverage, and the released darwin binary was never built in CI.

Kept deliberately minimal and cost-bounded (macOS minutes ~10× linux): no matrix, and no duplication of race/lint/govulncheck/harness (those are host-independent and already run on linux). The `git`/`tmux`/`update` GOOS branches are host-independent too.

## Verification

- `actionlint` clean.
- The filtered unit-test set passes locally on darwin (incl. `internal/ui/common`, exercising the pbcopy branch).
- Runs only on push to `main`, not on pull_request; existing ubuntu jobs unchanged.

---

⚠️ Stacked on #239. Tooling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)