### PR TITLE
Add make verify-loop close-the-loop gate and point docs at it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@
 - Tech stack: Go TUI built on Bubble Tea v2 (Charm); styling via Lip Gloss; terminal parsing via `internal/vterm`.
 - Entry points: `cmd/amux` (app) and `cmd/amux-harness` (headless render/perf).
 - E2E: PTY-driven tests live in `internal/e2e` and exercise the real binary.
-- Work autonomously: validate changes with tests and use the harness/emulator to verify UI behavior without a human.
-- Lint-driven workflow: run `make devcheck` for all non-trivial changes.
+- Work autonomously: validate changes with tests and use the harness/emulator to verify UI behavior without a human. The harness is render-only — it does not exercise tmux, the PTY, or a real agent.
+- Lint-driven workflow: run `make devcheck` for all non-trivial changes. Note `make devcheck` passes even when the real-tmux e2e tests skip, so it does not by itself verify input/send behavior.
+- Input/send/tmux/agent changes: run `make verify-loop`. It drives a real keystroke through amux's actual input path into a real raw-mode agent and asserts the bytes (including a literal carriage return) arrive intact — a green run means a real agent received the input end-to-end, which `make devcheck` and the harness cannot prove.
 - Formatting baseline includes `gofumpt`; use `make fmt` for style-only cleanup.
 - Phase 2 strict lint: run `make lint-strict-new` for changed-code ratcheting before finalizing substantial edits.
 - Phase 3 CI gate is automated (no PR-body parsing). For local confidence, run path-relevant checks (`make harness-presets`, `go test ./internal/tmux ./internal/e2e`) when touching those areas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Pull requests are CI-gated (automated). For local confidence before opening a PR
 - always: `make devcheck`, `make lint-strict-new`
 - if touching `internal/ui/`, `internal/vterm/`, or `cmd/amux-harness/`: `make harness-presets`
 - if touching `internal/tmux/`, `internal/e2e/`, or `internal/pty/`: `go test ./internal/tmux ./internal/e2e`
+- if touching the agent input/send path (`internal/tmux/send.go`, `internal/pty/`, agent keystroke forwarding): `make verify-loop` — proves a real agent receives keystrokes end-to-end (incl. a literal CR); `make devcheck` does not, since the real-tmux tests skip there
 
 Architecture references:
 

--- a/LINTING.md
+++ b/LINTING.md
@@ -108,6 +108,8 @@ Escalation is path-based and automated by CI jobs. For local confidence, use:
   - run `make harness-presets`
 - `internal/tmux/`, `internal/e2e/`, `internal/pty/`:
   - run `go test ./internal/tmux ./internal/e2e`
+- agent input/send path (`internal/tmux/send.go`, `internal/pty/`, keystroke forwarding):
+  - run `make verify-loop` — drives a real keystroke through amux into a real raw-mode agent and asserts it arrives intact (incl. a literal CR). `make devcheck` alone is insufficient: the real-tmux tests skip there, so it gives a false green for send/Enter behavior.
 - lint policy files (`.golangci.yml`, `.golangci.strict.yml`, `LINTING.md`, `Makefile`, `.github/workflows/ci.yml`):
   - call out intent in PR summary
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,17 @@ devcheck:
 # return) arrive intact. This is the gate to run for any change to the
 # send/Enter/tmux/agent input path: unlike `make devcheck` (which passes even
 # when the real-tmux tests skip) and the render-only harness, a green run here
-# means a real agent actually received the input end-to-end. Requires tmux; it
-# reports a skip with a clear reason if tmux is unavailable.
+# means a real agent actually received the input end-to-end. Requires git and
+# tmux, and fails before running tests if either is unavailable.
 verify-loop:
+	@command -v git >/dev/null 2>&1 || { echo "make verify-loop: git is required" >&2; exit 1; }
+	@command -v tmux >/dev/null 2>&1 || { echo "make verify-loop: tmux is required" >&2; exit 1; }
+	@server="amux-verify-loop-check-$$$$"; \
+	if ! tmux -L "$$server" new-session -d -s probe "sleep 5" >/dev/null 2>&1; then \
+		echo "make verify-loop: tmux is installed but unusable" >&2; \
+		exit 1; \
+	fi; \
+	tmux -L "$$server" kill-server >/dev/null 2>&1 || true
 	go test ./internal/e2e -run 'TestCloseLoopKeystrokeDeliveryToRawAgent|TestFakeAgentRecordsRawCarriageReturn' -count=1 -v
 
 bench:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HARNESS_SCROLLBACK_FRAMES ?= 600
 GOFUMPT ?= go run mvdan.cc/gofumpt@v0.9.2
 STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 
-.PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets
+.PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets
 
 build:
 	go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
@@ -25,6 +25,16 @@ devcheck:
 	go vet ./...
 	go test ./...
 	$(MAKE) lint
+
+# verify-loop drives a real keystroke through amux's actual input path into a
+# real raw-mode agent and asserts the bytes (including a literal carriage
+# return) arrive intact. This is the gate to run for any change to the
+# send/Enter/tmux/agent input path: unlike `make devcheck` (which passes even
+# when the real-tmux tests skip) and the render-only harness, a green run here
+# means a real agent actually received the input end-to-end. Requires tmux; it
+# reports a skip with a clear reason if tmux is unavailable.
+verify-loop:
+	go test ./internal/e2e -run 'TestCloseLoopKeystrokeDeliveryToRawAgent|TestFakeAgentRecordsRawCarriageReturn' -count=1 -v
 
 bench:
 	go test -bench=. -benchmem ./internal/ui/compositor/ -run=^$$
@@ -144,6 +154,7 @@ help:
 	@echo "  clean      - Remove build artifacts"
 	@echo "  run        - Build and run"
 	@echo "  dev        - Run with hot reload (requires air)"
+	@echo "  verify-loop - Drive a real keystroke through amux into a raw-mode agent (close-the-loop input gate; requires tmux)"
 	@echo "  bench      - Run rendering benchmarks"
 	@echo "  harness-center  - Run center harness preset"
 	@echo "  harness-sidebar - Run sidebar harness preset (deep scrollback)"


### PR DESCRIPTION
## Close-the-loop stack — PR 3/12

The actual "merge without manual testing" gate. Builds on PRs 1–2.

## Problem
`make devcheck` passes even when the real-tmux e2e tests **skip**, and `cmd/amux-harness` is render-only — neither touches tmux, the PTY, or a real agent. So an agent can change the send/Enter/input path, get a green `devcheck`, and still have shipped a broken keystroke path. That is the core complaint.

## Change
- `make verify-loop`: drives a real keystroke through amux's actual input path into a real raw-mode agent (the PR-1 fixture) and asserts the bytes — including a literal carriage return — arrive intact. Requires tmux; clear skip otherwise.
- `AGENTS.md` / `CONTRIBUTING.md` / `LINTING.md`: the agent workflow now runs `make verify-loop` for input/send/tmux/agent changes, and no longer implies the render-only harness or `devcheck` verify input behavior.

## Test
`make verify-loop` runs the fixture self-test + the close-the-loop E2E; both green locally (~2s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)