### PR TITLE
Consolidate tmux stderr classification into shared predicates

### DIFF
--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -17,9 +17,9 @@ func SessionNamesWithClients(opts Options) (map[string]bool, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if isExitCode1(err) {
-			stderr := strings.ToLower(strings.TrimSpace(string(output)))
+			stderr := strings.TrimSpace(string(output))
 			// No attached clients should not fail detached-session GC.
-			if stderr == "" || strings.Contains(stderr, "no client") || strings.Contains(stderr, "can't find client") {
+			if stderr == "" || isNoClientStderr(stderr) {
 				return attached, nil
 			}
 		}

--- a/internal/tmux/errors.go
+++ b/internal/tmux/errors.go
@@ -28,3 +28,26 @@ func IsNoServerError(err error) bool {
 		strings.Contains(msg, "failed to connect to server") ||
 		strings.Contains(msg, "connection refused")
 }
+
+// isSessionNotFoundStderr reports whether tmux stderr indicates the target
+// session does not exist.
+func isSessionNotFoundStderr(stderr string) bool {
+	s := strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(s, "session not found") ||
+		strings.Contains(s, "no such session") ||
+		strings.Contains(s, "can't find session")
+}
+
+// isNoClientStderr reports whether tmux stderr indicates there are no matching
+// clients attached to the session.
+func isNoClientStderr(stderr string) bool {
+	s := strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(s, "no client") || strings.Contains(s, "can't find client")
+}
+
+// isOptionMissingStderr reports whether tmux stderr indicates an unknown or
+// invalid option, the "missing option" signal for show-options/set-option.
+func isOptionMissingStderr(stderr string) bool {
+	s := strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(s, "invalid option") || strings.Contains(s, "unknown option")
+}

--- a/internal/tmux/errors_test.go
+++ b/internal/tmux/errors_test.go
@@ -48,3 +48,37 @@ func wrappedErr(message string) error { return testErr(message) }
 type testErr string
 
 func (e testErr) Error() string { return string(e) }
+
+func TestStderrClassifiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		stderr     string
+		session    bool
+		noClient   bool
+		optMissing bool
+	}{
+		{"session not found", "session not found: amux-x", true, false, false},
+		{"no such session", "no such session: amux-x", true, false, false},
+		{"cant find session", "can't find session amux-x", true, false, false},
+		{"no client", "no client found", false, true, false},
+		{"cant find client", "can't find client", false, true, false},
+		{"invalid option", "invalid option: @amux_x", false, false, true},
+		{"unknown option", "unknown option @amux_x", false, false, true},
+		{"mixed case session", "Session Not Found", true, false, false},
+		{"unrelated", "lost server", false, false, false},
+		{"empty", "", false, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSessionNotFoundStderr(tt.stderr); got != tt.session {
+				t.Errorf("isSessionNotFoundStderr(%q) = %v, want %v", tt.stderr, got, tt.session)
+			}
+			if got := isNoClientStderr(tt.stderr); got != tt.noClient {
+				t.Errorf("isNoClientStderr(%q) = %v, want %v", tt.stderr, got, tt.noClient)
+			}
+			if got := isOptionMissingStderr(tt.stderr); got != tt.optMissing {
+				t.Errorf("isOptionMissingStderr(%q) = %v, want %v", tt.stderr, got, tt.optMissing)
+			}
+		})
+	}
+}

--- a/internal/tmux/tags.go
+++ b/internal/tmux/tags.go
@@ -159,9 +159,7 @@ func SetSessionTagValues(sessionName string, tags []OptionValue, opts Options) e
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))
-			if strings.Contains(stderr, "session not found") ||
-				strings.Contains(stderr, "no such session") ||
-				strings.Contains(stderr, "can't find session") {
+			if isSessionNotFoundStderr(stderr) {
 				return nil
 			}
 			return fmt.Errorf("set-option -t %s (multi): %s: %w", sessionName, stderr, err)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -337,7 +337,7 @@ func GlobalOptionValue(key string, opts Options) (string, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if isExitCode1(err) {
-			if tmuxShowOptionMissingError(string(output)) {
+			if isOptionMissingStderr(string(output)) {
 				return "", nil
 			}
 			stderr := strings.TrimSpace(string(output))
@@ -346,11 +346,6 @@ func GlobalOptionValue(key string, opts Options) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
-}
-
-func tmuxShowOptionMissingError(stderr string) bool {
-	message := strings.ToLower(strings.TrimSpace(stderr))
-	return strings.Contains(message, "invalid option") || strings.Contains(message, "unknown option")
 }
 
 // OptionValue represents a tmux option key/value pair.
@@ -373,7 +368,7 @@ func SetGlobalOptionValue(key, value string, opts Options) error {
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))
-			if tmuxShowOptionMissingError(stderr) {
+			if isOptionMissingStderr(stderr) {
 				return nil
 			}
 			return fmt.Errorf("set-option -g %s: %s: %w", key, stderr, err)
@@ -422,7 +417,7 @@ func SetGlobalOptionValues(values []OptionValue, opts Options) error {
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))
-			if tmuxShowOptionMissingError(stderr) {
+			if isOptionMissingStderr(stderr) {
 				return nil
 			}
 			return fmt.Errorf("set-option -g (multi): %s: %w", stderr, err)


### PR DESCRIPTION
## What

Adds three unexported stderr classifiers in `errors.go` — `isSessionNotFoundStderr`, `isNoClientStderr`, and `isOptionMissingStderr` (the body of the former `tmuxShowOptionMissingError`, whose three callers are updated) — and replaces the inline `strings.Contains` blocks in `tags.go` and `clients.go`.

## Why

The package detected the same failure classes via ad-hoc `strings.Contains` checks duplicated across files with inconsistent substring sets per site. Centralizing the literals means a future phrasing change is a one-file edit, and every classifier is case-insensitive.

## Verification

- The session-not-found / no-client / invalid-option literals now appear only in `errors.go` (outside tests).
- A new table test asserts each phrasing maps to the correct predicate (incl. mixed-case + unrelated/empty negatives).
- Kept `IsNoServerError` as the only exported helper. `go build ./...`, `go test ./internal/tmux/` pass; golangci-lint clean.

---

⚠️ Stacked on #251. Error-handling from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)