### PR TITLE
Add a tmux 3.2a/3.6a version matrix to the real-tmux CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,15 @@ jobs:
 
   tmux-e2e:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Bug #1 (tmux 3.6a rejecting '='-prefixed set-option targets) is version
+        # specific, yet CI only ran ubuntu's apt tmux (3.2a-class) — OLDER than the
+        # version that produced the bug, so a 3.6a-only regression passed. Run the
+        # real-tmux suites against both the apt baseline and a from-source 3.6a so
+        # version-specific regressions fail on the leg that can see them.
+        tmux: [apt, "3.6a"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -97,11 +106,31 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux (${{ matrix.tmux }})
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.tmux }}" = "apt" ]; then
+            sudo apt-get update && sudo apt-get install -y tmux
+          else
+            sudo apt-get update
+            sudo apt-get install -y build-essential libevent-dev libncurses-dev bison pkg-config
+            ver="${{ matrix.tmux }}"
+            curl -fsSL "https://github.com/tmux/tmux/releases/download/${ver}/tmux-${ver}.tar.gz" -o /tmp/tmux.tar.gz
+            tar -xzf /tmp/tmux.tar.gz -C /tmp
+            cd "/tmp/tmux-${ver}"
+            ./configure
+            make -j"$(nproc)"
+            sudo make install
+            sudo ldconfig
+          fi
 
       - name: tmux version
-        run: tmux -V
+        run: |
+          set -euo pipefail
+          tmux -V
+          if [ "${{ matrix.tmux }}" != "apt" ]; then
+            tmux -V | grep -Fq "${{ matrix.tmux }}" || { echo "expected tmux ${{ matrix.tmux }} but got: $(tmux -V)"; exit 1; }
+          fi
 
       - name: Test (tmux)
         run: go test ./internal/tmux -count=1


### PR DESCRIPTION
## Close-the-loop stack — PR 5/12

The P0 guard for **bug #1** (tmux 3.6a rejecting `=`-prefixed `set-option` targets).

## Problem
The `tmux-e2e` job only ran ubuntu's apt tmux — **3.2a-class, older than the 3.6a that produced the bug**. So the exact escaped-bug category (version-specific tmux behavior) was uncatchable, and CI printed `tmux -V` without ever asserting it. A 3.6a-only rejection passed CI clean.

## Change
Matrix the `tmux-e2e` job over `{apt, 3.6a}`:
- **apt** leg: `apt-get install tmux` (the existing baseline).
- **3.6a** leg: download the 3.6a release tarball, `./configure && make`, install to `/usr/local/bin`.
- The version step **asserts** `tmux -V` matches the matrix entry, so silent version drift fails.
- `fail-fast: false` so one version failing still reports the other.

Both legs run the tmux + e2e + app real-tmux suites (the app one from PR 4), so a 3.6a-specific regression now fails on the leg that can see it.

## Verification
The tarball URL (`.../releases/download/3.6a/tmux-3.6a.tar.gz`) was confirmed reachable (~750KB). The from-source build itself runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)