### PR TITLE
Label PTY trace files by assistant instead of hardcoding 'claude'

### DIFF
--- a/internal/ui/center/model_pty_trace.go
+++ b/internal/ui/center/model_pty_trace.go
@@ -48,6 +48,27 @@ func ptyTraceDir() string {
 	return os.TempDir()
 }
 
+// ptyTraceFileName builds the trace filename for an assistant. The assistant
+// token is lowercased, trimmed, and reduced to [a-z0-9_-] (other runes become
+// '-'), falling back to "agent" when empty — so a codex/cline/gemini trace is
+// labeled correctly instead of the old hardcoded "claude".
+func ptyTraceFileName(assistant, tabID, ts string) string {
+	token := strings.ToLower(strings.TrimSpace(assistant))
+	if token == "" {
+		token = "agent"
+	} else {
+		token = strings.Map(func(r rune) rune {
+			switch {
+			case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_', r == '-':
+				return r
+			default:
+				return '-'
+			}
+		}, token)
+	}
+	return fmt.Sprintf("amux-pty-%s-%s-%s.log", token, tabID, ts)
+}
+
 func (m *Model) tracePTYOutput(tab *Tab, data []byte) {
 	if tab == nil || !ptyTraceAllowed(tab.Assistant) {
 		return
@@ -62,7 +83,7 @@ func (m *Model) tracePTYOutput(tab *Tab, data []byte) {
 
 	if tab.ptyTraceFile == nil {
 		dir := ptyTraceDir()
-		name := fmt.Sprintf("amux-pty-claude-%s-%s.log", tab.ID, time.Now().Format("20060102-150405"))
+		name := ptyTraceFileName(tab.Assistant, string(tab.ID), time.Now().Format("20060102-150405"))
 		path := filepath.Join(dir, name)
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {

--- a/internal/ui/center/model_pty_trace_test.go
+++ b/internal/ui/center/model_pty_trace_test.go
@@ -1,0 +1,30 @@
+package center
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPtyTraceFileName(t *testing.T) {
+	cases := []struct {
+		assistant  string
+		wantPrefix string
+	}{
+		{"claude", "amux-pty-claude-"},
+		{"codex", "amux-pty-codex-"},
+		{"Cline", "amux-pty-cline-"},
+		{"  gemini  ", "amux-pty-gemini-"},
+		{"open code", "amux-pty-open-code-"},
+		{"a/b\\c", "amux-pty-a-b-c-"},
+		{"", "amux-pty-agent-"},
+	}
+	for _, c := range cases {
+		got := ptyTraceFileName(c.assistant, "tab-1", "20060102-150405")
+		if !strings.HasPrefix(got, c.wantPrefix) {
+			t.Errorf("ptyTraceFileName(%q): got %q, want prefix %q", c.assistant, got, c.wantPrefix)
+		}
+		if !strings.HasSuffix(got, "-tab-1-20060102-150405.log") {
+			t.Errorf("ptyTraceFileName(%q): unexpected suffix in %q", c.assistant, got)
+		}
+	}
+}


### PR DESCRIPTION
## Plan stack — PR 4/41

## Problem
`AMUX_PTY_TRACE` named every file `amux-pty-claude-<tab>-<ts>.log` regardless of assistant, so a codex/cline/gemini/amp/opencode trace was labeled "claude". The filename is how you locate and disambiguate traces — this misled the exact debugging the trace exists for. `tab.Assistant` was already in scope but ignored for the filename.

## Change
Pure `ptyTraceFileName(assistant, tabID, ts)` helper: lowercase + trim, reduce to `[a-z0-9_-]` (other runes → `-`), fall back to `agent` when empty. Used at the trace-open site.

## Test
`TestPtyTraceFileName` covers claude/codex/Cline, whitespace, slashes, and empty; `go test ./internal/ui/center/` green; lint clean; file 129 lines.