### PR TITLE
Pass resolved tmux.Options to center/sidebar instead of re-deriving

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -142,8 +142,8 @@ func New(version, commit, date string) (*App, error) {
 	app.toast.SetStyles(app.styles)
 	app.setKeymapHintsEnabled(cfg.UI.ShowKeymapHints)
 	// Propagate tmux config to components
-	app.center.SetTmuxConfig(tmuxOpts.ServerName, tmuxOpts.ConfigPath)
-	app.sidebarTerminal.SetTmuxConfig(tmuxOpts.ServerName, tmuxOpts.ConfigPath)
+	app.center.SetTmuxOptions(tmuxOpts)
+	app.sidebarTerminal.SetTmuxOptions(tmuxOpts)
 	app.supervisor.Start("center.tab_actor", app.center.RunTabActor, supervisor.WithRestartPolicy(supervisor.RestartAlways))
 	if app.gitStatus != nil {
 		app.supervisor.Start("git.status_manager", app.gitStatus.Run)

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -53,25 +53,8 @@ type Model struct {
 	config     *config.Config
 	styles     common.Styles
 	tabHits    []tabHit
-	tmuxConfig tmuxConfig
+	tmuxOpts   tmux.Options
 	instanceID string
-}
-
-// tmuxConfig holds tmux-related configuration
-type tmuxConfig struct {
-	ServerName string
-	ConfigPath string
-}
-
-func (m *Model) getTmuxOptions() tmux.Options {
-	opts := tmux.DefaultOptions()
-	if m.tmuxConfig.ServerName != "" {
-		opts.ServerName = m.tmuxConfig.ServerName
-	}
-	if m.tmuxConfig.ConfigPath != "" {
-		opts.ConfigPath = m.tmuxConfig.ConfigPath
-	}
-	return opts
 }
 
 // SetInstanceID sets the tmux instance tag for sessions created by this model.
@@ -79,12 +62,12 @@ func (m *Model) SetInstanceID(id string) {
 	m.instanceID = id
 }
 
-// SetTmuxConfig updates the tmux configuration.
-func (m *Model) SetTmuxConfig(serverName, configPath string) {
-	m.tmuxConfig.ServerName = serverName
-	m.tmuxConfig.ConfigPath = configPath
+// SetTmuxOptions stores the resolved tmux options and forwards them to the
+// agent manager.
+func (m *Model) SetTmuxOptions(opts tmux.Options) {
+	m.tmuxOpts = opts
 	if m.agentManager != nil {
-		m.agentManager.SetTmuxOptions(m.getTmuxOptions())
+		m.agentManager.SetTmuxOptions(opts)
 	}
 }
 

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -32,7 +32,7 @@ func (m *Model) userInputActivityTagCmd(tab *Tab) tea.Cmd {
 		return nil
 	}
 	tab.lastInputTagAt = now
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 	timestamp := now.UnixMilli()
 	return func() tea.Msg {
 		raw := strconv.FormatInt(timestamp, 10)

--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -403,7 +403,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 					}
 				}
 				if tagSessionName != "" {
-					opts := m.getTmuxOptions()
+					opts := m.tmuxOpts
 					sessionName := tagSessionName
 					timestamp := strconv.FormatInt(tagTimestamp, 10)
 					cmds = append(cmds, func() tea.Msg {

--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -33,7 +33,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 		}
 		tab.mu.Unlock()
 		if tagSessionName != "" {
-			opts := m.getTmuxOptions()
+			opts := m.tmuxOpts
 			sessionName := tagSessionName
 			timestamp := strconv.FormatInt(tagTimestamp, 10)
 			cmds = append(cmds, func() tea.Msg {

--- a/internal/ui/center/model_lifecycle.go
+++ b/internal/ui/center/model_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -18,6 +19,7 @@ func New(cfg *config.Config) *Model {
 		agentManager:         appPty.NewAgentManager(cfg),
 		styles:               common.DefaultStyles(),
 		tabEvents:            make(chan tabEvent, 4096),
+		tmuxOpts:             tmux.DefaultOptions(),
 	}
 }
 

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -145,8 +145,8 @@ func (m *Model) createAgentTabWithSession(assistant string, ws *data.Workspace, 
 		// Fresh tabs must only seed history. The attached PTY still has unread
 		// startup bytes queued, so preloading the visible screen would replay the
 		// same banner/prompt a second time when the reader drains.
-		captureCols, captureRows := sessionHistoryCaptureSize(sessionName, termWidth, termHeight, m.getTmuxOptions())
-		scrollback, _ := tmux.CapturePane(sessionName, m.getTmuxOptions())
+		captureCols, captureRows := sessionHistoryCaptureSize(sessionName, termWidth, termHeight, m.tmuxOpts)
+		scrollback, _ := tmux.CapturePane(sessionName, m.tmuxOpts)
 
 		return ptyTabCreateResult{
 			Workspace:         ws,

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -32,7 +32,7 @@ func (m *Model) closeTabAt(index int) tea.Cmd {
 
 	// Capture session info before cleanup for async kill
 	sessionName := tab.SessionName
-	tmuxOpts := m.getTmuxOptions()
+	tmuxOpts := m.tmuxOpts
 
 	m.stopPTYReader(tab)
 

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -116,7 +116,7 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 	tm := m.terminalMetrics()
 	attachWidth := tm.Width
 	attachHeight := tm.Height
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 	return func() tea.Msg {
 		state, err := sessionStateForFn(sessionName, opts)
 		if err != nil {

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -145,7 +145,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 	assistant := tab.Assistant
 	ws := tab.Workspace
 	tabID := tab.ID
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 	return func() tea.Msg {
 		state, err := sessionStateForFn(sessionName, opts)
 		if err != nil {
@@ -311,7 +311,7 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 	if existingAgent != nil {
 		_ = m.agentManager.CloseAgent(existingAgent)
 	}
-	tmuxOpts := m.getTmuxOptions()
+	tmuxOpts := m.tmuxOpts
 
 	tm := m.terminalMetrics()
 	termWidth := tm.Width

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -427,7 +427,7 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 			}
 		}
 		if tagSessionName != "" {
-			opts := m.getTmuxOptions()
+			opts := m.tmuxOpts
 			sessionName := tagSessionName
 			timestamp := strconv.FormatInt(tagTimestamp, 10)
 			safego.Go("center.tmux_tag_write", func() {

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -127,9 +127,8 @@ type TerminalModel struct {
 	msgSink func(tea.Msg)
 
 	// tmux config
-	tmuxServerName string
-	tmuxConfigPath string
-	instanceID     string
+	tmuxOpts   tmux.Options
+	instanceID string
 }
 
 // NewTerminalModel creates a new sidebar terminal model
@@ -139,29 +138,18 @@ func NewTerminalModel() *TerminalModel {
 		activeTabByWorkspace: make(map[string]int),
 		pendingCreation:      make(map[string]bool),
 		styles:               common.DefaultStyles(),
+		tmuxOpts:             tmux.DefaultOptions(),
 	}
 }
 
-// SetTmuxConfig updates the tmux configuration.
-func (m *TerminalModel) SetTmuxConfig(serverName, configPath string) {
-	m.tmuxServerName = serverName
-	m.tmuxConfigPath = configPath
+// SetTmuxOptions stores the resolved tmux options for this model.
+func (m *TerminalModel) SetTmuxOptions(opts tmux.Options) {
+	m.tmuxOpts = opts
 }
 
 // SetInstanceID sets the tmux instance tag for sessions created by this model.
 func (m *TerminalModel) SetInstanceID(id string) {
 	m.instanceID = id
-}
-
-func (m *TerminalModel) getTmuxOptions() tmux.Options {
-	opts := tmux.DefaultOptions()
-	if m.tmuxServerName != "" {
-		opts.ServerName = m.tmuxServerName
-	}
-	if m.tmuxConfigPath != "" {
-		opts.ConfigPath = m.tmuxConfigPath
-	}
-	return opts
 }
 
 // SetShowKeymapHints controls whether helper text is rendered.

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -87,7 +87,7 @@ func (m *TerminalModel) createTerminalTab(ws *data.Workspace) tea.Cmd {
 	tabID := generateTerminalTabID()
 	termWidth, termHeight := m.sessionBootstrapViewportSize()
 	attachWidth, attachHeight := m.terminalContentSize()
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 	instanceID := m.instanceID
 	root := ws.Root
 
@@ -234,7 +234,7 @@ func (m *TerminalModel) RestartActiveTab() tea.Cmd {
 		sessionName = tmux.SessionName("amux", string(ws.ID()), string(tab.ID))
 	}
 	m.detachState(ts, false)
-	_ = tmux.KillSession(sessionName, m.getTmuxOptions())
+	_ = tmux.KillSession(sessionName, m.tmuxOpts)
 	return m.attachToSession(ws, tab.ID, sessionName, true, "restart")
 }
 
@@ -243,7 +243,7 @@ func (m *TerminalModel) attachToSession(ws *data.Workspace, tabID TerminalTabID,
 		return nil
 	}
 	// Snapshot model-dependent values so the async cmd doesn't race on TerminalModel fields.
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 	termWidth, termHeight := m.sessionBootstrapViewportSize()
 	attachWidth, attachHeight := m.terminalContentSize()
 	shell := os.Getenv("SHELL")

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -60,7 +60,7 @@ func (m *TerminalModel) closeTabAt(idx int) (*TerminalModel, tea.Cmd) {
 	wtID := m.workspaceID()
 	tab := tabs[idx]
 	sessionName := ""
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 
 	// Close PTY and cleanup
 	if tab.State != nil {

--- a/internal/ui/sidebar/terminal_tab_ops.go
+++ b/internal/ui/sidebar/terminal_tab_ops.go
@@ -79,7 +79,7 @@ func (m *TerminalModel) CloseActiveTab() tea.Cmd {
 
 	tab := tabs[idx]
 	sessionName := ""
-	opts := m.getTmuxOptions()
+	opts := m.tmuxOpts
 
 	// Close PTY and cleanup
 	if tab.State != nil {


### PR DESCRIPTION
## What

Renames `SetTmuxConfig(serverName, configPath)` → `SetTmuxOptions(opts tmux.Options)` on both `center.Model` and `sidebar.TerminalModel`, stores the resolved `tmux.Options` in one field per model, and deletes the `getTmuxOptions()` derivation methods + the `tmuxConfig` struct / `tmuxServerName`/`tmuxConfigPath` fields. ~16 internal callers now read the stored field; `app_init` passes `tmuxOpts` directly.

## Why

`app_init` built a resolved `tmux.Options`, decomposed it into strings via `SetTmuxConfig`, then center/sidebar recomposed it back into `tmux.Options` on every call — a needless round-trip reimplemented identically in two places.

## Verification

- `getTmuxOptions`/`SetTmuxConfig`/`tmuxConfig`/string fields all gone from `internal/ui`.
- The field defaults to `tmux.DefaultOptions()` in each constructor so tests (which build models directly and never call `SetTmuxOptions`) keep the prior "defaults when unset" behavior — the only remaining `DefaultOptions()` calls in `internal/ui`.
- `go build ./...`, `go test -race ./internal/ui/{center,sidebar}/...`, `go test ./internal/app/...` pass; golangci-lint clean.

---

⚠️ Stacked on #256. API/duplication cleanup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)