### PR TITLE
Wrap WorkspaceStore I/O errors and migrate os.IsNotExist to errors.Is

### DIFF
--- a/internal/app/app_persistence_test.go
+++ b/internal/app/app_persistence_test.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
@@ -187,7 +187,7 @@ func TestHandlePersistDebounceSkipsDeleteInFlightWorkspace(t *testing.T) {
 	if !app.dirtyWorkspaces[wsID] {
 		t.Fatal("expected dirty marker to remain while workspace delete is in-flight")
 	}
-	if _, err := store.Load(ws.ID()); !os.IsNotExist(err) {
+	if _, err := store.Load(ws.ID()); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("expected workspace metadata to remain absent, err=%v", err)
 	}
 }

--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,13 +100,13 @@ func (s *WorkspaceStore) load(id WorkspaceID, applyDefaults bool) (*Workspace, e
 	path := s.workspacePath(id)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read workspace %s: %w", id, err)
 	}
 
 	// Use workspaceJSON for backward-compatible loading
 	var raw workspaceJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode workspace %s: %w", id, err)
 	}
 
 	ws := &Workspace{
@@ -161,22 +162,22 @@ func (s *WorkspaceStore) Save(ws *Workspace) error {
 	defer unlockRegistryFiles(lockFiles)
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 
 	data, err := json.MarshalIndent(ws, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 
 	// Write to temp file first, then rename for atomic operation
 	tempPath := path + ".tmp"
 	if err := os.WriteFile(tempPath, data, 0o644); err != nil {
-		return err
+		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 	if err := os.Rename(tempPath, path); err != nil {
 		os.Remove(tempPath) // Clean up temp file on rename failure
-		return err
+		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 	if oldID != "" {
 		if err := s.deleteWorkspaceDir(oldID); err != nil {
@@ -326,7 +327,7 @@ func (s *WorkspaceStore) findStoredWorkspace(repo, root string) (*Workspace, Wor
 	if err == nil {
 		return ws, canonicalID, nil
 	}
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		return nil, "", err
 	}
 	targetRepo, targetRoot := canonicalLookupPath(repo), canonicalLookupPath(root)
@@ -344,7 +345,7 @@ func (s *WorkspaceStore) findStoredWorkspace(repo, root string) (*Workspace, Wor
 		// applyDefaults=false: see comment on first load call above.
 		candidate, err := s.load(id, false)
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				logging.Warn("Skipping unreadable workspace metadata %s during fallback lookup: %v", id, err)
 			}
 			continue
@@ -376,11 +377,13 @@ func (s *WorkspaceStore) listByRepo(repoPath string, includeArchived bool) ([]*W
 	var loadErrors int
 	var targetLoadErrors int
 	var unknownLoadErrors int
+	var loadErrs []error
 	for _, id := range ids {
 		ws, err := s.Load(id)
 		if err != nil {
 			logging.Warn("Failed to load workspace %s: %v", id, err)
 			loadErrors++
+			loadErrs = append(loadErrs, err)
 			if repo, ok := s.repoHintForWorkspaceID(id); ok {
 				if canonicalLookupPath(repo) == targetRepo {
 					targetLoadErrors++
@@ -417,13 +420,13 @@ func (s *WorkspaceStore) listByRepo(repoPath string, includeArchived bool) ([]*W
 	}
 
 	if targetLoadErrors > 0 && len(workspaces) == 0 {
-		return nil, fmt.Errorf("failed to load %d workspace(s) for repo %s", targetLoadErrors, repoPath)
+		return nil, fmt.Errorf("failed to load %d workspace(s) for repo %s: %w", targetLoadErrors, repoPath, errors.Join(loadErrs...))
 	}
 	if unknownLoadErrors > 0 && len(workspaces) == 0 {
-		return nil, fmt.Errorf("failed to load %d workspace(s) with unreadable repo for %s", unknownLoadErrors, repoPath)
+		return nil, fmt.Errorf("failed to load %d workspace(s) with unreadable repo for %s: %w", unknownLoadErrors, repoPath, errors.Join(loadErrs...))
 	}
 	if loadErrors > 0 && len(workspaces) == 0 && loadErrors == len(ids) {
-		return nil, fmt.Errorf("failed to load %d workspace(s) for repo %s", loadErrors, repoPath)
+		return nil, fmt.Errorf("failed to load %d workspace(s) for repo %s: %w", loadErrors, repoPath, errors.Join(loadErrs...))
 	}
 
 	return workspaces, nil

--- a/internal/data/workspace_store_test.go
+++ b/internal/data/workspace_store_test.go
@@ -1,8 +1,11 @@
 package data
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -149,8 +152,13 @@ func TestWorkspaceStore_LoadNotFound(t *testing.T) {
 	store := NewWorkspaceStore(root)
 
 	_, err := store.Load("nonexistent")
-	if !os.IsNotExist(err) {
+	// Load now wraps the underlying os error with %w, so check via errors.Is
+	// (os.IsNotExist does not unwrap) — the chain still reports not-found.
+	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("expected not found error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Fatalf("expected wrapped error to name the workspace id, got %v", err)
 	}
 }
 
@@ -179,5 +187,32 @@ func TestWorkspaceStore_ListByRepo_SkipsArchived(t *testing.T) {
 	}
 	if workspaces[0].Name != "active" {
 		t.Errorf("expected active workspace, got %s", workspaces[0].Name)
+	}
+}
+
+func TestWorkspaceStore_LoadCorruptNamesID(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	ws := &Workspace{Name: "ws", Repo: "/home/user/repo", Root: "/path/to/ws"}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	id := ws.ID()
+	path := filepath.Join(root, string(id), "workspace.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("corrupt write error = %v", err)
+	}
+
+	_, err := store.Load(id)
+	if err == nil {
+		t.Fatalf("expected decode error for corrupt workspace.json")
+	}
+	if !strings.Contains(err.Error(), string(id)) {
+		t.Fatalf("expected decode error to name the workspace id %s, got %v", id, err)
+	}
+	// A corrupt (present-but-invalid) file is not a not-found condition.
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("corrupt file should not report as not-found: %v", err)
 	}
 }


### PR DESCRIPTION
## What

- Wraps `load()`'s read/decode and `Save()`'s MkdirAll/Marshal/WriteFile/Rename errors with `%w`, naming the workspace id.
- Accumulates underlying causes in `listByRepo` via `errors.Join`.
- **Migrates the two `findStoredWorkspace` checks (and the `LoadNotFound` test) from `os.IsNotExist` to `errors.Is(err, fs.ErrNotExist)`.**

## Why

The persistence layer surfaced context-free `os`/`json` errors with no "which workspace, which operation" — exactly the context an operator needs — and `listByRepo` discarded every cause.

**The migration is load-bearing:** `os.IsNotExist` does **not** unwrap `%w`, so without it a missing metadata file would become a hard error in the `LoadMetadataFor` "safe to apply defaults" path. `findStoredWorkspace` is the only `os.IsNotExist` consumer of `load()`'s error (tabs callers propagate; the other `IsNotExist` sites are on `os.Stat`/`os.Remove`).

## Verification

- New tests assert (a) a corrupt `workspace.json` error names the id and is **not** reported as not-found, and (b) `LoadNotFound` still satisfies `errors.Is(fs.ErrNotExist)` through the wrap.
- `LoadMetadataFor_NotFound` (missing file → `(false, nil)`) still passes. `go test ./internal/data/...` green; golangci-lint (errorlint) clean.

---

⚠️ Stacked on #253. Error-handling from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)