### PR TITLE
Make log level configurable via AMUX_LOG_LEVEL

### DIFF
--- a/cmd/amux/main.go
+++ b/cmd/amux/main.go
@@ -79,7 +79,11 @@ func runTUI() {
 	// Initialize logging
 	home, _ := os.UserHomeDir()
 	logDir := filepath.Join(home, ".amux", "logs")
-	if err := logging.Initialize(logDir, logging.LevelInfo); err != nil {
+	logLevel := logging.LevelInfo
+	if lvl, ok := logging.ParseLevel(os.Getenv("AMUX_LOG_LEVEL")); ok {
+		logLevel = lvl
+	}
+	if err := logging.Initialize(logDir, logLevel); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not initialize logging: %v\n", err)
 	}
 	defer logging.Close()

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,4 +1,8 @@
 // Package logging is amux's file-based logger. Internal packages route
 // diagnostics through it (Debug/Info/Warn/Error) instead of writing to
 // stdout/stderr, which is reserved for the CLI entrypoints.
+//
+// The minimum level defaults to INFO; set AMUX_LOG_LEVEL=debug (or info/warn/
+// error) to change it, which is required to surface the Debug call sites.
+// AMUX_LOG_RETENTION_DAYS controls how many days of log files are retained.
 package logging

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -132,6 +132,33 @@ func SetEnabled(enabled bool) {
 	}
 }
 
+// ParseLevel maps a level name (debug/info/warn/error, case-insensitive and
+// trimmed) to a Level. The bool is false for unrecognized input so callers can
+// fall back to a default.
+func ParseLevel(name string) (Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "debug":
+		return LevelDebug, true
+	case "info":
+		return LevelInfo, true
+	case "warn":
+		return LevelWarn, true
+	case "error":
+		return LevelError, true
+	default:
+		return LevelInfo, false
+	}
+}
+
+// SetLevel updates the minimum severity the default logger emits.
+func SetLevel(level Level) {
+	if defaultLogger != nil {
+		defaultLogger.mu.Lock()
+		defaultLogger.level = level
+		defaultLogger.mu.Unlock()
+	}
+}
+
 // log writes a log entry
 func log(level Level, format string, args ...any) {
 	if defaultLogger == nil {

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -70,6 +70,50 @@ func TestSetEnabledDisablesLogging(t *testing.T) {
 	}
 }
 
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   Level
+		wantOk bool
+	}{
+		{"debug", LevelDebug, true},
+		{"DEBUG", LevelDebug, true},
+		{" Info ", LevelInfo, true},
+		{"warn", LevelWarn, true},
+		{"ERROR", LevelError, true},
+		{"verbose", LevelInfo, false},
+		{"", LevelInfo, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseLevel(c.in)
+		if got != c.want || ok != c.wantOk {
+			t.Errorf("ParseLevel(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.wantOk)
+		}
+	}
+}
+
+func TestSetLevelTogglesDebug(t *testing.T) {
+	logPath, cleanup := setupLogger(t, LevelInfo)
+	defer cleanup()
+
+	Debug("suppressed at info")
+	SetLevel(LevelDebug)
+	Debug("visible after setlevel")
+	cleanup()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "suppressed at info") {
+		t.Fatalf("debug line should be suppressed at INFO level: %q", content)
+	}
+	if !strings.Contains(content, "DEBUG: visible after setlevel") {
+		t.Fatalf("expected debug line after SetLevel(LevelDebug), got: %q", content)
+	}
+}
+
 func TestLevelFiltering(t *testing.T) {
 	logPath, cleanup := setupLogger(t, LevelWarn)
 	defer cleanup()


### PR DESCRIPTION
## Plan stack — PR 1/41 (foundation)

First ticket of the workspace/status/streaming/maintainability stacked diff (`STACKED_DIFF_PLAN.md`), bottom-up.

## Problem
The log level was hardcoded to `LevelInfo` at startup (`cmd/amux/main.go`), so **every** `logging.Debug` call site was unreachable in any real build — including the keystroke-delivery debug trail and the PTY write trace. Chasing a "keystroke not delivered" bug meant recompiling to see the debug logging.

## Change
- `logging.ParseLevel(string) (Level, bool)` — debug/info/warn/error, case-insensitive/trimmed, `ok=false` on unknown.
- `logging.SetLevel(Level)` — mutates the default logger's level under its mutex (nil-safe, mirrors `SetEnabled`).
- `runTUI()` reads `AMUX_LOG_LEVEL` and picks the initial level, falling back to INFO on unset/invalid.
- Documented in the package doc.

## Test
- `TestParseLevel` — the four names case-insensitively + `ok=false` on garbage.
- `TestSetLevelTogglesDebug` — Debug suppressed at INFO, written after `SetLevel(LevelDebug)`.
- `go test ./internal/logging/` green; lint/format clean.

## Unblocks
The observability tickets (#2, #30, #31) that need a runtime log toggle.