### PR TITLE
Fix center scroll handling

### DIFF
--- a/internal/app/app_prefix.go
+++ b/internal/app/app_prefix.go
@@ -145,7 +145,18 @@ func (a *App) prefixInputToken(msg tea.KeyPressMsg) (string, bool) {
 }
 
 func (a *App) prefixCommands() []prefixCommand {
-	return prefixCommandTable
+	commands := append([]prefixCommand(nil), prefixCommandTable...)
+	if a.centerScrollPrefixActive() {
+		commands = append(commands, prefixCommand{Sequence: []string{"u"}, Desc: "scroll up", Action: "scroll_up"})
+		for i := range commands {
+			if len(commands[i].Sequence) == 1 && commands[i].Sequence[0] == "d" {
+				commands[i].Desc = "scroll down"
+				commands[i].Action = "scroll_down"
+				break
+			}
+		}
+	}
+	return commands
 }
 
 // matchingPrefixCommands intentionally does not apply prefixActionVisible.
@@ -182,18 +193,20 @@ func (a *App) runPrefixAction(action string) tea.Cmd {
 		return a.focusPaneLeft()
 	case "focus_right":
 		return a.focusPaneRight()
+	case "scroll_up":
+		if a.centerScrollPrefixActive() {
+			a.center.ScrollActiveTerminalPage(1)
+		}
+		return nil
+	case "scroll_down":
+		if a.centerScrollPrefixActive() {
+			a.center.ScrollActiveTerminalPage(-1)
+		}
+		return nil
 	case "add_project":
 		return func() tea.Msg { return messages.ShowAddProjectDialog{} }
 	case "delete_workspace":
-		if a.activeWorkspace == nil || a.activeProject == nil {
-			return a.requireWorkspaceSelection("delete workspace")
-		}
-		return func() tea.Msg {
-			return messages.ShowDeleteWorkspaceDialog{
-				Project:   a.activeProject,
-				Workspace: a.activeWorkspace,
-			}
-		}
+		return a.deleteWorkspaceCommand()
 	case "open_settings":
 		return func() tea.Msg { return messages.ShowSettingsDialog{} }
 	case "quit":
@@ -238,6 +251,25 @@ func (a *App) runPrefixAction(action string) tea.Cmd {
 		return a.dispatchTabAction(a.center.RestartActiveTab, a.sidebarTerminal.RestartActiveTab)
 	default:
 		return nil
+	}
+}
+
+func (a *App) centerScrollPrefixActive() bool {
+	return a != nil &&
+		a.focusedPane == messages.PaneCenter &&
+		a.center != nil &&
+		a.center.HasActiveTerminal()
+}
+
+func (a *App) deleteWorkspaceCommand() tea.Cmd {
+	if a.activeWorkspace == nil || a.activeProject == nil {
+		return a.requireWorkspaceSelection("delete workspace")
+	}
+	return func() tea.Msg {
+		return messages.ShowDeleteWorkspaceDialog{
+			Project:   a.activeProject,
+			Workspace: a.activeWorkspace,
+		}
 	}
 }
 

--- a/internal/app/app_prefix_palette_visibility.go
+++ b/internal/app/app_prefix_palette_visibility.go
@@ -25,6 +25,8 @@ func (a *App) prefixActionVisible(action string) bool {
 			return false
 		}
 		return !a.tmuxCheckDone || a.tmuxAvailable
+	case "scroll_up", "scroll_down":
+		return a.centerScrollPrefixActive()
 	case "delete_workspace":
 		return a.activeWorkspace != nil && a.activeProject != nil
 	case "next_tab", "prev_tab":

--- a/internal/app/app_ui_prefix_test.go
+++ b/internal/app/app_ui_prefix_test.go
@@ -365,6 +365,56 @@ func TestRunPrefixAction_DeleteWorkspaceRequiresSelection(t *testing.T) {
 	}
 }
 
+func TestHandlePrefixScrollsFocusedCenterTerminal(t *testing.T) {
+	app, tab := newScrollableCenterWheelHarness(t)
+	before, _ := tab.Terminal.GetScrollInfo()
+
+	status, cmd := app.handlePrefixCommand(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if status != prefixMatchComplete {
+		t.Fatalf("expected prefix d to complete, got %v", status)
+	}
+	if cmd != nil {
+		t.Fatalf("expected prefix d center scroll to be synchronous, got %v", cmd)
+	}
+	afterDown, _ := tab.Terminal.GetScrollInfo()
+	if afterDown >= before {
+		t.Fatalf("expected prefix d to scroll toward bottom, before=%d after=%d", before, afterDown)
+	}
+
+	app.prefixSequence = nil
+	status, cmd = app.handlePrefixCommand(tea.KeyPressMsg{Code: 'u', Text: "u"})
+	if status != prefixMatchComplete {
+		t.Fatalf("expected prefix u to complete, got %v", status)
+	}
+	if cmd != nil {
+		t.Fatalf("expected prefix u center scroll to be synchronous, got %v", cmd)
+	}
+	afterUp, _ := tab.Terminal.GetScrollInfo()
+	if afterUp <= afterDown {
+		t.Fatalf("expected prefix u to scroll up into history, afterDown=%d afterUp=%d", afterDown, afterUp)
+	}
+}
+
+func TestHandlePrefixDDeletesWorkspaceOutsideCenterTerminal(t *testing.T) {
+	app, ws, _ := newPrefixTestApp(t)
+	project := &data.Project{Name: "p", Path: "/repo/ws"}
+	app.activeProject = project
+	app.activeWorkspace = ws
+	app.focusedPane = messages.PaneDashboard
+
+	status, cmd := app.handlePrefixCommand(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if status != prefixMatchComplete {
+		t.Fatalf("expected prefix d to complete, got %v", status)
+	}
+	if cmd == nil {
+		t.Fatal("expected prefix d outside center terminal to return delete command")
+	}
+	msg := cmd()
+	if _, ok := msg.(messages.ShowDeleteWorkspaceDialog); !ok {
+		t.Fatalf("expected ShowDeleteWorkspaceDialog from prefix d, got %T", msg)
+	}
+}
+
 func TestRunPrefixAction_FocusLeftPartialApp_NoPanic(t *testing.T) {
 	app, _, _ := newPrefixTestApp(t)
 	app.focusedPane = messages.PaneCenter

--- a/internal/e2e/closeloop_test.go
+++ b/internal/e2e/closeloop_test.go
@@ -89,13 +89,13 @@ func TestCloseLoopKeystrokeDeliveryToRawAgent(t *testing.T) {
 	// input, so waiting for it gates the test against premature sends (bug #4).
 	waitForUIContains(t, session, "FAKEAGENT READY", closeLoopTimeout)
 
-	// Type into the focused agent. amux must forward a literal CR (0x0D) — this
-	// is the exact path that dropped Cline's Enter and raced Codex's fast CR.
-	if err := session.SendString("hello\r"); err != nil {
+	// Type into the focused agent. amux must forward a literal CR (0x0D), Ctrl+U
+	// (0x15), and Ctrl+D (0x04) through the real TUI/tmux/raw-agent path.
+	if err := session.SendBytes([]byte{'h', 'e', 'l', 'l', 'o', 0x0d, 0x15, 0x04}); err != nil {
 		t.Fatalf("send keystrokes: %v", err)
 	}
 
-	want := []byte{'h', 'e', 'l', 'l', 'o', 0x0d}
+	want := []byte{'h', 'e', 'l', 'l', 'o', 0x0d, 0x15, 0x04}
 	got, ok := waitForFileBytes(logPath, want, closeLoopTimeout)
 	if !ok {
 		t.Fatalf("agent did not receive intact keystrokes via amux\n got: % x\nwant: % x\n\nscreen:\n%s",
@@ -103,5 +103,31 @@ func TestCloseLoopKeystrokeDeliveryToRawAgent(t *testing.T) {
 	}
 	if !bytes.Contains(got, []byte{0x0d}) {
 		t.Fatalf("Enter was not delivered as a literal carriage return (0x0D); got % x", got)
+	}
+	if !bytes.Contains(got, []byte{0x15, 0x04}) {
+		t.Fatalf("Ctrl+U/Ctrl+D were not delivered as literal control bytes; got % x", got)
+	}
+
+	// Some terminals send Ctrl+U/Ctrl+D using the CSI-u keyboard protocol once
+	// the app requests keyboard enhancements. Verify those enhanced key reports
+	// still become the control bytes a raw agent expects.
+	if err := session.SendString("\x1b[117;5u\x1b[100;5u"); err != nil {
+		t.Fatalf("send enhanced ctrl keys: %v", err)
+	}
+	wantEnhanced := append(want, 0x15, 0x04)
+	got, ok = waitForFileBytes(logPath, wantEnhanced, closeLoopTimeout)
+	if !ok {
+		t.Fatalf("agent did not receive enhanced Ctrl+U/Ctrl+D via amux\n got: % x\nwant: % x\n\nscreen:\n%s",
+			got, wantEnhanced, session.ScreenASCII())
+	}
+
+	wheelInput := centerPaneWheelUpInput(120, 30, 2, 3)
+	if err := session.SendString(wheelInput.outer); err != nil {
+		t.Fatalf("send mouse wheel: %v", err)
+	}
+	got, ok = waitForFileBytes(logPath, []byte(wheelInput.forwarded), closeLoopTimeout)
+	if !ok {
+		t.Fatalf("agent did not receive forwarded wheel input via amux\n got: % x\nwant: % x\nouter: % x\n\nscreen:\n%s",
+			got, []byte(wheelInput.forwarded), []byte(wheelInput.outer), session.ScreenASCII())
 	}
 }

--- a/internal/e2e/fakeagent/main.go
+++ b/internal/e2e/fakeagent/main.go
@@ -69,6 +69,9 @@ func main() {
 		time.Sleep(startupDelay)
 	}
 
+	// Match full-screen terminal apps that ask their host to deliver wheel
+	// events to stdin instead of using outer scrollback.
+	fmt.Fprint(os.Stdout, "\x1b[?1000h\x1b[?1006h")
 	// \r\n because the terminal is now raw (no NL->CRNL output translation).
 	fmt.Fprint(os.Stdout, readyBanner+"\r\n")
 

--- a/internal/e2e/mouse_helpers_test.go
+++ b/internal/e2e/mouse_helpers_test.go
@@ -1,0 +1,33 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/andyrewlee/amux/internal/ui/layout"
+)
+
+type wheelInput struct {
+	outer     string
+	forwarded string
+}
+
+func centerPaneLeftClickInput(width, height, termX, termY int) string {
+	l := layout.NewManager()
+	l.Resize(width, height)
+	centerStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX()
+	screenX := centerStartX + 2 + termX
+	screenY := l.TopGutter() + 2 + termY
+	return fmt.Sprintf("\x1b[<0;%d;%dM\x1b[<0;%d;%dm", screenX+1, screenY+1, screenX+1, screenY+1)
+}
+
+func centerPaneWheelUpInput(width, height, termX, termY int) wheelInput {
+	l := layout.NewManager()
+	l.Resize(width, height)
+	centerStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX()
+	screenX := centerStartX + 2 + termX
+	screenY := l.TopGutter() + 2 + termY
+	return wheelInput{
+		outer:     fmt.Sprintf("\x1b[<64;%d;%dM", screenX+1, screenY+1),
+		forwarded: fmt.Sprintf("\x1b[<64;%d;%dM", termX+1, termY+1),
+	}
+}

--- a/internal/e2e/mouse_scroll_test.go
+++ b/internal/e2e/mouse_scroll_test.go
@@ -1,0 +1,91 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMouseWheelScrollsNormalScreenChatRedrawHistory(t *testing.T) {
+	skipIfNoGit(t)
+	requireRealTmux(t)
+
+	home := t.TempDir()
+	repo := initRepo(t)
+	writeRegistry(t, home, repo)
+	binDir := writeRedrawAssistant(t, home, "claude")
+
+	server := fmt.Sprintf("amux-e2e-scroll-%d", time.Now().UnixNano())
+	defer killTmuxServer(t, server)
+
+	session, cleanup, err := StartPTYSession(PTYOptions{
+		Home: home,
+		Env:  sessionEnv(binDir, server),
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	defer cleanup()
+
+	waitForUIContains(t, session, filepath.Base(repo), closeLoopTimeout)
+	activatePrimaryWorkspace(t, session)
+	waitForUIContains(t, session, "[New agent]", closeLoopTimeout)
+	createAgentTab(t, session)
+	waitForUIContains(t, session, "REDRAW READY", closeLoopTimeout)
+	if err := session.SendString(centerPaneLeftClickInput(120, 30, 2, 3)); err != nil {
+		t.Fatalf("focus center pane by mouse: %v", err)
+	}
+	if err := session.SendString("go\r"); err != nil {
+		t.Fatalf("trigger redraw: %v", err)
+	}
+	waitForUIContains(t, session, "new-frame-00", closeLoopTimeout)
+
+	if stringsContains(session.ScreenASCII(), "old-frame-00") {
+		t.Fatalf("expected old frame to start off-screen before scroll\n\nscreen:\n%s", session.ScreenASCII())
+	}
+
+	wheelInput := centerPaneWheelUpInput(120, 30, 2, 3)
+	for i := 0; i < 4; i++ {
+		if err := session.SendString(wheelInput.outer); err != nil {
+			t.Fatalf("send mouse wheel: %v", err)
+		}
+	}
+	waitForUIContains(t, session, "old-frame-00", closeLoopTimeout)
+	waitForUIContains(t, session, "SCROLL:", closeLoopTimeout)
+
+	sendPrefixCommand(t, session, "d")
+	waitForUIContains(t, session, "new-frame-00", closeLoopTimeout)
+
+	sendPrefixCommand(t, session, "u")
+	waitForUIContains(t, session, "old-frame-00", closeLoopTimeout)
+	waitForUIContains(t, session, "SCROLL:", closeLoopTimeout)
+}
+
+func writeRedrawAssistant(t *testing.T, home, name string) string {
+	t.Helper()
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	scriptPath := filepath.Join(binDir, name)
+	script := `#!/bin/sh
+printf 'REDRAW READY\r\n'
+IFS= read -r _
+printf '\033[?2026h'
+for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
+  printf 'old-frame-%s\r\n' "$i"
+done
+printf '\033[2J\033[3J'
+for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
+  printf 'new-frame-%s\r\n' "$i"
+done
+printf '\033[?2026l'
+sleep 1000
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write redraw assistant: %v", err)
+	}
+	return binDir
+}

--- a/internal/ui/center/model_cursor_policy.go
+++ b/internal/ui/center/model_cursor_policy.go
@@ -13,4 +13,5 @@ func (m *Model) applyTerminalCursorPolicyLocked(tab *Tab) {
 	// directly, so this stays false for every tab.
 	tab.Terminal.IgnoreCursorVisibilityControls = false
 	tab.Terminal.TreatLFAsCRLF = isChat
+	tab.Terminal.CaptureNormalScreenOnClear = isChat
 }

--- a/internal/ui/center/model_input_keys.go
+++ b/internal/ui/center/model_input_keys.go
@@ -160,41 +160,35 @@ func (m *Model) handleTerminalCtrlKey(msg tea.KeyPressMsg, tab *Tab) (*Model, te
 }
 
 func (m *Model) handleScrollbackKey(msg tea.KeyPressMsg, tab *Tab) (*Model, tea.Cmd, bool) {
-	switch msg.Key().Code {
-	case tea.KeyPgUp:
-		if m.isTabActorReady() && m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventScrollPage,
-			scrollPage:  1,
-		}) {
-			return m, nil, true
-		}
-		tab.mu.Lock()
-		if tab.Terminal != nil {
-			m.scrollTerminalViewLocked(tab, common.ScrollDeltaForHeight(tab.Terminal.Height, 4))
-		}
-		tab.mu.Unlock()
-		return m, nil, true
-	case tea.KeyPgDown:
-		if m.isTabActorReady() && m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventScrollPage,
-			scrollPage:  -1,
-		}) {
-			return m, nil, true
-		}
-		tab.mu.Lock()
-		if tab.Terminal != nil {
-			m.scrollTerminalViewLocked(tab, -common.ScrollDeltaForHeight(tab.Terminal.Height, 4))
-		}
-		tab.mu.Unlock()
-		return m, nil, true
+	switch {
+	case msg.Key().Code == tea.KeyPgUp:
+		return m.scrollTerminalPage(tab, 1), nil, true
+	case msg.Key().Code == tea.KeyPgDown:
+		return m.scrollTerminalPage(tab, -1), nil, true
 	}
 	return m, nil, false
+}
+
+func (m *Model) scrollTerminalPage(tab *Tab, scrollPage int) *Model {
+	if tab == nil || scrollPage == 0 {
+		return m
+	}
+	if m.isTabActorReady() && m.sendTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventScrollPage,
+		scrollPage:  scrollPage,
+	}) {
+		return m
+	}
+	tab.mu.Lock()
+	if tab.Terminal != nil {
+		delta := common.ScrollDeltaForHeight(tab.Terminal.Height, 4)
+		m.scrollTerminalViewLocked(tab, delta*scrollPage)
+	}
+	tab.mu.Unlock()
+	return m
 }
 
 func (m *Model) scrollToBottomOnType(tab *Tab) {

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -1,12 +1,14 @@
 package center
 
 import (
+	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/diff"
+	"github.com/andyrewlee/amux/internal/vterm"
 )
 
 // updateMouseClick handles tea.MouseClickMsg in the Update switch.
@@ -214,6 +216,9 @@ func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
+	if model, cmd, handled := m.forwardMouseWheelToTerminal(msg, tab); handled {
+		return model, cmd
+	}
 
 	delta := 0
 	tab.mu.Lock()
@@ -256,6 +261,64 @@ func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 		tab.mu.Unlock()
 	}
 	return m, nil
+}
+
+func (m *Model) forwardMouseWheelToTerminal(msg tea.MouseWheelMsg, tab *Tab) (*Model, tea.Cmd, bool) {
+	if tab == nil {
+		return m, nil, false
+	}
+	termX, termY, inBounds := m.screenToTerminal(msg.X, msg.Y)
+	if !inBounds {
+		return m, nil, false
+	}
+
+	input := ""
+	tab.mu.Lock()
+	if tab.Terminal != nil {
+		input = mouseWheelInputSequence(tab.Terminal, msg.Button, termX, termY)
+	}
+	tab.mu.Unlock()
+	if input == "" {
+		return m, nil, false
+	}
+
+	if m.isTabActorReady() {
+		if m.sendTabEvent(tabEvent{
+			tab:         tab,
+			workspaceID: m.workspaceID(),
+			tabID:       tab.ID,
+			kind:        tabEventSendMouse,
+			input:       []byte(input),
+		}) {
+			return m, nil, true
+		}
+	}
+	model, sent, cmd := m.directSendToTerminal(tab, input, "Mouse wheel")
+	return model, cmd, sent || cmd != nil
+}
+
+func mouseWheelInputSequence(term *vterm.VTerm, button tea.MouseButton, termX, termY int) string {
+	if term == nil || !term.MouseReportingEnabled() || termX < 0 || termY < 0 {
+		return ""
+	}
+	buttonCode := 0
+	switch button {
+	case tea.MouseWheelUp:
+		buttonCode = 64
+	case tea.MouseWheelDown:
+		buttonCode = 65
+	default:
+		return ""
+	}
+	x := termX + 1
+	y := termY + 1
+	if term.MouseSGRMode() {
+		return fmt.Sprintf("\x1b[<%d;%d;%dM", buttonCode, x, y)
+	}
+	if x > 223 || y > 223 {
+		return ""
+	}
+	return string([]byte{0x1b, '[', 'M', byte(buttonCode + 32), byte(x + 32), byte(y + 32)})
 }
 
 func (m *Model) getDiffViewer(tab *Tab) *diff.Model {

--- a/internal/ui/center/model_input_mouse_test.go
+++ b/internal/ui/center/model_input_mouse_test.go
@@ -1,0 +1,161 @@
+package center
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func setupMouseReportingTerminal(t *testing.T) *vterm.VTerm {
+	t.Helper()
+	term := vterm.New(80, 24)
+	term.Write([]byte("\x1b[?1000h\x1b[?1006h"))
+	if !term.MouseReportingEnabled() || !term.MouseSGRMode() {
+		t.Fatal("expected test terminal to enable mouse reporting and SGR mode")
+	}
+	return term
+}
+
+func TestMouseWheelInputSequenceUsesSGRWhenRequested(t *testing.T) {
+	term := setupMouseReportingTerminal(t)
+
+	got := mouseWheelInputSequence(term, tea.MouseWheelUp, 2, 3)
+	if got != "\x1b[<64;3;4M" {
+		t.Fatalf("unexpected SGR wheel sequence: %q", got)
+	}
+}
+
+func TestMouseWheelInputSequenceUsesX10Fallback(t *testing.T) {
+	term := setupMouseReportingTerminal(t)
+	term.Write([]byte("\x1b[?1006l"))
+
+	got := mouseWheelInputSequence(term, tea.MouseWheelDown, 2, 3)
+	if got != "\x1b[Ma#$" {
+		t.Fatalf("unexpected X10 wheel sequence: %q", got)
+	}
+}
+
+func TestMouseWheelForwardsToMouseReportingTerminalInsteadOfLocalScroll(t *testing.T) {
+	m, tab := setupSelectionModel(t)
+	m.setTabActorReady()
+	m.tabEvents = make(chan tabEvent, 1)
+
+	tab.mu.Lock()
+	for i := 0; i < 40; i++ {
+		tab.Terminal.Write([]byte("line\n"))
+	}
+	tab.Terminal.Write([]byte("\x1b[?1000h\x1b[?1006h"))
+	tab.mu.Unlock()
+
+	tm := m.terminalMetrics()
+	_, _ = m.Update(tea.MouseWheelMsg{
+		Button: tea.MouseWheelUp,
+		X:      tm.ContentStartX + 2,
+		Y:      tm.ContentStartY + 3,
+	})
+
+	select {
+	case ev := <-m.tabEvents:
+		if ev.kind != tabEventSendMouse {
+			t.Fatalf("expected mouse input event, got %v", ev.kind)
+		}
+		if string(ev.input) != "\x1b[<64;3;4M" {
+			t.Fatalf("unexpected forwarded wheel input: %q", ev.input)
+		}
+	default:
+		t.Fatal("expected wheel input to be forwarded to tab actor")
+	}
+
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 0 {
+		t.Fatalf("expected forwarded wheel to leave local scroll offset at bottom, got %d", offset)
+	}
+}
+
+func TestCanConsumeWheelWhenTerminalRequestedMouseReporting(t *testing.T) {
+	m, tab := setupSelectionModel(t)
+
+	tab.mu.Lock()
+	tab.Terminal.Write([]byte("\x1b[?1000h\x1b[?1006h"))
+	offset, maxOffset := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 0 || maxOffset != 0 {
+		t.Fatalf("expected no local scrollback in test setup, got %d/%d", offset, maxOffset)
+	}
+	if !m.CanConsumeWheel() {
+		t.Fatal("expected mouse-reporting terminal to consume wheel without local scrollback")
+	}
+}
+
+func TestMouseWheelScrollsCapturedNormalScreenChatHistory(t *testing.T) {
+	m, tab := setupSelectionModel(t)
+	tab.Assistant = "claude"
+	m.showKeymapHints = false
+	m.SetSize(80, 28)
+	m.SetOffset(0)
+	tab.mu.Lock()
+	tab.Terminal.CaptureNormalScreenOnClear = true
+	tab.Terminal.TreatLFAsCRLF = true
+	tab.Terminal.Write([]byte("\x1b[?2026hold-frame-00\nold-frame-01\n\x1b[2J\x1b[3Jnew-frame-00\nnew-frame-01\n\x1b[?2026l"))
+	offsetBefore, maxBefore := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offsetBefore != 0 || maxBefore == 0 {
+		t.Fatalf("expected captured history at live bottom, got %d/%d", offsetBefore, maxBefore)
+	}
+
+	tm := m.terminalMetrics()
+	_, _ = m.Update(tea.MouseWheelMsg{
+		Button: tea.MouseWheelUp,
+		X:      tm.ContentStartX + 2,
+		Y:      tm.ContentStartY + 1,
+	})
+
+	tab.mu.Lock()
+	offsetAfter, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offsetAfter == 0 {
+		t.Fatal("expected mouse wheel to scroll captured normal-screen chat history")
+	}
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "old-frame-00") {
+		t.Fatalf("expected scrolled view to render captured old frame, got %q", view)
+	}
+}
+
+func TestMouseWheelScrollsTmuxWrappedChatRedrawHistory(t *testing.T) {
+	m, tab := setupSelectionModel(t)
+	tab.Assistant = "claude"
+	m.showKeymapHints = false
+	m.SetSize(80, 28)
+	m.SetOffset(0)
+	tab.mu.Lock()
+	tab.Terminal.AltScreen = true
+	tab.Terminal.AllowAltScreenScrollback = true
+	tab.Terminal.CaptureNormalScreenOnClear = true
+	tab.Terminal.TreatLFAsCRLF = true
+	tab.Terminal.Write([]byte("old-frame-00\nold-frame-01\n\x1b[H\x1b[Jnew-frame-00\nnew-frame-01\n"))
+	offsetBefore, maxBefore := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offsetBefore != 0 || maxBefore == 0 {
+		t.Fatalf("expected captured tmux-wrapped history at live bottom, got %d/%d", offsetBefore, maxBefore)
+	}
+
+	tm := m.terminalMetrics()
+	_, _ = m.Update(tea.MouseWheelMsg{
+		Button: tea.MouseWheelUp,
+		X:      tm.ContentStartX + 2,
+		Y:      tm.ContentStartY + 1,
+	})
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "old-frame-00") {
+		t.Fatalf("expected scrolled tmux-wrapped view to render captured old frame, got %q", view)
+	}
+}

--- a/internal/ui/center/model_input_test.go
+++ b/internal/ui/center/model_input_test.go
@@ -139,6 +139,67 @@ func TestUpdateKeyPgUpScrollsOneLineOnShortTerminal(t *testing.T) {
 	}
 }
 
+func TestUpdateCtrlUDoesNotScrollCenterTerminalHistory(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	term := vterm.New(80, 3)
+	for i := 0; i < 10; i++ {
+		term.Write([]byte("line\n"))
+	}
+	tab := &Tab{
+		ID:        TabID("tab-ctrl-u-scroll"),
+		Assistant: "claude",
+		Workspace: ws,
+		Terminal:  term,
+		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.workspace = ws
+	m.focused = true
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 0 {
+		t.Fatalf("expected raw Ctrl+U to pass through without scrolling, got offset %d", offset)
+	}
+}
+
+func TestUpdateCtrlDReturnsCenterTerminalToLiveOutput(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	term := vterm.New(80, 3)
+	for i := 0; i < 10; i++ {
+		term.Write([]byte("line\n"))
+	}
+	term.ScrollView(2)
+	tab := &Tab{
+		ID:        TabID("tab-ctrl-d-scroll"),
+		Assistant: "claude",
+		Workspace: ws,
+		Terminal:  term,
+		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+	m.workspace = ws
+	m.focused = true
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset != 0 {
+		t.Fatalf("expected raw Ctrl+D input to return to live output, got offset %d", offset)
+	}
+}
+
 func TestTabActorScrollPageScrollsOneLineOnShortTerminal(t *testing.T) {
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")

--- a/internal/ui/center/model_scrolled_history.go
+++ b/internal/ui/center/model_scrolled_history.go
@@ -17,7 +17,7 @@ func scrolledChatHistoryScrollbackLen(term *vterm.VTerm) int {
 }
 
 func scrolledChatHistoryMaxViewOffset(term *vterm.VTerm) int {
-	if term == nil || term.AltScreen {
+	if term == nil || (term.AltScreen && !term.CaptureNormalScreenOnClear) {
 		return 0
 	}
 	scrollbackLen := scrolledChatHistoryScrollbackLen(term)
@@ -51,7 +51,7 @@ func scrolledChatHistoryEffectiveViewOffset(term *vterm.VTerm) int {
 }
 
 func scrolledChatHistoryVisibleRange(term *vterm.VTerm, height int) (startLine, endLine int, ok bool) {
-	if term == nil || term.ViewOffset <= 0 || term.AltScreen {
+	if term == nil || term.ViewOffset <= 0 || (term.AltScreen && !term.CaptureNormalScreenOnClear) {
 		return 0, 0, false
 	}
 	if height <= 0 {
@@ -179,7 +179,7 @@ func (m *Model) displayedScrollInfoLocked(tab *Tab) (offset, maxOffset int) {
 //
 // Caller must hold tab.mu.
 func applyScrolledChatHistoryViewLocked(term *vterm.VTerm, snap *compositor.VTermSnapshot) {
-	if term == nil || snap == nil || snap.ViewOffset <= 0 || term.AltScreen {
+	if term == nil || snap == nil || snap.ViewOffset <= 0 || (term.AltScreen && !term.CaptureNormalScreenOnClear) {
 		return
 	}
 

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -345,6 +345,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	isChat := m.isChatTab(tab)
 	term.IgnoreCursorVisibilityControls = false
 	term.TreatLFAsCRLF = isChat
+	term.CaptureNormalScreenOnClear = isChat
 	if msg.CaptureFullPane {
 		ptyio.RestorePaneCapture(
 			term,

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -206,6 +206,22 @@ func (m *Model) SendToTerminal(s string) {
 	}
 }
 
+// ScrollActiveTerminalPage scrolls the active terminal by one page-sized step.
+// A positive direction scrolls up into history; a negative direction scrolls
+// down toward live output.
+func (m *Model) ScrollActiveTerminalPage(direction int) {
+	if direction == 0 {
+		return
+	}
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if len(tabs) == 0 || activeIdx >= len(tabs) {
+		return
+	}
+	tab := tabs[activeIdx]
+	m.scrollTerminalPage(tab, direction)
+}
+
 // GetTabsInfo returns information about current tabs for persistence
 func (m *Model) GetTabsInfo() ([]data.TabInfo, int) {
 	var result []data.TabInfo
@@ -293,6 +309,22 @@ func (m *Model) HasDiffViewer() bool {
 	tab.mu.Lock()
 	defer tab.mu.Unlock()
 	return tab.DiffViewer != nil
+}
+
+// HasActiveTerminal reports whether the active tab has a terminal viewport.
+func (m *Model) HasActiveTerminal() bool {
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if len(tabs) == 0 || activeIdx >= len(tabs) {
+		return false
+	}
+	tab := tabs[activeIdx]
+	if tab.isClosed() {
+		return false
+	}
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	return tab.Terminal != nil
 }
 
 // CloseAllTabs is deprecated - tabs now persist per-workspace

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -51,6 +51,7 @@ func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
 	isChat := m.isChatTab(tab)
 	term.IgnoreCursorVisibilityControls = false
 	term.TreatLFAsCRLF = isChat
+	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
 	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
 }
@@ -103,6 +104,7 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 	isChat := m.isChatTab(tab)
 	term.IgnoreCursorVisibilityControls = false
 	term.TreatLFAsCRLF = isChat
+	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
 	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
 	return tabID, sessionName

--- a/internal/ui/center/model_wheel.go
+++ b/internal/ui/center/model_wheel.go
@@ -31,7 +31,7 @@ func (m *Model) CanConsumeWheel() bool {
 		return tab.DiffViewer.CanConsumeWheel()
 	}
 	if tab.Terminal != nil {
-		return tab.Terminal.MaxViewOffset() > 0
+		return tab.Terminal.MouseReportingEnabled() || tab.Terminal.MaxViewOffset() > 0
 	}
 	return false
 }

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -27,6 +27,7 @@ const (
 	tabEventScrollToTop
 	tabEventDiffInput
 	tabEventSendInput
+	tabEventSendMouse
 	tabEventPaste
 	tabEventWriteOutput
 )
@@ -196,6 +197,8 @@ func (m *Model) handleTabEvent(ev tabEvent) {
 		m.handleDiffInput(ev)
 	case tabEventSendInput:
 		m.handleSendInput(ev)
+	case tabEventSendMouse:
+		m.handleSendMouse(ev)
 	case tabEventPaste:
 		m.handlePaste(ev)
 	case tabEventWriteOutput:
@@ -262,9 +265,29 @@ func (m *Model) handleSendInput(ev tabEvent) {
 	m.sendToTerminal(ev.tab, string(ev.input), ev.tabID, ev.workspaceID, "Input")
 }
 
+func (m *Model) handleSendMouse(ev tabEvent) {
+	m.sendMouseToTerminal(ev.tab, string(ev.input), ev.tabID, ev.workspaceID)
+}
+
 func (m *Model) handlePaste(ev tabEvent) {
 	if ev.pasteText != "" {
 		m.sendToTerminal(ev.tab, "\x1b[200~"+ev.pasteText+"\x1b[201~", ev.tabID, ev.workspaceID, "Paste")
+	}
+}
+
+func (m *Model) sendMouseToTerminal(tab *Tab, data string, tabID TabID, workspaceID string) {
+	if tab == nil || tab.Agent == nil || tab.Agent.Terminal == nil || data == "" {
+		return
+	}
+	if err := tab.Agent.Terminal.SendString(data); err != nil {
+		logging.Warn("Mouse input failed for tab %s: %v", tab.ID, err)
+		tab.mu.Lock()
+		tab.Running = false
+		tab.Detached = true
+		tab.mu.Unlock()
+		if m.msgSink != nil {
+			m.msgSink(TabInputFailed{TabID: tabID, WorkspaceID: workspaceID, Err: err})
+		}
 	}
 }
 

--- a/internal/vterm/accessors.go
+++ b/internal/vterm/accessors.go
@@ -1,5 +1,16 @@
 package vterm
 
+// MouseReportingEnabled reports whether the hosted terminal application has
+// requested mouse event reporting.
+func (v *VTerm) MouseReportingEnabled() bool {
+	return v != nil && v.mouseTrackingMode != 0
+}
+
+// MouseSGRMode reports whether SGR extended mouse coordinates are enabled.
+func (v *VTerm) MouseSGRMode() bool {
+	return v != nil && v.mouseSGRMode
+}
+
 // CursorRenderState is the cached cursor state from the previous render frame,
 // used to detect cursor-only changes and mark the affected lines dirty.
 type CursorRenderState struct {

--- a/internal/vterm/alt_screen_capture.go
+++ b/internal/vterm/alt_screen_capture.go
@@ -1,20 +1,21 @@
 package vterm
 
-// captureScreenToScrollback copies the visible alt-screen frame into the
+// captureScreenToScrollback copies the visible screen frame into the
 // scrollback buffer. It trims leading/trailing blank rows and clips each row
 // to the current terminal width so only what was actually visible is stored.
-// This is called before erase-display in alt-screen mode so that TUI content
-// (e.g. Claude Code plan mode) is preserved for amux scroll-back. A dedup
-// check avoids storing identical consecutive frames.
-func (v *VTerm) captureScreenToScrollback() {
+// This is called before selected full-screen redraw clears so TUI/chat content
+// is preserved for amux scroll-back. A dedup check avoids storing identical
+// consecutive frames. It reports whether there was a visible frame worth
+// preserving, even if that frame was already present in scrollback.
+func (v *VTerm) captureScreenToScrollback() bool {
 	lines := v.visibleCaptureFrame()
 	if len(lines) == 0 {
 		v.clearPendingRestoredAltScreenCapture()
-		return
+		return false
 	}
 	oldViewOffset := v.ViewOffset
 	if v.matchesPendingRestoredAltScreenCapture(lines) {
-		return
+		return true
 	}
 	pendingAdded := v.transitionPendingRestoredAltScreenCapture(lines)
 	v.clearPendingRestoredAltScreenCapture()
@@ -23,7 +24,7 @@ func (v *VTerm) captureScreenToScrollback() {
 			v.adjustAnchoredViewOffset(pendingAdded - dedupRemoved)
 		}
 		v.trimScrollback()
-		return
+		return true
 	}
 	removed, dropped, transitioned := v.transitionTrackedAltScreenCapture(lines)
 	if !transitioned {
@@ -47,7 +48,7 @@ func (v *VTerm) captureScreenToScrollback() {
 		}
 		deductOffset()
 		v.trimScrollback()
-		return
+		return true
 	}
 
 	// Partial overlap detection — skip lines already in scrollback from scrollUp
@@ -65,6 +66,7 @@ func (v *VTerm) captureScreenToScrollback() {
 		v.adjustAnchoredViewOffset(pendingAdded - removed + added)
 	}
 	v.trimScrollback()
+	return true
 }
 
 func (v *VTerm) visibleCaptureFrame() [][]Cell {

--- a/internal/vterm/csi.go
+++ b/internal/vterm/csi.go
@@ -86,6 +86,9 @@ func (p *Parser) getParam(idx, def int) int {
 }
 
 func (p *Parser) executeCSI(final byte) {
+	if p.vt.preserveScrollbackOnNextClear3 && !(final == 'J' && p.getParam(0, 0) == 3) {
+		p.vt.preserveScrollbackOnNextClear3 = false
+	}
 	switch final {
 	case 'A': // CUU - cursor up
 		p.vt.moveCursor(-p.getParam(0, 1), 0)

--- a/internal/vterm/modes.go
+++ b/internal/vterm/modes.go
@@ -63,7 +63,21 @@ func (p *Parser) executeMode(set bool) {
 			p.vt.setSynchronizedOutput(set)
 		case 2004: // Bracketed paste mode
 			// Ignore
+		case 1000, 1002, 1003: // XTerm mouse reporting modes
+			p.vt.setMouseTrackingMode(param, set)
+		case 1006: // SGR extended mouse coordinates
+			p.vt.mouseSGRMode = set
 		}
+	}
+}
+
+func (v *VTerm) setMouseTrackingMode(mode int, enabled bool) {
+	if enabled {
+		v.mouseTrackingMode = mode
+		return
+	}
+	if v.mouseTrackingMode == mode {
+		v.mouseTrackingMode = 0
 	}
 }
 

--- a/internal/vterm/modes_test.go
+++ b/internal/vterm/modes_test.go
@@ -1,0 +1,50 @@
+package vterm
+
+import "testing"
+
+func TestMouseReportingModesTracked(t *testing.T) {
+	term := New(80, 24)
+
+	term.Write([]byte("\x1b[?1000h"))
+	if !term.MouseReportingEnabled() {
+		t.Fatal("expected normal mouse reporting to be enabled")
+	}
+	if term.MouseSGRMode() {
+		t.Fatal("expected SGR mouse mode to start disabled")
+	}
+
+	term.Write([]byte("\x1b[?1006h"))
+	if !term.MouseSGRMode() {
+		t.Fatal("expected SGR mouse mode to be enabled")
+	}
+
+	term.Write([]byte("\x1b[?1000l"))
+	if term.MouseReportingEnabled() {
+		t.Fatal("expected mouse reporting to be disabled")
+	}
+	if !term.MouseSGRMode() {
+		t.Fatal("expected SGR coordinate mode to remain tracked independently")
+	}
+
+	term.Write([]byte("\x1b[?1006l"))
+	if term.MouseSGRMode() {
+		t.Fatal("expected SGR mouse mode to be disabled")
+	}
+}
+
+func TestMouseReportingModesClearOnTerminalReset(t *testing.T) {
+	term := New(80, 24)
+	term.Write([]byte("\x1b[?1000h\x1b[?1006h"))
+	if !term.MouseReportingEnabled() || !term.MouseSGRMode() {
+		t.Fatal("expected mouse reporting modes to start enabled")
+	}
+
+	term.Write([]byte("\x1bc"))
+
+	if term.MouseReportingEnabled() {
+		t.Fatal("expected terminal reset to disable mouse reporting")
+	}
+	if term.MouseSGRMode() {
+		t.Fatal("expected terminal reset to disable SGR mouse mode")
+	}
+}

--- a/internal/vterm/normal_screen_clear_capture_test.go
+++ b/internal/vterm/normal_screen_clear_capture_test.go
@@ -1,0 +1,153 @@
+package vterm
+
+import "testing"
+
+func TestNormalScreenClearCapturesChatRedrawFrame(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("\x1b[?2026hfirst\r\nsecond\x1b[2J\x1b[3J\x1b[?2026l"))
+
+	if len(vt.Scrollback) < 2 {
+		t.Fatalf("expected normal-screen redraw to be captured, got %d rows", len(vt.Scrollback))
+	}
+	if got := lineText(vt.Scrollback[0]); got != "first" {
+		t.Fatalf("expected first captured row, got %q", got)
+	}
+	if got := lineText(vt.Scrollback[1]); got != "second" {
+		t.Fatalf("expected second captured row, got %q", got)
+	}
+}
+
+func TestNormalScreenHomeEraseToEndCapturesChatRedrawFrame(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("first\r\nsecond\x1b[H\x1b[Jnew"))
+
+	if len(vt.Scrollback) < 2 {
+		t.Fatalf("expected home erase redraw to be captured, got %d rows", len(vt.Scrollback))
+	}
+	if got := lineText(vt.Scrollback[0]); got != "first" {
+		t.Fatalf("expected first captured row, got %q", got)
+	}
+	if got := lineText(vt.Scrollback[1]); got != "second" {
+		t.Fatalf("expected second captured row, got %q", got)
+	}
+}
+
+func TestNormalScreenHomeEraseToEndPreservesFrameThroughImmediateClear3(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("\x1b[?2026hfirst\r\nsecond\x1b[H\x1b[J\x1b[3Jnew\x1b[?2026l"))
+
+	if len(vt.Scrollback) < 2 {
+		t.Fatalf("expected home erase redraw to survive immediate 3J, got %d rows", len(vt.Scrollback))
+	}
+	if got := lineText(vt.Scrollback[0]); got != "first" {
+		t.Fatalf("expected first captured row, got %q", got)
+	}
+	if got := lineText(vt.Scrollback[1]); got != "second" {
+		t.Fatalf("expected second captured row, got %q", got)
+	}
+}
+
+func TestNormalScreenClearStillClearsScrollbackByDefault(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.Write([]byte("first\r\nsecond\x1b[2J\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected normal-screen clear to preserve default 3J behavior, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenClear3ClearsChatScrollbackWhenStandalone(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+	vt.Scrollback = append(vt.Scrollback, textLine("saved", vt.Width))
+
+	vt.Write([]byte("\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected standalone 3J to clear chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenClear3ClearsChatScrollbackAfterInterveningOutput(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("old\x1b[2Jnew\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected delayed 3J to clear captured chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenImmediateClear3ClearsChatScrollbackAfterUnsynchronizedClear2Capture(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("old\x1b[2J\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected unsynchronized 2J then 3J to clear captured chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenImmediateClear3ClearsChatScrollbackAfterUnsynchronizedHomeEraseCapture(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+
+	vt.Write([]byte("old\x1b[H\x1b[J\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected unsynchronized home erase then 3J to clear captured chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenImmediateClear3ClearsChatScrollbackWhenClear2CapturesNothing(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+	vt.Scrollback = append(vt.Scrollback, textLine("saved", vt.Width))
+
+	vt.Write([]byte("\x1b[2J\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected blank 2J then 3J to clear chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func TestNormalScreenImmediateClear3ClearsChatScrollbackWhenHomeEraseCapturesNothing(t *testing.T) {
+	t.Parallel()
+	vt := New(12, 4)
+	vt.CaptureNormalScreenOnClear = true
+	vt.Scrollback = append(vt.Scrollback, textLine("saved", vt.Width))
+
+	vt.Write([]byte("\x1b[H\x1b[J\x1b[3J"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("expected blank home erase then 3J to clear chat scrollback, got %d rows", len(vt.Scrollback))
+	}
+}
+
+func textLine(text string, width int) []Cell {
+	line := MakeBlankLine(width)
+	for i, r := range text {
+		if i >= len(line) {
+			break
+		}
+		line[i] = Cell{Rune: r, Width: 1}
+	}
+	return line
+}

--- a/internal/vterm/ops.go
+++ b/internal/vterm/ops.go
@@ -144,6 +144,10 @@ func (v *VTerm) backspace() {
 func (v *VTerm) eraseDisplay(mode int) {
 	switch mode {
 	case 0: // Cursor to end
+		if v.CursorX == 0 && v.CursorY == 0 && v.shouldCaptureScreenOnClear() {
+			captured := v.captureScreenToScrollback()
+			v.preserveScrollbackOnNextClear3 = v.syncActive && captured
+		}
 		// Clear from cursor to end of line
 		if v.CursorY < len(v.Screen) {
 			for x := v.CursorX; x < v.Width; x++ {
@@ -175,12 +179,13 @@ func (v *VTerm) eraseDisplay(mode int) {
 			}
 		}
 		v.markDirtyRange(0, v.CursorY)
-	case 2, 3: // Entire display (3 also clears scrollback)
+	case 2, 3: // Entire display (3 normally also clears scrollback)
 		// Capture non-blank screen lines to scrollback before erasing,
 		// so TUI content (like Claude Code plan mode) is preserved for
-		// amux scroll. Only in alt screen with AllowAltScreenScrollback.
-		if mode == 2 && v.AltScreen && v.AllowAltScreenScrollback {
-			v.captureScreenToScrollback()
+		// amux scroll.
+		if mode == 2 && v.shouldCaptureScreenOnClear() {
+			captured := v.captureScreenToScrollback()
+			v.preserveScrollbackOnNextClear3 = v.syncActive && captured
 		}
 		for y := 0; y < v.Height; y++ {
 			if y < len(v.Screen) {
@@ -188,11 +193,23 @@ func (v *VTerm) eraseDisplay(mode int) {
 			}
 		}
 		if mode == 3 {
-			v.Scrollback = v.Scrollback[:0]
-			v.invalidateAltScreenCapture()
+			if v.preserveScrollbackOnNextClear3 {
+				v.preserveScrollbackOnNextClear3 = false
+			} else {
+				v.Scrollback = v.Scrollback[:0]
+				v.invalidateAltScreenCapture()
+			}
+		}
+		if mode != 2 {
+			v.preserveScrollbackOnNextClear3 = false
 		}
 		v.markDirtyRange(0, v.Height-1)
 	}
+}
+
+func (v *VTerm) shouldCaptureScreenOnClear() bool {
+	return (v.AltScreen && v.AllowAltScreenScrollback) ||
+		(!v.AltScreen && v.CaptureNormalScreenOnClear)
 }
 
 // eraseLine clears parts of the current line

--- a/internal/vterm/parser.go
+++ b/internal/vterm/parser.go
@@ -216,6 +216,9 @@ func (p *Parser) parseByte(b byte) {
 }
 
 func (p *Parser) parseGround(b byte) {
+	if b != 0x1b {
+		p.vt.preserveScrollbackOnNextClear3 = false
+	}
 	// Handle UTF-8 continuation if we're in the middle of a sequence
 	if p.utf8Len > 0 {
 		if b >= 0x80 && b <= 0xBF {
@@ -286,6 +289,9 @@ func decodeUTF8(b []byte) rune {
 }
 
 func (p *Parser) parseEscape(b byte) {
+	if b != '[' {
+		p.vt.preserveScrollbackOnNextClear3 = false
+	}
 	switch b {
 	case '[': // CSI
 		p.state = stateCSI
@@ -324,6 +330,9 @@ func (p *Parser) parseEscape(b byte) {
 		p.vt.CurrentStyle = Style{}
 		p.vt.CursorX = 0
 		p.vt.CursorY = 0
+		p.vt.mouseTrackingMode = 0
+		p.vt.mouseSGRMode = false
+		p.vt.preserveScrollbackOnNextClear3 = false
 		p.state = stateGround
 	case '=', '>': // DECKPAM/DECKPNM (keypad modes)
 		p.state = stateGround

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -57,6 +57,10 @@ type VTerm struct {
 	// Origin mode (DECOM) - cursor positions are relative to scroll region.
 	OriginMode bool
 
+	// Mouse reporting modes requested by the hosted terminal application.
+	mouseTrackingMode int
+	mouseSGRMode      bool
+
 	// Current style for new characters
 	CurrentStyle Style
 
@@ -93,6 +97,12 @@ type VTerm struct {
 	// TreatLFAsCRLF makes bare LF advance to the next line and return to column 0.
 	// This is useful for some chat agents that emit LF-only streams.
 	TreatLFAsCRLF bool
+	// CaptureNormalScreenOnClear preserves chat-style full-screen redraw frames
+	// that use normal-screen CSI 2J/3J instead of the alternate screen.
+	CaptureNormalScreenOnClear bool
+	// preserveScrollbackOnNextClear3 is a one-shot guard for redraw sequences
+	// that capture on CSI 2J and immediately follow with CSI 3J.
+	preserveScrollbackOnNextClear3 bool
 
 	// Synchronized output (DEC mode 2026)
 	syncActive        bool


### PR DESCRIPTION
## Summary

Fix center-pane scrolling for chat/terminal tabs while preserving raw terminal input behavior.

## What changed

- Capture chat redraw history for normal-screen clear/redraw flows, including tmux-translated `ESC[H ESC[J` synchronized redraws.
- Forward mouse wheel events to embedded apps that request mouse reporting, using SGR coordinates when enabled.
- Add prefix-based center scroll controls: `C-Space u` scrolls up and `C-Space d` scrolls down when a center terminal is focused.
- Keep raw `Ctrl+U` and `Ctrl+D` flowing to the agent instead of using them as amux scroll shortcuts.
- Preserve explicit `CSI 3J` clearback semantics outside the synchronized redraw-preservation case.
- Add unit and real tmux/e2e coverage for wheel forwarding, chat redraw scrollback, prefix scrolling, and raw control byte delivery.

## Root cause

Amux was not preserving chat redraw frames when tmux translated full-screen clears into cursor-home plus erase-to-end. Separately, mouse wheel events were treated only as local scroll unless the embedded terminal's mouse reporting state was tracked.

## Validation

- `/Users/andrewlee/.agents/skills/autoreview/scripts/autoreview --mode local` clean
- `make verify-loop`
- `go test ./...`
- `make harness-presets`
- pinned `make devcheck`
- pinned `make lint-strict-new`
- `git diff --check`
- pre-push CI-parity lint, harness, and e2e hook passed
