### PR TITLE
Extract Tab.resetActorWriteStateLocked to dedup two identical reset blocks

### DIFF
--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -126,17 +126,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 	tab.reattachInFlight = false
 	tab.Running = true
 	resetChatCursorActivityStateLocked(tab)
-	tab.parserResetPending = false
-	tab.settlePTYBytesLocked(tab.actorQueuedBytes)
-	tab.actorQueuedBytes = 0
-	tab.actorWritesPending = 0
-	tab.actorWriteEpoch++
-	tab.clearCatchUpLocked()
-	tab.pendingOutputBytes = len(tab.pendingOutput)
-	tab.overflowTrimCarry = vterm.ParserCarryState{}
-	tab.ptyNoiseTrailing = nil
-	tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
-	tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
+	tab.resetActorWriteStateLocked()
 	tab.bootstrapActivity = true
 	tab.bootstrapLastOutputAt = time.Now()
 	tab.mu.Unlock()

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -232,6 +232,26 @@ func (t *Tab) clearCatchUpLocked() {
 	t.catchUpTargetBytes = 0
 }
 
+// resetActorWriteStateLocked resets all per-(re)attach actor-write and parser
+// state for a terminal that is being attached or recreated. The caller must
+// hold t.mu and t.Terminal must be non-nil (the final line reads
+// t.Terminal.ParserCarryState()). This sequence was duplicated byte-for-byte at
+// the reattach and recreate sites; a field addition or ordering fix now happens
+// once rather than being mirrored across both.
+func (t *Tab) resetActorWriteStateLocked() {
+	t.parserResetPending = false
+	t.settlePTYBytesLocked(t.actorQueuedBytes)
+	t.actorQueuedBytes = 0
+	t.actorWritesPending = 0
+	t.actorWriteEpoch++
+	t.clearCatchUpLocked()
+	t.pendingOutputBytes = len(t.pendingOutput)
+	t.overflowTrimCarry = vterm.ParserCarryState{}
+	t.ptyNoiseTrailing = nil
+	t.actorQueuedNoiseTrailing = t.actorQueuedNoiseTrailing[:0]
+	t.actorQueuedCarry = t.Terminal.ParserCarryState()
+}
+
 func (t *Tab) expireCatchUpLocked() {
 	if t == nil {
 		return

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -258,17 +258,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 		tab.SessionName = msg.Agent.Session
 		tab.Detached = false
 		tab.Running = true
-		tab.parserResetPending = false
-		tab.settlePTYBytesLocked(tab.actorQueuedBytes)
-		tab.actorQueuedBytes = 0
-		tab.actorWritesPending = 0
-		tab.actorWriteEpoch++
-		tab.clearCatchUpLocked()
-		tab.pendingOutputBytes = len(tab.pendingOutput)
-		tab.overflowTrimCarry = vterm.ParserCarryState{}
-		tab.ptyNoiseTrailing = nil
-		tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
-		tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
+		tab.resetActorWriteStateLocked()
 		m.applyTerminalCursorPolicyLocked(tab)
 		if tab.createdAt == 0 {
 			tab.createdAt = now.Unix()


### PR DESCRIPTION
## Plan stack — PR 5/41

## Problem
The "reset all actor-write/parser state for a (re)attached terminal" sequence was **byte-for-byte identical** at the reattach site (`model_input_lifecycle.go`) and the recreate site (`model_tabs.go`) — eleven fields in a fixed order. A future field addition or ordering fix had to be mirrored in both, or the streaming state machine silently drifts (e.g. a stale `actorQueuedCarry` garbling output after reattach).

## Change
Hoist the identical 11-statement block into `Tab.resetActorWriteStateLocked()` (precondition: caller holds `t.mu`, `t.Terminal != nil`) and call it from both sites. The surrounding-but-divergent statements stay at the call sites; the two genuinely-different `model_input_lifecycle_pty.go` variants are left untouched.

## Test
`go test ./internal/ui/center/` green; lint + strict ratchet clean; `grep actorWriteEpoch++` shows only the helper + the 2 pty variants remain; all files < 500 lines.