### PR TITLE
Extract the chat-cursor learning state machine from TerminalLayerWithCursorOwner

### DIFF
--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -261,74 +261,7 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 			if appOwnsCursor {
 				snap.ShowCursor = false
 			} else {
-				snap.CursorHidden = false
-				trustFullViewport := !restrictCursor
-				if restrictCursor {
-					tab.lastRestrictedVersion = version
-					if cursorOutputActive && !visibleOutputActive && tab.stableCursorSet {
-						tab.pendingIdleCursorRelearn = true
-					}
-				}
-				versionChangedFromStable := version != tab.stableCursorVersion
-				idleSameVersionRelearn := trustFullViewport &&
-					tab.stableCursorSet &&
-					!recentLocalInput &&
-					version == tab.lastRestrictedVersion &&
-					(tab.pendingIdleCursorRelearn || tab.stableCursorVersion == 0) &&
-					hasChatCursorContextNearPosition(snap, liveCursorY)
-				plausibleInitialCursor := isPlausibleInitialChatCursor(snap, liveCursorX, liveCursorY)
-				initialFullViewportLearn := !tab.stableCursorSet && plausibleInitialCursor
-				learnFullViewport := trustFullViewport &&
-					(initialFullViewportLearn ||
-						(tab.stableCursorSet && recentLocalInput) ||
-						idleSameVersionRelearn ||
-						(versionChangedFromStable && version != tab.lastRestrictedVersion))
-				liveCursorVisible := isChatInputCursorPosition(snap, liveCursorX, liveCursorY, trustFullViewport)
-				liveCursorDisplayable := liveCursorVisible &&
-					(!restrictCursor || !isSuspiciousBottomEdgeCornerCursor(snap, liveCursorX, liveCursorY)) &&
-					(tab.stableCursorSet || !trustFullViewport || plausibleInitialCursor)
-				liveCursorRenderable := isRenderableChatCursorPosition(
-					snap,
-					liveCursorX,
-					liveCursorY,
-					learnFullViewport,
-					recentLocalInput,
-				)
-				storedCursorInViewport := tab.stableCursorSet &&
-					isStoredChatCursorPosition(snap, tab.stableCursorX, tab.stableCursorY, true)
-				storedCursorVisible := tab.stableCursorSet &&
-					isStoredChatCursorPosition(snap, tab.stableCursorX, tab.stableCursorY, trustFullViewport)
-				// Stable chat cursor learning lives in the render path because it
-				// depends on the fully materialized snapshot and the current cursor
-				// trust policy. The cache key above prevents repeated View passes
-				// from churning this state when those inputs have not changed.
-				if liveCursorRenderable {
-					tab.stableCursorSet = true
-					tab.stableCursorX = liveCursorX
-					tab.stableCursorY = liveCursorY
-					tab.stableCursorVersion = version
-					tab.pendingIdleCursorRelearn = false
-				} else if tab.stableCursorSet &&
-					tab.stableCursorVersion == 0 &&
-					trustFullViewport &&
-					storedCursorVisible {
-					tab.stableCursorVersion = version
-				} else if tab.stableCursorSet &&
-					!storedCursorInViewport {
-					tab.stableCursorSet = false
-					tab.stableCursorVersion = 0
-					tab.pendingIdleCursorRelearn = false
-				}
-
-				switch {
-				case tab.stableCursorSet:
-					snap.CursorX = tab.stableCursorX
-					snap.CursorY = tab.stableCursorY
-				case liveCursorDisplayable:
-					// Leave the live cursor in place until we learn a stable input-band position.
-				default:
-					snap.ShowCursor = false
-				}
+				m.learnStableChatCursorLocked(tab, snap, version, liveCursorX, liveCursorY, recentLocalInput, restrictCursor, visibleOutputActive, cursorOutputActive)
 			}
 		}
 

--- a/internal/ui/center/model_pty_status_chat_cursor.go
+++ b/internal/ui/center/model_pty_status_chat_cursor.go
@@ -1,0 +1,104 @@
+package center
+
+import "github.com/andyrewlee/amux/internal/ui/compositor"
+
+// learnStableChatCursorLocked is the stable chat-cursor learning state machine,
+// run when the app does not own the cursor (live cursor visible, not alt-screen).
+// It computes the current cursor trust policy from the materialized snapshot and
+// then hands the decision flags to applyLearnedChatCursorLocked, which updates
+// the stable-cursor state and points snap's cursor at the chosen position.
+//
+// This lives in the render path because it depends on the fully materialized
+// snapshot; the snapshot cache key in TerminalLayerWithCursorOwner prevents
+// repeated View passes from churning this state when its inputs are unchanged.
+// Mutates snap and tab.stable* in place; the caller must hold tab.mu.
+func (m *Model) learnStableChatCursorLocked(
+	tab *Tab,
+	snap *compositor.VTermSnapshot,
+	version uint64,
+	liveCursorX, liveCursorY int,
+	recentLocalInput, restrictCursor, visibleOutputActive, cursorOutputActive bool,
+) {
+	snap.CursorHidden = false
+	trustFullViewport := !restrictCursor
+	if restrictCursor {
+		tab.lastRestrictedVersion = version
+		if cursorOutputActive && !visibleOutputActive && tab.stableCursorSet {
+			tab.pendingIdleCursorRelearn = true
+		}
+	}
+	versionChangedFromStable := version != tab.stableCursorVersion
+	idleSameVersionRelearn := trustFullViewport &&
+		tab.stableCursorSet &&
+		!recentLocalInput &&
+		version == tab.lastRestrictedVersion &&
+		(tab.pendingIdleCursorRelearn || tab.stableCursorVersion == 0) &&
+		hasChatCursorContextNearPosition(snap, liveCursorY)
+	plausibleInitialCursor := isPlausibleInitialChatCursor(snap, liveCursorX, liveCursorY)
+	initialFullViewportLearn := !tab.stableCursorSet && plausibleInitialCursor
+	learnFullViewport := trustFullViewport &&
+		(initialFullViewportLearn ||
+			(tab.stableCursorSet && recentLocalInput) ||
+			idleSameVersionRelearn ||
+			(versionChangedFromStable && version != tab.lastRestrictedVersion))
+	liveCursorVisible := isChatInputCursorPosition(snap, liveCursorX, liveCursorY, trustFullViewport)
+	liveCursorDisplayable := liveCursorVisible &&
+		(!restrictCursor || !isSuspiciousBottomEdgeCornerCursor(snap, liveCursorX, liveCursorY)) &&
+		(tab.stableCursorSet || !trustFullViewport || plausibleInitialCursor)
+	liveCursorRenderable := isRenderableChatCursorPosition(
+		snap,
+		liveCursorX,
+		liveCursorY,
+		learnFullViewport,
+		recentLocalInput,
+	)
+	storedCursorInViewport := tab.stableCursorSet &&
+		isStoredChatCursorPosition(snap, tab.stableCursorX, tab.stableCursorY, true)
+	storedCursorVisible := tab.stableCursorSet &&
+		isStoredChatCursorPosition(snap, tab.stableCursorX, tab.stableCursorY, trustFullViewport)
+
+	applyLearnedChatCursorLocked(tab, snap, version, liveCursorX, liveCursorY,
+		liveCursorRenderable, liveCursorDisplayable, trustFullViewport,
+		storedCursorVisible, storedCursorInViewport)
+}
+
+// applyLearnedChatCursorLocked updates the stable-cursor state from the computed
+// trust flags and then places snap's cursor: at the stable position when set,
+// left at the live position when displayable, otherwise hidden. Caller holds
+// tab.mu.
+func applyLearnedChatCursorLocked(
+	tab *Tab,
+	snap *compositor.VTermSnapshot,
+	version uint64,
+	liveCursorX, liveCursorY int,
+	liveCursorRenderable, liveCursorDisplayable, trustFullViewport,
+	storedCursorVisible, storedCursorInViewport bool,
+) {
+	if liveCursorRenderable {
+		tab.stableCursorSet = true
+		tab.stableCursorX = liveCursorX
+		tab.stableCursorY = liveCursorY
+		tab.stableCursorVersion = version
+		tab.pendingIdleCursorRelearn = false
+	} else if tab.stableCursorSet &&
+		tab.stableCursorVersion == 0 &&
+		trustFullViewport &&
+		storedCursorVisible {
+		tab.stableCursorVersion = version
+	} else if tab.stableCursorSet &&
+		!storedCursorInViewport {
+		tab.stableCursorSet = false
+		tab.stableCursorVersion = 0
+		tab.pendingIdleCursorRelearn = false
+	}
+
+	switch {
+	case tab.stableCursorSet:
+		snap.CursorX = tab.stableCursorX
+		snap.CursorY = tab.stableCursorY
+	case liveCursorDisplayable:
+		// Leave the live cursor in place until we learn a stable input-band position.
+	default:
+		snap.ShowCursor = false
+	}
+}


### PR DESCRIPTION
## What

Extracts the "stable chat cursor learning" state machine out of `TerminalLayerWithCursorOwner` (the densest function, gocyclo 71) into a new `model_pty_status_chat_cursor.go`:
- `learnStableChatCursorLocked` — computes the cursor trust policy from the materialized snapshot,
- `applyLearnedChatCursorLocked` — updates the stable-cursor state and places the cursor.

`model_pty_status.go` drops **369 → 302** lines.

## Why

The non-`appOwnsCursor` branch was a self-contained ~70-line state machine buried five levels deep inside `isChat && showCursor && !AltScreen`. Pulling it out flattens the render method and names the concern.

## Note on the split

The single extracted machine measured gocyclo **34** — over the strict `gocyclo:30` ratchet I added earlier in the stack. Rather than `//nolint`, I split it into the *decision* (`learnStableChatCursorLocked`) and the *apply* (`applyLearnedChatCursorLocked`); both are now under 30.

## Verification

- The caller keeps the history-view/`appOwnsCursor` decision, glyph sanitization, blink cleanup, and the `vterm_snapshot_cache_hit/miss` path inline (structural invariant untouched).
- `model_pty_status_chat_cursor_*_test.go` + `_stable_cursor_test.go` pass; `go test -race ./internal/ui/center/...` clean; `make lint-ci-parity` (strict ratchet) clean; center harness renders normally.

---

⚠️ Stacked on #258. Decomposition from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)