### PR TITLE
Add internal/testutil and dedup waitForCount/readiness poll loops

### DIFF
--- a/internal/app/app_msgpump_race_test.go
+++ b/internal/app/app_msgpump_race_test.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 func TestExternalMsgPumpConcurrent(t *testing.T) {
@@ -48,18 +49,5 @@ func TestExternalMsgPumpConcurrent(t *testing.T) {
 	close(app.externalMsgs)
 	close(app.externalCritical)
 
-	if !waitForCount(&delivered, 1, 2*time.Second) {
-		t.Fatalf("expected some messages delivered")
-	}
-}
-
-func waitForCount(val *int64, want int64, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if atomic.LoadInt64(val) >= want {
-			return true
-		}
-		time.Sleep(1 * time.Millisecond)
-	}
-	return atomic.LoadInt64(val) >= want
+	testutil.WaitForAtomic(t, func() int64 { return atomic.LoadInt64(&delivered) }, 1, 2*time.Second)
 }

--- a/internal/process/treekill_test.go
+++ b/internal/process/treekill_test.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 func TestKillProcessGroup_BasicTermination(t *testing.T) {
@@ -143,18 +145,9 @@ func TestKillProcessGroup_ChildProcessCleanup(t *testing.T) {
 	}
 
 	// Verify the process group is gone (children cleaned up), with retries for slow cleanup.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		err = syscall.Kill(-pgid, 0)
-		if err == syscall.ESRCH {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Errorf("process group still running")
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.Eventually(t, 500*time.Millisecond, 10*time.Millisecond, func() bool {
+		return syscall.Kill(-pgid, 0) == syscall.ESRCH
+	}, "process group still running")
 }
 
 func TestSetProcessGroup(t *testing.T) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 func TestNew(t *testing.T) {
@@ -116,7 +118,7 @@ func TestSupervisor_RestartNever(t *testing.T) {
 		return errors.New("fail")
 	}, WithRestartPolicy(RestartNever), WithSleep(func(time.Duration) {}))
 
-	waitForCount(t, &callCount, 1, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 1, time.Second)
 
 	if count := atomic.LoadInt32(&callCount); count != 1 {
 		t.Errorf("expected 1 call, got %d", count)
@@ -139,7 +141,7 @@ func TestSupervisor_RestartOnError(t *testing.T) {
 		return nil
 	}, WithRestartPolicy(RestartOnError), WithBackoff(10*time.Millisecond), WithMaxBackoff(20*time.Millisecond), WithSleep(func(time.Duration) {}))
 
-	waitForCount(t, &callCount, 3, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 3, time.Second)
 
 	if count := atomic.LoadInt32(&callCount); count != 3 {
 		t.Errorf("expected 3 calls, got %d", count)
@@ -188,7 +190,7 @@ func TestSupervisor_MaxRestarts(t *testing.T) {
 		return errors.New("fail")
 	}, WithRestartPolicy(RestartOnError), WithMaxRestarts(2), WithBackoff(10*time.Millisecond), WithSleep(func(time.Duration) {}))
 
-	waitForCount(t, &callCount, 3, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 3, time.Second)
 
 	// Should be 3 calls: initial + 2 restarts
 	if count := atomic.LoadInt32(&callCount); count != 3 {
@@ -289,7 +291,7 @@ func TestSupervisor_PanicRecovery(t *testing.T) {
 		return nil
 	}, WithRestartPolicy(RestartOnError), WithBackoff(10*time.Millisecond), WithSleep(func(time.Duration) {}))
 
-	waitForCount(t, &callCount, 2, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 2, time.Second)
 
 	if count := atomic.LoadInt32(&callCount); count < 2 {
 		t.Errorf("expected at least 2 calls (panic should trigger restart), got %d", count)
@@ -317,7 +319,7 @@ func TestSupervisor_BackoffDoubles(t *testing.T) {
 		mu.Unlock()
 	}))
 
-	waitForCount(t, &callCount, 4, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 4, time.Second)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -393,23 +395,9 @@ func TestSupervisor_ConcurrentStart(t *testing.T) {
 	}
 
 	wg.Wait()
-	waitForCount(t, &startedCount, 10, time.Second)
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&startedCount) }, 10, time.Second)
 
 	if count := atomic.LoadInt32(&startedCount); count != 10 {
 		t.Errorf("expected 10 workers started, got %d", count)
-	}
-}
-
-func waitForCount(t *testing.T, val *int32, want int32, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if atomic.LoadInt32(val) >= want {
-			return
-		}
-		time.Sleep(1 * time.Millisecond)
-	}
-	if got := atomic.LoadInt32(val); got < want {
-		t.Fatalf("timed out waiting for count %d (got %d)", want, got)
 	}
 }

--- a/internal/testutil/wait.go
+++ b/internal/testutil/wait.go
@@ -1,0 +1,44 @@
+// Package testutil provides small polling helpers shared across test packages,
+// so individual tests don't re-derive deadline/poll loops (which tend to drift
+// in interval and failure messaging).
+package testutil
+
+import (
+	"cmp"
+	"testing"
+	"time"
+)
+
+// Eventually polls cond until it returns true or timeout elapses, failing the
+// test (via t.Fatalf with the formatted message) on timeout.
+func Eventually(t *testing.T, timeout, interval time.Duration, cond func() bool, msgf string, args ...any) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf(msgf, args...)
+			return
+		}
+		time.Sleep(interval)
+	}
+}
+
+// WaitForAtomic polls load until it reports a value >= want or timeout elapses,
+// failing the test on timeout. load typically reads an atomic counter.
+func WaitForAtomic[T cmp.Ordered](t *testing.T, load func() T, want T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if load() >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for value >= %v (got %v)", timeout, want, load())
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/ui/center/model_actor_ready_test.go
+++ b/internal/ui/center/model_actor_ready_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/andyrewlee/amux/internal/testutil"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -79,13 +80,7 @@ func TestRunTabActor_SetsReadyWithoutEmittingLivenessMsgs(t *testing.T) {
 		done <- m.RunTabActor(ctx)
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for !m.isTabActorReady() {
-		if time.Now().After(deadline) {
-			t.Fatal("expected actor startup to set readiness directly")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.Eventually(t, time.Second, 10*time.Millisecond, m.isTabActorReady, "expected actor startup to set readiness directly")
 
 	select {
 	case msg := <-sinkMsgs:
@@ -154,13 +149,7 @@ func TestRunTabActor_EmitsRedrawForActorHandledUIEvent(t *testing.T) {
 		done <- m.RunTabActor(ctx)
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for !m.isTabActorReady() {
-		if time.Now().After(deadline) {
-			t.Fatal("expected actor startup to set readiness directly")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.Eventually(t, time.Second, 10*time.Millisecond, m.isTabActorReady, "expected actor startup to set readiness directly")
 
 	tab := &Tab{Terminal: vterm.New(80, 24)}
 	m.tabEvents <- tabEvent{kind: tabEventSelectionStart, tab: tab}
@@ -302,13 +291,7 @@ func TestRunTabActor_EventProcessingRefreshesHeartbeat(t *testing.T) {
 		done <- m.RunTabActor(ctx)
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for !m.isTabActorReady() {
-		if time.Now().After(deadline) {
-			t.Fatal("expected actor startup to set readiness directly")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.Eventually(t, time.Second, 10*time.Millisecond, m.isTabActorReady, "expected actor startup to set readiness directly")
 
 	stale := time.Now().Add(-(tabActorStallTimeout + time.Second)).UnixNano()
 	atomic.StoreInt64(&m.tabActorHeartbeat, stale)
@@ -318,13 +301,7 @@ func TestRunTabActor_EventProcessingRefreshesHeartbeat(t *testing.T) {
 
 	m.tabEvents <- tabEvent{kind: tabEventSelectionClear, tab: &Tab{}}
 
-	deadline = time.Now().Add(time.Second)
-	for !m.isTabActorReady() {
-		if time.Now().After(deadline) {
-			t.Fatal("expected processed event to refresh actor heartbeat")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.Eventually(t, time.Second, 10*time.Millisecond, m.isTabActorReady, "expected processed event to refresh actor heartbeat")
 
 	if got := atomic.LoadInt64(&m.tabActorHeartbeat); got <= stale {
 		t.Fatalf("expected processed event to advance heartbeat, got %d <= %d", got, stale)


### PR DESCRIPTION
## What

Adds a minimal `internal/testutil` package (Go 1.26 `cmp.Ordered`) with `WaitForAtomic[T](t, load, want, timeout)` and `Eventually(t, timeout, interval, cond, msgf, args...)`, and replaces:
- the two near-identical `waitForCount` helpers (app `*int64`-returning-bool; supervisor `*int32`-with-Fatal) and their call sites,
- the three `isTabActorReady` readiness poll loops (`model_actor_ready_test.go`),
- the treekill process-group poll (`treekill_test.go`).

## Why

Two helpers shared the name `waitForCount` with drifting bodies (different atomic widths, one returns bool, one fatals), and several hand-rolled deadline/poll loops repeated the same shape. One generic helper keeps them consistent.

## Verification

- Both `waitForCount` definitions deleted; `cmp.Ordered` (no `golang.org/x/exp`).
- `go test ./internal/{testutil,app,supervisor,process,ui/center}/...` (incl. `-race`) pass; golangci-lint clean.
- Out of scope (semantics differ): the e2e anti-assertions, value-returning domain wrappers, `waitForFile`.

---

⚠️ Stacked on #254. Test-quality from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)