### PR TITLE
Split PTY/tmux plumbing out of internal/ui/common into internal/ui/ptyio

### DIFF
--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -81,7 +82,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 	captureRows := msg.Rows
 	captureCols := msg.Cols
 	cols, rows := m.sessionRestoreLiveSize(msg.CaptureFullPane, captureCols, captureRows)
-	initialCols, initialRows := common.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, cols, rows)
+	initialCols, initialRows := ptyio.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, cols, rows)
 	tab.mu.Lock()
 	createdTerminal := false
 	if tab.Terminal == nil {
@@ -100,7 +101,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 			// Any preserved local PTY backlog may already be represented there and
 			// would duplicate on the next flush if we kept it alive.
 			tab.pendingOutput = nil
-			common.RestorePaneCapture(
+			ptyio.RestorePaneCapture(
 				tab.Terminal,
 				msg.ScrollbackCapture,
 				msg.PostAttachScrollbackCapture,
@@ -114,9 +115,9 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 				rows,
 			)
 		} else if createdTerminal || len(tab.Terminal.Scrollback) == 0 {
-			common.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
+			ptyio.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 		} else if m.width > 0 && m.height > 0 {
-			common.ResizeTerminalForSessionRestore(tab.Terminal, cols, rows)
+			ptyio.ResizeTerminalForSessionRestore(tab.Terminal, cols, rows)
 		}
 	}
 	tab.Agent = msg.Agent

--- a/internal/ui/center/model_input_lifecycle_capture_size_test.go
+++ b/internal/ui/center/model_input_lifecycle_capture_size_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	appPty "github.com/andyrewlee/amux/internal/pty"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -254,7 +254,7 @@ func TestRestoreTerminalScrollbackCapture_ScrollsToBottomBeforePrependingHistory
 		t.Fatal("expected seeded terminal to start scrolled into history")
 	}
 
-	common.RestoreScrollbackCapture(term, []byte("ancient\n"), 20, 1, 20, 2)
+	ptyio.RestoreScrollbackCapture(term, []byte("ancient\n"), 20, 1, 20, 2)
 
 	if term.ViewOffset != 0 {
 		t.Fatalf("expected history-only restore to land at live bottom, got view offset %d", term.ViewOffset)

--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -9,6 +9,7 @@ import (
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -21,7 +22,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 		data := msg.Data
 		tab.mu.Lock()
 		if tab.overflowTrimCarry != (vterm.ParserCarryState{}) {
-			data, tab.overflowTrimCarry = common.TrimPTYOverflowPrefix(data, 0, tab.overflowTrimCarry)
+			data, tab.overflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, tab.overflowTrimCarry)
 			tab.activityANSIState = ansiActivityText
 		}
 		tab.mu.Unlock()
@@ -79,7 +80,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				}
 				tab.mu.Unlock()
 			}
-			retained, overflowCarry := common.TrimPTYOverflowPrefix(tab.pendingOutput, overflow, seed)
+			retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(tab.pendingOutput, overflow, seed)
 			retainedStart := combinedLen - len(retained)
 			chunkStart := prevPendingLen
 			if retainedStart > chunkStart {
@@ -269,7 +270,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 						if prevPending > 0 {
 							previewTrailing = append(previewTrailing[:0], tab.actorQueuedNoiseTrailing...)
 						}
-						filteredPreview := common.FilterKnownPTYNoiseStream(chunk, &previewTrailing)
+						filteredPreview := ptyio.FilterKnownPTYNoiseStream(chunk, &previewTrailing)
 						nextCarry = vterm.AdvanceParserCarryState(seedCarry, filteredPreview)
 						nextNoiseTrailing = append(nextNoiseTrailing, previewTrailing...)
 						tab.actorWritesPending = prevPending + 1
@@ -418,7 +419,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 // tab.Terminal != nil. It returns the filtered byte count, whether the
 // post-write redraw should be suppressed, and the activity tag to publish.
 func (m *Model) applyPTYChunkLocked(tab *Tab, chunk []byte, hasMoreBuffered bool, visibleSeq uint64) (filteredLen int, suppressRedraw bool, tagSessionName string, tagTimestamp int64) {
-	filtered := common.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
+	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
 	filteredLen = len(filtered)
 	if len(filtered) > 0 {
 		flushDone := perf.Time("pty_flush")

--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 // updatePTYStopped handles PTYStopped.
@@ -24,7 +25,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 		m.stopPTYReader(tab)
 		tab.mu.Lock()
 		if tab.Terminal != nil && len(tab.ptyNoiseTrailing) > 0 {
-			trailing := common.DrainKnownPTYNoiseTrailing(&tab.ptyNoiseTrailing)
+			trailing := ptyio.DrainKnownPTYNoiseTrailing(&tab.ptyNoiseTrailing)
 			flushDone := perf.Time("pty_flush")
 			tab.Terminal.Write(trailing)
 			flushDone()

--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -7,7 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/safego"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
@@ -52,13 +52,13 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 
 	safego.Go("center.pty_reader", func() {
 		defer m.markPTYReaderStopped(tab)
-		common.RunPTYReader(term, msgCh, cancel, &tab.ptyHeartbeat, common.PTYReaderConfig{
+		ptyio.RunPTYReader(term, msgCh, cancel, &tab.ptyHeartbeat, ptyio.PTYReaderConfig{
 			Label:           "center.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
 			FrameInterval:   ptyFrameInterval,
 			MaxPendingBytes: ptyMaxPendingBytes,
-		}, common.PTYMsgFactory{
+		}, ptyio.PTYMsgFactory{
 			Output:  func(data []byte) tea.Msg { return PTYOutput{WorkspaceID: wtID, TabID: tabID, Data: data} },
 			Stopped: func(err error) tea.Msg { return PTYStopped{WorkspaceID: wtID, TabID: tabID, Err: err} },
 		})

--- a/internal/ui/center/model_pty_reader.go
+++ b/internal/ui/center/model_pty_reader.go
@@ -5,7 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func (m *Model) flushTiming(tab *Tab, active bool) (time.Duration, time.Duration) {
@@ -99,7 +99,7 @@ func (m *Model) busyPTYTabCount(now time.Time) int {
 }
 
 func (m *Model) forwardPTYMsgs(msgCh <-chan tea.Msg) {
-	common.ForwardPTYMsgs(msgCh, m.msgSink, common.OutputMerger{
+	ptyio.ForwardPTYMsgs(msgCh, m.msgSink, ptyio.OutputMerger{
 		ExtractData: func(msg tea.Msg) ([]byte, bool) {
 			if out, ok := msg.(PTYOutput); ok {
 				return out.Data, true

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -181,7 +181,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	captureRows := msg.Rows
 	captureCols := msg.Cols
 	cols, rows := m.sessionRestoreLiveSize(msg.CaptureFullPane, captureCols, captureRows)
-	initialCols, initialRows := common.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, cols, rows)
+	initialCols, initialRows := ptyio.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, cols, rows)
 
 	wsID := string(msg.Workspace.ID())
 	tabs := m.tabsByWorkspace[wsID]
@@ -231,7 +231,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 				// A full tmux pane snapshot supersedes any preserved local PTY
 				// backlog for this terminal state.
 				tab.pendingOutput = nil
-				common.RestorePaneCapture(
+				ptyio.RestorePaneCapture(
 					tab.Terminal,
 					msg.ScrollbackCapture,
 					msg.PostAttachScrollbackCapture,
@@ -245,9 +245,9 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 					rows,
 				)
 			} else if createdTerminal || len(tab.Terminal.Scrollback) == 0 {
-				common.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
+				ptyio.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 			} else if m.width > 0 && m.height > 0 {
-				common.ResizeTerminalForSessionRestore(tab.Terminal, cols, rows)
+				ptyio.ResizeTerminalForSessionRestore(tab.Terminal, cols, rows)
 			}
 		}
 		if tab.Name == "" {
@@ -346,7 +346,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	term.IgnoreCursorVisibilityControls = false
 	term.TreatLFAsCRLF = isChat
 	if msg.CaptureFullPane {
-		common.RestorePaneCapture(
+		ptyio.RestorePaneCapture(
 			term,
 			msg.ScrollbackCapture,
 			msg.PostAttachScrollbackCapture,
@@ -360,7 +360,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 			rows,
 		)
 	} else {
-		common.RestoreScrollbackCapture(term, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
+		ptyio.RestoreScrollbackCapture(term, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 	}
 
 	// Set up response writer for terminal queries (DSR, DA, etc.)

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -9,7 +9,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 // These package-level indirections are test seams for reattach/bootstrap
@@ -39,10 +39,10 @@ var (
 	}
 )
 
-type sessionBootstrapCapture = common.SessionBootstrapCapture
+type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 
-func sessionBootstrapFns() common.SessionBootstrapFns {
-	return common.SessionBootstrapFns{
+func sessionBootstrapFns() ptyio.SessionBootstrapFns {
+	return ptyio.SessionBootstrapFns{
 		SessionHasClients:       sessionHasClientsFn,
 		SessionClientCount:      sessionClientCountFn,
 		SessionActiveWithin:     sessionActiveWithinFn,
@@ -57,23 +57,23 @@ func sessionBootstrapFns() common.SessionBootstrapFns {
 }
 
 func captureExistingSessionBootstrap(sessionName string, cols, rows int, opts tmux.Options) sessionBootstrapCapture {
-	return common.CaptureExistingSessionBootstrap(sessionName, cols, rows, common.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
+	return ptyio.CaptureExistingSessionBootstrap(sessionName, cols, rows, ptyio.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
 }
 
 func bootstrapSnapshotStillMatchesSession(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) bool {
-	return common.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
+	return ptyio.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
 }
 
 func rollbackExistingSessionBootstrap(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) {
-	common.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
+	ptyio.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
 }
 
 func sessionHistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) (int, int) {
-	return common.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
+	return ptyio.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
 }
 
 func captureSessionHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
-	return common.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
+	return ptyio.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
 }
 
 func (m *Model) sessionBootstrapViewportSize() (int, int) {

--- a/internal/ui/center/tab_actor_write.go
+++ b/internal/ui/center/tab_actor_write.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/safego"
 	"github.com/andyrewlee/amux/internal/tmux"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func (m *Model) handleWriteOutput(ev tabEvent) {
@@ -60,7 +60,7 @@ func (m *Model) handleWriteOutput(ev tabEvent) {
 // byte count, whether the filter ran, whether the redraw should be suppressed,
 // whether a follow-up flush is needed, and the activity tag to publish.
 func (m *Model) applyActorWriteLocked(tab *Tab, ev tabEvent, processedBytes int) (filteredLen int, filterApplied, suppressRedraw, requestFlush bool, tagSessionName string, tagTimestamp int64) {
-	output := common.FilterKnownPTYNoiseStream(ev.output, &tab.ptyNoiseTrailing)
+	output := ptyio.FilterKnownPTYNoiseStream(ev.output, &tab.ptyNoiseTrailing)
 	filteredLen = len(output)
 	filterApplied = true
 	if len(output) > 0 {

--- a/internal/ui/ptyio/doc.go
+++ b/internal/ui/ptyio/doc.go
@@ -1,0 +1,6 @@
+// Package ptyio holds the low-level PTY/tmux plumbing shared by the center and
+// sidebar terminals: the PTY read loop and output forwarding/merging, PTY-noise
+// filtering and overflow trimming, and tmux session bootstrap/restore (capture,
+// snapshot, scrollback). It was split out of internal/ui/common so panes that do
+// no terminal I/O don't transitively depend on tmux/vterm/safego through it.
+package ptyio

--- a/internal/ui/ptyio/pty_output_filter.go
+++ b/internal/ui/ptyio/pty_output_filter.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"bytes"

--- a/internal/ui/ptyio/pty_output_filter_test.go
+++ b/internal/ui/ptyio/pty_output_filter_test.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import "testing"
 

--- a/internal/ui/ptyio/pty_overflow_trim.go
+++ b/internal/ui/ptyio/pty_overflow_trim.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import "github.com/andyrewlee/amux/internal/vterm"
 

--- a/internal/ui/ptyio/pty_overflow_trim_test.go
+++ b/internal/ui/ptyio/pty_overflow_trim_test.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"testing"

--- a/internal/ui/ptyio/pty_reader.go
+++ b/internal/ui/ptyio/pty_reader.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"io"

--- a/internal/ui/ptyio/pty_reader_test.go
+++ b/internal/ui/ptyio/pty_reader_test.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"errors"

--- a/internal/ui/ptyio/session_bootstrap.go
+++ b/internal/ui/ptyio/session_bootstrap.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"time"

--- a/internal/ui/ptyio/session_bootstrap_test.go
+++ b/internal/ui/ptyio/session_bootstrap_test.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"testing"

--- a/internal/ui/ptyio/session_restore.go
+++ b/internal/ui/ptyio/session_restore.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"github.com/andyrewlee/amux/internal/tmux"

--- a/internal/ui/ptyio/session_restore_test.go
+++ b/internal/ui/ptyio/session_restore_test.go
@@ -1,4 +1,4 @@
-package common
+package ptyio
 
 import (
 	"testing"

--- a/internal/ui/sidebar/terminal_capture_size_test.go
+++ b/internal/ui/sidebar/terminal_capture_size_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/pty"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -288,7 +288,7 @@ func TestRestoreSidebarScrollbackCapture_ScrollsToBottomBeforePrependingHistory(
 		t.Fatal("expected seeded terminal to start scrolled into history")
 	}
 
-	common.RestoreScrollbackCapture(vt, []byte("ancient\n"), 20, 1, 20, 2)
+	ptyio.RestoreScrollbackCapture(vt, []byte("ancient\n"), 20, 1, 20, 2)
 
 	if vt.ViewOffset != 0 {
 		t.Fatalf("expected history-only restore to land at live bottom, got view offset %d", vt.ViewOffset)

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -13,7 +13,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 // These package-level indirections are test seams for terminal attach/bootstrap
@@ -35,10 +35,10 @@ var (
 	verifyTerminalSessionTagsFn = verifyTerminalSessionTags
 )
 
-type sessionBootstrapCapture = common.SessionBootstrapCapture
+type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 
-func sessionBootstrapFns() common.SessionBootstrapFns {
-	return common.SessionBootstrapFns{
+func sessionBootstrapFns() ptyio.SessionBootstrapFns {
+	return ptyio.SessionBootstrapFns{
 		SessionHasClients:       sessionHasClientsFn,
 		SessionClientCount:      sessionClientCountFn,
 		SessionActiveWithin:     sessionActiveWithinFn,
@@ -53,23 +53,23 @@ func sessionBootstrapFns() common.SessionBootstrapFns {
 }
 
 func captureExistingSessionBootstrap(sessionName string, cols, rows int, opts tmux.Options) sessionBootstrapCapture {
-	return common.CaptureExistingSessionBootstrap(sessionName, cols, rows, common.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
+	return ptyio.CaptureExistingSessionBootstrap(sessionName, cols, rows, ptyio.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
 }
 
 func bootstrapSnapshotStillMatchesSession(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) bool {
-	return common.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
+	return ptyio.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
 }
 
 func rollbackExistingSessionBootstrap(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) {
-	common.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
+	ptyio.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
 }
 
 func sessionHistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) (int, int) {
-	return common.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
+	return ptyio.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
 }
 
 func captureSessionHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
-	return common.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
+	return ptyio.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
 }
 
 func (m *TerminalModel) sessionBootstrapViewportSize() (int, int) {

--- a/internal/ui/sidebar/terminal_pty_lifecycle.go
+++ b/internal/ui/sidebar/terminal_pty_lifecycle.go
@@ -10,7 +10,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/safego"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -147,13 +147,13 @@ func (m *TerminalModel) startPTYReader(wsID string, tabID TerminalTabID) tea.Cmd
 
 	safego.Go("sidebar.pty_reader", func() {
 		defer m.markPTYReaderStopped(ts)
-		common.RunPTYReader(term, msgCh, cancel, &ts.ptyHeartbeat, common.PTYReaderConfig{
+		ptyio.RunPTYReader(term, msgCh, cancel, &ts.ptyHeartbeat, ptyio.PTYReaderConfig{
 			Label:           "sidebar.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
 			FrameInterval:   ptyFrameInterval,
 			MaxPendingBytes: ptyMaxPendingBytes,
-		}, common.PTYMsgFactory{
+		}, ptyio.PTYMsgFactory{
 			Output: func(data []byte) tea.Msg {
 				return messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: data}
 			},

--- a/internal/ui/sidebar/terminal_pty_reader.go
+++ b/internal/ui/sidebar/terminal_pty_reader.go
@@ -4,11 +4,11 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/messages"
-	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func (m *TerminalModel) forwardPTYMsgs(msgCh <-chan tea.Msg) {
-	common.ForwardPTYMsgs(msgCh, m.msgSink, common.OutputMerger{
+	ptyio.ForwardPTYMsgs(msgCh, m.msgSink, ptyio.OutputMerger{
 		ExtractData: func(msg tea.Msg) ([]byte, bool) {
 			if out, ok := msg.(messages.SidebarPTYOutput); ok {
 				return out.Data, true

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -9,6 +9,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -24,7 +25,7 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	data := msg.Data
 	ts.mu.Lock()
 	if ts.overflowTrimCarry != (vterm.ParserCarryState{}) {
-		data, ts.overflowTrimCarry = common.TrimPTYOverflowPrefix(data, 0, ts.overflowTrimCarry)
+		data, ts.overflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, ts.overflowTrimCarry)
 	}
 	ts.mu.Unlock()
 	prevPendingLen := len(ts.pendingOutput)
@@ -41,7 +42,7 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 			ts.VTerm.ResetParserState()
 		}
 		ts.mu.Unlock()
-		retained, overflowCarry := common.TrimPTYOverflowPrefix(ts.pendingOutput, overflow, seed)
+		retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(ts.pendingOutput, overflow, seed)
 		retainedStart := combinedLen - len(retained)
 		ts.pendingOutput = append([]byte(nil), retained...)
 		ts.mu.Lock()
@@ -104,7 +105,7 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 			copy(ts.pendingOutput, ts.pendingOutput[chunkSize:])
 			ts.pendingOutput = ts.pendingOutput[:len(ts.pendingOutput)-chunkSize]
 			processedBytes := len(chunk)
-			filtered := common.FilterKnownPTYNoiseStream(chunk, &ts.ptyNoiseTrailing)
+			filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.ptyNoiseTrailing)
 			filteredBytes := processedBytes - len(filtered)
 			perf.Count("pty_flush_bytes_processed", int64(processedBytes))
 			if filteredBytes > 0 {
@@ -151,7 +152,7 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 	termAlive := ts.Terminal != nil && !ts.Terminal.IsClosed()
 	ts.mu.Lock()
 	if ts.VTerm != nil && len(ts.ptyNoiseTrailing) > 0 {
-		trailing := common.DrainKnownPTYNoiseTrailing(&ts.ptyNoiseTrailing)
+		trailing := ptyio.DrainKnownPTYNoiseTrailing(&ts.ptyNoiseTrailing)
 		flushDone := perf.Time("pty_flush")
 		ts.VTerm.Write(trailing)
 		flushDone()

--- a/internal/ui/sidebar/terminal_update_session.go
+++ b/internal/ui/sidebar/terminal_update_session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -20,7 +21,7 @@ func (m *TerminalModel) sessionRestoreLiveSize(captureFullPane bool, snapshotCol
 // handleTerminalCreated wires up a newly created terminal and its scrollback.
 func (m *TerminalModel) handleTerminalCreated(msg SidebarTerminalCreated) tea.Cmd {
 	currentWidth, currentHeight := m.sessionRestoreLiveSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows)
-	initialWidth, initialHeight := common.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, currentWidth, currentHeight)
+	initialWidth, initialHeight := ptyio.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, currentWidth, currentHeight)
 	ts := m.createTerminalStateForTabWithSizeAndRefresh(
 		msg.WorkspaceID,
 		msg.TabID,
@@ -36,7 +37,7 @@ func (m *TerminalModel) handleTerminalCreated(msg SidebarTerminalCreated) tea.Cm
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			if msg.CaptureFullPane {
-				common.RestorePaneCapture(
+				ptyio.RestorePaneCapture(
 					ts.VTerm,
 					msg.Scrollback,
 					msg.PostAttachScrollback,
@@ -52,7 +53,7 @@ func (m *TerminalModel) handleTerminalCreated(msg SidebarTerminalCreated) tea.Cm
 				ts.lastWidth = currentWidth
 				ts.lastHeight = currentHeight
 			} else if len(msg.Scrollback) > 0 {
-				common.RestoreScrollbackCapture(
+				ptyio.RestoreScrollbackCapture(
 					ts.VTerm,
 					msg.Scrollback,
 					msg.CaptureCols,
@@ -88,7 +89,7 @@ func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) 
 	if ts.VTerm != nil {
 		ts.VTerm.AllowAltScreenScrollback = true
 		if msg.CaptureFullPane {
-			common.RestorePaneCapture(
+			ptyio.RestorePaneCapture(
 				ts.VTerm,
 				msg.Scrollback,
 				msg.PostAttachScrollback,
@@ -103,7 +104,7 @@ func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) 
 			)
 		} else {
 			if len(msg.Scrollback) > 0 && len(ts.VTerm.Scrollback) == 0 {
-				common.RestoreScrollbackCapture(
+				ptyio.RestoreScrollbackCapture(
 					ts.VTerm,
 					msg.Scrollback,
 					msg.CaptureCols,


### PR DESCRIPTION
## What

Moves the low-level PTY/tmux plumbing — `pty_reader.go`, `pty_output_filter.go`, `pty_overflow_trim.go`, `session_bootstrap.go`, `session_restore.go` (+ tests) — out of `internal/ui/common` into a new `internal/ui/ptyio` package, and repoints the ~15 center/sidebar call sites (`RunPTYReader`, `ForwardPTYMsgs`, `FilterKnownPTYNoise*`, `TrimPTYOverflowPrefix`, `CaptureExistingSessionBootstrap`, `RestorePaneCapture`, `SessionSnapshotSize`, …).

## Why

`internal/ui/common` was a 31-file junk drawer mixing theming, widgets, and PTY/tmux plumbing, so **every** consumer (app, dashboard, diff) transitively pulled tmux/vterm/safego even when doing no terminal I/O.

## Verification

- **Layering win:** `go list -deps ./internal/ui/common` no longer contains `internal/tmux` or `internal/safego` (they moved with ptyio). No import cycle — `ptyio` doesn't import `common`.
- Pure file moves, no behavior change. `go build ./...`, `go test ./internal/ui/{ptyio,common,center,sidebar}/...` (incl. `-race`) pass; gofumpt/goimports/golangci-lint clean; center+sidebar harness render normally. New `ptyio/doc.go` added.

---

⚠️ Stacked on #265. The first of the two-PR `common` split (architecture) from the maintainability audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)