### PR TITLE
Inline guarded readerCancel close and delete common.SafeClose

### DIFF
--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -39,7 +39,7 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 	atomic.StoreInt64(&tab.ptyHeartbeat, time.Now().UnixNano())
 
 	if tab.readerCancel != nil {
-		common.SafeClose(tab.readerCancel)
+		close(tab.readerCancel)
 	}
 	tab.readerCancel = make(chan struct{})
 	tab.ptyMsgCh = make(chan tea.Msg, ptyReadQueueSize)
@@ -90,7 +90,7 @@ func (m *Model) stopPTYReader(tab *Tab) {
 	}
 	tab.mu.Lock()
 	if tab.readerCancel != nil {
-		common.SafeClose(tab.readerCancel)
+		close(tab.readerCancel)
 		tab.readerCancel = nil
 	}
 	tab.readerActive = false

--- a/internal/ui/common/pty_reader.go
+++ b/internal/ui/common/pty_reader.go
@@ -243,11 +243,3 @@ func ForwardPTYMsgs(msgCh <-chan tea.Msg, sink func(tea.Msg), merger OutputMerge
 	nextMsg:
 	}
 }
-
-// SafeClose closes ch, recovering from double-close panics.
-func SafeClose(ch chan struct{}) {
-	defer func() {
-		_ = recover()
-	}()
-	close(ch)
-}

--- a/internal/ui/sidebar/terminal_pty_lifecycle.go
+++ b/internal/ui/sidebar/terminal_pty_lifecycle.go
@@ -132,7 +132,7 @@ func (m *TerminalModel) startPTYReader(wsID string, tabID TerminalTabID) tea.Cmd
 	}
 
 	if ts.readerCancel != nil {
-		common.SafeClose(ts.readerCancel)
+		close(ts.readerCancel)
 	}
 	ts.readerCancel = make(chan struct{})
 	ts.ptyMsgCh = make(chan tea.Msg, ptyReadQueueSize)
@@ -227,7 +227,7 @@ func (m *TerminalModel) stopPTYReader(ts *TerminalState) {
 	}
 	ts.mu.Lock()
 	if ts.readerCancel != nil {
-		common.SafeClose(ts.readerCancel)
+		close(ts.readerCancel)
 		ts.readerCancel = nil
 	}
 	ts.readerActive = false


### PR DESCRIPTION
## What

Replaces the four `common.SafeClose(x.readerCancel)` calls with a plain guarded `close(x.readerCancel)` and deletes `common.SafeClose`.

## Why

`SafeClose` existed only to `recover()` from double-close panics. That recover was already-dead defensive code: both closers (`startPTYReader`/`stopPTYReader`, center + sidebar) run under the held mutex, guard `if readerCancel != nil`, and immediately reassign (start) or nil (stop) the field — so a double-close can't happen. Advertising distrust of close ownership masks future genuine bugs; now a real double-close surfaces as a detectable panic.

The start sites keep their reassign (no nil); the stop sites keep their `= nil`.

## Verification

- `grep` confirms no `SafeClose`/`recover()` remains on the readerCancel path; four guarded `close()` sites.
- `go vet` + `go test -race ./internal/ui/{center,sidebar,common}/...` pass (incl. PTY restart/stall/rebind tests); golangci-lint clean.

---

⚠️ Stacked on #244. Concurrency cleanup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)