### PR TITLE
Stop logging raw agent input in Terminal.SendString

### DIFF
--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -115,9 +116,31 @@ func (t *Terminal) SendString(s string) error {
 	if err != nil {
 		logging.Error("SendString failed: %v", err)
 	} else {
-		logging.Debug("SendString wrote %d bytes: %q", n, s)
+		// Log a control-byte classification, never the literal input: SendString
+		// is the single funnel for all agent input, which can contain pasted
+		// secrets (API keys, passwords) and prompt text.
+		logging.Debug("SendString wrote %d bytes (%s)", n, controlByteHint(s))
 	}
 	return err
+}
+
+// controlByteHint summarizes the control framing of agent input for debug logs
+// without recording any literal bytes.
+func controlByteHint(s string) string {
+	var hints []string
+	if strings.Contains(s, "\x1b[200~") || strings.Contains(s, "\x1b[201~") {
+		hints = append(hints, "paste")
+	}
+	if strings.ContainsRune(s, 0x0d) {
+		hints = append(hints, "cr")
+	}
+	if strings.ContainsRune(s, 0x03) {
+		hints = append(hints, "ctrl-c")
+	}
+	if len(hints) == 0 {
+		return "text"
+	}
+	return strings.Join(hints, "+")
 }
 
 // Close closes the terminal


### PR DESCRIPTION
## Plan stack — PR 2/41

## Problem
`Terminal.SendString` is the single funnel for all agent input (every keystroke + bracketed paste from center/sidebar) and logged the full raw string via `Debug("... %q", n, s)`. `s` can contain pasted **API keys, passwords, tokens, prompt text**. The line was inert only because Debug was gated off — but PR 1 lets `AMUX_LOG_LEVEL=debug` enable it at runtime, so diagnosing a delivery bug would write secrets verbatim to a 14-day-retained log.

## Change
Log a **control-byte classification** (paste framing / CR / Ctrl-C presence) instead of the literal bytes — keeps the delivery-debug signal, records no payload.

## Test
`grep '%q' internal/pty/terminal.go` → none; `go test ./internal/pty/` green; lint/format clean.