### PR TITLE
Wire a nil-safe deleteInFlight predicate into workspaceService

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -154,6 +154,11 @@ func New(version, commit, date string) (*App, error) {
 	if stateWatcher != nil {
 		app.supervisor.Start("app.state_watcher", stateWatcher.Run, supervisor.WithBackoff(supervisorBackoff))
 	}
+
+	// Let the service's load/rescan path consult the App's delete-in-flight guard
+	// so it can skip workspaces that are being deleted (used by the rescan guard).
+	workspaceService.deleteInFlight = app.isWorkspaceDeleteInFlight
+
 	return app, nil
 }
 

--- a/internal/app/workspace_service_delete_inflight_test.go
+++ b/internal/app/workspace_service_delete_inflight_test.go
@@ -1,0 +1,34 @@
+package app
+
+import "testing"
+
+// TestWorkspaceServiceIsDeleteInFlight verifies the predicate is nil-safe (so a
+// service constructed without it — as the rescan tests do — treats every
+// workspace as not in flight) and consults the wired function when present.
+func TestWorkspaceServiceIsDeleteInFlight(t *testing.T) {
+	var nilService *workspaceService
+	if nilService.isDeleteInFlight("ws") {
+		t.Fatal("nil service should report not in flight")
+	}
+
+	unwired := &workspaceService{}
+	if unwired.isDeleteInFlight("ws") {
+		t.Fatal("nil predicate should report not in flight")
+	}
+
+	wired := &workspaceService{}
+	var got string
+	wired.deleteInFlight = func(id string) bool {
+		got = id
+		return id == "deleting"
+	}
+	if !wired.isDeleteInFlight("deleting") {
+		t.Fatal("wired predicate should report the deleting workspace in flight")
+	}
+	if got != "deleting" {
+		t.Fatalf("predicate received %q, want \"deleting\"", got)
+	}
+	if wired.isDeleteInFlight("other") {
+		t.Fatal("wired predicate should report a non-deleting workspace not in flight")
+	}
+}

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -41,6 +41,17 @@ type workspaceService struct {
 	workspacesRoot     string
 	gitOps             GitOperations
 	gitPathWaitTimeout time.Duration
+	// deleteInFlight reports whether a workspace is currently mid-delete. It is
+	// wired to the App's guard in app_init; nil when the service is constructed
+	// directly (e.g. in tests) and then treated as "never in flight".
+	deleteInFlight func(wsID string) bool
+}
+
+// isDeleteInFlight reports whether the workspace is mid-delete. It is nil-safe so
+// a service built without the predicate (tests) treats every workspace as not in
+// flight.
+func (s *workspaceService) isDeleteInFlight(wsID string) bool {
+	return s != nil && s.deleteInFlight != nil && s.deleteInFlight(wsID)
 }
 
 func newWorkspaceService(registry ProjectRegistry, store WorkspaceStore, scripts *process.ScriptRunner, workspacesRoot string) *workspaceService {


### PR DESCRIPTION
## Plan stack — PR 9/41 (scaffolding for #10)

## Problem
The delete-in-flight invariant (`App.isWorkspaceDeleteInFlight`) is an App-layer concept consulted in the persistence and tmux-sync paths but never reachable from the service load/rescan path. PR 10 (skip discovery upsert + archival save for a workspace mid-delete during `RescanWorkspaces`) needs the service to consult it. Landing the shared wiring here keeps the dependent fix a one-line guard.

## Change
- `workspaceService.deleteInFlight func(wsID string) bool` + nil-safe `isDeleteInFlight` accessor (nil service or nil predicate → not in flight, so service-only/rescan tests are unaffected).
- Wired in `app_init` to `app.isWorkspaceDeleteInFlight`.

Zero behavior change — unused until PR 10.

## Test
`TestWorkspaceServiceIsDeleteInFlight` (nil-safe + predicate consulted); full `./internal/app` suite green; lint clean.