### PR TITLE
Extract the duplicated PTY-chunk apply kernel into applyPTYChunkLocked

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -336,21 +336,8 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 							suppressRedraw := false
 							tab.mu.Lock()
 							if tab.Terminal != nil {
-								filtered := common.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
-								filteredLen = len(filtered)
+								filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
 								filterApplied = true
-								if len(filtered) > 0 {
-									flushDone := perf.Time("pty_flush")
-									tab.Terminal.Write(filtered)
-									flushDone()
-									perf.Count("pty_flush_bytes", int64(len(filtered)))
-								}
-								// Activity state intentionally tracks visible terminal mutations only.
-								// Noise-only chunks are filtered above and must not update activity tags.
-								// We still run this to clear pending visible state when no mutation occurred.
-								tagSessionName, tagTimestamp, _ = m.noteVisibleActivityLockedWithOutput(tab, hasMoreBuffered, visibleSeq, filtered)
-								catchUpBefore, catchUpAfter := tab.settlePTYBytesLocked(processedBytes)
-								suppressRedraw = catchUpBefore && catchUpAfter
 								tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
 								tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.ptyNoiseTrailing...)
 							}
@@ -374,21 +361,8 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 					suppressRedraw := false
 					tab.mu.Lock()
 					if tab.Terminal != nil {
-						filtered := common.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
-						filteredLen = len(filtered)
+						filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
 						filterApplied = true
-						if len(filtered) > 0 {
-							flushDone := perf.Time("pty_flush")
-							tab.Terminal.Write(filtered)
-							flushDone()
-							perf.Count("pty_flush_bytes", int64(len(filtered)))
-						}
-						// Activity state intentionally tracks visible terminal mutations only.
-						// Noise-only chunks are filtered above and must not update activity tags.
-						// We still run this to clear pending visible state when no mutation occurred.
-						tagSessionName, tagTimestamp, _ = m.noteVisibleActivityLockedWithOutput(tab, hasMoreBuffered, visibleSeq, filtered)
-						catchUpBefore, catchUpAfter := tab.settlePTYBytesLocked(processedBytes)
-						suppressRedraw = catchUpBefore && catchUpAfter
 					}
 					tab.mu.Unlock()
 					if !suppressRedraw {
@@ -436,4 +410,27 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 		}
 	}
 	return common.SafeBatch(cmds...)
+}
+
+// applyPTYChunkLocked filters chunk for known PTY noise, writes it to the
+// terminal, updates visible-activity state and catch-up accounting, and emits
+// the per-flush perf counters. The caller must hold tab.mu and have verified
+// tab.Terminal != nil. It returns the filtered byte count, whether the
+// post-write redraw should be suppressed, and the activity tag to publish.
+func (m *Model) applyPTYChunkLocked(tab *Tab, chunk []byte, hasMoreBuffered bool, visibleSeq uint64) (filteredLen int, suppressRedraw bool, tagSessionName string, tagTimestamp int64) {
+	filtered := common.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
+	filteredLen = len(filtered)
+	if len(filtered) > 0 {
+		flushDone := perf.Time("pty_flush")
+		tab.Terminal.Write(filtered)
+		flushDone()
+		perf.Count("pty_flush_bytes", int64(len(filtered)))
+	}
+	// Activity state intentionally tracks visible terminal mutations only.
+	// Noise-only chunks are filtered above and must not update activity tags.
+	// We still run this to clear pending visible state when no mutation occurred.
+	tagSessionName, tagTimestamp, _ = m.noteVisibleActivityLockedWithOutput(tab, hasMoreBuffered, visibleSeq, filtered)
+	catchUpBefore, catchUpAfter := tab.settlePTYBytesLocked(len(chunk))
+	suppressRedraw = catchUpBefore && catchUpAfter
+	return filteredLen, suppressRedraw, tagSessionName, tagTimestamp
 }


### PR DESCRIPTION
## What

Extracts the shared PTY-chunk apply kernel from `updatePTYFlush`'s two byte-identical blocks into `(m *Model) applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)`, which runs under the already-held `tab.mu` and returns `(filteredLen, suppressRedraw, tagSessionName, tagTimestamp)`.

## Why

The kernel — filter known PTY noise → timed `Terminal.Write` + `pty_flush_bytes` → `noteVisibleActivityLockedWithOutput` → `settlePTYBytesLocked` → flush counters — was hand-inlined twice, differing only in that the actor-fallback block also sets `actorQueuedCarry`/`actorQueuedNoiseTrailing`. Any change to PTY write semantics had to be made identically in both.

## Verification

- `perf.Time("pty_flush")` + `pty_flush_bytes` stay inside the lock; `pty_flush_bytes_processed`/`_filtered` stay outside — **counter names and ordering byte-identical**, so `PERF_BASELINES` comparisons hold.
- Both callers preserved; the actor-fallback caller still sets the two carry fields after the call.
- `go test -race ./internal/ui/center/...` (flush/activity/actor suites) pass; golangci-lint + `make lint-ci-parity` (strict ratchet) clean; center harness renders normally.

## Scope note

The `tab_actor.go` `tabEventWriteOutput` "third copy" is left out of scope — its kernel is interwoven with stale-write epoch guarding, actorWritesPending accounting, and a different downstream; unifying it is a separate, higher-risk step.

---

⚠️ Stacked on #260. Duplication-extraction from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)