### PR TITLE
Normalize quotes in isBranchAlreadyExistsError

### DIFF
--- a/internal/git/workspace.go
+++ b/internal/git/workspace.go
@@ -115,17 +115,14 @@ func isBranchAlreadyExistsError(err error, branch string) bool {
 	if branch == "" {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
+	// Normalize backtick quoting to a single straight quote so we match git's
+	// "a branch named '<x>'" and "branch '<x>'" phrasings without enumerating
+	// quote permutations.
+	msg := strings.ReplaceAll(strings.ToLower(err.Error()), "`", "'")
 	if strings.Contains(msg, "a branch named '"+branch+"' already exists") {
 		return true
 	}
-	if strings.Contains(msg, "a branch named `"+branch+"` already exists") {
-		return true
-	}
 	if strings.Contains(msg, "branch '"+branch+"' already exists") {
-		return true
-	}
-	if strings.Contains(msg, "branch `"+branch+"` already exists") {
 		return true
 	}
 	return strings.Contains(msg, "already exists") && strings.Contains(msg, branch)

--- a/internal/git/workspace_test.go
+++ b/internal/git/workspace_test.go
@@ -141,6 +141,9 @@ func TestIsBranchAlreadyExistsError(t *testing.T) {
 	if !isBranchAlreadyExistsError(err, "feature-a") {
 		t.Fatalf("expected branch already exists error to match")
 	}
+	if !isBranchAlreadyExistsError(errors.New("fatal: a branch named `feature-a` already exists"), "feature-a") {
+		t.Fatalf("expected backtick-quoted branch error to match after normalization")
+	}
 	if isBranchAlreadyExistsError(err, "feature-b") {
 		t.Fatalf("expected non-matching branch name to return false")
 	}


### PR DESCRIPTION
## What

Replaces the four quote-permutation `strings.Contains` checks in `isBranchAlreadyExistsError` with a single backtick→straight-quote normalization plus two phrasing checks; keeps the guarded loose fallback.

## Why

The function enumerated straight-vs-backtick quotes × two phrasings — fragile against wording changes. Normalizing quotes once and checking the two distinct phrasings (`a branch named '<x>'` and `branch '<x>'`) is equivalent and clearer. A backtick-quoted test case locks in the normalization.

## Verification

- `go test ./internal/git/ -run 'TestIsBranchAlreadyExistsError|TestCreateWorkspaceReusesExistingBranch'` passes, including the new backtick case.
- No `ErrBranchAlreadyExists` sentinel added — over-engineered for the single same-package caller. golangci-lint clean.

---

⚠️ Stacked on #241. Error-handling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)