### PR TITLE
Cover the rebuffer prepend-order invariant with a trailing pending tail

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -445,3 +445,45 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 		t.Fatalf("expected user-input echo not to set lastActivityTagAt, got %v", tab.lastActivityTagAt)
 	}
 }
+
+func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) {
+	m := newTestModel()
+	m.setTabActorReady()
+	m.tabEvents = make(chan tabEvent, 1)
+	m.tabEvents <- tabEvent{kind: tabEventWriteOutput} // fill queue so sendTabEvent fails
+
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	// head exceeds the active drain chunk so the flush leaves a non-empty
+	// remainder; tail makes prepend-vs-append distinguishable (the existing
+	// rebuffer test seeds pendingOutput==chunk, an empty tail that cannot).
+	head := bytes.Repeat([]byte("H"), ptyFlushChunkSizeActive+8)
+	tail := []byte("TAILxyz")
+	original := append(append([]byte(nil), head...), tail...)
+
+	tab := &Tab{
+		ID:                 TabID("tab-order"),
+		Assistant:          "codex",
+		Workspace:          ws,
+		Terminal:           vterm.New(80, 24),
+		Running:            true,
+		pendingOutput:      append([]byte(nil), original...),
+		pendingOutputBytes: len(original),
+		actorWritesPending: 1,
+		actorWriteEpoch:    11,
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+
+	if !bytes.Equal(tab.pendingOutput, original) {
+		t.Fatalf("rebuffer must restore original stream order (prepend); len=%d endsWithTail=%v",
+			len(tab.pendingOutput), bytes.HasSuffix(tab.pendingOutput, tail))
+	}
+	if !bytes.HasSuffix(tab.pendingOutput, tail) {
+		t.Fatalf("tail no longer at the end — chunk was appended, reordering the stream")
+	}
+}


### PR DESCRIPTION
## Plan stack — PR 7/41 (test-only)

## Problem
When the actor queue is full and older writes are pending, the flush kernel restores the failed chunk to the **front** of `pendingOutput` (`restored = chunk + pendingOutput`) to preserve stream order. The only existing rebuffer test seeds `pendingOutput == chunk`, so the tail is empty after the drain and the assertion **cannot distinguish prepend from append** — a regression that reordered streamed output would pass.

## Change
`TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending`: seed `pendingOutput = head+tail` where `head` exceeds `ptyFlushChunkSizeActive`, so the active-tab drain leaves a non-empty remainder. After the rebuffer, assert `pendingOutput` equals the original `head+tail` and still ends with the tail — fails on append (reorder) or drop (loss).

Test-only; file stays at 489/500 lines.