### PR TITLE
Replace four VTerm Last* cursor getters with LastCursorState()

### DIFF
--- a/internal/ui/compositor/vtermlayer_snapshot.go
+++ b/internal/ui/compositor/vtermlayer_snapshot.go
@@ -59,23 +59,20 @@ func NewVTermSnapshotWithCache(term *vterm.VTerm, showCursor bool, prev *VTermSn
 	// Cursor moves or visibility toggles don't always touch renderDirty,
 	// so we force redraw of the previous and current cursor lines when needed.
 	if !allDirty && term.ViewOffset == 0 {
-		lastCursorX := term.LastCursorX()
-		lastCursorY := term.LastCursorY()
-		lastShowCursor := term.LastShowCursor()
-		lastCursorHidden := term.LastCursorHidden()
+		last := term.LastCursorState()
 
-		cursorChanged := showCursor != lastShowCursor ||
-			term.CursorHiddenForRender() != lastCursorHidden ||
-			term.CursorX != lastCursorX ||
-			term.CursorY != lastCursorY
+		cursorChanged := showCursor != last.ShowCursor ||
+			term.CursorHiddenForRender() != last.Hidden ||
+			term.CursorX != last.X ||
+			term.CursorY != last.Y
 
 		if cursorChanged {
 			// Defensive: ensure dirtyLinesCopy matches screen height.
 			if dirtyLinesCopy == nil {
 				dirtyLinesCopy = make([]bool, height)
 			}
-			if lastCursorY >= 0 && lastCursorY < len(dirtyLinesCopy) {
-				dirtyLinesCopy[lastCursorY] = true
+			if last.Y >= 0 && last.Y < len(dirtyLinesCopy) {
+				dirtyLinesCopy[last.Y] = true
 			}
 			if term.CursorY >= 0 && term.CursorY < len(dirtyLinesCopy) {
 				dirtyLinesCopy[term.CursorY] = true

--- a/internal/vterm/accessors.go
+++ b/internal/vterm/accessors.go
@@ -1,25 +1,22 @@
 package vterm
 
-// LastCursorX returns the cursor X position from the previous render frame.
-// Used to detect cursor movement and mark dirty lines.
-func (v *VTerm) LastCursorX() int {
-	return v.lastCursorX
+// CursorRenderState is the cached cursor state from the previous render frame,
+// used to detect cursor-only changes and mark the affected lines dirty.
+type CursorRenderState struct {
+	X, Y       int
+	ShowCursor bool
+	Hidden     bool
 }
 
-// LastCursorY returns the cursor Y position from the previous render frame.
-// Used to detect cursor movement and mark old cursor line dirty.
-func (v *VTerm) LastCursorY() int {
-	return v.lastCursorY
-}
-
-// LastShowCursor returns the cursor visibility from the previous render frame.
-func (v *VTerm) LastShowCursor() bool {
-	return v.lastShowCursor
-}
-
-// LastCursorHidden returns the DECTCEM cursor hidden state from the previous render frame.
-func (v *VTerm) LastCursorHidden() bool {
-	return v.lastCursorHidden
+// LastCursorState returns the cursor position and visibility from the previous
+// render frame.
+func (v *VTerm) LastCursorState() CursorRenderState {
+	return CursorRenderState{
+		X:          v.lastCursorX,
+		Y:          v.lastCursorY,
+		ShowCursor: v.lastShowCursor,
+		Hidden:     v.lastCursorHidden,
+	}
 }
 
 // CursorHiddenForRender returns the effective cursor-hidden state for rendering.


### PR DESCRIPTION
## What

Replaces `LastCursorX()`/`LastCursorY()`/`LastShowCursor()`/`LastCursorHidden()` with a `CursorRenderState` struct and a single `(*VTerm) LastCursorState()` method; updates the one consumer (`compositor/vtermlayer_snapshot.go`).

## Why

The four getters were always consumed together — the cached cursor state from the previous render — and the single external caller read all four in adjacent lines. One struct-returning method is cleaner and keeps them in sync.

## Verification

- All four getters removed; the consumer reads `last.X/Y/ShowCursor/Hidden`.
- Did **not** reuse `compositor.CursorState` (it lacks `Hidden`, and vterm can't import compositor). `render.go`/`cache.go` read the backing fields directly and are untouched.
- `go build ./...`, `go test ./internal/vterm/ ./internal/ui/compositor/` pass; center harness renders identically; golangci-lint clean.

---

⚠️ Stacked on #252. API cleanup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)