### PR TITLE
Convert vterm StyleToANSI/StyleToDeltaANSI free functions to Style methods

### DIFF
--- a/internal/ui/compositor/benchmark_test.go
+++ b/internal/ui/compositor/benchmark_test.go
@@ -238,8 +238,8 @@ func BenchmarkStringDrawableCreation(b *testing.B) {
 	}
 }
 
-// BenchmarkStyleToDeltaANSI benchmarks delta style encoding
-func BenchmarkStyleToDeltaANSI(b *testing.B) {
+// BenchmarkStyleDeltaANSI benchmarks delta style encoding
+func BenchmarkStyleDeltaANSI(b *testing.B) {
 	scenarios := []struct {
 		name string
 		prev vterm.Style
@@ -278,14 +278,14 @@ func BenchmarkStyleToDeltaANSI(b *testing.B) {
 		b.Run(s.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_ = vterm.StyleToDeltaANSI(s.prev, s.next)
+				_ = s.prev.DeltaANSI(s.next)
 			}
 		})
 	}
 }
 
-// BenchmarkStyleToANSI benchmarks full style encoding
-func BenchmarkStyleToANSI(b *testing.B) {
+// BenchmarkStyleANSI benchmarks full style encoding
+func BenchmarkStyleANSI(b *testing.B) {
 	scenarios := []struct {
 		name  string
 		style vterm.Style
@@ -313,7 +313,7 @@ func BenchmarkStyleToANSI(b *testing.B) {
 		b.Run(s.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_ = vterm.StyleToANSI(s.style)
+				_ = s.style.ANSI()
 			}
 		})
 	}

--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -219,9 +219,9 @@ func (c *Canvas) Render() string {
 			if style != lastStyle {
 				// Use full style for first cell (after reset), delta for subsequent
 				if firstCell {
-					b.WriteString(vterm.StyleToANSI(style))
+					b.WriteString(style.ANSI())
 				} else {
-					b.WriteString(vterm.StyleToDeltaANSI(lastStyle, style))
+					b.WriteString(lastStyle.DeltaANSI(style))
 				}
 				lastStyle = style
 			}

--- a/internal/vterm/ansi.go
+++ b/internal/vterm/ansi.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// StyleToANSI converts a Style to ANSI escape codes.
+// ANSI converts a Style to a full ANSI escape sequence, leading with a reset.
 // Optimized to avoid allocations using strings.Builder.
-func StyleToANSI(s Style) string {
+func (s Style) ANSI() string {
 	var b strings.Builder
 	b.Grow(32) // Pre-allocate for typical SGR sequence
 
@@ -48,11 +48,12 @@ func StyleToANSI(s Style) string {
 	return b.String()
 }
 
-// StyleToDeltaANSI returns the minimal SGR escape sequence to transition from prev to next style.
-// This avoids the overhead of always emitting a full reset.
+// DeltaANSI returns the minimal SGR escape sequence to transition from the
+// receiver (the previous style) to next. It avoids the overhead of always
+// emitting a full reset, and returns "" when nothing changed.
 // Optimized to avoid allocations using strings.Builder.
-func StyleToDeltaANSI(prev, next Style) string {
-	if prev == next {
+func (s Style) DeltaANSI(next Style) string {
+	if s == next {
 		return ""
 	}
 
@@ -70,133 +71,14 @@ func StyleToDeltaANSI(prev, next Style) string {
 		b.WriteString(code)
 	}
 
-	// Check if we need to reset (turning OFF attributes that can't be individually disabled)
-	turningOff := 0
-	if prev.Bold && !next.Bold {
-		turningOff++
-	}
-	if prev.Dim && !next.Dim {
-		turningOff++
-	}
-	if prev.Italic && !next.Italic {
-		turningOff++
-	}
-	if prev.Underline && !next.Underline {
-		turningOff++
-	}
-	if prev.Blink && !next.Blink {
-		turningOff++
-	}
-	if prev.Reverse && !next.Reverse {
-		turningOff++
-	}
-	if prev.Hidden && !next.Hidden {
-		turningOff++
-	}
-	if prev.Strike && !next.Strike {
-		turningOff++
-	}
-
-	// If turning off multiple attributes, reset is more efficient
-	if turningOff > 1 {
-		writeCode("0")
-		// After reset, add all active attributes
-		if next.Bold {
-			writeCode("1")
-		}
-		if next.Dim {
-			writeCode("2")
-		}
-		if next.Italic {
-			writeCode("3")
-		}
-		if next.Underline {
-			writeCode("4")
-		}
-		if next.Blink {
-			writeCode("5")
-		}
-		if next.Reverse {
-			writeCode("7")
-		}
-		if next.Hidden {
-			writeCode("8")
-		}
-		if next.Strike {
-			writeCode("9")
-		}
-		// Colors after reset
-		writeColorToBuilderFirst(&b, next.Fg, true, &first)
-		writeColorToBuilderFirst(&b, next.Bg, false, &first)
+	// When turning off more than one attribute, a full reset followed by the
+	// surviving attributes is cheaper than disabling each individually.
+	if s.attrsTurningOff(next) > 1 {
+		next.appendResetThenActive(writeCode, &b, &first)
 	} else {
-		// Emit individual changes only
-
-		// Turn off attributes individually
-		emitted22 := false
-		if (prev.Bold && !next.Bold) || (prev.Dim && !next.Dim) {
-			writeCode("22") // Normal intensity
-			emitted22 = true
-		}
-		if prev.Italic && !next.Italic {
-			writeCode("23")
-		}
-		if prev.Underline && !next.Underline {
-			writeCode("24")
-		}
-		if prev.Blink && !next.Blink {
-			writeCode("25")
-		}
-		if prev.Reverse && !next.Reverse {
-			writeCode("27")
-		}
-		if prev.Hidden && !next.Hidden {
-			writeCode("28")
-		}
-		if prev.Strike && !next.Strike {
-			writeCode("29")
-		}
-
-		// Turn on attributes
-		if (!prev.Bold && next.Bold) || (emitted22 && next.Bold) {
-			writeCode("1")
-		}
-		if (!prev.Dim && next.Dim) || (emitted22 && next.Dim) {
-			writeCode("2")
-		}
-		if !prev.Italic && next.Italic {
-			writeCode("3")
-		}
-		if !prev.Underline && next.Underline {
-			writeCode("4")
-		}
-		if !prev.Blink && next.Blink {
-			writeCode("5")
-		}
-		if !prev.Reverse && next.Reverse {
-			writeCode("7")
-		}
-		if !prev.Hidden && next.Hidden {
-			writeCode("8")
-		}
-		if !prev.Strike && next.Strike {
-			writeCode("9")
-		}
-
-		// Colors only if changed
-		if prev.Fg != next.Fg {
-			if next.Fg.Type == ColorDefault {
-				writeCode("39")
-			} else {
-				writeColorToBuilderFirst(&b, next.Fg, true, &first)
-			}
-		}
-		if prev.Bg != next.Bg {
-			if next.Bg.Type == ColorDefault {
-				writeCode("49")
-			} else {
-				writeColorToBuilderFirst(&b, next.Bg, false, &first)
-			}
-		}
+		emitted22 := s.appendAttrDisables(next, writeCode)
+		s.appendAttrEnables(next, emitted22, writeCode)
+		s.appendColorChanges(next, writeCode, &b, &first)
 	}
 
 	if first {
@@ -205,6 +87,151 @@ func StyleToDeltaANSI(prev, next Style) string {
 
 	b.WriteByte('m')
 	return b.String()
+}
+
+// attrsTurningOff counts boolean attributes set in the receiver (previous style)
+// but cleared in next. These cannot all be disabled with a single SGR code, so
+// the count decides whether a full reset is the more compact transition.
+func (s Style) attrsTurningOff(next Style) int {
+	turningOff := 0
+	if s.Bold && !next.Bold {
+		turningOff++
+	}
+	if s.Dim && !next.Dim {
+		turningOff++
+	}
+	if s.Italic && !next.Italic {
+		turningOff++
+	}
+	if s.Underline && !next.Underline {
+		turningOff++
+	}
+	if s.Blink && !next.Blink {
+		turningOff++
+	}
+	if s.Reverse && !next.Reverse {
+		turningOff++
+	}
+	if s.Hidden && !next.Hidden {
+		turningOff++
+	}
+	if s.Strike && !next.Strike {
+		turningOff++
+	}
+	return turningOff
+}
+
+// appendResetThenActive emits a reset (0) followed by every attribute and color
+// active in the receiver style. Used when disabling attributes individually
+// would be longer than starting from a clean reset.
+func (s Style) appendResetThenActive(writeCode func(string), b *strings.Builder, first *bool) {
+	writeCode("0")
+	if s.Bold {
+		writeCode("1")
+	}
+	if s.Dim {
+		writeCode("2")
+	}
+	if s.Italic {
+		writeCode("3")
+	}
+	if s.Underline {
+		writeCode("4")
+	}
+	if s.Blink {
+		writeCode("5")
+	}
+	if s.Reverse {
+		writeCode("7")
+	}
+	if s.Hidden {
+		writeCode("8")
+	}
+	if s.Strike {
+		writeCode("9")
+	}
+	writeColorToBuilderFirst(b, s.Fg, true, first)
+	writeColorToBuilderFirst(b, s.Bg, false, first)
+}
+
+// appendAttrDisables emits the individual SGR codes (22-29) that turn off
+// attributes set in the receiver (previous style) but cleared in next. It
+// reports whether code 22 (normal intensity) was emitted, since that resets
+// both bold and dim and so the caller must re-enable either if next wants it.
+func (s Style) appendAttrDisables(next Style, writeCode func(string)) (emitted22 bool) {
+	if (s.Bold && !next.Bold) || (s.Dim && !next.Dim) {
+		writeCode("22") // Normal intensity
+		emitted22 = true
+	}
+	if s.Italic && !next.Italic {
+		writeCode("23")
+	}
+	if s.Underline && !next.Underline {
+		writeCode("24")
+	}
+	if s.Blink && !next.Blink {
+		writeCode("25")
+	}
+	if s.Reverse && !next.Reverse {
+		writeCode("27")
+	}
+	if s.Hidden && !next.Hidden {
+		writeCode("28")
+	}
+	if s.Strike && !next.Strike {
+		writeCode("29")
+	}
+	return emitted22
+}
+
+// appendAttrEnables emits the individual SGR codes that turn on attributes set
+// in next but not in the receiver (previous style). When emitted22 is true,
+// bold/dim were just reset by code 22 and must be re-emitted if next wants them.
+func (s Style) appendAttrEnables(next Style, emitted22 bool, writeCode func(string)) {
+	if (!s.Bold && next.Bold) || (emitted22 && next.Bold) {
+		writeCode("1")
+	}
+	if (!s.Dim && next.Dim) || (emitted22 && next.Dim) {
+		writeCode("2")
+	}
+	if !s.Italic && next.Italic {
+		writeCode("3")
+	}
+	if !s.Underline && next.Underline {
+		writeCode("4")
+	}
+	if !s.Blink && next.Blink {
+		writeCode("5")
+	}
+	if !s.Reverse && next.Reverse {
+		writeCode("7")
+	}
+	if !s.Hidden && next.Hidden {
+		writeCode("8")
+	}
+	if !s.Strike && next.Strike {
+		writeCode("9")
+	}
+}
+
+// appendColorChanges emits foreground/background SGR codes only when the color
+// differs between the receiver (previous style) and next, using 39/49 to return
+// to the default color.
+func (s Style) appendColorChanges(next Style, writeCode func(string), b *strings.Builder, first *bool) {
+	if s.Fg != next.Fg {
+		if next.Fg.Type == ColorDefault {
+			writeCode("39")
+		} else {
+			writeColorToBuilderFirst(b, next.Fg, true, first)
+		}
+	}
+	if s.Bg != next.Bg {
+		if next.Bg.Type == ColorDefault {
+			writeCode("49")
+		} else {
+			writeColorToBuilderFirst(b, next.Bg, false, first)
+		}
+	}
 }
 
 // writeColorToBuilder appends color codes to a strings.Builder.

--- a/internal/vterm/ansi_test.go
+++ b/internal/vterm/ansi_test.go
@@ -1,0 +1,65 @@
+package vterm
+
+import "testing"
+
+// goldenStyle builds Style/Color literals tersely for the table below.
+func idxColor(v uint32) Color { return Color{Type: ColorIndexed, Value: v} }
+func rgbColor(v uint32) Color { return Color{Type: ColorRGB, Value: v} }
+
+// TestStyleANSIAndDeltaGolden is a characterization test locking the exact SGR
+// output of Style.ANSI and Style.DeltaANSI across both transition branches
+// (full-reset and individual-change), the bold/dim code-22 interaction, every
+// color kind (indexed <8, bright 8-15, 256-color, RGB) and return-to-default.
+// The golden strings were captured from the original free-function
+// implementation so any behavior drift in the method form fails loudly.
+func TestStyleANSIAndDeltaGolden(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		prev, next  Style
+		wantDelta   string
+		wantFullNxt string
+	}{
+		{"nochange", Style{Bold: true, Fg: idxColor(3)}, Style{Bold: true, Fg: idxColor(3)}, "", "\x1b[0;1;33m"},
+		{"blank_to_bold", Style{}, Style{Bold: true}, "\x1b[1m", "\x1b[0;1m"},
+		{"blank_to_all_attrs", Style{}, Style{Bold: true, Dim: true, Italic: true, Underline: true, Blink: true, Reverse: true, Hidden: true, Strike: true}, "\x1b[1;2;3;4;5;7;8;9m", "\x1b[0;1;2;3;4;5;7;8;9m"},
+		{"bold_off_single", Style{Bold: true}, Style{}, "\x1b[22m", "\x1b[0m"},
+		{"dim_off_single", Style{Dim: true}, Style{}, "\x1b[22m", "\x1b[0m"},
+		{"italic_off", Style{Italic: true}, Style{}, "\x1b[23m", "\x1b[0m"},
+		{"underline_off", Style{Underline: true}, Style{}, "\x1b[24m", "\x1b[0m"},
+		{"two_off_triggers_reset", Style{Bold: true, Italic: true}, Style{}, "\x1b[0m", "\x1b[0m"},
+		{"three_off_reset_keep_underline", Style{Bold: true, Italic: true, Blink: true, Underline: true}, Style{Underline: true}, "\x1b[0;4m", "\x1b[0;4m"},
+		{"bold_to_dim_emitted22", Style{Bold: true}, Style{Dim: true}, "\x1b[22;2m", "\x1b[0;2m"},
+		{"dim_to_bold_emitted22", Style{Dim: true}, Style{Bold: true}, "\x1b[22;1m", "\x1b[0;1m"},
+		{"bolddim_to_bold", Style{Bold: true, Dim: true}, Style{Bold: true}, "\x1b[22;1m", "\x1b[0;1m"},
+		{"fg_indexed_low", Style{}, Style{Fg: idxColor(2)}, "\x1b[32m", "\x1b[0;32m"},
+		{"fg_indexed_bright", Style{}, Style{Fg: idxColor(12)}, "\x1b[94m", "\x1b[0;94m"},
+		{"fg_indexed_256", Style{}, Style{Fg: idxColor(200)}, "\x1b[38;5;200m", "\x1b[0;38;5;200m"},
+		{"fg_rgb", Style{}, Style{Fg: rgbColor(0x1affc0)}, "\x1b[38;2;26;255;192m", "\x1b[0;38;2;26;255;192m"},
+		{"bg_indexed_low", Style{}, Style{Bg: idxColor(1)}, "\x1b[41m", "\x1b[0;41m"},
+		{"bg_rgb", Style{}, Style{Bg: rgbColor(0x102030)}, "\x1b[48;2;16;32;48m", "\x1b[0;48;2;16;32;48m"},
+		{"fg_to_default", Style{Fg: idxColor(5)}, Style{}, "\x1b[39m", "\x1b[0m"},
+		{"bg_to_default", Style{Bg: idxColor(5)}, Style{}, "\x1b[49m", "\x1b[0m"},
+		{"fg_change", Style{Fg: idxColor(1)}, Style{Fg: idxColor(4)}, "\x1b[34m", "\x1b[0;34m"},
+		{"bg_change", Style{Bg: rgbColor(0x010203)}, Style{Bg: rgbColor(0x040506)}, "\x1b[48;2;4;5;6m", "\x1b[0;48;2;4;5;6m"},
+		{"attr_and_color", Style{}, Style{Bold: true, Underline: true, Fg: idxColor(2), Bg: rgbColor(0xabcdef)}, "\x1b[1;4;32;48;2;171;205;239m", "\x1b[0;1;4;32;48;2;171;205;239m"},
+		{"reset_with_color", Style{Bold: true, Italic: true, Fg: idxColor(1)}, Style{Fg: idxColor(2)}, "\x1b[0;32m", "\x1b[0;32m"},
+		{"complex_mix", Style{Bold: true, Dim: true, Fg: idxColor(7), Bg: idxColor(0)}, Style{Italic: true, Fg: rgbColor(0x00ff00)}, "\x1b[0;3;38;2;0;255;0m", "\x1b[0;3;38;2;0;255;0m"},
+		{"strike_blink_on", Style{}, Style{Strike: true, Blink: true}, "\x1b[5;9m", "\x1b[0;5;9m"},
+		{"reverse_hidden_off", Style{Reverse: true, Hidden: true}, Style{}, "\x1b[0m", "\x1b[0m"},
+		{"one_off_one_on", Style{Italic: true}, Style{Bold: true}, "\x1b[23;1m", "\x1b[0;1m"},
+		{"fg_rgb_to_indexed", Style{Fg: rgbColor(0x123456)}, Style{Fg: idxColor(9)}, "\x1b[91m", "\x1b[0;91m"},
+		{"all_to_blank", Style{Bold: true, Dim: true, Italic: true, Underline: true, Blink: true, Reverse: true, Hidden: true, Strike: true, Fg: idxColor(3), Bg: idxColor(4)}, Style{}, "\x1b[0m", "\x1b[0m"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := c.prev.DeltaANSI(c.next); got != c.wantDelta {
+				t.Errorf("DeltaANSI: got %q, want %q", got, c.wantDelta)
+			}
+			if got := c.next.ANSI(); got != c.wantFullNxt {
+				t.Errorf("ANSI: got %q, want %q", got, c.wantFullNxt)
+			}
+		})
+	}
+}

--- a/internal/vterm/render.go
+++ b/internal/vterm/render.go
@@ -259,9 +259,9 @@ func (v *VTerm) renderRow(row []Cell, y int) string {
 		if style != lastStyle || inSel != lastReverse || isCursor {
 			// Use delta encoding after the first style (which has reset)
 			if x == 0 {
-				buf.WriteString(StyleToANSI(style))
+				buf.WriteString(style.ANSI())
 			} else {
-				buf.WriteString(StyleToDeltaANSI(lastStyle, style))
+				buf.WriteString(lastStyle.DeltaANSI(style))
 			}
 			lastStyle = style
 			lastReverse = inSel
@@ -336,7 +336,7 @@ func (v *VTerm) renderWithScrollbackFrom(screen [][]Cell, scrollbackLen int) str
 			style = suppressBlankUnderline(cell, style)
 
 			if firstCell || style != lastStyle || inSel != lastReverse {
-				buf.WriteString(StyleToANSI(style))
+				buf.WriteString(style.ANSI())
 				lastStyle = style
 				lastReverse = inSel
 				firstCell = false

--- a/internal/vterm/vterm_render_test.go
+++ b/internal/vterm/vterm_render_test.go
@@ -21,7 +21,7 @@ func TestStyleToDeltaANSIPreservesBoldWhenTurningOffDim(t *testing.T) {
 	t.Parallel()
 	prev := Style{Bold: true, Dim: true}
 	next := Style{Bold: true}
-	out := StyleToDeltaANSI(prev, next)
+	out := prev.DeltaANSI(next)
 	if !strings.Contains(out, "22") || !strings.Contains(out, "1") {
 		t.Fatalf("expected delta to disable dim and preserve bold, got %q", out)
 	}


### PR DESCRIPTION
## Summary
`StyleToANSI(s)` and `StyleToDeltaANSI(prev, next)` took the `Style` they operate on as their first parameter — idiomatically these are methods on `Style`. Convert them to value-receiver methods `s.ANSI()` and `prev.DeltaANSI(next)`, removing the `StyleTo…` stutter, and update the 5 production call sites (`render.go`, `canvas.go`) plus the benchmarks.

## The complexity wrinkle
`StyleToDeltaANSI` carried a gocyclo complexity of **69** (the full SGR attribute/color transition logic). A bare receiver-only rename changes the declaration line, which would trip the **gocyclo-30 strict ratchet** introduced earlier in this stack. Rather than `//nolint`, the body is decomposed into cohesive, well-named helpers:

| helper | role | complexity |
|---|---|---|
| `attrsTurningOff` | count attrs needing disable | 17 |
| `appendResetThenActive` | full-reset transition path | 9 |
| `appendAttrDisables` | emit individual 22–29 disables (reports code-22) | 17 |
| `appendAttrEnables` | emit individual enables | 21 |
| `appendColorChanges` | emit fg/bg changes incl. 39/49 default | 5 |
| `DeltaANSI` (orchestrator) | two-branch decision | 5 |

Max complexity drops from 69 → 21, all under the threshold.

## Behavior safety
Adds `ansi_test.go`: a **30-case golden characterization test** covering both transition branches (full-reset vs individual-change), the bold/dim code-22 interaction, every color kind (indexed <8, bright 8–15, 256-color, RGB), and return-to-default. Golden strings were captured from the *original* implementation, so any drift fails loudly. Benchmarks confirm an identical allocation profile (0 allocs no-change, 1 single-change).

## Test plan
- `go build ./...`, `go vet ./internal/vterm/ ./internal/ui/compositor/`
- `go test -race ./internal/vterm/ ./internal/ui/compositor/`
- `make lint-ci-parity` (strict gocyclo/funlen/nestif ratchet) — clean
- `go test -bench 'BenchmarkStyleDeltaANSI|BenchmarkStyleANSI' -benchmem` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)