### PR TITLE
Fold delete-in-flight IDs into the orphan-GC known-set

### DIFF
--- a/internal/app/app_tmux_gc.go
+++ b/internal/app/app_tmux_gc.go
@@ -43,6 +43,13 @@ func (a *App) collectKnownWorkspaceIDs() map[string]bool {
 	for id := range a.creatingWorkspaceIDs {
 		ids[id] = true
 	}
+	// A workspace mid-delete may already be absent from a.projects (loadProjects
+	// replaces it after each WorkspaceDeleted), so without this a concurrently
+	// scheduled orphan GC would see its session as unknown and kill it — racing
+	// the orderly cleanup, and on a failed delete killing a still-needed agent.
+	for id := range a.snapshotDeletingWorkspaceIDs() {
+		ids[id] = true
+	}
 	return ids
 }
 

--- a/internal/app/app_tmux_gc_safety_test.go
+++ b/internal/app/app_tmux_gc_safety_test.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func TestGcOrphanedTmuxSessions_SkipsAttachedOrphans(t *testing.T) {
 			return []tmux.SessionTagValues{
 				{Name: "attached-orphan", Tags: map[string]string{
 					"@amux_workspace":  "dead-ws",
-					"@amux_created_at": fmt.Sprintf("%d", staleTS),
+					"@amux_created_at": strconv.FormatInt(staleTS, 10),
 				}},
 			}, nil
 		},
@@ -97,7 +97,7 @@ func TestGcOrphanedTmuxSessions_SkipsRecentOrphans(t *testing.T) {
 			return []tmux.SessionTagValues{
 				{Name: "recent-orphan", Tags: map[string]string{
 					"@amux_workspace":  "dead-ws",
-					"@amux_created_at": fmt.Sprintf("%d", recentTS),
+					"@amux_created_at": strconv.FormatInt(recentTS, 10),
 				}},
 			}, nil
 		},
@@ -130,7 +130,7 @@ func TestGcOrphanedTmuxSessions_KillsStaleDetachedOrphans(t *testing.T) {
 			return []tmux.SessionTagValues{
 				{Name: "stale-orphan", Tags: map[string]string{
 					"@amux_workspace":  "dead-ws",
-					"@amux_created_at": fmt.Sprintf("%d", staleTS),
+					"@amux_created_at": strconv.FormatInt(staleTS, 10),
 				}},
 			}, nil
 		},
@@ -213,5 +213,43 @@ func TestGcOrphanedTmuxSessions_UsesInstanceScopedMatchWhenInstanceIDSet(t *test
 	}
 	if capturedMatch["@amux_instance"] != "test-instance-123" {
 		t.Fatalf("expected @amux_instance=test-instance-123, got %v", capturedMatch["@amux_instance"])
+	}
+}
+
+func TestGcOrphanedTmuxSessions_SkipsDeleteInFlightOrphan(t *testing.T) {
+	now := time.Now()
+	staleTS := now.Add(-2 * time.Minute).Unix()
+
+	ops := &gcOrphanOps{
+		sessionsWithTags: func(match map[string]string, keys []string, opts tmux.Options) ([]tmux.SessionTagValues, error) {
+			return []tmux.SessionTagValues{
+				{Name: "deleting-orphan", Tags: map[string]string{
+					"@amux_workspace":  "dead-ws",
+					"@amux_created_at": strconv.FormatInt(staleTS, 10),
+				}},
+			}, nil
+		},
+		sessionHasClients: func(name string, opts tmux.Options) (bool, error) {
+			return false, nil // detached
+		},
+	}
+	app := newGCTestApp(ops)
+	// dead-ws is mid-delete and already absent from a.projects; orphan GC must
+	// treat it as known and leave its session for the orderly delete cleanup.
+	app.deletingWorkspaceIDs = map[string]bool{"dead-ws": true}
+
+	msg := app.gcOrphanedTmuxSessions()()
+	result, ok := msg.(orphanGCResult)
+	if !ok {
+		t.Fatalf("expected orphanGCResult, got %T", msg)
+	}
+	if result.Err != nil {
+		t.Fatalf("GC error: %v", result.Err)
+	}
+	if result.Killed != 0 {
+		t.Fatalf("expected 0 killed for a delete-in-flight orphan, got %d", result.Killed)
+	}
+	if len(ops.killed) != 0 {
+		t.Fatalf("expected no sessions killed, got %v", ops.killed)
 	}
 }

--- a/internal/app/app_tmux_gc_test.go
+++ b/internal/app/app_tmux_gc_test.go
@@ -349,3 +349,16 @@ func TestGcOrphanedTmuxSessions_NoSessions(t *testing.T) {
 		t.Fatalf("expected 0 killed, got %d", result.Killed)
 	}
 }
+
+func TestCollectKnownWorkspaceIDs_IncludesDeleting(t *testing.T) {
+	ws := data.Workspace{Repo: "/repo-d", Root: "/repo-d/ws-delete"}
+	deletingID := string(ws.ID())
+	app := &App{
+		deletingWorkspaceIDs: map[string]bool{deletingID: true},
+	}
+
+	ids := app.collectKnownWorkspaceIDs()
+	if !ids[deletingID] {
+		t.Fatalf("expected delete-in-flight workspace ID %s to be included even when absent from projects", deletingID)
+	}
+}

--- a/internal/app/workspace_delete_guard.go
+++ b/internal/app/workspace_delete_guard.go
@@ -33,6 +33,24 @@ func (a *App) isWorkspaceDeleteInFlight(wsID string) bool {
 	return a.deletingWorkspaceIDs[wsID]
 }
 
+// snapshotDeletingWorkspaceIDs returns a copy of the IDs currently marked
+// delete-in-flight. The RLock is required because callers like
+// collectKnownWorkspaceIDs run on the Update goroutine while the map is also
+// mutated from worker goroutines.
+func (a *App) snapshotDeletingWorkspaceIDs() map[string]bool {
+	a.deletingWorkspaceMu.RLock()
+	defer a.deletingWorkspaceMu.RUnlock()
+
+	if len(a.deletingWorkspaceIDs) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(a.deletingWorkspaceIDs))
+	for id := range a.deletingWorkspaceIDs {
+		out[id] = true
+	}
+	return out
+}
+
 // runUnlessWorkspaceDeleteInFlight runs fn while holding a shared delete-state
 // lock only when wsID is not currently marked delete-in-flight. Holding the
 // lock across fn keeps the check and side effect atomic with respect to


### PR DESCRIPTION
## Plan stack — PR 11/41

## Problem
`collectKnownWorkspaceIDs` built the orphan-GC known-set from `a.projects` + `a.creatingWorkspaceIDs` but **not** the delete-in-flight set. During a delete, `loadProjects` fires after each `WorkspaceDeleted` and replaces `a.projects`, so a workspace still mid-delete may already be absent. A concurrently scheduled `gcOrphanedTmuxSessions` then sees its `@amux_workspace` session as "unknown" and **kills it** — racing the orderly cleanup, and in the `WorkspaceDeleteFailed` case (which keeps the workspace) killing its still-needed agent session.

## Change
Add `snapshotDeletingWorkspaceIDs` (RLock-guarded copy — the map is read on the Update goroutine and mutated by workers) and fold it into the known-set, symmetric with the existing `creating` guard. The marker is cleared on both success and failure paths, so the failure case is covered.

## Test
- `TestCollectKnownWorkspaceIDs_IncludesDeleting`: a delete-in-flight ID is known even when absent from projects.
- `TestGcOrphanedTmuxSessions_SkipsDeleteInFlightOrphan`: a stale detached orphan for a delete-in-flight workspace is **not** killed; the existing stale-orphan test still kills a non-delete-in-flight one.
- `go test -race ./internal/app` green; strict ratchet clean.