### PR TITLE
Extract pure SendKeys arg builders and unit-test them

### DIFF
--- a/internal/tmux/send.go
+++ b/internal/tmux/send.go
@@ -8,6 +8,21 @@ import "time"
 // 50ms is enough for every tested agent while keeping sends snappy.
 const enterDelay = 50 * time.Millisecond
 
+// sendTextArgs builds the send-keys argv that delivers text literally. The -l
+// flag forces literal mode and the -- guard ensures a leading-dash payload is
+// not parsed as a flag. The raw sessionName is passed without a sessionTarget
+// prefix.
+func sendTextArgs(sessionName, text string) []string {
+	return []string{"send-keys", "-l", "-t", sessionName, "--", text}
+}
+
+// sendEnterArgs builds the send-keys argv that delivers a carriage return as a
+// hex byte (-H 0D) rather than the named "Enter" key, which some raw-mode TUIs
+// (e.g. Cline) drop.
+func sendEnterArgs(sessionName string) []string {
+	return []string{"send-keys", "-H", "-t", sessionName, "0D"}
+}
+
 // SendKeys sends text to a tmux session via send-keys.
 // If enter is true, an Enter key is sent after the text.
 func SendKeys(sessionName, text string, enter bool, opts Options) error {
@@ -18,8 +33,7 @@ func SendKeys(sessionName, text string, enter bool, opts Options) error {
 		return err
 	}
 
-	args := []string{"send-keys", "-l", "-t", sessionName, "--", text}
-	cmd, cancel := tmuxCommand(opts, args...)
+	cmd, cancel := tmuxCommand(opts, sendTextArgs(sessionName, text)...)
 	defer cancel()
 	if err := cmd.Run(); err != nil {
 		return err
@@ -30,10 +44,7 @@ func SendKeys(sessionName, text string, enter bool, opts Options) error {
 		// before we deliver the carriage return.
 		time.Sleep(enterDelay)
 
-		// Use -H 0D (hex carriage return) instead of the named "Enter" key.
-		// Some TUI agents (e.g. Cline) use raw terminal mode where the named
-		// Enter key is dropped, but the raw CR byte is always delivered.
-		enterCmd, enterCancel := tmuxCommand(opts, "send-keys", "-H", "-t", sessionName, "0D")
+		enterCmd, enterCancel := tmuxCommand(opts, sendEnterArgs(sessionName)...)
 		defer enterCancel()
 		return enterCmd.Run()
 	}

--- a/internal/tmux/send_test.go
+++ b/internal/tmux/send_test.go
@@ -60,3 +60,64 @@ func TestSendKeysDeliversTextAndEnter(t *testing.T) {
 		t.Fatalf("expected 'ping' at least twice (typed + echo), got %d in:\n%s", count, text)
 	}
 }
+
+func TestSendTextArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		session string
+		text    string
+	}{
+		{"plain", "amux-ws-tab", "hello"},
+		{"leading dash payload", "amux-ws-tab", "-x"},
+		{"empty text", "amux-ws-tab", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := sendTextArgs(tt.session, tt.text)
+			if len(args) == 0 || args[0] != "send-keys" {
+				t.Fatalf("args[0] = %q, want send-keys (%v)", args, args)
+			}
+			if !contains(args, "-l") {
+				t.Fatalf("missing -l (literal) flag: %v", args)
+			}
+			// The user text must be the final element, immediately preceded by --,
+			// so a leading-dash payload is never parsed as a flag.
+			if args[len(args)-1] != tt.text {
+				t.Fatalf("text not last element: %v", args)
+			}
+			if args[len(args)-2] != "--" {
+				t.Fatalf("-- must immediately precede the text: %v", args)
+			}
+			// Raw session name, no sessionTarget '=' prefix.
+			if !contains(args, tt.session) {
+				t.Fatalf("raw session name %q not present: %v", tt.session, args)
+			}
+		})
+	}
+}
+
+func TestSendEnterArgs(t *testing.T) {
+	args := sendEnterArgs("amux-ws-tab")
+	if len(args) == 0 || args[0] != "send-keys" {
+		t.Fatalf("args[0] = %q, want send-keys (%v)", args, args)
+	}
+	if !contains(args, "-H") {
+		t.Fatalf("enter must use hex mode -H: %v", args)
+	}
+	if args[len(args)-1] != "0D" {
+		t.Fatalf("enter payload must be 0D (hex CR), got: %v", args)
+	}
+	// Must not use a named "Enter" key.
+	if contains(args, "Enter") {
+		t.Fatalf("enter must be a raw 0D byte, not the named Enter key: %v", args)
+	}
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Extracts `sendTextArgs(session, text)` and `sendEnterArgs(session)` as pure helpers from `SendKeys`, and adds table-driven unit tests that run **without tmux**.

## Why

The send-keys argv is load-bearing and has regressed twice (named "Enter" dropped by raw-mode TUIs → `-H 0D`; literal `-l --` framing), but the only test exercising real flags needs a live tmux server + fixed sleeps, so it can't catch a flag-composition regression deterministically.

The tests assert: `-l` present; `--` immediately precedes the user text; a leading-dash payload (`-x`) stays the final element after `--`; the enter path is `-H … 0D` (not a named key); and the raw session name is passed without a `=` prefix.

## Verification

- New tests pass with tmux absent (no skip) and fail if `-l`/`--`/`-H … 0D` is removed or reordered.
- Helpers are pure (no I/O); existing tmux tests still pass; golangci-lint clean.

---

⚠️ Stacked on #249. Test-quality from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)