### PR TITLE
Log agent teardown and SIGKILL escalation in internal/pty

### DIFF
--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
@@ -192,6 +193,12 @@ func (m *AgentManager) CloseAgent(agent *Agent) error {
 		agent.Terminal.Close()
 	}
 
+	wsID := ""
+	if agent.Workspace != nil {
+		wsID = string(agent.Workspace.ID())
+	}
+	logging.Info("agent closed: type=%s session=%s workspace=%s", agent.Type, agent.Session, wsID)
+
 	// Remove from list
 	if agent.Workspace != nil {
 		m.mu.Lock()
@@ -215,6 +222,14 @@ func (m *AgentManager) CloseAll() {
 	m.agents = make(map[data.WorkspaceID][]*Agent)
 	m.mu.Unlock()
 
+	total := 0
+	for _, agents := range agentsByWorkspace {
+		total += len(agents)
+	}
+	if total > 0 {
+		logging.Info("closing all %d agents across %d workspaces", total, len(agentsByWorkspace))
+	}
+
 	for _, agents := range agentsByWorkspace {
 		for _, agent := range agents {
 			if agent.Terminal != nil {
@@ -234,6 +249,9 @@ func (m *AgentManager) CloseWorkspaceAgents(ws *data.Workspace) {
 	agents := m.agents[wsID]
 	delete(m.agents, wsID)
 	m.mu.Unlock()
+	if len(agents) > 0 {
+		logging.Info("closing %d agents for workspace %s", len(agents), wsID)
+	}
 	for _, agent := range agents {
 		if agent.Terminal != nil {
 			agent.Terminal.Close()

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -177,6 +177,7 @@ func (t *Terminal) Close() error {
 			case <-done:
 				// Process exited cleanly.
 			case <-time.After(terminalCloseTimeout):
+				logging.Warn("agent did not exit within %s of SIGTERM; escalating to SIGKILL (pid %d)", terminalCloseTimeout, leaderPID)
 				_ = process.ForceKillProcess(leaderPID)
 				<-done
 			}


### PR DESCRIPTION
## Plan stack — PR 3/41

## Problem
The pty package owns the real agent process lifecycle but emitted almost no lifecycle logs. `agent.go` had zero logging; `Terminal.Close()` escalated SIGTERM→SIGKILL after a 5s timeout silently. A hung/force-killed agent, or a workspace delete tearing down N agents, was invisible — impossible to correlate "agent disappeared" or "delete hung on a stuck agent" against the log.

## Change
- `Terminal.Close()`: `Warn` on the SIGKILL-escalation arm only, with the leader PID.
- `agent.go`: `Info` at the deliberate-teardown boundaries — `CloseAgent` (type/session/workspace), `CloseAll` and `CloseWorkspaceAgents` (counts). No creation logging (already logged at the UI layer → no duplicate lines).

All Info/Warn (survive default level); lifecycle only, no per-byte logging.

## Test
`go test ./internal/pty/` green; lint clean; both files < 500 lines.