### PR TITLE
Guard the seam packages against t.Parallel

### DIFF
--- a/internal/ui/center/no_parallel_guard_test.go
+++ b/internal/ui/center/no_parallel_guard_test.go
@@ -1,0 +1,33 @@
+package center
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoTParallelInSeamPackage enforces the constraint documented on this
+// package's test seams (mutable package-global vars saved/restored via defer):
+// a test using t.Parallel would race those seams and pass or fail spuriously.
+// The constraint was only a comment; this guard turns it into a build break if
+// any test file introduces t.Parallel.
+func TestNoTParallelInSeamPackage(t *testing.T) {
+	files, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test files: %v", err)
+	}
+	const self = "no_parallel_guard_test.go"
+	for _, f := range files {
+		if f == self {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if strings.Contains(string(src), "t.Parallel()") {
+			t.Errorf("%s calls t.Parallel(), but this package's test seams are mutable package globals restored via defer; parallel tests race them. Remove t.Parallel() or inject the seam per-test instead.", f)
+		}
+	}
+}

--- a/internal/ui/sidebar/no_parallel_guard_test.go
+++ b/internal/ui/sidebar/no_parallel_guard_test.go
@@ -1,0 +1,33 @@
+package sidebar
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoTParallelInSeamPackage enforces the constraint documented on this
+// package's test seams (mutable package-global vars saved/restored via defer):
+// a test using t.Parallel would race those seams and pass or fail spuriously.
+// The constraint was only a comment; this guard turns it into a build break if
+// any test file introduces t.Parallel.
+func TestNoTParallelInSeamPackage(t *testing.T) {
+	files, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test files: %v", err)
+	}
+	const self = "no_parallel_guard_test.go"
+	for _, f := range files {
+		if f == self {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if strings.Contains(string(src), "t.Parallel()") {
+			t.Errorf("%s calls t.Parallel(), but this package's test seams are mutable package globals restored via defer; parallel tests race them. Remove t.Parallel() or inject the seam per-test instead.", f)
+		}
+	}
+}


### PR DESCRIPTION
## Close-the-loop stack — PR 9/12

## Problem
`internal/ui/center` and `internal/ui/sidebar` route tmux capture/resize/reattach through **mutable package-global test seams** that tests override and restore via `defer`. A test that adds `t.Parallel` in these packages would race those shared seams and pass/fail spuriously — masking or faking a real reattach bug. The constraint was only a comment on the seam declarations, with nothing enforcing it.

## Change
A self-contained guard test in each package scans its own `*_test.go` files and fails if any introduces `t.Parallel()`. A global forbidigo rule was avoided because `t.Parallel` is correct and wanted elsewhere in the repo.

## Verification
Confirmed it **fails** on a planted `t.Parallel()` and **passes** once removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)