### PR TITLE
Dedup the cursor-delegation block in viewLayerBased

### DIFF
--- a/internal/app/app_view.go
+++ b/internal/app/app_view.go
@@ -149,19 +149,8 @@ func (a *App) viewLayerBased() tea.View {
 			termOffsetX, termOffsetY, termW, termH := a.center.TerminalViewport()
 			termX := centerX + termOffsetX
 			termY := topGutter + termOffsetY
-			if centerOwnsCursor && termLayer.Snap != nil {
-				snap := termLayer.Snap
-				if snap.ShowCursor && !snap.CursorHidden && snap.ViewOffset == 0 &&
-					snap.CursorX >= 0 && snap.CursorY >= 0 &&
-					snap.CursorX < termW && snap.CursorY < termH {
-					setTerminalCursor(termX+snap.CursorX, termY+snap.CursorY)
-					// Keep exactly one visible cursor by delegating to the hardware cursor.
-					// This shallow copy is intentional: only ShowCursor changes here, and
-					// the snapshot screen data remains read-only for rendering.
-					snapCopy := *snap
-					snapCopy.ShowCursor = false
-					termLayer = compositor.NewVTermLayer(&snapCopy)
-				}
+			if centerOwnsCursor {
+				termLayer = delegateTerminalCursor(termLayer, termX, termY, termW, termH, setTerminalCursor)
 			}
 
 			// Compose terminal layer first; chrome is drawn on top without clearing the content area.
@@ -321,19 +310,8 @@ func (a *App) viewLayerBased() tea.View {
 				if termH > maxTermHeight {
 					termH = maxTermHeight
 				}
-				if sidebarOwnsCursor && termLayer.Snap != nil {
-					snap := termLayer.Snap
-					if snap.ShowCursor && !snap.CursorHidden && snap.ViewOffset == 0 &&
-						snap.CursorX >= 0 && snap.CursorY >= 0 &&
-						snap.CursorX < termW && snap.CursorY < termH {
-						setTerminalCursor(originX+snap.CursorX, originY+snap.CursorY)
-						// Keep exactly one visible cursor by delegating to the hardware cursor.
-						// This shallow copy is intentional: only ShowCursor changes here, and
-						// the snapshot screen data remains read-only for rendering.
-						snapCopy := *snap
-						snapCopy.ShowCursor = false
-						termLayer = compositor.NewVTermLayer(&snapCopy)
-					}
+				if sidebarOwnsCursor {
+					termLayer = delegateTerminalCursor(termLayer, originX, originY, termW, termH, setTerminalCursor)
 				}
 
 				positioned := &compositor.PositionedVTermLayer{

--- a/internal/app/app_view_panes.go
+++ b/internal/app/app_view_panes.go
@@ -1,0 +1,25 @@
+package app
+
+import "github.com/andyrewlee/amux/internal/ui/compositor"
+
+// delegateTerminalCursor moves a terminal pane's in-snapshot cursor onto the
+// hardware cursor (via setCursor) when it is visible and in bounds, returning a
+// layer whose snapshot has ShowCursor=false so exactly one cursor renders. The
+// shallow snapshot copy is intentional: only ShowCursor changes; the screen data
+// stays read-only for rendering. Returns termLayer unchanged when there is no
+// visible cursor to delegate.
+func delegateTerminalCursor(termLayer *compositor.VTermLayer, originX, originY, termW, termH int, setCursor func(x, y int)) *compositor.VTermLayer {
+	if termLayer == nil || termLayer.Snap == nil {
+		return termLayer
+	}
+	snap := termLayer.Snap
+	if snap.ShowCursor && !snap.CursorHidden && snap.ViewOffset == 0 &&
+		snap.CursorX >= 0 && snap.CursorY >= 0 &&
+		snap.CursorX < termW && snap.CursorY < termH {
+		setCursor(originX+snap.CursorX, originY+snap.CursorY)
+		snapCopy := *snap
+		snapCopy.ShowCursor = false
+		termLayer = compositor.NewVTermLayer(&snapCopy)
+	}
+	return termLayer
+}


### PR DESCRIPTION
## What

Extracts `delegateTerminalCursor` into a new `app_view_panes.go` and replaces the two identical cursor-delegation blocks in `viewLayerBased` (center + sidebar) with one call each.

## Why

The block — move the in-snapshot cursor onto the hardware cursor when visible/in-bounds, then rebuild the layer with `ShowCursor=false` so exactly one cursor renders — was duplicated verbatim, differing only in local variable names (`termX/termY` vs `originX/originY`). These are the only two `ShowCursor=false` sites in the repo.

## Verification

- `app_view_cursor_overlay_test.go` passes (incl. `TestViewHardwareCursorDelegationDoesNotMutateCachedSnapshot` — the shallow-copy invariant is preserved in the helper).
- All three harness presets (center/sidebar/monitor) render normally; `go build ./...`, `go test ./internal/app/...` pass; gofumpt + golangci-lint clean.

## Scope note

This does the cursor-delegation dedup (the clean, high-value half). The larger `composeCenterPane`/`composeSidebarPane` split of `viewLayerBased` is deferred — it is entangled with shared geometry locals and is the riskier half; it deserves its own focused PR.

---

⚠️ Stacked on #259. Decomposition/dedup from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)