### PR TITLE
Enable gofumpt extra-rules in base config and align Makefile fmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,8 @@ linters-settings:
             desc: Use standard library errors/fmt wrapping instead.
           - pkg: io/ioutil
             desc: Use os or io packages instead of io/ioutil.
+  gofumpt:
+    extra-rules: true
   goimports:
     local-prefixes: github.com/andyrewlee/amux
   errcheck:

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ check-file-length:
 	@find . -name '*.go' -exec wc -l {} + | awk '!/total$$/ && $$1 > 500 { print "ERROR: " $$2 " has " $$1 " lines (max 500)"; found=1 } END { if(found) exit 1 }'
 
 fmt:
-	$(GOFUMPT) -w .
+	$(GOFUMPT) -extra -w .
 	goimports -w .
 
 fmt-check:
-	@test -z "$$($(GOFUMPT) -l .)" || ($(GOFUMPT) -l .; exit 1)
+	@test -z "$$($(GOFUMPT) -extra -l .)" || ($(GOFUMPT) -extra -l .; exit 1)
 
 vet:
 	go vet ./...

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -446,7 +446,7 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 	}
 }
 
-func (m *Model) sendToTerminal(tab *Tab, data string, tabID TabID, workspaceID string, label string) {
+func (m *Model) sendToTerminal(tab *Tab, data string, tabID TabID, workspaceID, label string) {
 	if tab == nil || tab.Agent == nil || tab.Agent.Terminal == nil {
 		return
 	}


### PR DESCRIPTION
## What

- Fixes the single `gofumpt -extra` offender (`tab_actor.go`: `workspaceID string, label string` → `workspaceID, label string`).
- Adds `gofumpt: { extra-rules: true }` to `.golangci.yml` (base).
- Adds `-extra` to the Makefile `fmt` and `fmt-check` targets.

## Why

Base and strict configs diverged on gofumpt: strict had `extra-rules: true` but base had no gofumpt settings, so formatting base accepts could be rejected by strict. The tree is conformant except one file. Aligning the Makefile's own formatter is the part that closes the loop — otherwise `make fmt` could produce code base CI rejects with no local auto-fix.

## Verification

- `gofumpt -extra -l .` reports no files.
- Full-tree base `golangci-lint run` passes with extra-rules enabled (pre-commit parity).
- Base and strict no longer diverge on gofumpt.

---

⚠️ Stacked on #240. Tooling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)