### PR TITLE
Clear deleted workspace from the active set in handleWorkspaceDeleted

### DIFF
--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -20,6 +20,11 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 		return
 	}
 	for wsID := range a.tmuxActiveWorkspaceIDs {
+		// A scan completing after a delete began must not re-publish the workspace
+		// as active; the delete-in-flight guard keeps the dashboard consistent.
+		if a.isWorkspaceDeleteInFlight(wsID) {
+			continue
+		}
 		activeWorkspaces[wsID] = true
 	}
 	a.dashboard.SetActiveWorkspaces(activeWorkspaces)

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -119,6 +119,11 @@ func (a *App) handleWorkspaceDeleteFailed(msg messages.WorkspaceDeleteFailed) te
 		if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		if a.tmuxAvailable {
+			if cmd := a.scanTmuxActivityNow(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 		if cmd := a.persistWorkspaceTabs(string(msg.Workspace.ID())); cmd != nil {
 			cmds = append(cmds, cmd)
 		}

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -84,6 +84,11 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 	var cmds []tea.Cmd
 	if msg.Workspace != nil {
 		a.markWorkspaceDeleteInFlight(msg.Workspace, false)
+		// Drop the deleted workspace from the active set now rather than waiting
+		// for the async loadProjects -> scan reconcile, so a killed-but-not-yet-
+		// reaped agent session cannot keep it shown as active by tag alone.
+		delete(a.tmuxActiveWorkspaceIDs, string(msg.Workspace.ID()))
+		a.syncActiveWorkspacesToDashboard()
 		delete(a.dirtyWorkspaces, string(msg.Workspace.ID()))
 		if cleanup := a.cleanupWorkspaceTmuxSessions(msg.Workspace); cleanup != nil {
 			cmds = append(cmds, cleanup)

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -79,3 +79,28 @@ func TestHandleWorkspaceDeleteFailedRequestsFreshActivityScan(t *testing.T) {
 		t.Fatal("expected failed delete to request a fresh tmux activity scan")
 	}
 }
+
+func TestHandleWorkspaceDeleted_ClearsActiveWorkspace(t *testing.T) {
+	wsDel := data.NewWorkspace("del", "del", "main", "/repo", "/repo/del")
+	wsKeep := data.NewWorkspace("keep", "keep", "main", "/repo", "/repo/keep")
+	idDel, idKeep := string(wsDel.ID()), string(wsKeep.ID())
+
+	app := &App{
+		dashboard:              dashboard.New(),
+		center:                 center.New(nil),
+		sidebar:                sidebar.NewTabbedSidebar(),
+		sidebarTerminal:        sidebar.NewTerminalModel(),
+		tmuxActivitySettled:    true,
+		tmuxActiveWorkspaceIDs: map[string]bool{idDel: true, idKeep: true},
+		deletingWorkspaceIDs:   map[string]bool{idDel: true},
+	}
+
+	app.handleWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: wsDel})
+
+	if app.tmuxActiveWorkspaceIDs[idDel] {
+		t.Fatal("expected deleted workspace cleared from the active set")
+	}
+	if !app.tmuxActiveWorkspaceIDs[idKeep] {
+		t.Fatal("expected surviving workspace to remain in the active set")
+	}
+}

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
@@ -30,5 +31,51 @@ func TestHandleWorkspaceDeletedClearsDirtyWorkspaceMarker(t *testing.T) {
 	}
 	if app.dirtyWorkspaces[wsID] {
 		t.Fatal("expected dirty workspace marker to be cleared on delete success")
+	}
+}
+
+func TestSyncActiveWorkspacesToDashboard_SkipsDeleteInFlight(t *testing.T) {
+	wsA := &data.Workspace{Repo: "/repo", Root: "/repo/a"}
+	wsB := &data.Workspace{Repo: "/repo", Root: "/repo/b"}
+	idA, idB := string(wsA.ID()), string(wsB.ID())
+
+	app := &App{
+		tmuxActivitySettled:    true,
+		tmuxActiveWorkspaceIDs: map[string]bool{idA: true, idB: true},
+		dashboard:              dashboard.New(),
+	}
+	app.markWorkspaceDeleteInFlight(wsA, true)
+	app.syncActiveWorkspacesToDashboard()
+
+	if got := dashboardActiveWorkspaceCount(app.dashboard); got != 1 {
+		t.Fatalf("expected 1 active workspace (delete-in-flight wsA excluded), got %d", got)
+	}
+}
+
+func TestHandleWorkspaceDeleteFailedRequestsFreshActivityScan(t *testing.T) {
+	ws := &data.Workspace{Repo: "/repo", Root: "/repo/a"}
+	wsID := string(ws.ID())
+	app := &App{
+		tmuxActivitySettled:    true,
+		tmuxActiveWorkspaceIDs: map[string]bool{wsID: true},
+		tmuxAvailable:          true,
+		dashboard:              dashboard.New(),
+	}
+
+	app.markWorkspaceDeleteInFlight(ws, true)
+	app.syncActiveWorkspacesToDashboard()
+	if got := dashboardActiveWorkspaceCount(app.dashboard); got != 0 {
+		t.Fatalf("expected active workspace to be filtered during delete, got %d", got)
+	}
+
+	app.handleWorkspaceDeleteFailed(messages.WorkspaceDeleteFailed{
+		Workspace: ws,
+		Err:       errors.New("delete failed"),
+	})
+	if got := dashboardActiveWorkspaceCount(app.dashboard); got != 0 {
+		t.Fatalf("expected cached active state to stay filtered until fresh scan, got %d", got)
+	}
+	if !app.tmuxActivityScanInFlight {
+		t.Fatal("expected failed delete to request a fresh tmux activity scan")
 	}
 }

--- a/internal/ui/dashboard/active_test.go
+++ b/internal/ui/dashboard/active_test.go
@@ -102,3 +102,23 @@ func TestDashboardHomeActive(t *testing.T) {
 		t.Errorf("expected activeRoot to be empty after ShowWelcome")
 	}
 }
+
+func TestDashboardProjectRowActive_DeletingSupersedesActive(t *testing.T) {
+	t.Parallel()
+	main := &data.Workspace{Name: "p", Branch: "main", Repo: "/p", Root: "/p"}
+	mainID := string(main.ID())
+
+	m := New()
+	m.activeWorkspaceIDs = map[string]bool{mainID: true}
+
+	if !m.projectRowActive(mainID, main) {
+		t.Fatal("expected an active main workspace to render the project row active")
+	}
+
+	// Mark the project deleting: the row must no longer render active even though
+	// the workspace is still in the active set.
+	m.deletingWorkspaces = map[string]bool{main.Root: true}
+	if m.projectRowActive(mainID, main) {
+		t.Fatal("a deleting project must not render active")
+	}
+}

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -38,8 +38,8 @@ func (m *Model) renderRow(row Row, selected bool) string {
 		status := ""
 		statusText := ""
 		dirty := false
-		active := row.ActivityWorkspaceID != "" && m.activeWorkspaceIDs[row.ActivityWorkspaceID]
 		main := row.MainWorkspace
+		active := m.projectRowActive(row.ActivityWorkspaceID, main)
 		if main != nil {
 			if m.deletingWorkspaces[main.Root] {
 				frame := common.SpinnerFrame(m.spinnerFrame)

--- a/internal/ui/dashboard/dashboard_state.go
+++ b/internal/ui/dashboard/dashboard_state.go
@@ -181,6 +181,20 @@ func (m *Model) isProjectActive(p *data.Project) bool {
 	return m.activeWorkspaceIDs[string(mainWS.ID())]
 }
 
+// projectRowActive reports whether a project header row should render as active.
+// A project being deleted is never active even if its main workspace still has
+// an active agent — the delete supersedes the active styling, otherwise a
+// deleting project would render with active color (a status desync).
+func (m *Model) projectRowActive(activityWorkspaceID string, main *data.Workspace) bool {
+	if activityWorkspaceID == "" || !m.activeWorkspaceIDs[activityWorkspaceID] {
+		return false
+	}
+	if main != nil && m.deletingWorkspaces[main.Root] {
+		return false
+	}
+	return true
+}
+
 // getMainWorkspace returns the primary or main branch workspace for a project
 func (m *Model) getMainWorkspace(p *data.Project) *data.Workspace {
 	if p == nil {


### PR DESCRIPTION
## Plan stack — PR 13/41

## Problem
`handleWorkspaceDeleted` never cleared the deleted workspace's ID from `a.tmuxActiveWorkspaceIDs`; it relied on the async `loadProjects → ProjectsLoaded → scanTmuxActivityNow` chain, while `cleanupWorkspaceTmuxSessions` kills sessions concurrently with no ordering. A still-alive killed agent session can re-enter the active set **by tag alone**, so a deleted workspace could briefly show active.

## Change
Delete the workspace from `tmuxActiveWorkspaceIDs` and re-sync the dashboard synchronously inside `handleWorkspaceDeleted`.

## Test
With both a deleted and a surviving workspace in the active set, the deleted one is removed and the surviving one remains. Fails against current main (deletes neither). Strict ratchet clean.