### PR TITLE
Add t.Parallel() to internal/vterm unit tests

### DIFF
--- a/internal/vterm/alt_screen_erase_capture_test.go
+++ b/internal/vterm/alt_screen_erase_capture_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestAltScreenEraseCapturesScrollback(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h")) // enter alt screen
@@ -28,6 +29,7 @@ func TestAltScreenEraseCapturesScrollback(t *testing.T) {
 }
 
 func TestAltScreenEraseDedup(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -48,6 +50,7 @@ func TestAltScreenEraseDedup(t *testing.T) {
 }
 
 func TestAltScreenEraseDedupedHistoryIsPreserved(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.AllowAltScreenScrollback = true
 	line := MakeBlankLine(5)
@@ -86,6 +89,7 @@ func TestAltScreenEraseDedupedHistoryIsPreserved(t *testing.T) {
 }
 
 func TestAltScreenEraseBlankNotCaptured(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -98,6 +102,7 @@ func TestAltScreenEraseBlankNotCaptured(t *testing.T) {
 }
 
 func TestAltScreenEraseNoCaptureWithoutFlag(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	// AllowAltScreenScrollback is false (default)
 	vt.Write([]byte("\x1b[?1049h"))
@@ -111,6 +116,7 @@ func TestAltScreenEraseNoCaptureWithoutFlag(t *testing.T) {
 }
 
 func TestNormalScreenEraseNoCapture(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	// NOT in alt screen
@@ -124,6 +130,7 @@ func TestNormalScreenEraseNoCapture(t *testing.T) {
 }
 
 func TestAltScreenEraseRepaintReplacesPriorCapture(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -150,6 +157,7 @@ func TestAltScreenEraseRepaintReplacesPriorCapture(t *testing.T) {
 }
 
 func TestAltScreenEraseAnchorsViewOffset(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	for i := 0; i < 2; i++ {
@@ -169,6 +177,7 @@ func TestAltScreenEraseAnchorsViewOffset(t *testing.T) {
 }
 
 func TestAltScreenEraseReplacementPreservesViewOffset(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -186,6 +195,7 @@ func TestAltScreenEraseReplacementPreservesViewOffset(t *testing.T) {
 }
 
 func TestAltScreenEraseTrackedMatchDedupsViewOffset(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 4)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -204,6 +214,7 @@ func TestAltScreenEraseTrackedMatchDedupsViewOffset(t *testing.T) {
 }
 
 func TestAltScreenEraseTrimsLeadingBlankRows(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 6)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -220,6 +231,7 @@ func TestAltScreenEraseTrimsLeadingBlankRows(t *testing.T) {
 }
 
 func TestAltScreenEraseClipsCapturedRowsToVisibleWidth(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -245,6 +257,7 @@ func TestAltScreenEraseClipsCapturedRowsToVisibleWidth(t *testing.T) {
 }
 
 func TestAltScreenEraseDedupedFrameRemainsReservedOnResizeGrow(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.AllowAltScreenScrollback = true
 	line := MakeBlankLine(5)
@@ -273,6 +286,7 @@ func TestAltScreenEraseDedupedFrameRemainsReservedOnResizeGrow(t *testing.T) {
 }
 
 func TestAltScreenEraseCapturedFrameNotRestoredOnResizeGrow(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -290,6 +304,7 @@ func TestAltScreenEraseCapturedFrameNotRestoredOnResizeGrow(t *testing.T) {
 }
 
 func TestAltScreenEraseDropsWideRuneClippedAtEdge(t *testing.T) {
+	t.Parallel()
 	vt := New(4, 2)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -307,6 +322,7 @@ func TestAltScreenEraseDropsWideRuneClippedAtEdge(t *testing.T) {
 }
 
 func TestAltScreenErasePreservesStyledSpaceRows(t *testing.T) {
+	t.Parallel()
 	vt := New(4, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -355,6 +371,7 @@ func dumpScrollback(t *testing.T, vt *VTerm) {
 }
 
 func TestAltScreenEraseDedupsScrollUpOverlap(t *testing.T) {
+	t.Parallel()
 	// Simulate content that overflows a 4-row terminal:
 	// 6 lines of content → first 2 scroll off via scrollUp,
 	// last 4 remain on screen. After erase+redraw cycle(s),

--- a/internal/vterm/alt_screen_erase_overlap_test.go
+++ b/internal/vterm/alt_screen_erase_overlap_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestAltScreenEraseNoOverlapWhenContentDiffers(t *testing.T) {
+	t.Parallel()
 	// Verify that overlap detection does not falsely match when content changes.
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
@@ -39,6 +40,7 @@ func TestAltScreenEraseNoOverlapWhenContentDiffers(t *testing.T) {
 }
 
 func TestAltScreenErasePartialOverlap(t *testing.T) {
+	t.Parallel()
 	// Manually set up scrollback to have specific tail lines,
 	// then verify partial overlap detection works.
 	vt := New(10, 3)
@@ -84,6 +86,7 @@ func TestAltScreenErasePartialOverlap(t *testing.T) {
 }
 
 func TestAltScreenEraseOverlapAcrossMultipleRedraws(t *testing.T) {
+	t.Parallel()
 	// Verify duplication doesn't compound over 5 erase cycles
 	// with content that overflows the terminal.
 	vt := New(10, 3)
@@ -120,6 +123,7 @@ func TestAltScreenEraseOverlapAcrossMultipleRedraws(t *testing.T) {
 }
 
 func TestAltScreenEraseContentChangeAfterOverflow(t *testing.T) {
+	t.Parallel()
 	// After overflowing content, changing the content should replace
 	// the old capture properly.
 	vt := New(10, 4)
@@ -164,6 +168,7 @@ func TestAltScreenEraseContentChangeAfterOverflow(t *testing.T) {
 }
 
 func TestAltScreenScrollbackTailOverlap(t *testing.T) {
+	t.Parallel()
 	makeLine := func(text string, width int) []Cell {
 		line := MakeBlankLine(width)
 		for i, r := range text {
@@ -192,6 +197,7 @@ func TestAltScreenScrollbackTailOverlap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var sb [][]Cell
 			for _, s := range tt.sb {
 				sb = append(sb, makeLine(s, 5))
@@ -209,6 +215,7 @@ func TestAltScreenScrollbackTailOverlap(t *testing.T) {
 }
 
 func TestAltScreenEraseManyOverflowCyclesStable(t *testing.T) {
+	t.Parallel()
 	// Stress test: 20 redraw cycles of overflowing content.
 	// Scrollback should stabilize and never grow unbounded.
 	vt := New(10, 4)
@@ -245,6 +252,7 @@ func TestAltScreenEraseManyOverflowCyclesStable(t *testing.T) {
 }
 
 func TestAltScreenErasePartialOverlapReservesFullFrameOnResizeGrow(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -288,6 +296,7 @@ func TestAltScreenErasePartialOverlapReservesFullFrameOnResizeGrow(t *testing.T)
 }
 
 func TestAltScreenEndOffsetPreservedOnPartialDedup(t *testing.T) {
+	t.Parallel()
 	// Regression: dedupScrollUpTrailing must not zero altScreenCaptureEndOffset
 	// when trailing lines don't overlap with pre-capture content.
 	// Scenario: cycle 1 captures [C,D,E], cycle 2 adds scrollUp lines [X,Y]
@@ -324,6 +333,7 @@ func TestAltScreenEndOffsetPreservedOnPartialDedup(t *testing.T) {
 }
 
 func TestResizeGrowReservesTrackedCaptureEndOffset(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.AltScreen = true
@@ -366,6 +376,7 @@ func TestResizeGrowReservesTrackedCaptureEndOffset(t *testing.T) {
 }
 
 func TestScrollUpCustomScrollRegionPreservesTrackedAltScreenCaptureReplacement(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 4)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -414,6 +425,7 @@ func TestScrollUpCustomScrollRegionPreservesTrackedAltScreenCaptureReplacement(t
 }
 
 func TestAltScreenDropRecaptureResetsEndOffset(t *testing.T) {
+	t.Parallel()
 	// Regression: dropTrackedAltScreenCapture must zero altScreenCaptureEndOffset
 	// after dedup so the next capture starts with a clean offset. Without the fix,
 	// stale endOffset from cycle 1 causes captureStart miscalculation in cycle 3.

--- a/internal/vterm/alt_screen_transcript_capture_test.go
+++ b/internal/vterm/alt_screen_transcript_capture_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestAltScreenEraseTranscriptShiftPreservesScrolledOffTop(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))

--- a/internal/vterm/alt_screen_transcript_dedup_test.go
+++ b/internal/vterm/alt_screen_transcript_dedup_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestAltScreenRepeatedAboveFoldChangesDoNotDuplicateIdenticalRedraw(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -39,6 +40,7 @@ func TestAltScreenRepeatedAboveFoldChangesDoNotDuplicateIdenticalRedraw(t *testi
 }
 
 func TestAltScreenShiftRedrawDoesNotDuplicateRowsAlreadyScrolledOffDuringDraw(t *testing.T) {
+	t.Parallel()
 	vt := New(12, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))
@@ -72,6 +74,7 @@ func TestAltScreenShiftRedrawDoesNotDuplicateRowsAlreadyScrolledOffDuringDraw(t 
 }
 
 func TestAltScreenLongTranscriptShiftDoesNotDuplicateOrDropLines(t *testing.T) {
+	t.Parallel()
 	vt := New(16, 3)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))

--- a/internal/vterm/pane_capture_alt_cursor_test.go
+++ b/internal/vterm/pane_capture_alt_cursor_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestLoadPaneCaptureWithCursorAndModes_ClampsAltSavedCursorAfterResize(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.Write([]byte("shell"))
 	vt.enterAltScreen()

--- a/internal/vterm/pane_capture_modes_test.go
+++ b/internal/vterm/pane_capture_modes_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestLoadPaneCaptureWithCursorAndModes_PreservesActiveAltScreenBuffer(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 3)
 	vt.Write([]byte("shell"))
 	vt.enterAltScreen()
@@ -54,6 +55,7 @@ func TestLoadPaneCaptureWithCursorAndModes_PreservesActiveAltScreenBuffer(t *tes
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_AppliesPaneModesToSubsequentWrites(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 4)
 	vt.LoadPaneCaptureWithCursorAndModes(
 		[]byte("head\nbody\nmid\nfoot"),
@@ -94,6 +96,7 @@ func TestLoadPaneCaptureWithCursorAndModes_AppliesPaneModesToSubsequentWrites(t 
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_ClearsStaleAltScreenState(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 3)
 	vt.Write([]byte("oldhome"))
 	vt.enterAltScreen()
@@ -142,6 +145,7 @@ func TestLoadPaneCaptureWithCursorAndModes_ClearsStaleAltScreenState(t *testing.
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_FreshAltScreenSnapshotKeepsHistoryWithoutInventingMainBuffer(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 2)
 
 	vt.LoadPaneCaptureWithCursorAndModes(
@@ -199,6 +203,7 @@ func TestLoadPaneCaptureWithCursorAndModes_FreshAltScreenSnapshotKeepsHistoryWit
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenRedrawDoesNotDuplicateRestoredFrame(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 2)
 	vt.AllowAltScreenScrollback = true
 
@@ -246,6 +251,7 @@ func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenRedrawDoesNotDuplicateR
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenShiftAfterAttachPreservesScrolledOffTop(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 3)
 	vt.AllowAltScreenScrollback = true
 
@@ -278,6 +284,7 @@ func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenShiftAfterAttachPreserv
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenRedrawAfterResizeDoesNotDuplicateRestoredFrame(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 3)
 	vt.AllowAltScreenScrollback = true
 
@@ -319,6 +326,7 @@ func TestLoadPaneCaptureWithCursorAndModes_FirstAltScreenRedrawAfterResizeDoesNo
 }
 
 func TestAppendScrollbackDeltaWithSize_PreservesPendingAltScreenDedupAfterHistoryAppend(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 2)
 	vt.AllowAltScreenScrollback = true
 
@@ -350,6 +358,7 @@ func TestAppendScrollbackDeltaWithSize_PreservesPendingAltScreenDedupAfterHistor
 }
 
 func TestLoadPaneCaptureWithCursor_PreservesExistingAltScreenStateWhenModesUnknown(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 3)
 	vt.Write([]byte("shell"))
 	vt.enterAltScreen()
@@ -372,6 +381,7 @@ func TestLoadPaneCaptureWithCursor_PreservesExistingAltScreenStateWhenModesUnkno
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_DoesNotReplaceExistingMainBufferWithHistoryTail(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 2)
 	vt.Write([]byte("oldhome"))
 	vt.enterAltScreen()
@@ -416,6 +426,7 @@ func TestLoadPaneCaptureWithCursorAndModes_DoesNotReplaceExistingMainBufferWithH
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_PreservesExistingAltSavedCursorWhenOmitted(t *testing.T) {
+	t.Parallel()
 	vt := New(8, 3)
 	vt.Write([]byte("shell"))
 	vt.enterAltScreen()
@@ -451,6 +462,7 @@ func TestLoadPaneCaptureWithCursorAndModes_PreservesExistingAltSavedCursorWhenOm
 }
 
 func TestLoadPaneCaptureWithCursorAndModes_ResetsScrollRegionWhenOmitted(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 4)
 	vt.ScrollTop = 1
 	vt.ScrollBottom = 3

--- a/internal/vterm/parser_extra_test.go
+++ b/internal/vterm/parser_extra_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestParserLegacyAltScreen47(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Enable Alt Screen using CSI ? 47 h
@@ -19,6 +20,7 @@ func TestParserLegacyAltScreen47(t *testing.T) {
 }
 
 func TestParserLegacyAltScreen1047(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Enable Alt Screen using CSI ? 1047 h

--- a/internal/vterm/parser_state_test.go
+++ b/internal/vterm/parser_state_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestParserStateSnapshot_RestoresContinuationAcrossReset(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.Write([]byte("\x1b[>"))
 

--- a/internal/vterm/parser_test.go
+++ b/internal/vterm/parser_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestResetParserStateClearsCarriedCSI(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 2)
 
 	vt.Write([]byte("\x1b["))

--- a/internal/vterm/prepend_scrollback_load_test.go
+++ b/internal/vterm/prepend_scrollback_load_test.go
@@ -1,0 +1,252 @@
+package vterm
+
+import "testing"
+
+func TestLoadPaneCapture_RestoresVisibleScreenAndScrollback(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
+
+	if len(vt.Scrollback) != 1 {
+		t.Fatalf("expected 1 scrollback line, got %d", len(vt.Scrollback))
+	}
+	if got := vt.Scrollback[0][0].Rune; got != 'h' {
+		t.Fatalf("expected scrollback to start with history, got %q", got)
+	}
+	if got := vt.Screen[0][0].Rune; got != 's' {
+		t.Fatalf("expected first visible row to start with screen data, got %q", got)
+	}
+	if got := vt.Screen[1][0].Rune; got != 's' {
+		t.Fatalf("expected second visible row to start with screen data, got %q", got)
+	}
+}
+
+func TestLoadPaneCapture_RestoresCurrentStyle(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.LoadPaneCapture([]byte("\x1b[1;31mstyled prompt"))
+
+	if !vt.CurrentStyle.Bold {
+		t.Fatal("expected CurrentStyle.Bold to remain active after pane restore")
+	}
+	if vt.CurrentStyle.Fg.Type != ColorIndexed || vt.CurrentStyle.Fg.Value != 1 {
+		t.Fatalf("expected CurrentStyle foreground to remain red, got type=%v value=%d", vt.CurrentStyle.Fg.Type, vt.CurrentStyle.Fg.Value)
+	}
+}
+
+func TestLoadPaneCapture_RestoresCursorFromCaptureWhenMetadataUnavailable(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.CursorX = 7
+	vt.CursorY = 1
+
+	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
+
+	if vt.CursorX != 10 || vt.CursorY != 1 {
+		t.Fatalf("expected cursor to follow the restored frame when explicit metadata is unavailable, got (%d,%d)", vt.CursorX, vt.CursorY)
+	}
+}
+
+func TestLoadPaneCaptureWithCursor_RestoresExplicitCursor(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+
+	vt.LoadPaneCaptureWithCursorAndModes([]byte("history\nscreen one\nscreen two\n"), 5, 1, true, PaneModeState{PreserveExistingState: true})
+
+	if vt.CursorX != 5 || vt.CursorY != 1 {
+		t.Fatalf("expected explicit pane cursor to be restored, got (%d,%d)", vt.CursorX, vt.CursorY)
+	}
+}
+
+func TestLoadPaneCapture_ExitsSynchronizedOutput(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.Write([]byte("stale frame"))
+	vt.setSynchronizedOutput(true)
+	vt.Write([]byte("\nignored while frozen"))
+
+	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
+
+	if vt.SyncActive() {
+		t.Fatal("expected synchronized output to be disabled after pane restore")
+	}
+	screen, _ := vt.RenderBuffers()
+	if got := screen[0][0].Rune; got != 's' {
+		t.Fatalf("expected restored frame to be visible after sync reset, got %q", got)
+	}
+}
+
+func TestLoadPaneCapture_ReplacesAltScreenScrollback(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	line := MakeBlankLine(20)
+	line[0] = Cell{Rune: 'h', Width: 1}
+	vt.Scrollback = append(vt.Scrollback, line)
+	vt.enterAltScreen()
+
+	vt.LoadPaneCapture([]byte("screen one\nscreen two\n"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected full pane restore to replace stale alt-screen scrollback, got %d lines", len(vt.Scrollback))
+	}
+}
+
+func TestLoadPaneCapture_EmptyCaptureClearsFrameAndParserState(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.Write([]byte("stale"))
+	vt.Write([]byte("\x1b["))
+
+	vt.LoadPaneCaptureWithCursorAndModes(nil, 3, 0, true, PaneModeState{PreserveExistingState: true})
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected empty authoritative snapshot to clear scrollback, got %d lines", len(vt.Scrollback))
+	}
+	if got := vt.Screen[0][0].Rune; got != ' ' {
+		t.Fatalf("expected first cell to be blank after empty full restore, got %q", got)
+	}
+	if vt.ParserCarryState() != (ParserCarryState{}) {
+		t.Fatalf("expected parser carry reset after full restore, got %+v", vt.ParserCarryState())
+	}
+	if vt.CursorX != 3 || vt.CursorY != 0 {
+		t.Fatalf("expected explicit cursor restored on empty full capture, got (%d,%d)", vt.CursorX, vt.CursorY)
+	}
+}
+
+func TestLoadPaneCapture_EmptyCaptureWithoutCursorMetadataResetsCursorToOrigin(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	vt.CursorX = 11
+	vt.CursorY = 1
+
+	vt.LoadPaneCapture(nil)
+
+	if vt.CursorX != 0 || vt.CursorY != 0 {
+		t.Fatalf("expected empty authoritative snapshot without cursor metadata to reset stale cursor, got (%d,%d)", vt.CursorX, vt.CursorY)
+	}
+}
+
+func TestLoadPaneCapture_EmptyCaptureClearsAltScreenScrollback(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 2)
+	line := MakeBlankLine(20)
+	line[0] = Cell{Rune: 'h', Width: 1}
+	vt.Scrollback = append(vt.Scrollback, line)
+	vt.enterAltScreen()
+	vt.Write([]byte("stale"))
+
+	vt.LoadPaneCaptureWithCursorAndModes(nil, 0, 0, true, PaneModeState{PreserveExistingState: true})
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected empty authoritative snapshot to clear stale alt-screen scrollback, got %d lines", len(vt.Scrollback))
+	}
+	if got := vt.Screen[0][0].Rune; got != ' ' {
+		t.Fatalf("expected empty authoritative snapshot to blank the visible screen, got %q", got)
+	}
+}
+
+func TestLoadPaneCapture_ResetsTerminalModes(t *testing.T) {
+	t.Parallel()
+	vt := New(6, 3)
+	vt.enterAltScreen()
+	vt.altScreenBuf[0][0] = Cell{Rune: 'x', Width: 1}
+	vt.ScrollTop = 1
+	vt.ScrollBottom = 2
+	vt.OriginMode = true
+	vt.CursorHidden = true
+	vt.SavedCursorX = 5
+	vt.SavedCursorY = 2
+	vt.SavedStyle = Style{Bold: true}
+
+	vt.LoadPaneCaptureWithCursorAndModes(
+		[]byte("\x1b[32mone\ntwo\nthree"),
+		4,
+		2,
+		true,
+		PaneModeState{
+			HasState:     true,
+			AltScreen:    false,
+			OriginMode:   false,
+			CursorHidden: false,
+			ScrollTop:    0,
+			ScrollBottom: vt.Height,
+		},
+	)
+
+	if vt.AltScreen {
+		t.Fatal("expected full pane restore to leave alt screen mode")
+	}
+	if vt.altScreenBuf != nil {
+		t.Fatal("expected alt screen buffer cleared after full pane restore")
+	}
+	if vt.ScrollTop != 0 || vt.ScrollBottom != vt.Height {
+		t.Fatalf("expected full pane restore to reset scroll region, got top=%d bottom=%d height=%d", vt.ScrollTop, vt.ScrollBottom, vt.Height)
+	}
+	if vt.OriginMode {
+		t.Fatal("expected origin mode reset after full pane restore")
+	}
+	if vt.CursorHidden {
+		t.Fatal("expected cursor visibility mode reset after full pane restore")
+	}
+	if vt.SavedCursorX != vt.CursorX || vt.SavedCursorY != vt.CursorY {
+		t.Fatalf("expected saved cursor to sync to restored cursor, got saved=(%d,%d) cursor=(%d,%d)", vt.SavedCursorX, vt.SavedCursorY, vt.CursorX, vt.CursorY)
+	}
+	if vt.SavedStyle != vt.CurrentStyle {
+		t.Fatalf("expected saved style to sync to restored style, got saved=%+v current=%+v", vt.SavedStyle, vt.CurrentStyle)
+	}
+}
+
+func TestLoadPaneCapture_ResetModesAffectSubsequentWrites(t *testing.T) {
+	t.Parallel()
+	vt := New(6, 3)
+	vt.enterAltScreen()
+	vt.ScrollTop = 1
+	vt.ScrollBottom = 2
+	vt.OriginMode = true
+
+	vt.LoadPaneCaptureWithCursorAndModes(
+		[]byte("one\ntwo\nthree"),
+		0,
+		2,
+		true,
+		PaneModeState{
+			HasState:     true,
+			AltScreen:    false,
+			OriginMode:   false,
+			CursorHidden: false,
+			ScrollTop:    0,
+			ScrollBottom: vt.Height,
+		},
+	)
+	vt.Write([]byte("\n"))
+
+	if len(vt.Scrollback) != 1 {
+		t.Fatalf("expected newline after restore to scroll full screen, got %d scrollback lines", len(vt.Scrollback))
+	}
+	if got := vt.Scrollback[0][0].Rune; got != 'o' {
+		t.Fatalf("expected top row to scroll into history after restore, got %q", got)
+	}
+	if got := vt.Screen[0][0].Rune; got != 't' {
+		t.Fatalf("expected second row to become first visible row after restore scroll, got %q", got)
+	}
+}
+
+func TestIsBlankLine(t *testing.T) {
+	t.Parallel()
+	blank := MakeBlankLine(10)
+	if !isBlankLine(blank) {
+		t.Error("MakeBlankLine should produce a blank line")
+	}
+
+	nonBlank := MakeBlankLine(10)
+	nonBlank[5] = Cell{Rune: 'x', Width: 1}
+	if isBlankLine(nonBlank) {
+		t.Error("line with 'x' should not be blank")
+	}
+
+	// Null rune cells should be considered blank
+	nullLine := make([]Cell, 10)
+	if !isBlankLine(nullLine) {
+		t.Error("line with null runes should be blank")
+	}
+}

--- a/internal/vterm/prepend_scrollback_test.go
+++ b/internal/vterm/prepend_scrollback_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestPrependScrollbackEmpty(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	vt.PrependScrollback(nil)
 	if len(vt.Scrollback) != 0 {
@@ -18,6 +19,7 @@ func TestPrependScrollbackEmpty(t *testing.T) {
 }
 
 func TestPrependScrollbackPlainText(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	vt.PrependScrollback([]byte("hello\nworld\n"))
 
@@ -32,6 +34,7 @@ func TestPrependScrollbackPlainText(t *testing.T) {
 }
 
 func TestPrependScrollbackPreservesExisting(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Add existing scrollback
@@ -59,6 +62,7 @@ func TestPrependScrollbackPreservesExisting(t *testing.T) {
 }
 
 func TestPrependScrollbackWithANSI(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Bold red text: ESC[1;31m
@@ -81,6 +85,7 @@ func TestPrependScrollbackWithANSI(t *testing.T) {
 }
 
 func TestPrependScrollbackTrimsTrailingBlankLines(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 5)
 
 	// One line of text followed by nothing -- the temp vterm will have
@@ -97,6 +102,7 @@ func TestPrependScrollbackTrimsTrailingBlankLines(t *testing.T) {
 }
 
 func TestPrependScrollbackLargeContent(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Generate content that exceeds the screen height to produce scrollback
@@ -119,6 +125,7 @@ func TestPrependScrollbackLargeContent(t *testing.T) {
 }
 
 func TestPrependScrollbackRespectsMaxScrollback(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Fill existing scrollback close to max
@@ -139,6 +146,7 @@ func TestPrependScrollbackRespectsMaxScrollback(t *testing.T) {
 }
 
 func TestPrependScrollbackAllBlankContent(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	// Feed whitespace-only content -- should be a no-op
 	vt.PrependScrollback([]byte("   \n   \n"))
@@ -154,6 +162,7 @@ func TestPrependScrollbackAllBlankContent(t *testing.T) {
 }
 
 func TestPrependScrollbackTreatsCaptureLFAsAsRowSeparators(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 5)
 	vt.TreatLFAsCRLF = false
 	vt.PrependScrollback([]byte("abc\nx"))
@@ -167,6 +176,7 @@ func TestPrependScrollbackTreatsCaptureLFAsAsRowSeparators(t *testing.T) {
 }
 
 func TestAppendScrollbackDelta_AppendsMissingSuffix(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
 
@@ -187,6 +197,7 @@ func TestAppendScrollbackDelta_AppendsMissingSuffix(t *testing.T) {
 }
 
 func TestAppendScrollbackDelta_IgnoresMismatchedCapture(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
 
@@ -201,6 +212,7 @@ func TestAppendScrollbackDelta_IgnoresMismatchedCapture(t *testing.T) {
 }
 
 func TestAppendScrollbackDelta_MatchesRetainedSuffixAfterTrim(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("zero\none\ntwo\nthree\nscreen one\nscreen two\n"))
 	vt.Scrollback = append([][]Cell(nil), vt.Scrollback[2:]...)
@@ -222,6 +234,7 @@ func TestAppendScrollbackDelta_MatchesRetainedSuffixAfterTrim(t *testing.T) {
 }
 
 func TestAppendScrollbackDelta_IgnoresTrailingStyledBlankDifferences(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 1)
 	line := MakeBlankLine(6)
 	line[0] = Cell{Rune: 'x', Width: 1}
@@ -241,6 +254,7 @@ func TestAppendScrollbackDelta_IgnoresTrailingStyledBlankDifferences(t *testing.
 }
 
 func TestAppendScrollbackDelta_PrefersMatchAlignedWithCurrentScreenPrefix(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("prompt\ncmd output\nprompt\n"))
 
@@ -257,242 +271,5 @@ func TestAppendScrollbackDelta_PrefersMatchAlignedWithCurrentScreenPrefix(t *tes
 	}
 	if got := vt.Scrollback[2][0].Rune; got != 'p' {
 		t.Fatalf("expected repeated trailing prompt to reconcile after the middle row, got %q", got)
-	}
-}
-
-func TestLoadPaneCapture_RestoresVisibleScreenAndScrollback(t *testing.T) {
-	vt := New(20, 2)
-	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
-
-	if len(vt.Scrollback) != 1 {
-		t.Fatalf("expected 1 scrollback line, got %d", len(vt.Scrollback))
-	}
-	if got := vt.Scrollback[0][0].Rune; got != 'h' {
-		t.Fatalf("expected scrollback to start with history, got %q", got)
-	}
-	if got := vt.Screen[0][0].Rune; got != 's' {
-		t.Fatalf("expected first visible row to start with screen data, got %q", got)
-	}
-	if got := vt.Screen[1][0].Rune; got != 's' {
-		t.Fatalf("expected second visible row to start with screen data, got %q", got)
-	}
-}
-
-func TestLoadPaneCapture_RestoresCurrentStyle(t *testing.T) {
-	vt := New(20, 2)
-	vt.LoadPaneCapture([]byte("\x1b[1;31mstyled prompt"))
-
-	if !vt.CurrentStyle.Bold {
-		t.Fatal("expected CurrentStyle.Bold to remain active after pane restore")
-	}
-	if vt.CurrentStyle.Fg.Type != ColorIndexed || vt.CurrentStyle.Fg.Value != 1 {
-		t.Fatalf("expected CurrentStyle foreground to remain red, got type=%v value=%d", vt.CurrentStyle.Fg.Type, vt.CurrentStyle.Fg.Value)
-	}
-}
-
-func TestLoadPaneCapture_RestoresCursorFromCaptureWhenMetadataUnavailable(t *testing.T) {
-	vt := New(20, 2)
-	vt.CursorX = 7
-	vt.CursorY = 1
-
-	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
-
-	if vt.CursorX != 10 || vt.CursorY != 1 {
-		t.Fatalf("expected cursor to follow the restored frame when explicit metadata is unavailable, got (%d,%d)", vt.CursorX, vt.CursorY)
-	}
-}
-
-func TestLoadPaneCaptureWithCursor_RestoresExplicitCursor(t *testing.T) {
-	vt := New(20, 2)
-
-	vt.LoadPaneCaptureWithCursorAndModes([]byte("history\nscreen one\nscreen two\n"), 5, 1, true, PaneModeState{PreserveExistingState: true})
-
-	if vt.CursorX != 5 || vt.CursorY != 1 {
-		t.Fatalf("expected explicit pane cursor to be restored, got (%d,%d)", vt.CursorX, vt.CursorY)
-	}
-}
-
-func TestLoadPaneCapture_ExitsSynchronizedOutput(t *testing.T) {
-	vt := New(20, 2)
-	vt.Write([]byte("stale frame"))
-	vt.setSynchronizedOutput(true)
-	vt.Write([]byte("\nignored while frozen"))
-
-	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
-
-	if vt.SyncActive() {
-		t.Fatal("expected synchronized output to be disabled after pane restore")
-	}
-	screen, _ := vt.RenderBuffers()
-	if got := screen[0][0].Rune; got != 's' {
-		t.Fatalf("expected restored frame to be visible after sync reset, got %q", got)
-	}
-}
-
-func TestLoadPaneCapture_ReplacesAltScreenScrollback(t *testing.T) {
-	vt := New(20, 2)
-	line := MakeBlankLine(20)
-	line[0] = Cell{Rune: 'h', Width: 1}
-	vt.Scrollback = append(vt.Scrollback, line)
-	vt.enterAltScreen()
-
-	vt.LoadPaneCapture([]byte("screen one\nscreen two\n"))
-
-	if len(vt.Scrollback) != 0 {
-		t.Fatalf("expected full pane restore to replace stale alt-screen scrollback, got %d lines", len(vt.Scrollback))
-	}
-}
-
-func TestLoadPaneCapture_EmptyCaptureClearsFrameAndParserState(t *testing.T) {
-	vt := New(20, 2)
-	vt.Write([]byte("stale"))
-	vt.Write([]byte("\x1b["))
-
-	vt.LoadPaneCaptureWithCursorAndModes(nil, 3, 0, true, PaneModeState{PreserveExistingState: true})
-
-	if len(vt.Scrollback) != 0 {
-		t.Fatalf("expected empty authoritative snapshot to clear scrollback, got %d lines", len(vt.Scrollback))
-	}
-	if got := vt.Screen[0][0].Rune; got != ' ' {
-		t.Fatalf("expected first cell to be blank after empty full restore, got %q", got)
-	}
-	if vt.ParserCarryState() != (ParserCarryState{}) {
-		t.Fatalf("expected parser carry reset after full restore, got %+v", vt.ParserCarryState())
-	}
-	if vt.CursorX != 3 || vt.CursorY != 0 {
-		t.Fatalf("expected explicit cursor restored on empty full capture, got (%d,%d)", vt.CursorX, vt.CursorY)
-	}
-}
-
-func TestLoadPaneCapture_EmptyCaptureWithoutCursorMetadataResetsCursorToOrigin(t *testing.T) {
-	vt := New(20, 2)
-	vt.CursorX = 11
-	vt.CursorY = 1
-
-	vt.LoadPaneCapture(nil)
-
-	if vt.CursorX != 0 || vt.CursorY != 0 {
-		t.Fatalf("expected empty authoritative snapshot without cursor metadata to reset stale cursor, got (%d,%d)", vt.CursorX, vt.CursorY)
-	}
-}
-
-func TestLoadPaneCapture_EmptyCaptureClearsAltScreenScrollback(t *testing.T) {
-	vt := New(20, 2)
-	line := MakeBlankLine(20)
-	line[0] = Cell{Rune: 'h', Width: 1}
-	vt.Scrollback = append(vt.Scrollback, line)
-	vt.enterAltScreen()
-	vt.Write([]byte("stale"))
-
-	vt.LoadPaneCaptureWithCursorAndModes(nil, 0, 0, true, PaneModeState{PreserveExistingState: true})
-
-	if len(vt.Scrollback) != 0 {
-		t.Fatalf("expected empty authoritative snapshot to clear stale alt-screen scrollback, got %d lines", len(vt.Scrollback))
-	}
-	if got := vt.Screen[0][0].Rune; got != ' ' {
-		t.Fatalf("expected empty authoritative snapshot to blank the visible screen, got %q", got)
-	}
-}
-
-func TestLoadPaneCapture_ResetsTerminalModes(t *testing.T) {
-	vt := New(6, 3)
-	vt.enterAltScreen()
-	vt.altScreenBuf[0][0] = Cell{Rune: 'x', Width: 1}
-	vt.ScrollTop = 1
-	vt.ScrollBottom = 2
-	vt.OriginMode = true
-	vt.CursorHidden = true
-	vt.SavedCursorX = 5
-	vt.SavedCursorY = 2
-	vt.SavedStyle = Style{Bold: true}
-
-	vt.LoadPaneCaptureWithCursorAndModes(
-		[]byte("\x1b[32mone\ntwo\nthree"),
-		4,
-		2,
-		true,
-		PaneModeState{
-			HasState:     true,
-			AltScreen:    false,
-			OriginMode:   false,
-			CursorHidden: false,
-			ScrollTop:    0,
-			ScrollBottom: vt.Height,
-		},
-	)
-
-	if vt.AltScreen {
-		t.Fatal("expected full pane restore to leave alt screen mode")
-	}
-	if vt.altScreenBuf != nil {
-		t.Fatal("expected alt screen buffer cleared after full pane restore")
-	}
-	if vt.ScrollTop != 0 || vt.ScrollBottom != vt.Height {
-		t.Fatalf("expected full pane restore to reset scroll region, got top=%d bottom=%d height=%d", vt.ScrollTop, vt.ScrollBottom, vt.Height)
-	}
-	if vt.OriginMode {
-		t.Fatal("expected origin mode reset after full pane restore")
-	}
-	if vt.CursorHidden {
-		t.Fatal("expected cursor visibility mode reset after full pane restore")
-	}
-	if vt.SavedCursorX != vt.CursorX || vt.SavedCursorY != vt.CursorY {
-		t.Fatalf("expected saved cursor to sync to restored cursor, got saved=(%d,%d) cursor=(%d,%d)", vt.SavedCursorX, vt.SavedCursorY, vt.CursorX, vt.CursorY)
-	}
-	if vt.SavedStyle != vt.CurrentStyle {
-		t.Fatalf("expected saved style to sync to restored style, got saved=%+v current=%+v", vt.SavedStyle, vt.CurrentStyle)
-	}
-}
-
-func TestLoadPaneCapture_ResetModesAffectSubsequentWrites(t *testing.T) {
-	vt := New(6, 3)
-	vt.enterAltScreen()
-	vt.ScrollTop = 1
-	vt.ScrollBottom = 2
-	vt.OriginMode = true
-
-	vt.LoadPaneCaptureWithCursorAndModes(
-		[]byte("one\ntwo\nthree"),
-		0,
-		2,
-		true,
-		PaneModeState{
-			HasState:     true,
-			AltScreen:    false,
-			OriginMode:   false,
-			CursorHidden: false,
-			ScrollTop:    0,
-			ScrollBottom: vt.Height,
-		},
-	)
-	vt.Write([]byte("\n"))
-
-	if len(vt.Scrollback) != 1 {
-		t.Fatalf("expected newline after restore to scroll full screen, got %d scrollback lines", len(vt.Scrollback))
-	}
-	if got := vt.Scrollback[0][0].Rune; got != 'o' {
-		t.Fatalf("expected top row to scroll into history after restore, got %q", got)
-	}
-	if got := vt.Screen[0][0].Rune; got != 't' {
-		t.Fatalf("expected second row to become first visible row after restore scroll, got %q", got)
-	}
-}
-
-func TestIsBlankLine(t *testing.T) {
-	blank := MakeBlankLine(10)
-	if !isBlankLine(blank) {
-		t.Error("MakeBlankLine should produce a blank line")
-	}
-
-	nonBlank := MakeBlankLine(10)
-	nonBlank[5] = Cell{Rune: 'x', Width: 1}
-	if isBlankLine(nonBlank) {
-		t.Error("line with 'x' should not be blank")
-	}
-
-	// Null rune cells should be considered blank
-	nullLine := make([]Cell, 10)
-	if !isBlankLine(nullLine) {
-		t.Error("line with null runes should be blank")
 	}
 }

--- a/internal/vterm/scrollback_alt_screen_test.go
+++ b/internal/vterm/scrollback_alt_screen_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestAltScreenScrollbackDisabled(t *testing.T) {
+	t.Parallel()
 	vt := New(3, 2)
 	vt.Write([]byte("\x1b[?1049h"))
 	if !vt.AltScreen {
@@ -16,6 +17,7 @@ func TestAltScreenScrollbackDisabled(t *testing.T) {
 }
 
 func TestAltScreenScrollbackEnabled(t *testing.T) {
+	t.Parallel()
 	vt := New(3, 2)
 	vt.AllowAltScreenScrollback = true
 	vt.Write([]byte("\x1b[?1049h"))

--- a/internal/vterm/selection_trim_test.go
+++ b/internal/vterm/selection_trim_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestTrimScrollbackShiftsSelection(t *testing.T) {
+	t.Parallel()
 	vt := New(2, 1)
 	vt.Scrollback = make([][]Cell, MaxScrollback+2)
 	vt.Screen[0] = MakeBlankLine(2)
@@ -22,6 +23,7 @@ func TestTrimScrollbackShiftsSelection(t *testing.T) {
 }
 
 func TestTrimScrollbackClearsFullyTrimmedSelection(t *testing.T) {
+	t.Parallel()
 	vt := New(2, 1)
 	vt.Scrollback = make([][]Cell, MaxScrollback+2)
 	vt.Screen[0] = MakeBlankLine(2)

--- a/internal/vterm/sync_mapping_test.go
+++ b/internal/vterm/sync_mapping_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestSelectionMappingUsesSyncBuffers(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.Scrollback = [][]Cell{
 		MakeBlankLine(5),
@@ -30,6 +31,7 @@ func TestSelectionMappingUsesSyncBuffers(t *testing.T) {
 }
 
 func TestSyncScrollClampsToFrozenScrollback(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.Scrollback = [][]Cell{
 		MakeBlankLine(5),
@@ -57,6 +59,7 @@ func TestSyncScrollClampsToFrozenScrollback(t *testing.T) {
 }
 
 func TestSyncScrollbackGrowthDoesNotShiftAnchoredView(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.Scrollback = [][]Cell{
 		MakeBlankLine(5),
@@ -89,6 +92,7 @@ func TestSyncScrollbackGrowthDoesNotShiftAnchoredView(t *testing.T) {
 }
 
 func TestSyncOutputKeepsLiveBottomWhenViewportNeverScrolled(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.Scrollback = [][]Cell{
 		MakeBlankLine(5),
@@ -110,6 +114,7 @@ func TestSyncOutputKeepsLiveBottomWhenViewportNeverScrolled(t *testing.T) {
 }
 
 func TestSyncOutputDoesNotRestoreHistoryAfterUserReturnsToBottom(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 	vt.Scrollback = [][]Cell{
 		MakeBlankLine(5),

--- a/internal/vterm/vterm_capture_test.go
+++ b/internal/vterm/vterm_capture_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestCaptureLines_PreservesExplicitBlankTailRows(t *testing.T) {
+	t.Parallel()
 	data := []byte("first\n\n")
 	tmp := parseCaptureWithSize(data, 8, 4)
 	lines := captureLines(data, tmp)
@@ -19,6 +20,7 @@ func TestCaptureLines_PreservesExplicitBlankTailRows(t *testing.T) {
 }
 
 func TestCaptureLines_DropsImplicitUnusedScreenRows(t *testing.T) {
+	t.Parallel()
 	data := []byte("first\nsecond\n")
 	tmp := parseCaptureWithSize(data, 8, 4)
 	lines := captureLines(data, tmp)

--- a/internal/vterm/vterm_render_test.go
+++ b/internal/vterm/vterm_render_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 1)
 	vt.CurrentStyle.Underline = true
 	vt.Write([]byte("     "))
@@ -17,6 +18,7 @@ func TestRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
 }
 
 func TestStyleToDeltaANSIPreservesBoldWhenTurningOffDim(t *testing.T) {
+	t.Parallel()
 	prev := Style{Bold: true, Dim: true}
 	next := Style{Bold: true}
 	out := StyleToDeltaANSI(prev, next)
@@ -26,6 +28,7 @@ func TestStyleToDeltaANSIPreservesBoldWhenTurningOffDim(t *testing.T) {
 }
 
 func TestRenderKeepsUnderlineForText(t *testing.T) {
+	t.Parallel()
 	vt := New(2, 1)
 	vt.CurrentStyle.Underline = true
 	vt.Write([]byte("A "))

--- a/internal/vterm/vterm_scrollback_delta_test.go
+++ b/internal/vterm/vterm_scrollback_delta_test.go
@@ -3,6 +3,7 @@ package vterm
 import "testing"
 
 func TestAppendScrollbackDeltaWithSize_MatchesRetainedSuffixAfterTrim(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("zero\none\ntwo\nthree\nscreen one\nscreen two\n"))
 	vt.Scrollback = append([][]Cell(nil), vt.Scrollback[2:]...)
@@ -24,6 +25,7 @@ func TestAppendScrollbackDeltaWithSize_MatchesRetainedSuffixAfterTrim(t *testing
 }
 
 func TestAppendScrollbackDeltaWithSize_PrefersScreenAlignedRepeatedMatch(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("prompt\ncmd output\nprompt\n"))
 
@@ -44,6 +46,7 @@ func TestAppendScrollbackDeltaWithSize_PrefersScreenAlignedRepeatedMatch(t *test
 }
 
 func TestAppendScrollbackDeltaWithSize_DropsVisibleTailAfterViewportGrowth(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("history\nscreen one\nscreen two\n"))
 	vt.Resize(20, 3)
@@ -59,6 +62,7 @@ func TestAppendScrollbackDeltaWithSize_DropsVisibleTailAfterViewportGrowth(t *te
 }
 
 func TestAppendScrollbackDeltaWithSize_PrefersLatestRepeatedRetainedSuffix(t *testing.T) {
+	t.Parallel()
 	vt := New(20, 2)
 	vt.LoadPaneCapture([]byte("A\nB\nscreen one\nscreen two\n"))
 	vt.Scrollback = append([][]Cell(nil), vt.Scrollback[:2]...)

--- a/internal/vterm/vterm_test.go
+++ b/internal/vterm/vterm_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestScrollUpClamping(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	// Set scroll region to lines 5-15 (10 lines)
 	vt.ScrollTop = 5
@@ -27,6 +28,7 @@ func TestScrollUpClamping(t *testing.T) {
 }
 
 func TestScrollDownClamping(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	// Set scroll region to lines 5-15 (10 lines)
 	vt.ScrollTop = 5
@@ -49,6 +51,7 @@ func TestScrollDownClamping(t *testing.T) {
 }
 
 func TestInsertLinesClamping(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	vt.ScrollTop = 0
 	vt.ScrollBottom = 24
@@ -71,6 +74,7 @@ func TestInsertLinesClamping(t *testing.T) {
 }
 
 func TestDeleteLinesClamping(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	vt.ScrollTop = 0
 	vt.ScrollBottom = 24
@@ -93,6 +97,7 @@ func TestDeleteLinesClamping(t *testing.T) {
 }
 
 func TestResizeMinimumDimensions(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 	vt.CursorX = 10
 	vt.CursorY = 10
@@ -115,6 +120,7 @@ func TestResizeMinimumDimensions(t *testing.T) {
 }
 
 func TestResizeNegativeDimensions(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Resize to negative dimensions (should clamp to 1x1)
@@ -129,6 +135,7 @@ func TestResizeNegativeDimensions(t *testing.T) {
 }
 
 func TestViewOffsetClampedAfterTrim(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Add scrollback lines
@@ -152,6 +159,7 @@ func TestViewOffsetClampedAfterTrim(t *testing.T) {
 }
 
 func TestCSISubParameterParsing(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Test colon-separated 256-color foreground: ESC[38:5:196m
@@ -178,6 +186,7 @@ func TestCSISubParameterParsing(t *testing.T) {
 }
 
 func TestCSISemicolonParameterParsing(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Test semicolon-separated 256-color (existing format, should still work)
@@ -191,6 +200,7 @@ func TestCSISemicolonParameterParsing(t *testing.T) {
 }
 
 func TestVersionBumpsOnCursorMoveAndAltScreenCursorHide(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 5)
 	v0 := vt.Version()
 	vt.Write([]byte("\x1b[C")) // CUF - cursor forward
@@ -209,6 +219,7 @@ func TestVersionBumpsOnCursorMoveAndAltScreenCursorHide(t *testing.T) {
 }
 
 func TestMode25IgnoredWhenCursorVisibilityControlsDisabled(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 5)
 	vt.IgnoreCursorVisibilityControls = true
 	v0 := vt.Version()
@@ -223,6 +234,7 @@ func TestMode25IgnoredWhenCursorVisibilityControlsDisabled(t *testing.T) {
 }
 
 func TestScrollbackViewOffsetAnchorsOnScrollUp(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 3)
 	// Seed scrollback so ViewOffset is meaningful.
 	for i := 0; i < 3; i++ {
@@ -241,6 +253,7 @@ func TestScrollbackViewOffsetAnchorsOnScrollUp(t *testing.T) {
 }
 
 func TestScrollbackViewOffsetAnchorsOnResize(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 3)
 	// Seed scrollback so ViewOffset is meaningful.
 	for i := 0; i < 2; i++ {
@@ -259,6 +272,7 @@ func TestScrollbackViewOffsetAnchorsOnResize(t *testing.T) {
 }
 
 func TestLFDoesNotResetColumnByDefault(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.Write([]byte("abc\nx"))
 
@@ -268,6 +282,7 @@ func TestLFDoesNotResetColumnByDefault(t *testing.T) {
 }
 
 func TestLFResetsColumnWhenTreatLFAsCRLFEnabled(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 3)
 	vt.TreatLFAsCRLF = true
 	vt.Write([]byte("abc\nx"))
@@ -278,6 +293,7 @@ func TestLFResetsColumnWhenTreatLFAsCRLFEnabled(t *testing.T) {
 }
 
 func TestResizeRestoresScrollbackOnGrow(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 3)
 	// Seed scrollback with two lines.
 	for i := 0; i < 2; i++ {
@@ -313,6 +329,7 @@ func TestResizeRestoresScrollbackOnGrow(t *testing.T) {
 }
 
 func TestTrimScrollbackPreservesTrackedAltScreenCapturePosition(t *testing.T) {
+	t.Parallel()
 	vt := New(5, 2)
 
 	makeLine := func(text string) []Cell {
@@ -354,6 +371,7 @@ func TestTrimScrollbackPreservesTrackedAltScreenCapturePosition(t *testing.T) {
 }
 
 func TestIncrementalCursorPositionedWrites(t *testing.T) {
+	t.Parallel()
 	// Test cursor positioning + partial writes (common in Ink/React TUIs, progress bars, etc.)
 	vt := New(20, 3)
 

--- a/internal/vterm/vterm_widechar_test.go
+++ b/internal/vterm/vterm_widechar_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestWideCharacterWidth(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Write a wide character (CJK)
@@ -27,6 +28,7 @@ func TestWideCharacterWidth(t *testing.T) {
 }
 
 func TestWideCharacterAtEndOfLine(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 5) // Narrow terminal
 	vt.CursorX = 9   // Last column
 
@@ -47,6 +49,7 @@ func TestWideCharacterAtEndOfLine(t *testing.T) {
 }
 
 func TestRowToStringSkipsContinuationCells(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 	vt.Write([]byte("你A"))
 
@@ -57,6 +60,7 @@ func TestRowToStringSkipsContinuationCells(t *testing.T) {
 }
 
 func TestSearchSkipsContinuationCells(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 	vt.Write([]byte("你A"))
 
@@ -67,6 +71,7 @@ func TestSearchSkipsContinuationCells(t *testing.T) {
 }
 
 func TestGetSelectedTextSkipsContinuationCells(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 	vt.Write([]byte("你A"))
 
@@ -77,6 +82,7 @@ func TestGetSelectedTextSkipsContinuationCells(t *testing.T) {
 }
 
 func TestNormalCharacterWidth(t *testing.T) {
+	t.Parallel()
 	vt := New(80, 24)
 
 	// Write a normal ASCII character
@@ -107,6 +113,7 @@ func assertLineNormalized(t *testing.T, line []Cell) {
 }
 
 func TestWideGlyphNormalizationAfterEdits(t *testing.T) {
+	t.Parallel()
 	vt := New(6, 1)
 	vt.Write([]byte("你A"))
 
@@ -127,6 +134,7 @@ func TestWideGlyphNormalizationAfterEdits(t *testing.T) {
 }
 
 func TestOverwriteWideCharWithNarrowChar(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 
 	// Write a wide character
@@ -163,6 +171,7 @@ func TestOverwriteWideCharWithNarrowChar(t *testing.T) {
 }
 
 func TestOverwriteContinuationCellWithNarrowChar(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 
 	// Write a wide character
@@ -192,6 +201,7 @@ func TestOverwriteContinuationCellWithNarrowChar(t *testing.T) {
 }
 
 func TestOverwriteNarrowCharsWithWideChar(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 
 	// Write two narrow characters
@@ -218,6 +228,7 @@ func TestOverwriteNarrowCharsWithWideChar(t *testing.T) {
 }
 
 func TestOverwriteWideCharWithWideChar(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 
 	// Write first wide character
@@ -244,6 +255,7 @@ func TestOverwriteWideCharWithWideChar(t *testing.T) {
 }
 
 func TestWideCharOverwritesAdjacentWideChar(t *testing.T) {
+	t.Parallel()
 	vt := New(10, 1)
 
 	// Write two adjacent wide characters: "你好" at positions 0-1 and 2-3
@@ -285,6 +297,7 @@ func TestWideCharOverwritesAdjacentWideChar(t *testing.T) {
 }
 
 func TestWideCharIncrementalUpdate(t *testing.T) {
+	t.Parallel()
 	// Test that wide characters in incremental updates don't leave orphans
 	vt := New(20, 1)
 


### PR DESCRIPTION
## What

Adds `t.Parallel()` as the first statement of all 124 top-level `internal/vterm` test functions plus the one table-driven subtest (skipping the two `Fuzz` entry points). Splits `prepend_scrollback_test.go`'s `LoadPaneCapture` group into `prepend_scrollback_load_test.go` since the added lines pushed it over the 500-line guard.

## Why

The suite used zero `t.Parallel()`. vterm is the ideal low-risk starting point: each test builds an isolated `New(w,h)` terminal with no package-level mutable state, no `t.Setenv`, no shared resources. Under `-race`, `t.Parallel()` proves the emulator tests share no hidden global state and guards against future package-level caches.

## Verification

- No `t.Setenv`/`t.Chdir`/pre-existing `t.Parallel` in the suite.
- `go test -race ./internal/vterm/ -count=5` passes (no data races); both split files < 500 lines; `go vet` + golangci-lint clean.
- Scoped strictly to vterm.

---

⚠️ Stacked on #255. Test-quality from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)