### PR TITLE
Delete the readerActiveState atomic mirror

### DIFF
--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -24,7 +24,6 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 	if tab.readerActive {
 		if tab.ptyMsgCh == nil || tab.readerCancel == nil {
 			tab.readerActive = false
-			atomic.StoreUint32(&tab.readerActiveState, 0)
 		} else {
 			tab.mu.Unlock()
 			return nil
@@ -32,12 +31,10 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 	}
 	if tab.Agent == nil || tab.Agent.Terminal == nil || tab.Agent.Terminal.IsClosed() {
 		tab.readerActive = false
-		atomic.StoreUint32(&tab.readerActiveState, 0)
 		tab.mu.Unlock()
 		return nil
 	}
 	tab.readerActive = true
-	atomic.StoreUint32(&tab.readerActiveState, 1)
 	tab.ptyRestartBackoff = 0
 	atomic.StoreInt64(&tab.ptyHeartbeat, time.Now().UnixNano())
 
@@ -97,7 +94,6 @@ func (m *Model) stopPTYReader(tab *Tab) {
 		tab.readerCancel = nil
 	}
 	tab.readerActive = false
-	atomic.StoreUint32(&tab.readerActiveState, 0)
 	tab.ptyMsgCh = nil
 	tab.mu.Unlock()
 	atomic.StoreInt64(&tab.ptyHeartbeat, 0)
@@ -109,7 +105,6 @@ func (m *Model) markPTYReaderStopped(tab *Tab) {
 	}
 	tab.mu.Lock()
 	tab.readerActive = false
-	atomic.StoreUint32(&tab.readerActiveState, 0)
 	tab.ptyMsgCh = nil
 	tab.mu.Unlock()
 	atomic.StoreInt64(&tab.ptyHeartbeat, 0)

--- a/internal/ui/center/model_pty_reader.go
+++ b/internal/ui/center/model_pty_reader.go
@@ -1,7 +1,6 @@
 package center
 
 import (
-	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -86,7 +85,9 @@ func (m *Model) busyPTYTabCount(now time.Time) int {
 			if tab == nil || tab.isClosed() {
 				continue
 			}
-			busy := atomic.LoadUint32(&tab.readerActiveState) == 1 || len(tab.pendingOutput) > 0
+			tab.mu.Lock()
+			busy := tab.readerActive || len(tab.pendingOutput) > 0
+			tab.mu.Unlock()
 			if busy {
 				count++
 			}

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -56,15 +56,14 @@ type Tab struct {
 	SessionName string
 	Detached    bool
 	// reattachInFlight prevents overlapping reattach attempts for the same tab.
-	reattachInFlight  bool
-	Terminal          *vterm.VTerm // Virtual terminal emulator with scrollback
-	DiffViewer        *diff.Model  // Native diff viewer (replaces PTY-based viewer)
-	mu                sync.Mutex   // Protects Terminal
-	closed            uint32
-	closing           uint32
-	Running           bool   // Whether the agent is actively running
-	readerActive      bool   // Guard to ensure only one PTY read loop per tab
-	readerActiveState uint32 // Mirrors readerActive for lock-free atomic reads
+	reattachInFlight bool
+	Terminal         *vterm.VTerm // Virtual terminal emulator with scrollback
+	DiffViewer       *diff.Model  // Native diff viewer (replaces PTY-based viewer)
+	mu               sync.Mutex   // Protects Terminal
+	closed           uint32
+	closing          uint32
+	Running          bool // Whether the agent is actively running
+	readerActive     bool // Guard to ensure only one PTY read loop per tab
 	// Buffer PTY output to avoid rendering partial screen updates.
 
 	pendingOutput            []byte


### PR DESCRIPTION
## What

Removes the `readerActiveState uint32` lock-free mirror of `center.Tab.readerActive`, its five `atomic.StoreUint32` writes, and the now-unused `sync/atomic` import in `model_pty_reader.go`. `busyPTYTabCount` now reads `readerActive` under `tab.mu`.

## Why

`Tab` tracked the same fact twice — a mutex-guarded `readerActive bool` and a duplicate atomic mirror updated in lockstep at five sites. A missed pairing silently desyncs busy-tab accounting. The mirror had exactly **one** reader (`busyPTYTabCount`, `model_pty_reader.go:89`), which already reads the unguarded `pendingOutput` on the same goroutine; the sidebar's equivalent uses a single bool under its mutex and works fine.

## Not a race fix

`busyPTYTabCount` runs on the Bubble Tea Update goroutine and is throttled to once per 100ms, so the per-tab lock is negligible. No race existed; **no race-fix claim**.

## Verification

- `grep -rn readerActiveState internal/ui/center` → nothing.
- `go build ./...`, `go test -race ./internal/ui/center/...` pass (busyPTYTabCount-dependent tests produce identical counts); golangci-lint clean.

---

⚠️ Stacked on #243. Concurrency cleanup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)