### PR TITLE
Run internal/app real-tmux integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
       - name: Test (e2e)
         run: go test ./internal/e2e -count=1
 
+      # internal/app has real-tmux integration tests (dead-session GC, activity
+      # leases, shared-attach) that t.Skip in the tmux-less `test` job and were
+      # never run here, so app-layer tmux orchestration only got coverage in the
+      # off-PR nightly run. Run them here, where tmux is installed.
+      - name: Test (app, real tmux)
+        run: go test ./internal/app -count=1
+
   lint-strict-pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Close-the-loop stack — PR 4/12

## Problem
`internal/app` has real-tmux integration tests (dead-session GC, activity leases, shared-attach), but they **never run on a PR**:
- the `test` job has no tmux → they `t.Skip`,
- the `tmux-e2e` job installs tmux but only runs `./internal/tmux` + `./internal/e2e`.

So app-layer tmux orchestration was only exercised by the off-PR nightly run — a green PR gave an agent no signal it had broken lease/GC behavior.

## Change
Add `go test ./internal/app` to the `tmux-e2e` job (which has tmux installed). These tests already use a robust keepalive-session probe and pass locally against real tmux (verified vs 3.6a).

## Note
This composes with the next PR (tmux version matrix): once that lands, these app tests run under both tmux versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)