### PR TITLE
Unify duplicated PTY tab-merge logic with generic common.MergeByID

### DIFF
--- a/internal/ui/center/model_workspace_rebind.go
+++ b/internal/ui/center/model_workspace_rebind.go
@@ -101,37 +101,7 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 }
 
 func mergeTabsByID(existing, incoming []*Tab, incomingActive int) ([]*Tab, int) {
-	merged := make([]*Tab, 0, len(existing)+len(incoming))
-	indexByID := make(map[TabID]int, len(existing)+len(incoming))
-
-	for _, tab := range existing {
-		if tab == nil {
-			continue
-		}
-		if _, ok := indexByID[tab.ID]; ok {
-			continue
-		}
-		indexByID[tab.ID] = len(merged)
-		merged = append(merged, tab)
-	}
-
-	migratedActive := -1
-	for i, tab := range incoming {
-		if tab == nil {
-			continue
-		}
-		if idx, ok := indexByID[tab.ID]; ok {
-			if i == incomingActive {
-				migratedActive = idx
-			}
-			continue
-		}
-		indexByID[tab.ID] = len(merged)
-		merged = append(merged, tab)
-		if i == incomingActive {
-			migratedActive = len(merged) - 1
-		}
-	}
-
-	return merged, migratedActive
+	return common.MergeByID(existing, incoming, incomingActive,
+		func(t *Tab) TabID { return t.ID },
+		func(t *Tab) bool { return t == nil })
 }

--- a/internal/ui/common/merge.go
+++ b/internal/ui/common/merge.go
@@ -1,0 +1,41 @@
+package common
+
+// MergeByID merges incoming into existing, de-duplicating by id while preserving
+// order (existing first, then new incoming items). It returns the merged slice
+// and the index that incoming[incomingActive] maps to in the result (-1 if the
+// active item was nil or out of range). isNil filters out nil/zero entries.
+func MergeByID[T any, K comparable](existing, incoming []T, incomingActive int, id func(T) K, isNil func(T) bool) ([]T, int) {
+	merged := make([]T, 0, len(existing)+len(incoming))
+	indexByID := make(map[K]int, len(existing)+len(incoming))
+
+	for _, item := range existing {
+		if isNil(item) {
+			continue
+		}
+		if _, ok := indexByID[id(item)]; ok {
+			continue
+		}
+		indexByID[id(item)] = len(merged)
+		merged = append(merged, item)
+	}
+
+	migratedActive := -1
+	for i, item := range incoming {
+		if isNil(item) {
+			continue
+		}
+		if idx, ok := indexByID[id(item)]; ok {
+			if i == incomingActive {
+				migratedActive = idx
+			}
+			continue
+		}
+		indexByID[id(item)] = len(merged)
+		merged = append(merged, item)
+		if i == incomingActive {
+			migratedActive = len(merged) - 1
+		}
+	}
+
+	return merged, migratedActive
+}

--- a/internal/ui/common/merge_test.go
+++ b/internal/ui/common/merge_test.go
@@ -1,0 +1,55 @@
+package common
+
+import "testing"
+
+func TestMergeByID(t *testing.T) {
+	t.Parallel()
+	id := func(s string) string { return s }
+	isNil := func(s string) bool { return s == "" }
+
+	t.Run("dedupes preserving order, existing first", func(t *testing.T) {
+		t.Parallel()
+		merged, active := MergeByID([]string{"a", "b"}, []string{"b", "c"}, 1, id, isNil)
+		if got, want := merged, []string{"a", "b", "c"}; !eq(got, want) {
+			t.Fatalf("merged = %v, want %v", got, want)
+		}
+		// incoming[1] == "c" is appended at index 2.
+		if active != 2 {
+			t.Fatalf("active = %d, want 2", active)
+		}
+	})
+
+	t.Run("active maps to existing index when duplicate", func(t *testing.T) {
+		t.Parallel()
+		merged, active := MergeByID([]string{"a", "b"}, []string{"b"}, 0, id, isNil)
+		if !eq(merged, []string{"a", "b"}) {
+			t.Fatalf("merged = %v", merged)
+		}
+		if active != 1 { // incoming "b" maps to existing index 1
+			t.Fatalf("active = %d, want 1", active)
+		}
+	})
+
+	t.Run("nil entries skipped, active -1 when none", func(t *testing.T) {
+		t.Parallel()
+		merged, active := MergeByID([]string{"", "a"}, []string{""}, 0, id, isNil)
+		if !eq(merged, []string{"a"}) {
+			t.Fatalf("merged = %v, want [a]", merged)
+		}
+		if active != -1 {
+			t.Fatalf("active = %d, want -1", active)
+		}
+	})
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/ui/sidebar/terminal_workspace_rebind.go
+++ b/internal/ui/sidebar/terminal_workspace_rebind.go
@@ -88,37 +88,7 @@ func (m *TerminalModel) RebindWorkspaceID(previous, current *data.Workspace) tea
 }
 
 func mergeTerminalTabsByID(existing, incoming []*TerminalTab, incomingActive int) ([]*TerminalTab, int) {
-	merged := make([]*TerminalTab, 0, len(existing)+len(incoming))
-	indexByID := make(map[TerminalTabID]int, len(existing)+len(incoming))
-
-	for _, tab := range existing {
-		if tab == nil {
-			continue
-		}
-		if _, ok := indexByID[tab.ID]; ok {
-			continue
-		}
-		indexByID[tab.ID] = len(merged)
-		merged = append(merged, tab)
-	}
-
-	migratedActive := -1
-	for i, tab := range incoming {
-		if tab == nil {
-			continue
-		}
-		if idx, ok := indexByID[tab.ID]; ok {
-			if i == incomingActive {
-				migratedActive = idx
-			}
-			continue
-		}
-		indexByID[tab.ID] = len(merged)
-		merged = append(merged, tab)
-		if i == incomingActive {
-			migratedActive = len(merged) - 1
-		}
-	}
-
-	return merged, migratedActive
+	return common.MergeByID(existing, incoming, incomingActive,
+		func(t *TerminalTab) TerminalTabID { return t.ID },
+		func(t *TerminalTab) bool { return t == nil })
 }


### PR DESCRIPTION
## What

Adds `common.MergeByID[T any, K comparable](existing, incoming, incomingActive, id, isNil)` and reduces `center.mergeTabsByID` / `sidebar.mergeTerminalTabsByID` to thin typed wrappers, so only one copy of the dedupe + active-index logic remains.

## Why

The two functions were line-for-line identical, differing only in element/ID type (`*Tab`/`TabID` vs `*TerminalTab`/`TerminalTabID`). The subtle "dedupe by ID preserving order while tracking the migrated active index" math is exactly where the recent workspace-rebind commits keep introducing off-by-one risk.

## Verification

- New unit test covers order-preserving dedupe, active→existing-index mapping, and nil-skipping (`active == -1`).
- `go test -race ./internal/ui/{common,center,sidebar}/...` (rebind/workspace tests) pass; golangci-lint clean. No import cycle (`common` doesn't import center/sidebar).
- The active-index **clamp** in `RebindWorkspaceID` is left inline (entangled with `activeTabByWorkspace` assignments) — only the merge is unified.

---

⚠️ Stacked on #257. Duplication-extraction from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)