### PR TITLE
Extract theme into internal/ui/theme package

### DIFF
--- a/internal/ui/common/theme_reexport.go
+++ b/internal/ui/common/theme_reexport.go
@@ -1,0 +1,90 @@
+// Package common re-exports the internal/ui/theme symbols so existing
+// common.* references keep working after theme was split into its own
+// package. New code should import internal/ui/theme directly.
+package common
+
+import "github.com/andyrewlee/amux/internal/ui/theme"
+
+type (
+	Styles      = theme.Styles
+	Theme       = theme.Theme
+	ThemeColors = theme.ThemeColors
+	ThemeID     = theme.ThemeID
+)
+
+const (
+	ThemeTokyoNight      = theme.ThemeTokyoNight
+	ThemeDracula         = theme.ThemeDracula
+	ThemeNord            = theme.ThemeNord
+	ThemeCatppuccin      = theme.ThemeCatppuccin
+	ThemeGruvbox         = theme.ThemeGruvbox
+	ThemeSolarized       = theme.ThemeSolarized
+	ThemeMonokai         = theme.ThemeMonokai
+	ThemeRosePine        = theme.ThemeRosePine
+	ThemeOneDark         = theme.ThemeOneDark
+	ThemeKanagawa        = theme.ThemeKanagawa
+	ThemeEverforest      = theme.ThemeEverforest
+	ThemeAyuDark         = theme.ThemeAyuDark
+	ThemeGitHubDark      = theme.ThemeGitHubDark
+	ThemeSolarizedLight  = theme.ThemeSolarizedLight
+	ThemeGitHubLight     = theme.ThemeGitHubLight
+	ThemeCatppuccinLatte = theme.ThemeCatppuccinLatte
+	ThemeOneLight        = theme.ThemeOneLight
+	ThemeGruvboxLight    = theme.ThemeGruvboxLight
+	ThemeRosePineDawn    = theme.ThemeRosePineDawn
+)
+
+var (
+	AgentColor           = theme.AgentColor
+	AvailableThemes      = theme.AvailableThemes
+	AyuDarkTheme         = theme.AyuDarkTheme
+	CatppuccinLatteTheme = theme.CatppuccinLatteTheme
+	CatppuccinTheme      = theme.CatppuccinTheme
+	ColorBackground      = theme.ColorBackground
+	ColorBorder          = theme.ColorBorder
+	ColorBorderFocused   = theme.ColorBorderFocused
+	ColorError           = theme.ColorError
+	ColorForeground      = theme.ColorForeground
+	ColorInfo            = theme.ColorInfo
+	ColorMuted           = theme.ColorMuted
+	ColorPrimary         = theme.ColorPrimary
+	ColorSecondary       = theme.ColorSecondary
+	ColorSelection       = theme.ColorSelection
+	ColorSuccess         = theme.ColorSuccess
+	ColorSurface0        = theme.ColorSurface0
+	ColorSurface1        = theme.ColorSurface1
+	ColorSurface2        = theme.ColorSurface2
+	ColorWarning         = theme.ColorWarning
+	DefaultStyles        = theme.DefaultStyles
+	DraculaTheme         = theme.DraculaTheme
+	EverforestTheme      = theme.EverforestTheme
+	GetCurrentTheme      = theme.GetCurrentTheme
+	GetTheme             = theme.GetTheme
+	GitHubDarkTheme      = theme.GitHubDarkTheme
+	GitHubLightTheme     = theme.GitHubLightTheme
+	GruvboxLightTheme    = theme.GruvboxLightTheme
+	GruvboxTheme         = theme.GruvboxTheme
+	HexColor             = theme.HexColor
+	KanagawaTheme        = theme.KanagawaTheme
+	MonokaiTheme         = theme.MonokaiTheme
+	NordTheme            = theme.NordTheme
+	OneDarkTheme         = theme.OneDarkTheme
+	OneLightTheme        = theme.OneLightTheme
+	RosePineDawnTheme    = theme.RosePineDawnTheme
+	RosePineTheme        = theme.RosePineTheme
+	SetCurrentTheme      = theme.SetCurrentTheme
+	SolarizedLightTheme  = theme.SolarizedLightTheme
+	SolarizedTheme       = theme.SolarizedTheme
+	SpinnerFrame         = theme.SpinnerFrame
+	TokyoNightTheme      = theme.TokyoNightTheme
+	Icons                = theme.Icons
+	ColorClaude          = theme.ColorClaude
+	ColorCodex           = theme.ColorCodex
+	ColorGemini          = theme.ColorGemini
+	ColorAmp             = theme.ColorAmp
+	ColorOpencode        = theme.ColorOpencode
+	ColorDroid           = theme.ColorDroid
+	ColorCline           = theme.ColorCline
+	ColorCursor          = theme.ColorCursor
+	ColorPi              = theme.ColorPi
+)

--- a/internal/ui/theme/colors.go
+++ b/internal/ui/theme/colors.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 import (
 	"fmt"

--- a/internal/ui/theme/icons.go
+++ b/internal/ui/theme/icons.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 // Icons used throughout the application
 // Uses Unicode characters with fallbacks for broad terminal support

--- a/internal/ui/theme/styles.go
+++ b/internal/ui/theme/styles.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 import "charm.land/lipgloss/v2"
 

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 import (
 	"image/color"

--- a/internal/ui/theme/theme_dark.go
+++ b/internal/ui/theme/theme_dark.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 import (
 	"charm.land/lipgloss/v2"

--- a/internal/ui/theme/theme_light.go
+++ b/internal/ui/theme/theme_light.go
@@ -1,4 +1,4 @@
-package common
+package theme
 
 import (
 	"charm.land/lipgloss/v2"


### PR DESCRIPTION
## Summary
Final ticket in the maintainability stack. Moves the color/style/icon/theme definitions out of the catch-all `internal/ui/common` package into a focused, single-responsibility `internal/ui/theme` package (~1200 lines: 20 built-in themes, color palette, styles, icons).

A generated re-export shim (`internal/ui/common/theme_reexport.go`) aliases every theme symbol back into `common` via `type`/`const`/`var` aliases, so the ~30 existing `common.<symbol>` call sites across `center`/`sidebar`/`dashboard`/`app` keep compiling unchanged. New code should import `internal/ui/theme` directly.

## Why
`internal/ui/common` had grown into a grab-bag. Theming is a cohesive, independently-evolving concern (palettes, per-agent colors, styles, icons) and now lives in its own package that can be imported without pulling in the rest of `common`.

## Risk / behavior
No behavior change — the shim aliases are identity (`X = theme.X`). All UI + app tests pass; `go vet` clean; `golangci-lint` clean on both packages.

## Test plan
- `go build ./...`
- `go vet ./internal/...`
- `go test ./internal/ui/theme/ ./internal/ui/common/ ./internal/ui/center/ ./internal/ui/sidebar/ ./internal/ui/dashboard/ ./internal/ui/diff/ ./internal/app/`
- `golangci-lint run ./internal/ui/theme/ ./internal/ui/common/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)