### PR TITLE
Add a test seam for the SendKeys enter delay

### DIFF
--- a/internal/tmux/send.go
+++ b/internal/tmux/send.go
@@ -8,6 +8,13 @@ import "time"
 // 50ms is enough for every tested agent while keeping sends snappy.
 const enterDelay = 50 * time.Millisecond
 
+// enterSleep performs the pause between text and Enter. It is a package var so a
+// test can observe that the delay is applied (and assert its value) without
+// waiting in real time. Without this seam, reducing enterDelay — which would
+// re-introduce the dropped-Enter race against a fast agent — compiles and passes
+// every test silently.
+var enterSleep = time.Sleep
+
 // sendTextArgs builds the send-keys argv that delivers text literally. The -l
 // flag forces literal mode and the -- guard ensures a leading-dash payload is
 // not parsed as a flag. The raw sessionName is passed without a sessionTarget
@@ -42,7 +49,7 @@ func SendKeys(sessionName, text string, enter bool, opts Options) error {
 	if enter {
 		// Brief pause so the TUI finishes processing the text insertion
 		// before we deliver the carriage return.
-		time.Sleep(enterDelay)
+		enterSleep(enterDelay)
 
 		enterCmd, enterCancel := tmuxCommand(opts, sendEnterArgs(sessionName)...)
 		defer enterCancel()

--- a/internal/tmux/send_seam_test.go
+++ b/internal/tmux/send_seam_test.go
@@ -1,0 +1,37 @@
+package tmux
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSendKeysAppliesEnterDelayOnlyWhenSendingEnter pins the inter-keystroke
+// delay behavior via the enterSleep seam: SendKeys must pause exactly once, for
+// enterDelay, between the text and the carriage return when enter is true, and
+// must not pause at all when enter is false. Without this, reducing or dropping
+// enterDelay (re-introducing the dropped-Enter race) would pass silently.
+func TestSendKeysAppliesEnterDelayOnlyWhenSendingEnter(t *testing.T) {
+	opts := realTmuxServerWithKeepalive(t)
+
+	var slept []time.Duration
+	orig := enterSleep
+	enterSleep = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { enterSleep = orig })
+
+	// enter=true: exactly one pause, of enterDelay, between text and CR.
+	if err := SendKeys("_keepalive", "x", true, opts); err != nil {
+		t.Fatalf("SendKeys(enter=true): %v", err)
+	}
+	if len(slept) != 1 || slept[0] != enterDelay {
+		t.Fatalf("expected exactly one %v pause, got %v", enterDelay, slept)
+	}
+
+	// enter=false: no pause at all.
+	slept = nil
+	if err := SendKeys("_keepalive", "y", false, opts); err != nil {
+		t.Fatalf("SendKeys(enter=false): %v", err)
+	}
+	if len(slept) != 0 {
+		t.Fatalf("expected no pause when enter=false, got %v", slept)
+	}
+}


### PR DESCRIPTION
## Close-the-loop stack — PR 8/12

## Problem
`enterDelay` (the 50ms pause between text and the CR that keeps a fast agent from dropping Enter — bug #3) was a bare `time.Sleep` inside `SendKeys` with no way to observe it. Reducing or removing it compiled and passed every test silently. The `supervisor` package already uses a `WithSleep` seam for exactly this.

## Change
Route the pause through a package var `enterSleep = time.Sleep`, and add a test asserting `SendKeys` pauses **exactly once, for `enterDelay`**, between text and Enter when `enter` is true — and not at all when false. A silent change to the delay now changes what the test sees.

## Test
Seam test passes 3/3; the PR-7 `SendKeys` real-agent delivery test still passes (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)