### PR TITLE
Preserve the exec.ExitError chain (%w) in tmux failure wrappers

### DIFF
--- a/internal/tmux/tags.go
+++ b/internal/tmux/tags.go
@@ -164,7 +164,7 @@ func SetSessionTagValues(sessionName string, tags []OptionValue, opts Options) e
 				strings.Contains(stderr, "can't find session") {
 				return nil
 			}
-			return fmt.Errorf("set-option -t %s (multi): %s", sessionName, stderr)
+			return fmt.Errorf("set-option -t %s (multi): %s: %w", sessionName, stderr, err)
 		}
 		return err
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -341,7 +341,7 @@ func GlobalOptionValue(key string, opts Options) (string, error) {
 				return "", nil
 			}
 			stderr := strings.TrimSpace(string(output))
-			return "", fmt.Errorf("show-options -g %s: %s", key, stderr)
+			return "", fmt.Errorf("show-options -g %s: %s: %w", key, stderr, err)
 		}
 		return "", err
 	}
@@ -376,7 +376,7 @@ func SetGlobalOptionValue(key, value string, opts Options) error {
 			if tmuxShowOptionMissingError(stderr) {
 				return nil
 			}
-			return fmt.Errorf("set-option -g %s: %s", key, stderr)
+			return fmt.Errorf("set-option -g %s: %s: %w", key, stderr, err)
 		}
 		return err
 	}
@@ -425,7 +425,7 @@ func SetGlobalOptionValues(values []OptionValue, opts Options) error {
 			if tmuxShowOptionMissingError(stderr) {
 				return nil
 			}
-			return fmt.Errorf("set-option -g (multi): %s", stderr)
+			return fmt.Errorf("set-option -g (multi): %s: %w", stderr, err)
 		}
 		return err
 	}

--- a/internal/tmux/tmux_global_options.go
+++ b/internal/tmux/tmux_global_options.go
@@ -41,7 +41,7 @@ func GlobalOptionValues(keys []string, opts Options) (map[string]string, error) 
 			if stderr == "" {
 				return values, err
 			}
-			return values, fmt.Errorf("display-message -p: %s", stderr)
+			return values, fmt.Errorf("display-message -p: %s: %w", stderr, err)
 		}
 		return values, err
 	}


### PR DESCRIPTION
## What

Adds `%w` wrapping of the original `err` (keeping the stderr snippet) at five tmux failure sites: `tmux.go` (`show-options -g`, `set-option -g`, `set-option -g (multi)`), `tags.go` (`set-option -t … (multi)`), `tmux_global_options.go` (`display-message -p`).

## Why

These wrappers built a fresh error from only the stderr string and dropped the original `err` (an `*exec.ExitError`), so the exit code and chain were lost — and `errorlint` couldn't catch it because there was no `%w` to validate. The empty-stderr branch already returned the raw `err`, so the same failure produced two incompatible error types; now both stay wrap-compatible.

## Verification

- All five sites wrap with `%w` and still embed the stderr snippet, so `tmux.IsNoServerError` (which inspects the message) keeps working.
- `go build ./...`, `go test ./internal/tmux/` pass; golangci-lint (errorlint) clean. No control-flow change.

---

⚠️ Stacked on #242. Error-handling batch from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)