### PR TITLE
Stop killing workspace tmux sessions before delete validation passes

### DIFF
--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+	"github.com/andyrewlee/amux/internal/ui/sidebar"
+)
+
+// killRecordingTmuxOps records session-kill calls so a delete test can prove no
+// session is destroyed before the delete is validated.
+type killRecordingTmuxOps struct {
+	stubTmuxOps
+	killTagsCalls int
+	killWsCalls   int
+}
+
+func (k *killRecordingTmuxOps) KillSessionsMatchingTags(map[string]string, tmux.Options) (bool, error) {
+	k.killTagsCalls++
+	return false, nil
+}
+
+func (k *killRecordingTmuxOps) KillWorkspaceSessions(string, tmux.Options) error {
+	k.killWsCalls++
+	return nil
+}
+
+// TestHandleDeleteWorkspace_DoesNotKillSessionsUpFront pins the keystone fix:
+// dispatching a delete must not kill the workspace's tmux sessions, because all
+// real validation runs later in the async DeleteWorkspace cmd. A rejected or
+// failed delete must therefore be a no-op, not destroy live agent sessions.
+func TestHandleDeleteWorkspace_DoesNotKillSessionsUpFront(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	project := data.NewProject("/repo")
+
+	ops := &killRecordingTmuxOps{}
+	app := &App{
+		dashboard:   dashboard.New(),
+		tmuxService: ops,
+		tmuxOptions: tmux.Options{},
+	}
+
+	cmds := app.handleDeleteWorkspace(messages.DeleteWorkspace{Project: project, Workspace: ws})
+	// Run any returned cmds so an async kill would be triggered if one existed.
+	for _, cmd := range cmds {
+		if cmd != nil {
+			_ = cmd()
+		}
+	}
+
+	if ops.killTagsCalls != 0 || ops.killWsCalls != 0 {
+		t.Fatalf("delete dispatch must not kill sessions before validation; KillSessionsMatchingTags=%d KillWorkspaceSessions=%d",
+			ops.killTagsCalls, ops.killWsCalls)
+	}
+	if !app.isWorkspaceDeleteInFlight(string(ws.ID())) {
+		t.Fatal("expected workspace marked delete-in-flight after dispatch")
+	}
+}
+
+// TestDeleteWorkspace_NavigatesHomeOnlyOnConfirmedDelete proves goHome moved off
+// the up-front path: dispatching the delete leaves the active workspace put, and
+// only the confirmed WorkspaceDeleted sends the user home.
+func TestDeleteWorkspace_NavigatesHomeOnlyOnConfirmedDelete(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	project := data.NewProject("/repo")
+
+	app := &App{
+		dashboard:       dashboard.New(),
+		center:          center.New(nil),
+		sidebar:         sidebar.NewTabbedSidebar(),
+		sidebarTerminal: sidebar.NewTerminalModel(),
+		activeWorkspace: ws,
+	}
+
+	_ = app.deleteWorkspace(project, ws)
+	if app.activeWorkspace == nil {
+		t.Fatal("deleteWorkspace must not navigate home before the delete is confirmed")
+	}
+
+	app.handleWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: ws})
+	if app.activeWorkspace != nil {
+		t.Fatal("expected goHome (activeWorkspace cleared) once the delete is confirmed")
+	}
+}

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -18,9 +18,11 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		return nil
 	}
 	a.markWorkspaceDeleteInFlight(msg.Workspace, true)
-	if cleanup := a.cleanupWorkspaceTmuxSessions(msg.Workspace); cleanup != nil {
-		cmds = append(cmds, cleanup)
-	}
+	// Do NOT kill the workspace's tmux sessions here. All real delete validation
+	// (primary-checkout guard, repo/path checks, worktree removal) runs later in
+	// the async DeleteWorkspace cmd; killing up-front means a rejected or failed
+	// delete still destroys live agent sessions and scrollback. The kill now runs
+	// only on the confirmed-success path in handleWorkspaceDeleted.
 	if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, true); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
@@ -89,6 +91,11 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 		// reaped agent session cannot keep it shown as active by tag alone.
 		delete(a.tmuxActiveWorkspaceIDs, string(msg.Workspace.ID()))
 		a.syncActiveWorkspacesToDashboard()
+		// Navigate home only now that the delete is confirmed (moved off the
+		// up-front deleteWorkspace path so a failed delete leaves the user put).
+		if a.activeWorkspace != nil && a.activeWorkspace.Root == msg.Workspace.Root {
+			a.goHome()
+		}
 		delete(a.dirtyWorkspaces, string(msg.Workspace.ID()))
 		if cleanup := a.cleanupWorkspaceTmuxSessions(msg.Workspace); cleanup != nil {
 			cmds = append(cmds, cleanup)

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -94,11 +94,11 @@ func (a *App) runSetupAsync(ws *data.Workspace) tea.Cmd {
 	return a.workspaceService.RunSetupAsync(ws)
 }
 
-// deleteWorkspace deletes a workspace.
+// deleteWorkspace deletes a workspace. The user is NOT navigated home here: that
+// happens only once the delete is confirmed (handleWorkspaceDeleted), so a
+// rejected or failed delete does not bounce the user out of a workspace it left
+// intact.
 func (a *App) deleteWorkspace(project *data.Project, ws *data.Workspace) tea.Cmd {
-	if a.activeWorkspace != nil && ws != nil && a.activeWorkspace.Root == ws.Root {
-		a.goHome()
-	}
 	if a.workspaceService == nil {
 		return nil
 	}


### PR DESCRIPTION
## Plan stack — PR 14/41 (keystone)

## Problem
`handleDeleteWorkspace` unconditionally fired `cleanupWorkspaceTmuxSessions` (which **kills** the agent + terminal tmux sessions) and `deleteWorkspace` called `goHome()` up-front — **before any precondition was checked**. All real validation (primary-checkout guard, project/path/repo checks, managed-root, the actual worktree removal) runs later in the async `DeleteWorkspace` cmd. So a rejected or failed delete had already destroyed the user's live agent sessions/scrollback and bounced them home, with nothing recreating them: **a no-op delete was destructive**.

## Change
- Remove the up-front kill from `handleDeleteWorkspace` (the success path already re-runs cleanup in `handleWorkspaceDeleted`).
- Move `goHome` from `deleteWorkspace` into `handleWorkspaceDeleted`, so it runs only once the delete is confirmed — still on the Update goroutine (no race on `activeWorkspace`).

## Test
- Dispatching a delete records **zero** `KillSessionsMatchingTags`/`KillWorkspaceSessions` calls (fails on current main, which kills up-front).
- The active workspace stays put on dispatch and is cleared only on the confirmed `WorkspaceDeleted`.

Full `./internal/app` suite green; strict ratchet clean. This is the keystone of the delete-correctness theme — #15/#17/#35 sequence around its kill placement.