### PR TITLE
Hoist duplicated workspace-rebind active-index reconciliation to common

### DIFF
--- a/internal/ui/center/model_workspace_rebind.go
+++ b/internal/ui/center/model_workspace_rebind.go
@@ -48,31 +48,9 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 		return nil
 	}
 
-	newTabs := m.tabsByWorkspace[newID]
-	oldActive, oldActiveOK := m.activeTabByWorkspace[oldID]
-	newActive, newActiveOK := m.activeTabByWorkspace[newID]
-	merged, migratedActive := mergeTabsByID(newTabs, oldTabs, oldActive)
-
-	m.tabsByWorkspace[newID] = merged
-	delete(m.tabsByWorkspace, oldID)
-	if oldActiveOK && (!newActiveOK || len(newTabs) == 0) {
-		if migratedActive < 0 {
-			migratedActive = 0
-		}
-		if len(merged) == 0 {
-			migratedActive = 0
-		} else if migratedActive >= len(merged) {
-			migratedActive = len(merged) - 1
-		}
-		m.activeTabByWorkspace[newID] = migratedActive
-	} else if newActiveOK {
-		if len(merged) == 0 {
-			m.activeTabByWorkspace[newID] = 0
-		} else if newActive >= len(merged) {
-			m.activeTabByWorkspace[newID] = len(merged) - 1
-		}
-	}
-	delete(m.activeTabByWorkspace, oldID)
+	merged := common.RebindTabMaps(m.tabsByWorkspace, m.activeTabByWorkspace, oldID, newID,
+		func(t *Tab) TabID { return t.ID },
+		func(t *Tab) bool { return t == nil })
 
 	if m.workspace != nil && m.workspaceID() == oldID {
 		m.setWorkspace(current)
@@ -98,10 +76,4 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 
 	m.noteTabsChanged()
 	return common.SafeBatch(cmds...)
-}
-
-func mergeTabsByID(existing, incoming []*Tab, incomingActive int) ([]*Tab, int) {
-	return common.MergeByID(existing, incoming, incomingActive,
-		func(t *Tab) TabID { return t.ID },
-		func(t *Tab) bool { return t == nil })
 }

--- a/internal/ui/common/merge.go
+++ b/internal/ui/common/merge.go
@@ -39,3 +39,48 @@ func MergeByID[T any, K comparable](existing, incoming []T, incomingActive int, 
 
 	return merged, migratedActive
 }
+
+// RebindTabMaps migrates a workspace's tab slice and active-tab index from oldID
+// to newID across the two per-workspace maps: it merges any tabs already present
+// under newID (via MergeByID), writes the result under newID, deletes oldID from
+// both maps, and clamps the surviving active index. It returns the merged slice.
+//
+// Callers keep their own surrounding logic (the "seen but empty" special case,
+// workspace-pointer fixups, PTY restarts) and delegate only this reconciliation,
+// which was byte-identical between the center and sidebar panes — so a clamp fix
+// now happens once instead of being mirrored.
+func RebindTabMaps[T any, K comparable](
+	tabsByWorkspace map[string][]T,
+	activeByWorkspace map[string]int,
+	oldID, newID string,
+	id func(T) K, isNil func(T) bool,
+) []T {
+	oldTabs := tabsByWorkspace[oldID]
+	newTabs := tabsByWorkspace[newID]
+	oldActive, oldActiveOK := activeByWorkspace[oldID]
+	newActive, newActiveOK := activeByWorkspace[newID]
+	merged, migratedActive := MergeByID(newTabs, oldTabs, oldActive, id, isNil)
+
+	tabsByWorkspace[newID] = merged
+	delete(tabsByWorkspace, oldID)
+	switch {
+	case oldActiveOK && (!newActiveOK || len(newTabs) == 0):
+		if migratedActive < 0 {
+			migratedActive = 0
+		}
+		if len(merged) == 0 {
+			migratedActive = 0
+		} else if migratedActive >= len(merged) {
+			migratedActive = len(merged) - 1
+		}
+		activeByWorkspace[newID] = migratedActive
+	case newActiveOK:
+		if len(merged) == 0 {
+			activeByWorkspace[newID] = 0
+		} else if newActive >= len(merged) {
+			activeByWorkspace[newID] = len(merged) - 1
+		}
+	}
+	delete(activeByWorkspace, oldID)
+	return merged
+}

--- a/internal/ui/common/merge_test.go
+++ b/internal/ui/common/merge_test.go
@@ -53,3 +53,48 @@ func eq(a, b []string) bool {
 	}
 	return true
 }
+
+func TestRebindTabMaps_ClampsActiveIndex(t *testing.T) {
+	t.Parallel()
+	id := func(s string) string { return s }
+	isNil := func(s string) bool { return s == "" }
+
+	t.Run("migrates old active when new has none", func(t *testing.T) {
+		tabs := map[string][]string{"old": {"a", "b"}}
+		active := map[string]int{"old": 1}
+		merged := RebindTabMaps(tabs, active, "old", "new", id, isNil)
+		if len(merged) != 2 {
+			t.Fatalf("merged = %v", merged)
+		}
+		if active["new"] != 1 {
+			t.Fatalf("active[new] = %d, want 1", active["new"])
+		}
+		if _, ok := tabs["old"]; ok {
+			t.Fatal("old tab key not deleted")
+		}
+		if _, ok := active["old"]; ok {
+			t.Fatal("old active key not deleted")
+		}
+	})
+
+	t.Run("clamps new active out of range after merge", func(t *testing.T) {
+		tabs := map[string][]string{"old": {"x", "y"}, "new": {"x"}}
+		active := map[string]int{"old": 0, "new": 5}
+		merged := RebindTabMaps(tabs, active, "old", "new", id, isNil)
+		if got, want := active["new"], len(merged)-1; got != want {
+			t.Fatalf("active[new] = %d, want clamp to %d (merged=%v)", got, want, merged)
+		}
+	})
+
+	t.Run("empty merged yields active 0", func(t *testing.T) {
+		tabs := map[string][]string{"old": {}, "new": {}}
+		active := map[string]int{"old": 3, "new": 2}
+		merged := RebindTabMaps(tabs, active, "old", "new", id, isNil)
+		if len(merged) != 0 {
+			t.Fatalf("merged = %v", merged)
+		}
+		if active["new"] != 0 {
+			t.Fatalf("active[new] = %d, want 0", active["new"])
+		}
+	})
+}

--- a/internal/ui/sidebar/terminal_workspace_rebind.go
+++ b/internal/ui/sidebar/terminal_workspace_rebind.go
@@ -32,31 +32,9 @@ func (m *TerminalModel) RebindWorkspaceID(previous, current *data.Workspace) tea
 		return nil
 	}
 
-	newTabs := m.tabsByWorkspace[newID]
-	oldActive, oldActiveOK := m.activeTabByWorkspace[oldID]
-	newActive, newActiveOK := m.activeTabByWorkspace[newID]
-	merged, migratedActive := mergeTerminalTabsByID(newTabs, oldTabs, oldActive)
-
-	m.tabsByWorkspace[newID] = merged
-	delete(m.tabsByWorkspace, oldID)
-	if oldActiveOK && (!newActiveOK || len(newTabs) == 0) {
-		if migratedActive < 0 {
-			migratedActive = 0
-		}
-		if len(merged) == 0 {
-			migratedActive = 0
-		} else if migratedActive >= len(merged) {
-			migratedActive = len(merged) - 1
-		}
-		m.activeTabByWorkspace[newID] = migratedActive
-	} else if newActiveOK {
-		if len(merged) == 0 {
-			m.activeTabByWorkspace[newID] = 0
-		} else if newActive >= len(merged) {
-			m.activeTabByWorkspace[newID] = len(merged) - 1
-		}
-	}
-	delete(m.activeTabByWorkspace, oldID)
+	merged := common.RebindTabMaps(m.tabsByWorkspace, m.activeTabByWorkspace, oldID, newID,
+		func(t *TerminalTab) TerminalTabID { return t.ID },
+		func(t *TerminalTab) bool { return t == nil })
 
 	if m.pendingCreation[oldID] {
 		m.pendingCreation[newID] = true
@@ -85,10 +63,4 @@ func (m *TerminalModel) RebindWorkspaceID(previous, current *data.Workspace) tea
 	}
 
 	return common.SafeBatch(cmds...)
-}
-
-func mergeTerminalTabsByID(existing, incoming []*TerminalTab, incomingActive int) ([]*TerminalTab, int) {
-	return common.MergeByID(existing, incoming, incomingActive,
-		func(t *TerminalTab) TerminalTabID { return t.ID },
-		func(t *TerminalTab) bool { return t == nil })
 }


### PR DESCRIPTION
## Plan stack — PR 8/41

## Problem
The post-merge active-tab-index reconciliation in `RebindWorkspaceID` was **byte-identical** between center and sidebar (only the merge-helper name differed): both shuffle `tabsByWorkspace`/`activeTabByWorkspace` and clamp the migrated active index. A clamp fix had to be mirrored or the two panes' selection silently diverged after an ID rewrite. Both functions were also at/over the gocyclo ratchet (34 center / 30 sidebar).

## Change
Generic `common.RebindTabMaps[T,K]`: merges via `MergeByID`, writes `newID`, deletes `oldID` from both maps, applies the exact clamp logic, returns `merged`. Both callers delegate and keep their divergent surrounding logic (seen-but-empty case, workspace/`pendingCreation` fixups, PTY restarts). Per-package merge helpers deleted.

## Test
`RebindWorkspaceID` drops to gocyclo **25 / 21**. New `TestRebindTabMaps_ClampsActiveIndex` covers old-active migration, new-active out-of-range clamp, and empty-merged→0. All three packages' tests pass with no existing-test edits; strict ratchet clean.