### PR TITLE
Replace fixed-sleep notification assertions in FileWatcher test with polling

### DIFF
--- a/internal/git/watcher_test.go
+++ b/internal/git/watcher_test.go
@@ -217,16 +217,14 @@ func TestFileWatcher(t *testing.T) {
 			t.Fatalf("rename: %v", err)
 		}
 
-		// Wait for notification
-		time.Sleep(100 * time.Millisecond)
+		// Wait for the notification by polling rather than a fixed sleep.
+		waitForNotifyCount(t, &notifyCount, 1, 2*time.Second)
 
-		if notifyCount.Load() == 0 {
-			t.Fatalf("expected notification after atomic file replacement")
-		}
-
-		// Reset counter and wait for debounce
+		// Reset counter and wait out the debounce window before the next change.
+		// This is a debounce wait, not a notification wait — the count is
+		// intentionally 0 here.
 		notifyCount.Store(0)
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(2 * fw.debounce)
 
 		// Make another change - this verifies the watch is still active
 		tempPath2 := filepath.Join(gitDir, "index.lock")
@@ -237,11 +235,22 @@ func TestFileWatcher(t *testing.T) {
 			t.Fatalf("rename2: %v", err)
 		}
 
-		// Wait for notification
-		time.Sleep(100 * time.Millisecond)
-
-		if notifyCount.Load() == 0 {
-			t.Fatalf("expected notification after second atomic file replacement")
-		}
+		// Wait for the second notification.
+		waitForNotifyCount(t, &notifyCount, 1, 2*time.Second)
 	})
+}
+
+// waitForNotifyCount polls c until it reaches at least want or the timeout
+// elapses, failing the test on timeout. Used in place of a fixed sleep plus an
+// immediate Load, which is flaky on slow CI and wastes time on fast machines.
+func waitForNotifyCount(t *testing.T, c *atomic.Int32, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.Load() >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for notify count >= %d (got %d)", timeout, want, c.Load())
 }

--- a/internal/git/watcher_test.go
+++ b/internal/git/watcher_test.go
@@ -220,11 +220,11 @@ func TestFileWatcher(t *testing.T) {
 		// Wait for the notification by polling rather than a fixed sleep.
 		waitForNotifyCount(t, &notifyCount, 1, 2*time.Second)
 
-		// Reset counter and wait out the debounce window before the next change.
-		// This is a debounce wait, not a notification wait — the count is
-		// intentionally 0 here.
-		notifyCount.Store(0)
+		// Wait out the debounce window before the next change, then reset the
+		// counter so late events from the first replacement cannot satisfy the
+		// second assertion.
 		time.Sleep(2 * fw.debounce)
+		notifyCount.Store(0)
 
 		// Make another change - this verifies the watch is still active
 		tempPath2 := filepath.Join(gitDir, "index.lock")


### PR DESCRIPTION
## What

Replaces the two `time.Sleep(100ms)` + immediate `notifyCount.Load() != 0` pairs in the FileWatcher "atomic file replacement" subtest with a local `waitForNotifyCount` polling helper, and expresses the inter-change wait as `2*fw.debounce`.

## Why

Asserting a notification by sleeping a fixed 100ms then reading the counter is timing-dependent — flaky on slow CI, wasteful on fast machines. Polling until the counter reaches the target (or a 2s deadline) is deterministic. The line-229 sleep is a *debounce* wait (count is intentionally 0 there), now labeled as such via `2*fw.debounce`.

## Verification

- `go test ./internal/git/ -run TestFileWatcher -count=20` passes deterministically; `-race -count=3` clean.
- No testify/third-party dependency added; `notifyCount` is `atomic.Int32` so the helper takes `*atomic.Int32`; golangci-lint clean.

---

⚠️ Stacked on #250. Test-quality from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)