### PR TITLE
Extract the tmux-activity lease protocol into internal/app/activity

### DIFF
--- a/internal/app/activity/lease.go
+++ b/internal/app/activity/lease.go
@@ -1,0 +1,238 @@
+package activity
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// tmux global option names backing the cross-instance activity-scan lease.
+const (
+	OwnerOption     = "@amux_activity_owner"
+	HeartbeatOption = "@amux_activity_owner_heartbeat_ms"
+	EpochOption     = "@amux_activity_owner_epoch"
+	SnapshotOption  = "@amux_activity_active_workspaces"
+)
+
+const (
+	// OwnerLeaseTTL controls how long an activity-scan owner lease stays valid
+	// after its last heartbeat before another instance may claim ownership.
+	OwnerLeaseTTL = 7 * time.Second
+	// OwnerFutureSkewTolerance caps how far in the future a lease heartbeat may be
+	// (clock skew) before it is treated as expired rather than alive.
+	OwnerFutureSkewTolerance = 2 * time.Second
+	// SnapshotStaleAfter controls how long a shared activity snapshot is trusted
+	// after its timestamp before followers ignore it.
+	SnapshotStaleAfter = 10 * time.Second
+)
+
+// OwnerLease is the cross-instance activity-scan owner lease stored in tmux
+// global options.
+type OwnerLease struct {
+	OwnerID     string
+	HeartbeatAt time.Time
+	Epoch       int64
+}
+
+// OwnerLeaseAlive reports whether lease is a live owner lease at now, tolerating
+// small forward clock skew but expiring stale or far-future heartbeats.
+func OwnerLeaseAlive(lease OwnerLease, now time.Time) bool {
+	if strings.TrimSpace(lease.OwnerID) == "" {
+		return false
+	}
+	if lease.HeartbeatAt.IsZero() {
+		return false
+	}
+	if lease.HeartbeatAt.After(now) {
+		return lease.HeartbeatAt.Sub(now) <= OwnerFutureSkewTolerance
+	}
+	return now.Sub(lease.HeartbeatAt) <= OwnerLeaseTTL
+}
+
+// ReadOwnerLease reads the current owner lease from tmux global options.
+func ReadOwnerLease(opts tmux.Options) (OwnerLease, error) {
+	lease := OwnerLease{}
+	values, err := tmux.GlobalOptionValues([]string{
+		OwnerOption,
+		HeartbeatOption,
+		EpochOption,
+	}, opts)
+	if err != nil {
+		return lease, err
+	}
+	lease.OwnerID = strings.TrimSpace(values[OwnerOption])
+
+	heartbeatRaw := strings.TrimSpace(values[HeartbeatOption])
+	if heartbeatRaw != "" {
+		heartbeatMS, parseErr := strconv.ParseInt(heartbeatRaw, 10, 64)
+		if parseErr == nil && heartbeatMS > 0 {
+			lease.HeartbeatAt = time.UnixMilli(heartbeatMS)
+		}
+	}
+
+	epochRaw := strings.TrimSpace(values[EpochOption])
+	if epochRaw != "" {
+		epoch, parseErr := strconv.ParseInt(epochRaw, 10, 64)
+		if parseErr == nil && epoch > 0 {
+			lease.Epoch = epoch
+		}
+	}
+	return lease, nil
+}
+
+// WriteOwnerLease claims ownership by writing owner/epoch/heartbeat. tmux global
+// options offer no atomic CAS; callers confirm by re-reading and checking epoch.
+func WriteOwnerLease(opts tmux.Options, ownerID string, epoch int64, now time.Time) error {
+	if epoch < 1 {
+		epoch = 1
+	}
+	return tmux.SetGlobalOptionValues([]tmux.OptionValue{
+		{Key: OwnerOption, Value: strings.TrimSpace(ownerID)},
+		{Key: EpochOption, Value: strconv.FormatInt(epoch, 10)},
+		{Key: HeartbeatOption, Value: strconv.FormatInt(now.UnixMilli(), 10)},
+	}, opts)
+}
+
+// RenewOwnerLeaseHeartbeat refreshes only the heartbeat timestamp.
+func RenewOwnerLeaseHeartbeat(opts tmux.Options, now time.Time) error {
+	return tmux.SetGlobalOptionValue(HeartbeatOption, strconv.FormatInt(now.UnixMilli(), 10), opts)
+}
+
+// ReadSnapshot reads the shared active-workspaces snapshot, returning ok=false
+// when it is missing, malformed, from a different epoch, or stale.
+func ReadSnapshot(opts tmux.Options, now time.Time, expectedEpoch int64) (map[string]bool, bool, error) {
+	raw, err := tmux.GlobalOptionValue(SnapshotOption, opts)
+	if err != nil {
+		return nil, false, err
+	}
+	parsed, snapshotEpoch, at, ok := DecodeSnapshot(raw)
+	if !ok {
+		return nil, false, nil
+	}
+	if expectedEpoch > 0 && snapshotEpoch != expectedEpoch {
+		return nil, false, nil
+	}
+	if at.After(now) {
+		return parsed, true, nil
+	}
+	if now.Sub(at) > SnapshotStaleAfter {
+		return nil, false, nil
+	}
+	return parsed, true, nil
+}
+
+// EncodeSnapshot serializes the active-workspace set with epoch and timestamp.
+func EncodeSnapshot(active map[string]bool, epoch int64, now time.Time) string {
+	if epoch < 1 {
+		epoch = 1
+	}
+	ids := make([]string, 0, len(active))
+	for wsID, isActive := range active {
+		if isActive {
+			trimmed := strings.TrimSpace(wsID)
+			if trimmed != "" {
+				ids = append(ids, trimmed)
+			}
+		}
+	}
+	sort.Strings(ids)
+	encodedPayload, err := json.Marshal(ids)
+	if err != nil {
+		encodedPayload = []byte("[]")
+	}
+	payload := "j:" + base64.RawURLEncoding.EncodeToString(encodedPayload)
+	return strconv.FormatInt(epoch, 10) + ";" + strconv.FormatInt(now.UnixMilli(), 10) + ";" + payload
+}
+
+// DecodeSnapshot parses an encoded snapshot, accepting both the JSON payload and
+// legacy comma-delimited formats. Returns ok=false on malformed input.
+func DecodeSnapshot(raw string) (map[string]bool, int64, time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, 0, time.Time{}, false
+	}
+	parts := strings.SplitN(raw, ";", 3)
+	if len(parts) != 3 {
+		return nil, 0, time.Time{}, false
+	}
+	epoch, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil || epoch <= 0 {
+		return nil, 0, time.Time{}, false
+	}
+	timestampMS, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+	if err != nil || timestampMS <= 0 {
+		return nil, 0, time.Time{}, false
+	}
+	active := make(map[string]bool)
+	payload := strings.TrimSpace(parts[2])
+	if payload == "" {
+		return active, epoch, time.UnixMilli(timestampMS), true
+	}
+	if strings.HasPrefix(payload, "j:") {
+		if parsed, ok := decodeSnapshotJSONPayload(payload); ok {
+			return parsed, epoch, time.UnixMilli(timestampMS), true
+		}
+	}
+
+	legacyCandidates := make([]string, 0)
+	for _, candidate := range strings.Split(payload, ",") {
+		wsID := strings.TrimSpace(candidate)
+		if wsID != "" {
+			legacyCandidates = append(legacyCandidates, wsID)
+		}
+	}
+	if len(legacyCandidates) == 0 {
+		return active, epoch, time.UnixMilli(timestampMS), true
+	}
+
+	// Legacy payloads: comma-delimited plain IDs with optional b:<base64(id)> entries.
+	// Note: plain IDs that literally start with "b:" and are valid base64 will be
+	// interpreted as encoded legacy IDs by design for backward compatibility.
+	for _, candidate := range legacyCandidates {
+		if !strings.HasPrefix(candidate, "b:") {
+			active[candidate] = true
+			continue
+		}
+
+		decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(candidate, "b:"))
+		if err != nil {
+			active[candidate] = true
+			continue
+		}
+
+		wsID := strings.TrimSpace(string(decoded))
+		if wsID == "" {
+			active[candidate] = true
+			continue
+		}
+		active[wsID] = true
+	}
+	return active, epoch, time.UnixMilli(timestampMS), true
+}
+
+// decodeSnapshotJSONPayload decodes a "j:"-prefixed base64 JSON array of
+// workspace IDs into an active set. Returns ok=false on malformed input.
+func decodeSnapshotJSONPayload(payload string) (map[string]bool, bool) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(payload, "j:"))
+	if err != nil {
+		return nil, false
+	}
+	var ids []string
+	if err := json.Unmarshal(decoded, &ids); err != nil {
+		return nil, false
+	}
+	active := make(map[string]bool)
+	for _, candidate := range ids {
+		wsID := strings.TrimSpace(candidate)
+		if wsID == "" {
+			continue
+		}
+		active[wsID] = true
+	}
+	return active, true
+}

--- a/internal/app/app_tmux_activity_shared.go
+++ b/internal/app/app_tmux_activity_shared.go
@@ -1,22 +1,12 @@
 package app
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/tmux"
-)
-
-const (
-	tmuxActivityOwnerOption     = "@amux_activity_owner"
-	tmuxActivityHeartbeatOption = "@amux_activity_owner_heartbeat_ms"
-	tmuxActivityEpochOption     = "@amux_activity_owner_epoch"
-	tmuxActivitySnapshotOption  = "@amux_activity_active_workspaces"
 )
 
 var errTmuxActivityOwnershipLostAfterPublish = errors.New("tmux activity ownership lost after snapshot publish")
@@ -39,46 +29,46 @@ func (a *App) resolveTmuxActivityScanRole(
 	// instanceID is assigned once at init; trim once here so all lease-owner
 	// comparisons use the same normalized representation.
 	instanceID := strings.TrimSpace(a.instanceID)
-	lease, err := readTmuxActivityOwnerLease(opts)
+	lease, err := activity.ReadOwnerLease(opts)
 	if err != nil {
 		// Epoch 0 is intentional on unresolved ownership; callers normalize to 1
 		// only when publishing as owner in a known epoch.
 		return tmuxActivityRoleOwner, nil, false, 0, err
 	}
-	if ownerLeaseAlive(lease, now) && lease.ownerID != instanceID {
-		active, ok, err := readTmuxActivitySnapshot(opts, now, lease.epoch)
+	if activity.OwnerLeaseAlive(lease, now) && lease.OwnerID != instanceID {
+		active, ok, err := activity.ReadSnapshot(opts, now, lease.Epoch)
 		if err != nil {
-			return tmuxActivityRoleFollower, nil, false, lease.epoch, err
+			return tmuxActivityRoleFollower, nil, false, lease.Epoch, err
 		}
-		return tmuxActivityRoleFollower, active, ok, lease.epoch, nil
+		return tmuxActivityRoleFollower, active, ok, lease.Epoch, nil
 	}
-	if ownerLeaseAlive(lease, now) && lease.ownerID == instanceID {
-		epoch := lease.epoch
+	if activity.OwnerLeaseAlive(lease, now) && lease.OwnerID == instanceID {
+		epoch := lease.Epoch
 		if epoch < 1 {
 			epoch = 1
 		}
 		return tmuxActivityRoleOwner, nil, false, epoch, nil
 	}
 
-	candidateEpoch := lease.epoch + 1
+	candidateEpoch := lease.Epoch + 1
 	if candidateEpoch < 1 {
 		candidateEpoch = 1
 	}
 	// tmux global options provide no atomic compare-and-swap primitive. Claim by
 	// write-then-confirm-read and rely on epoch checks to prevent split-brain use.
-	if err := writeTmuxActivityOwnerLease(opts, instanceID, candidateEpoch, now); err != nil {
+	if err := activity.WriteOwnerLease(opts, instanceID, candidateEpoch, now); err != nil {
 		return tmuxActivityRoleOwner, nil, false, candidateEpoch, err
 	}
-	confirmedLease, err := readTmuxActivityOwnerLease(opts)
+	confirmedLease, err := activity.ReadOwnerLease(opts)
 	if err != nil {
 		return tmuxActivityRoleOwner, nil, false, candidateEpoch, err
 	}
-	if confirmedLease.ownerID != instanceID || confirmedLease.epoch != candidateEpoch {
-		active, ok, err := readTmuxActivitySnapshot(opts, now, confirmedLease.epoch)
+	if confirmedLease.OwnerID != instanceID || confirmedLease.Epoch != candidateEpoch {
+		active, ok, err := activity.ReadSnapshot(opts, now, confirmedLease.Epoch)
 		if err != nil {
-			return tmuxActivityRoleFollower, nil, false, confirmedLease.epoch, err
+			return tmuxActivityRoleFollower, nil, false, confirmedLease.Epoch, err
 		}
-		return tmuxActivityRoleFollower, active, ok, confirmedLease.epoch, nil
+		return tmuxActivityRoleFollower, active, ok, confirmedLease.Epoch, nil
 	}
 	return tmuxActivityRoleOwner, nil, false, candidateEpoch, nil
 }
@@ -88,21 +78,21 @@ func (a *App) canPublishTmuxActivitySnapshot(opts tmux.Options, epoch int64, now
 	if instanceID == "" {
 		return false, 0, nil
 	}
-	lease, err := readTmuxActivityOwnerLease(opts)
+	lease, err := activity.ReadOwnerLease(opts)
 	if err != nil {
 		return false, 0, err
 	}
-	if !ownerLeaseAlive(lease, now) {
-		return false, lease.epoch, nil
+	if !activity.OwnerLeaseAlive(lease, now) {
+		return false, lease.Epoch, nil
 	}
-	if lease.ownerID != instanceID || lease.epoch != epoch {
-		return false, lease.epoch, nil
+	if lease.OwnerID != instanceID || lease.Epoch != epoch {
+		return false, lease.Epoch, nil
 	}
-	return true, lease.epoch, nil
+	return true, lease.Epoch, nil
 }
 
 func (a *App) publishTmuxActivitySnapshot(opts tmux.Options, active map[string]bool, epoch int64, now time.Time) error {
-	if err := tmux.SetGlobalOptionValue(tmuxActivitySnapshotOption, encodeTmuxActivitySnapshot(active, epoch, now), opts); err != nil {
+	if err := tmux.SetGlobalOptionValue(activity.SnapshotOption, activity.EncodeSnapshot(active, epoch, now), opts); err != nil {
 		return err
 	}
 	// Snapshot write and ownership validation are not atomic; epoch checks on
@@ -116,189 +106,5 @@ func (a *App) publishTmuxActivitySnapshot(opts tmux.Options, active map[string]b
 	}
 	// Heartbeat renewal may race with ownership turnover. Ownership/epoch checks
 	// on readers and subsequent scans handle this by treating mismatches as stale.
-	return renewTmuxActivityOwnerLeaseHeartbeat(opts, now)
-}
-
-type tmuxActivityLease struct {
-	ownerID     string
-	heartbeatAt time.Time
-	epoch       int64
-}
-
-func ownerLeaseAlive(lease tmuxActivityLease, now time.Time) bool {
-	if strings.TrimSpace(lease.ownerID) == "" {
-		return false
-	}
-	if lease.heartbeatAt.IsZero() {
-		return false
-	}
-	if lease.heartbeatAt.After(now) {
-		// Small forward skew is tolerated, but large future timestamps should not
-		// keep stale ownership alive indefinitely.
-		return lease.heartbeatAt.Sub(now) <= tmuxActivityOwnerFutureSkewTolerance
-	}
-	return now.Sub(lease.heartbeatAt) <= tmuxActivityOwnerLeaseTTL
-}
-
-func readTmuxActivityOwnerLease(opts tmux.Options) (tmuxActivityLease, error) {
-	lease := tmuxActivityLease{}
-	values, err := tmux.GlobalOptionValues([]string{
-		tmuxActivityOwnerOption,
-		tmuxActivityHeartbeatOption,
-		tmuxActivityEpochOption,
-	}, opts)
-	if err != nil {
-		return lease, err
-	}
-	lease.ownerID = strings.TrimSpace(values[tmuxActivityOwnerOption])
-
-	heartbeatRaw := strings.TrimSpace(values[tmuxActivityHeartbeatOption])
-	if heartbeatRaw != "" {
-		heartbeatMS, parseErr := strconv.ParseInt(heartbeatRaw, 10, 64)
-		if parseErr == nil && heartbeatMS > 0 {
-			lease.heartbeatAt = time.UnixMilli(heartbeatMS)
-		}
-	}
-
-	epochRaw := strings.TrimSpace(values[tmuxActivityEpochOption])
-	if epochRaw != "" {
-		epoch, parseErr := strconv.ParseInt(epochRaw, 10, 64)
-		if parseErr == nil && epoch > 0 {
-			lease.epoch = epoch
-		}
-	}
-	return lease, nil
-}
-
-func writeTmuxActivityOwnerLease(opts tmux.Options, ownerID string, epoch int64, now time.Time) error {
-	if epoch < 1 {
-		epoch = 1
-	}
-	return tmux.SetGlobalOptionValues([]tmux.OptionValue{
-		{Key: tmuxActivityOwnerOption, Value: strings.TrimSpace(ownerID)},
-		{Key: tmuxActivityEpochOption, Value: strconv.FormatInt(epoch, 10)},
-		{Key: tmuxActivityHeartbeatOption, Value: strconv.FormatInt(now.UnixMilli(), 10)},
-	}, opts)
-}
-
-func renewTmuxActivityOwnerLeaseHeartbeat(opts tmux.Options, now time.Time) error {
-	return tmux.SetGlobalOptionValue(tmuxActivityHeartbeatOption, strconv.FormatInt(now.UnixMilli(), 10), opts)
-}
-
-func readTmuxActivitySnapshot(opts tmux.Options, now time.Time, expectedEpoch int64) (map[string]bool, bool, error) {
-	raw, err := tmux.GlobalOptionValue(tmuxActivitySnapshotOption, opts)
-	if err != nil {
-		return nil, false, err
-	}
-	parsed, snapshotEpoch, at, ok := decodeTmuxActivitySnapshot(raw)
-	if !ok {
-		return nil, false, nil
-	}
-	if expectedEpoch > 0 && snapshotEpoch != expectedEpoch {
-		return nil, false, nil
-	}
-	if at.After(now) {
-		return parsed, true, nil
-	}
-	if now.Sub(at) > tmuxActivitySnapshotStaleAfter {
-		return nil, false, nil
-	}
-	return parsed, true, nil
-}
-
-func encodeTmuxActivitySnapshot(active map[string]bool, epoch int64, now time.Time) string {
-	if epoch < 1 {
-		epoch = 1
-	}
-	ids := make([]string, 0, len(active))
-	for wsID, isActive := range active {
-		if isActive {
-			trimmed := strings.TrimSpace(wsID)
-			if trimmed != "" {
-				ids = append(ids, trimmed)
-			}
-		}
-	}
-	sort.Strings(ids)
-	encodedPayload, err := json.Marshal(ids)
-	if err != nil {
-		encodedPayload = []byte("[]")
-	}
-	payload := "j:" + base64.RawURLEncoding.EncodeToString(encodedPayload)
-	return strconv.FormatInt(epoch, 10) + ";" + strconv.FormatInt(now.UnixMilli(), 10) + ";" + payload
-}
-
-func decodeTmuxActivitySnapshot(raw string) (map[string]bool, int64, time.Time, bool) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, 0, time.Time{}, false
-	}
-	parts := strings.SplitN(raw, ";", 3)
-	if len(parts) != 3 {
-		return nil, 0, time.Time{}, false
-	}
-	epoch, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
-	if err != nil || epoch <= 0 {
-		return nil, 0, time.Time{}, false
-	}
-	timestampMS, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
-	if err != nil || timestampMS <= 0 {
-		return nil, 0, time.Time{}, false
-	}
-	active := make(map[string]bool)
-	payload := strings.TrimSpace(parts[2])
-	if payload == "" {
-		return active, epoch, time.UnixMilli(timestampMS), true
-	}
-	if strings.HasPrefix(payload, "j:") {
-		decodedPayload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(payload, "j:"))
-		if err == nil {
-			var ids []string
-			if err := json.Unmarshal(decodedPayload, &ids); err == nil {
-				for _, candidate := range ids {
-					wsID := strings.TrimSpace(candidate)
-					if wsID == "" {
-						continue
-					}
-					active[wsID] = true
-				}
-				return active, epoch, time.UnixMilli(timestampMS), true
-			}
-		}
-	}
-
-	legacyCandidates := make([]string, 0)
-	for _, candidate := range strings.Split(payload, ",") {
-		wsID := strings.TrimSpace(candidate)
-		if wsID != "" {
-			legacyCandidates = append(legacyCandidates, wsID)
-		}
-	}
-	if len(legacyCandidates) == 0 {
-		return active, epoch, time.UnixMilli(timestampMS), true
-	}
-
-	// Legacy payloads: comma-delimited plain IDs with optional b:<base64(id)> entries.
-	// Note: plain IDs that literally start with "b:" and are valid base64 will be
-	// interpreted as encoded legacy IDs by design for backward compatibility.
-	for _, candidate := range legacyCandidates {
-		if !strings.HasPrefix(candidate, "b:") {
-			active[candidate] = true
-			continue
-		}
-
-		decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(candidate, "b:"))
-		if err != nil {
-			active[candidate] = true
-			continue
-		}
-
-		wsID := strings.TrimSpace(string(decoded))
-		if wsID == "" {
-			active[candidate] = true
-			continue
-		}
-		active[wsID] = true
-	}
-	return active, epoch, time.UnixMilli(timestampMS), true
+	return activity.RenewOwnerLeaseHeartbeat(opts, now)
 }

--- a/internal/app/app_tmux_activity_shared_scan_test.go
+++ b/internal/app/app_tmux_activity_shared_scan_test.go
@@ -34,10 +34,10 @@ func TestRunTmuxActivityScan_FollowerReconcilesStoppedTabsFromSharedSnapshot(t *
 	opts := gcTestServer(t)
 
 	now := time.Now()
-	if err := writeTmuxActivityOwnerLease(opts, "shared-owner", 3, now); err != nil {
+	if err := activity.WriteOwnerLease(opts, "shared-owner", 3, now); err != nil {
 		t.Fatalf("write owner lease: %v", err)
 	}
-	if err := tmux.SetGlobalOptionValue(tmuxActivitySnapshotOption, encodeTmuxActivitySnapshot(map[string]bool{"ws-shared": true}, 3, now), opts); err != nil {
+	if err := tmux.SetGlobalOptionValue(activity.SnapshotOption, activity.EncodeSnapshot(map[string]bool{"ws-shared": true}, 3, now), opts); err != nil {
 		t.Fatalf("set shared snapshot: %v", err)
 	}
 
@@ -117,10 +117,10 @@ func TestRunTmuxActivityScan_OwnerLeaseRevalidatedBeforePublish(t *testing.T) {
 	opts := gcTestServer(t)
 
 	initialNow := time.Now()
-	if err := writeTmuxActivityOwnerLease(opts, "owner-a", 2, initialNow); err != nil {
+	if err := activity.WriteOwnerLease(opts, "owner-a", 2, initialNow); err != nil {
 		t.Fatalf("write initial owner lease: %v", err)
 	}
-	if err := tmux.SetGlobalOptionValue(tmuxActivitySnapshotOption, encodeTmuxActivitySnapshot(map[string]bool{"ws-old": true}, 2, initialNow), opts); err != nil {
+	if err := tmux.SetGlobalOptionValue(activity.SnapshotOption, activity.EncodeSnapshot(map[string]bool{"ws-old": true}, 2, initialNow), opts); err != nil {
 		t.Fatalf("write initial snapshot: %v", err)
 	}
 
@@ -131,10 +131,10 @@ func TestRunTmuxActivityScan_OwnerLeaseRevalidatedBeforePublish(t *testing.T) {
 				allStates: map[string]tmux.SessionState{},
 			},
 			onSessionsCall: func() {
-				if err := writeTmuxActivityOwnerLease(opts, "owner-b", 3, time.Now()); err != nil {
+				if err := activity.WriteOwnerLease(opts, "owner-b", 3, time.Now()); err != nil {
 					t.Fatalf("simulate owner takeover: %v", err)
 				}
-				if err := tmux.SetGlobalOptionValue(tmuxActivitySnapshotOption, encodeTmuxActivitySnapshot(map[string]bool{"ws-new": true}, 3, time.Now()), opts); err != nil {
+				if err := tmux.SetGlobalOptionValue(activity.SnapshotOption, activity.EncodeSnapshot(map[string]bool{"ws-new": true}, 3, time.Now()), opts); err != nil {
 					t.Fatalf("write takeover snapshot: %v", err)
 				}
 			},
@@ -155,18 +155,18 @@ func TestRunTmuxActivityScan_OwnerLeaseRevalidatedBeforePublish(t *testing.T) {
 		t.Fatalf("expected scanner epoch to update to current owner epoch 3, got %d", result.ScannerEpoch)
 	}
 
-	lease, err := readTmuxActivityOwnerLease(opts)
+	lease, err := activity.ReadOwnerLease(opts)
 	if err != nil {
 		t.Fatalf("read lease after scan: %v", err)
 	}
-	if lease.ownerID != "owner-b" {
-		t.Fatalf("expected takeover owner to remain owner-b, got %q", lease.ownerID)
+	if lease.OwnerID != "owner-b" {
+		t.Fatalf("expected takeover owner to remain owner-b, got %q", lease.OwnerID)
 	}
-	if lease.epoch != 3 {
-		t.Fatalf("expected takeover epoch to remain 3, got %d", lease.epoch)
+	if lease.Epoch != 3 {
+		t.Fatalf("expected takeover epoch to remain 3, got %d", lease.Epoch)
 	}
 
-	shared, ok, err := readTmuxActivitySnapshot(opts, time.Now(), 3)
+	shared, ok, err := activity.ReadSnapshot(opts, time.Now(), 3)
 	if err != nil {
 		t.Fatalf("read snapshot after scan: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestRunTmuxActivityScan_OwnerLeaseRevalidatedBeforePublish(t *testing.T) {
 func TestRunTmuxActivityScan_LeaseRevalidationErrorBeforePublishSkipsApply(t *testing.T) {
 	skipIfNoTmux(t)
 	opts := gcTestServer(t)
-	if err := writeTmuxActivityOwnerLease(opts, "owner-a", 4, time.Now()); err != nil {
+	if err := activity.WriteOwnerLease(opts, "owner-a", 4, time.Now()); err != nil {
 		t.Fatalf("write owner lease: %v", err)
 	}
 

--- a/internal/app/app_tmux_activity_shared_test.go
+++ b/internal/app/app_tmux_activity_shared_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
@@ -70,15 +71,15 @@ func TestResolveTmuxActivityScanRole_OwnerFollowerSnapshotEpoch(t *testing.T) {
 
 func TestOwnerLeaseAlive_FutureHeartbeatTolerance(t *testing.T) {
 	now := time.Now()
-	lease := tmuxActivityLease{
-		ownerID: "owner-a",
+	lease := activity.OwnerLease{
+		OwnerID: "owner-a",
 	}
-	lease.heartbeatAt = now.Add(tmuxActivityOwnerFutureSkewTolerance - time.Millisecond)
-	if !ownerLeaseAlive(lease, now) {
+	lease.HeartbeatAt = now.Add(activity.OwnerFutureSkewTolerance - time.Millisecond)
+	if !activity.OwnerLeaseAlive(lease, now) {
 		t.Fatal("expected lease to be alive for small forward clock skew")
 	}
-	lease.heartbeatAt = now.Add(tmuxActivityOwnerFutureSkewTolerance + time.Millisecond)
-	if ownerLeaseAlive(lease, now) {
+	lease.HeartbeatAt = now.Add(activity.OwnerFutureSkewTolerance + time.Millisecond)
+	if activity.OwnerLeaseAlive(lease, now) {
 		t.Fatal("expected lease to be stale for large forward clock skew")
 	}
 }
@@ -89,7 +90,7 @@ func TestPublishTmuxActivitySnapshot_ReturnsOwnershipLostAfterPublish(t *testing
 
 	now := time.Now()
 	app := &App{instanceID: "owner-a"}
-	if err := writeTmuxActivityOwnerLease(opts, "owner-b", 9, now); err != nil {
+	if err := activity.WriteOwnerLease(opts, "owner-b", 9, now); err != nil {
 		t.Fatalf("write owner lease: %v", err)
 	}
 	err := app.publishTmuxActivitySnapshot(opts, map[string]bool{"ws-a": true}, 9, now)
@@ -112,7 +113,7 @@ func TestReadTmuxActivitySnapshot_EpochMismatchReturnsNotOK(t *testing.T) {
 		t.Fatalf("publish snapshot: %v", err)
 	}
 
-	shared, ok, err := readTmuxActivitySnapshot(opts, now, epoch+1)
+	shared, ok, err := activity.ReadSnapshot(opts, now, epoch+1)
 	if err != nil {
 		t.Fatalf("read snapshot: %v", err)
 	}
@@ -126,7 +127,7 @@ func TestResolveTmuxActivityScanRole_FollowerWithoutSnapshotSkipsApply(t *testin
 	opts := gcTestServer(t)
 
 	now := time.Now()
-	if err := writeTmuxActivityOwnerLease(opts, "other-owner", 7, now); err != nil {
+	if err := activity.WriteOwnerLease(opts, "other-owner", 7, now); err != nil {
 		t.Fatalf("write owner lease: %v", err)
 	}
 
@@ -160,7 +161,7 @@ func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testin
 		t.Fatalf("publish snapshot: %v", err)
 	}
 
-	beforeRaw, err := tmux.GlobalOptionValue(tmuxActivityHeartbeatOption, opts)
+	beforeRaw, err := tmux.GlobalOptionValue(activity.HeartbeatOption, opts)
 	if err != nil {
 		t.Fatalf("read heartbeat before resolve: %v", err)
 	}
@@ -180,7 +181,7 @@ func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testin
 		t.Fatalf("expected owner epoch %d, got %d", epoch, renewedEpoch)
 	}
 
-	afterRaw, err := tmux.GlobalOptionValue(tmuxActivityHeartbeatOption, opts)
+	afterRaw, err := tmux.GlobalOptionValue(activity.HeartbeatOption, opts)
 	if err != nil {
 		t.Fatalf("read heartbeat after resolve: %v", err)
 	}
@@ -195,12 +196,12 @@ func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testin
 
 func TestEncodeDecodeTmuxActivitySnapshot_EncodesWorkspaceIDsSafely(t *testing.T) {
 	now := time.Now()
-	raw := encodeTmuxActivitySnapshot(map[string]bool{
+	raw := activity.EncodeSnapshot(map[string]bool{
 		"ws-with,comma": true,
 		"ws/with space": true,
 	}, 7, now)
 
-	active, epoch, at, ok := decodeTmuxActivitySnapshot(raw)
+	active, epoch, at, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected snapshot to decode, raw=%q", raw)
 	}
@@ -217,7 +218,7 @@ func TestEncodeDecodeTmuxActivitySnapshot_EncodesWorkspaceIDsSafely(t *testing.T
 
 func TestDecodeTmuxActivitySnapshot_LegacyUnencodedWorkspaceIDs(t *testing.T) {
 	raw := "3;1700000000000;ws-a,ws-b"
-	active, epoch, at, ok := decodeTmuxActivitySnapshot(raw)
+	active, epoch, at, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected legacy snapshot to decode, raw=%q", raw)
 	}
@@ -234,7 +235,7 @@ func TestDecodeTmuxActivitySnapshot_LegacyUnencodedWorkspaceIDs(t *testing.T) {
 
 func TestDecodeTmuxActivitySnapshot_LegacyBEncodedWorkspaceIDs(t *testing.T) {
 	raw := "3;1700000000000;b:d3MtYQ,b:d3MtYg"
-	active, epoch, at, ok := decodeTmuxActivitySnapshot(raw)
+	active, epoch, at, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected legacy b:-encoded snapshot to decode, raw=%q", raw)
 	}
@@ -251,7 +252,7 @@ func TestDecodeTmuxActivitySnapshot_LegacyBEncodedWorkspaceIDs(t *testing.T) {
 
 func TestDecodeTmuxActivitySnapshot_LegacyMixedEncodedAndPlainWorkspaceIDs(t *testing.T) {
 	raw := "3;1700000000000;b:d3MtYQ,ws-b"
-	active, _, _, ok := decodeTmuxActivitySnapshot(raw)
+	active, _, _, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected mixed legacy snapshot to decode, raw=%q", raw)
 	}
@@ -265,7 +266,7 @@ func TestDecodeTmuxActivitySnapshot_LegacyMixedEncodedAndPlainWorkspaceIDs(t *te
 
 func TestDecodeTmuxActivitySnapshot_LegacyPlainWorkspaceIDStartingWithJPrefix(t *testing.T) {
 	raw := "3;1700000000000;j:ws-plain,ws-b"
-	active, _, _, ok := decodeTmuxActivitySnapshot(raw)
+	active, _, _, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected legacy plain snapshot to decode, raw=%q", raw)
 	}
@@ -276,7 +277,7 @@ func TestDecodeTmuxActivitySnapshot_LegacyPlainWorkspaceIDStartingWithJPrefix(t 
 
 func TestDecodeTmuxActivitySnapshot_LegacyBPrefixIDsRemainLiteral(t *testing.T) {
 	raw := "3;1700000000000;b:workspace,ws-b"
-	active, _, _, ok := decodeTmuxActivitySnapshot(raw)
+	active, _, _, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected legacy snapshot to decode, raw=%q", raw)
 	}
@@ -290,7 +291,7 @@ func TestDecodeTmuxActivitySnapshot_LegacyBPrefixIDsRemainLiteral(t *testing.T) 
 
 func TestDecodeTmuxActivitySnapshot_LegacyBPrefixValidBase64Decodes(t *testing.T) {
 	raw := "3;1700000000000;b:d3M,ws-b"
-	active, _, _, ok := decodeTmuxActivitySnapshot(raw)
+	active, _, _, ok := activity.DecodeSnapshot(raw)
 	if !ok {
 		t.Fatalf("expected legacy snapshot to decode, raw=%q", raw)
 	}

--- a/internal/app/defaults.go
+++ b/internal/app/defaults.go
@@ -43,18 +43,6 @@ const (
 	// tmuxCommandTimeout caps tmux command duration for activity scans.
 	tmuxCommandTimeout = 2 * time.Second
 
-	// tmuxActivityOwnerLeaseTTL controls how long an activity-scan owner lease
-	// stays valid before another instance can take ownership.
-	tmuxActivityOwnerLeaseTTL = 7 * time.Second
-
-	// tmuxActivityOwnerFutureSkewTolerance caps how far in the future a lease
-	// heartbeat can be and still be treated as alive (clock-skew protection).
-	tmuxActivityOwnerFutureSkewTolerance = 2 * time.Second
-
-	// tmuxActivitySnapshotStaleAfter controls how long shared activity snapshots
-	// are trusted by follower instances.
-	tmuxActivitySnapshotStaleAfter = 10 * time.Second
-
 	// supervisorBackoff controls restart backoff for file/state watchers.
 	supervisorBackoff = 500 * time.Millisecond
 


### PR DESCRIPTION
## What

Moves the cross-instance activity-scan **lease protocol** out of the god `internal/app` package into `internal/app/activity/lease.go` (exported): the `@amux_activity_*` option names, the lease TTL/skew/stale constants (from `defaults.go`), the `OwnerLease` type, `OwnerLeaseAlive`, `Read/Write/RenewOwnerLease[Heartbeat]`, and `Read/Encode/Decode Snapshot`. `App` keeps thin wrapper methods (`resolveTmuxActivityScanRole`, `can/publishTmuxActivitySnapshot`, `sharedTmuxActivityEnabled`) that read `a.instanceID` and delegate.

## Why

It's a self-contained distributed subsystem (leader election, owner lease w/ heartbeat, snapshot encode/decode) that was flattened into `internal/app` (59 src files) and coupled to the App object only by `a.instanceID` — it belongs beside the activity-detection domain it complements.

## Verification

- **No import cycle** — `activity` imports only `internal/tmux`. `go build ./...`, `go vet`, `go test ./internal/app/... ./internal/app/activity/...` pass; golangci-lint + `make lint-ci-parity` (strict ratchet) clean.
- `DecodeSnapshot`'s JSON branch was extracted to `decodeSnapshotJSONPayload` to clear `nestif`.
- The existing `activity/fetch_lease_test.go` tests a different per-session lease — no name collision.

---

⚠️ Stacked on #264. Architecture move from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)