### PR TITLE
Skip rescan upsert and archival for delete-in-flight workspaces

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -158,6 +158,7 @@ func New(version, commit, date string) (*App, error) {
 	// Let the service's load/rescan path consult the App's delete-in-flight guard
 	// so it can skip workspaces that are being deleted (used by the rescan guard).
 	workspaceService.deleteInFlight = app.isWorkspaceDeleteInFlight
+	workspaceService.deleteInFlightGuard = app.runUnlessWorkspaceDeleteInFlight
 
 	return app, nil
 }

--- a/internal/app/app_operations_rescan_test.go
+++ b/internal/app/app_operations_rescan_test.go
@@ -185,3 +185,53 @@ func TestCreateWorkspaceMissingGitDoesNotPersist(t *testing.T) {
 		t.Fatalf("expected no persisted workspaces, got %d", len(ids))
 	}
 }
+
+func TestRescanWorkspaces_SkipsDeleteInFlight(t *testing.T) {
+	skipIfNoGit(t)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	tmp := t.TempDir()
+	registry := data.NewRegistry(filepath.Join(tmp, "projects.json"))
+	if err := registry.AddProject(repo); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	store := data.NewWorkspaceStore(filepath.Join(tmp, "workspaces-metadata"))
+	workspacesRoot := filepath.Join(tmp, "workspaces")
+	ghost := &data.Workspace{
+		Name: "ghost",
+		Repo: repo,
+		Root: filepath.Join(workspacesRoot, filepath.Base(repo), "ghost"),
+	}
+	if err := store.Save(ghost); err != nil {
+		t.Fatalf("Save ghost workspace: %v", err)
+	}
+
+	workspaceService := newWorkspaceService(registry, store, nil, workspacesRoot)
+	// Mark the ghost as mid-delete: an unmanaged workspace would normally be
+	// archived by rescan, but a delete-in-flight one must be left untouched.
+	workspaceService.deleteInFlight = func(id string) bool {
+		return id == string(ghost.ID())
+	}
+	app := &App{workspaceService: workspaceService}
+
+	rescanMsg := app.rescanWorkspaces()()
+	if _, ok := rescanMsg.(messages.RefreshDashboard); !ok {
+		t.Fatalf("expected RefreshDashboard from rescan, got %T", rescanMsg)
+	}
+
+	loaded, err := store.Load(ghost.ID())
+	if err != nil {
+		t.Fatalf("Load ghost workspace: %v", err)
+	}
+	if loaded.Archived {
+		t.Fatalf("delete-in-flight workspace must not be archived by rescan")
+	}
+}

--- a/internal/app/app_operations_rescan_test.go
+++ b/internal/app/app_operations_rescan_test.go
@@ -235,3 +235,63 @@ func TestRescanWorkspaces_SkipsDeleteInFlight(t *testing.T) {
 		t.Fatalf("delete-in-flight workspace must not be archived by rescan")
 	}
 }
+
+func TestRescanWorkspaces_GuardsArchiveWriteAgainstConcurrentDelete(t *testing.T) {
+	skipIfNoGit(t)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	tmp := t.TempDir()
+	registry := data.NewRegistry(filepath.Join(tmp, "projects.json"))
+	if err := registry.AddProject(repo); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	store := data.NewWorkspaceStore(filepath.Join(tmp, "workspaces-metadata"))
+	workspacesRoot := filepath.Join(tmp, "workspaces")
+	ghost := &data.Workspace{
+		Name: "ghost",
+		Repo: repo,
+		Root: filepath.Join(workspacesRoot, filepath.Base(repo), "ghost"),
+	}
+	if err := store.Save(ghost); err != nil {
+		t.Fatalf("Save ghost workspace: %v", err)
+	}
+
+	workspaceService := newWorkspaceService(registry, store, nil, workspacesRoot)
+	ghostID := string(ghost.ID())
+	guardCalled := false
+	workspaceService.deleteInFlightGuard = func(id string, fn func()) bool {
+		if id != ghostID {
+			if fn != nil {
+				fn()
+			}
+			return true
+		}
+		guardCalled = true
+		return false
+	}
+	app := &App{workspaceService: workspaceService}
+
+	rescanMsg := app.rescanWorkspaces()()
+	if _, ok := rescanMsg.(messages.RefreshDashboard); !ok {
+		t.Fatalf("expected RefreshDashboard from rescan, got %T", rescanMsg)
+	}
+	if !guardCalled {
+		t.Fatal("expected delete-in-flight guard to protect archive write")
+	}
+
+	loaded, err := store.Load(ghost.ID())
+	if err != nil {
+		t.Fatalf("Load ghost workspace: %v", err)
+	}
+	if loaded.Archived {
+		t.Fatalf("guarded archive write must not persist while delete starts concurrently")
+	}
+}

--- a/internal/app/workspace_service_delete_inflight_test.go
+++ b/internal/app/workspace_service_delete_inflight_test.go
@@ -32,3 +32,49 @@ func TestWorkspaceServiceIsDeleteInFlight(t *testing.T) {
 		t.Fatal("wired predicate should report a non-deleting workspace not in flight")
 	}
 }
+
+func TestWorkspaceServiceRunUnlessDeleteInFlight(t *testing.T) {
+	unwired := &workspaceService{}
+	ran := false
+	if !unwired.runUnlessDeleteInFlight("ws", func() { ran = true }) {
+		t.Fatal("unwired service should run the callback")
+	}
+	if !ran {
+		t.Fatal("unwired service did not run callback")
+	}
+
+	predicateOnly := &workspaceService{
+		deleteInFlight: func(id string) bool { return id == "deleting" },
+	}
+	if predicateOnly.runUnlessDeleteInFlight("deleting", func() {
+		t.Fatal("predicate-only service should not run callback for deleting workspace")
+	}) {
+		t.Fatal("predicate-only service should report skipped callback")
+	}
+
+	guarded := &workspaceService{}
+	var gotID string
+	guarded.deleteInFlightGuard = func(id string, fn func()) bool {
+		gotID = id
+		if id == "blocked" {
+			return false
+		}
+		fn()
+		return true
+	}
+	if guarded.runUnlessDeleteInFlight("blocked", func() {
+		t.Fatal("guard should not run blocked callback")
+	}) {
+		t.Fatal("guard should report skipped callback")
+	}
+	if gotID != "blocked" {
+		t.Fatalf("guard received %q, want \"blocked\"", gotID)
+	}
+	ran = false
+	if !guarded.runUnlessDeleteInFlight("open", func() { ran = true }) {
+		t.Fatal("guard should run open callback")
+	}
+	if !ran {
+		t.Fatal("guard did not run open callback")
+	}
+}

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -45,6 +45,9 @@ type workspaceService struct {
 	// wired to the App's guard in app_init; nil when the service is constructed
 	// directly (e.g. in tests) and then treated as "never in flight".
 	deleteInFlight func(wsID string) bool
+	// deleteInFlightGuard runs a store mutation only when the workspace is not
+	// mid-delete, keeping the check atomic with App delete-state updates.
+	deleteInFlightGuard func(wsID string, fn func()) bool
 }
 
 // isDeleteInFlight reports whether the workspace is mid-delete. It is nil-safe so
@@ -52,6 +55,22 @@ type workspaceService struct {
 // flight.
 func (s *workspaceService) isDeleteInFlight(wsID string) bool {
 	return s != nil && s.deleteInFlight != nil && s.deleteInFlight(wsID)
+}
+
+func (s *workspaceService) runUnlessDeleteInFlight(wsID string, fn func()) bool {
+	if s == nil {
+		return false
+	}
+	if s.deleteInFlightGuard != nil {
+		return s.deleteInFlightGuard(wsID, fn)
+	}
+	if s.isDeleteInFlight(wsID) {
+		return false
+	}
+	if fn != nil {
+		fn()
+	}
+	return true
 }
 
 func newWorkspaceService(registry ProjectRegistry, store WorkspaceStore, scripts *process.ScriptRunner, workspacesRoot string) *workspaceService {

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -129,6 +129,11 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 				if !s.shouldSurfaceWorkspace(path, ws) {
 					continue
 				}
+				if s.isDeleteInFlight(string(ws.ID())) {
+					// A workspace being deleted must not be re-imported by a
+					// concurrent rescan racing the delete; the delete flow owns it.
+					continue
+				}
 				// Set the default assistant for newly discovered workspaces. Note:
 				// UpsertFromDiscovery below merges with stored metadata, where stored
 				// metadata takes precedence if non-empty. This is intentional — stored
@@ -155,6 +160,11 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 
 			for _, ws := range storedWorkspaces {
 				if ws == nil {
+					continue
+				}
+				if s.isDeleteInFlight(string(ws.ID())) {
+					// Leave a workspace mid-delete untouched: neither archival Save
+					// path below should run while the delete flow is removing it.
 					continue
 				}
 				if !s.shouldSurfaceWorkspace(path, ws) {

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -129,7 +129,9 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 				if !s.shouldSurfaceWorkspace(path, ws) {
 					continue
 				}
-				if s.isDeleteInFlight(string(ws.ID())) {
+				wsID := string(ws.ID())
+				discoveredSet[wsID] = true
+				if s.isDeleteInFlight(wsID) {
 					// A workspace being deleted must not be re-imported by a
 					// concurrent rescan racing the delete; the delete flow owns it.
 					continue
@@ -141,10 +143,16 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 				if strings.TrimSpace(ws.Assistant) == "" {
 					ws.Assistant = s.resolvedDefaultAssistant()
 				}
-				discoveredSet[string(ws.ID())] = true
 				if s.store != nil {
-					if err := s.store.UpsertFromDiscovery(ws); err != nil {
-						logging.Warn("Failed to import workspace %s: %v", ws.Name, err)
+					var upsertErr error
+					imported := s.runUnlessDeleteInFlight(wsID, func() {
+						upsertErr = s.store.UpsertFromDiscovery(ws)
+					})
+					if !imported {
+						continue
+					}
+					if upsertErr != nil {
+						logging.Warn("Failed to import workspace %s: %v", ws.Name, upsertErr)
 					}
 				}
 			}
@@ -169,12 +177,19 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 				}
 				if !s.shouldSurfaceWorkspace(path, ws) {
 					if !ws.Archived {
-						ws.Archived = true
-						ws.ArchivedAt = time.Now()
-						if s.store != nil {
-							if err := s.store.Save(ws); err != nil {
-								logging.Warn("Failed to archive unmanaged workspace %s: %v", ws.Name, err)
+						var saveErr error
+						saved := s.runUnlessDeleteInFlight(string(ws.ID()), func() {
+							ws.Archived = true
+							ws.ArchivedAt = time.Now()
+							if s.store != nil {
+								saveErr = s.store.Save(ws)
 							}
+						})
+						if !saved {
+							continue
+						}
+						if saveErr != nil {
+							logging.Warn("Failed to archive unmanaged workspace %s: %v", ws.Name, saveErr)
 						}
 					}
 					continue
@@ -183,12 +198,19 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 					continue
 				}
 				if !ws.Archived {
-					ws.Archived = true
-					ws.ArchivedAt = time.Now()
-					if s.store != nil {
-						if err := s.store.Save(ws); err != nil {
-							logging.Warn("Failed to archive workspace %s: %v", ws.Name, err)
+					var saveErr error
+					saved := s.runUnlessDeleteInFlight(string(ws.ID()), func() {
+						ws.Archived = true
+						ws.ArchivedAt = time.Now()
+						if s.store != nil {
+							saveErr = s.store.Save(ws)
 						}
+					})
+					if !saved {
+						continue
+					}
+					if saveErr != nil {
+						logging.Warn("Failed to archive workspace %s: %v", ws.Name, saveErr)
 					}
 				}
 			}


### PR DESCRIPTION
## Plan stack — PR 10/41

## Problem
`RescanWorkspaces` runs on a background cadence and **races workspace delete**: it re-imports discovered worktrees (`UpsertFromDiscovery`) and archives stored workspaces it no longer surfaces (`Save`). A workspace mid-delete (worktree being removed, store entry about to be deleted) could be re-imported or archived mid-flight — resurrecting it on the dashboard or fighting the delete flow.

## Change
Consult `workspaceService.deleteInFlight` (the predicate wired in PR 9) at both points:
- discovery loop: skip a delete-in-flight workspace (no re-import),
- top of the stored loop: skip it (neither archival `Save` path runs).

The delete flow owns removal.

## Test
`TestRescanWorkspaces_SkipsDeleteInFlight`: a delete-in-flight ghost that would otherwise be archived as unmanaged is left untouched. Existing rescan tests (no predicate wired → nil-safe) still pass; strict ratchet clean.