### PR TITLE
Kill workspace tmux sessions before worktree removal in the delete path

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -159,6 +159,9 @@ func New(version, commit, date string) (*App, error) {
 	// so it can skip workspaces that are being deleted (used by the rescan guard).
 	workspaceService.deleteInFlight = app.isWorkspaceDeleteInFlight
 	workspaceService.deleteInFlightGuard = app.runUnlessWorkspaceDeleteInFlight
+	// Let the validated delete path tear down the workspace's tmux sessions just
+	// before removing the worktree (kill the agent before yanking its CWD).
+	workspaceService.killWorkspaceSessions = app.killWorkspaceSessionsSync
 
 	return app, nil
 }

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -159,8 +159,8 @@ func New(version, commit, date string) (*App, error) {
 	// so it can skip workspaces that are being deleted (used by the rescan guard).
 	workspaceService.deleteInFlight = app.isWorkspaceDeleteInFlight
 	workspaceService.deleteInFlightGuard = app.runUnlessWorkspaceDeleteInFlight
-	// Let the validated delete path tear down the workspace's tmux sessions just
-	// before removing the worktree (kill the agent before yanking its CWD).
+	// Let the delete path tear down workspace tmux sessions after worktree
+	// removal succeeds, without killing live sessions for failed deletes.
 	workspaceService.killWorkspaceSessions = app.killWorkspaceSessionsSync
 
 	return app, nil

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -40,6 +40,26 @@ func (a *App) cleanupWorkspaceTmuxSessions(ws *data.Workspace) tea.Cmd {
 	}
 }
 
+// killWorkspaceSessionsSync synchronously tears down a workspace's tmux sessions
+// by tag. The delete path calls this after validation passes but before removing
+// the worktree, so the agent process group (CWD = worktree root) is gone before
+// its directory is. No-op when tmux is unavailable.
+func (a *App) killWorkspaceSessionsSync(wsID string) {
+	if a.tmuxService == nil || wsID == "" {
+		return
+	}
+	tags := map[string]string{
+		"@amux":           "1",
+		"@amux_workspace": wsID,
+	}
+	if _, err := a.tmuxService.KillSessionsMatchingTags(tags, a.tmuxOptions); err != nil {
+		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
+	}
+	if err := a.tmuxService.KillWorkspaceSessions(wsID, a.tmuxOptions); err != nil {
+		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
+	}
+}
+
 func (a *App) cleanupAllTmuxSessions() tea.Cmd {
 	opts := a.tmuxOptions
 	svc := a.tmuxService

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -41,9 +41,9 @@ func (a *App) cleanupWorkspaceTmuxSessions(ws *data.Workspace) tea.Cmd {
 }
 
 // killWorkspaceSessionsSync synchronously tears down a workspace's tmux sessions
-// by tag. The delete path calls this after validation passes but before removing
-// the worktree, so the agent process group (CWD = worktree root) is gone before
-// its directory is. No-op when tmux is unavailable.
+// by tag. The delete path calls this only after worktree removal succeeds, so a
+// failed delete does not destroy live agent sessions. No-op when tmux is
+// unavailable.
 func (a *App) killWorkspaceSessionsSync(wsID string) {
 	if a.tmuxService == nil || wsID == "" {
 		return

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -274,21 +274,15 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("validate_managed_root", fmt.Errorf("workspace root %s is outside managed project root", ws.Root))
 		}
 
-		// Validation passed, so this delete will proceed. Tear down the workspace's
-		// tmux sessions before removing the worktree: the agent pane's CWD is the
-		// worktree root, so killing the process group first avoids removing a
-		// directory still held by a live process (and the spurious remove warnings
-		// that follow). The kill happens only here, after validation — never on a
-		// rejected delete.
-		if s.killWorkspaceSessions != nil {
-			s.killWorkspaceSessions(wsID)
-		}
-
 		if err := s.gitOps.RemoveWorkspace(projectPath, ws.Root); err != nil {
 			if !git.IsUnregisteredWorkspacePathError(err) {
+				if workspacePathGone(ws.Root) {
+					s.killWorkspaceSessionsForDelete(wsID)
+				}
 				return fail("remove_worktree", err)
 			}
 			if _, statErr := os.Stat(ws.Root); os.IsNotExist(statErr) {
+				s.killWorkspaceSessionsForDelete(wsID)
 				return fail("remove_worktree", err)
 			} else if statErr != nil {
 				return fail("remove_worktree", errors.Join(err, statErr))
@@ -301,6 +295,11 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			}
 			logging.Warn("workspace delete stale cleanup workspace_id=%s workspace_root=%s remove_error=%v", wsID, ws.Root, err)
 		}
+
+		// The worktree removal has succeeded or an owned stale path was cleaned up.
+		// Tear down any remaining workspace tmux sessions before metadata deletion,
+		// but never kill sessions for a delete that failed and left the workspace.
+		s.killWorkspaceSessionsForDelete(wsID)
 
 		if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
 			logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
@@ -323,6 +322,17 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			Workspace: ws,
 		}
 	}
+}
+
+func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) {
+	if s != nil && s.killWorkspaceSessions != nil {
+		s.killWorkspaceSessions(wsID)
+	}
+}
+
+func workspacePathGone(path string) bool {
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
 }
 
 // RemoveProject removes a project from the registry (does not delete files).

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -274,6 +274,16 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("validate_managed_root", fmt.Errorf("workspace root %s is outside managed project root", ws.Root))
 		}
 
+		// Validation passed, so this delete will proceed. Tear down the workspace's
+		// tmux sessions before removing the worktree: the agent pane's CWD is the
+		// worktree root, so killing the process group first avoids removing a
+		// directory still held by a live process (and the spurious remove warnings
+		// that follow). The kill happens only here, after validation — never on a
+		// rejected delete.
+		if s.killWorkspaceSessions != nil {
+			s.killWorkspaceSessions(wsID)
+		}
+
 		if err := s.gitOps.RemoveWorkspace(projectPath, ws.Root); err != nil {
 			if !git.IsUnregisteredWorkspacePathError(err) {
 				return fail("remove_worktree", err)

--- a/internal/app/workspace_service_delete_kill_order_test.go
+++ b/internal/app/workspace_service_delete_kill_order_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,10 +10,7 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 )
 
-// TestDeleteWorkspace_KillsSessionsBeforeWorktreeRemoval proves the delete path
-// tears down the workspace's tmux sessions before removing the worktree, so the
-// agent process group (CWD = worktree root) is gone before its directory is.
-func TestDeleteWorkspace_KillsSessionsBeforeWorktreeRemoval(t *testing.T) {
+func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -51,7 +49,74 @@ func TestDeleteWorkspace_KillsSessionsBeforeWorktreeRemoval(t *testing.T) {
 	if removeOrder == -1 {
 		t.Fatal("expected the worktree to be removed during delete")
 	}
-	if killOrder >= removeOrder {
-		t.Fatalf("expected kill (order %d) before worktree removal (order %d)", killOrder, removeOrder)
+	if killOrder <= removeOrder {
+		t.Fatalf("expected kill (order %d) after worktree removal (order %d)", killOrder, removeOrder)
+	}
+}
+
+func TestDeleteWorkspace_DoesNotKillSessionsWhenWorktreeRemovalFails(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error {
+			return errors.New("remove failed")
+		},
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	svc.killWorkspaceSessions = func(wsID string) {
+		t.Fatal("failed delete must not kill workspace tmux sessions")
+	}
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+}
+
+func TestDeleteWorkspace_KillsSessionsWhenRemovalFailsAfterPathGone(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error {
+			if err := os.RemoveAll(workspacePath); err != nil {
+				t.Fatalf("RemoveAll(workspacePath) error = %v", err)
+			}
+			return errors.New("remove failed after path removal")
+		},
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	killed := false
+	svc.killWorkspaceSessions = func(wsID string) {
+		killed = true
+	}
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+	if !killed {
+		t.Fatal("expected sessions killed when removal failed after deleting workspace path")
 	}
 }

--- a/internal/app/workspace_service_delete_kill_order_test.go
+++ b/internal/app/workspace_service_delete_kill_order_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// TestDeleteWorkspace_KillsSessionsBeforeWorktreeRemoval proves the delete path
+// tears down the workspace's tmux sessions before removing the worktree, so the
+// agent process group (CWD = worktree root) is gone before its directory is.
+func TestDeleteWorkspace_KillsSessionsBeforeWorktreeRemoval(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	order := 0
+	killOrder, removeOrder := -1, -1
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error {
+			order++
+			removeOrder = order
+			return nil
+		},
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	svc.killWorkspaceSessions = func(wsID string) {
+		order++
+		killOrder = order
+	}
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleted); !ok {
+		t.Fatalf("expected WorkspaceDeleted, got %T", msg)
+	}
+	if killOrder == -1 {
+		t.Fatal("expected workspace tmux sessions to be killed during delete")
+	}
+	if removeOrder == -1 {
+		t.Fatal("expected the worktree to be removed during delete")
+	}
+	if killOrder >= removeOrder {
+		t.Fatalf("expected kill (order %d) before worktree removal (order %d)", killOrder, removeOrder)
+	}
+}

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -50,8 +50,8 @@ type workspaceService struct {
 	deleteInFlightGuard func(wsID string, fn func()) bool
 	// killWorkspaceSessions synchronously tears down a workspace's tmux sessions.
 	// Wired in app_init; nil in directly-constructed services (a no-op). Called
-	// after delete validation passes but before the worktree is removed, so the
-	// agent process group (CWD = workspace root) is gone before its dir is.
+	// only after worktree removal succeeds, so failed deletes leave live sessions
+	// intact.
 	killWorkspaceSessions func(wsID string)
 }
 

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -48,6 +48,11 @@ type workspaceService struct {
 	// deleteInFlightGuard runs a store mutation only when the workspace is not
 	// mid-delete, keeping the check atomic with App delete-state updates.
 	deleteInFlightGuard func(wsID string, fn func()) bool
+	// killWorkspaceSessions synchronously tears down a workspace's tmux sessions.
+	// Wired in app_init; nil in directly-constructed services (a no-op). Called
+	// after delete validation passes but before the worktree is removed, so the
+	// agent process group (CWD = workspace root) is gone before its dir is.
+	killWorkspaceSessions func(wsID string)
 }
 
 // isDeleteInFlight reports whether the workspace is mid-delete. It is nil-safe so


### PR DESCRIPTION
## Plan stack — PR 15/41

## Problem
Agent panes have CWD = `ws.Root`. After the keystone (PR 14) moved the kill to the confirmed-success handler, the kill ran **after** `git worktree remove`, so the agent process group still held the worktree directory while it was removed (relying on rename-aside recovery, emitting spurious remove warnings).

## Change
Rather than re-introduce an app-layer kill cmd (which PR 14 deliberately removed), wire a nil-safe `killWorkspaceSessions` hook into `workspaceService` (mirroring `deleteInFlight`) and call it in `DeleteWorkspace` **after all validation passes but before `gitOps.RemoveWorkspace`**. The kill happens only on a delete that will proceed — never a rejected one (preserving the keystone fix) — and the agent is gone before its CWD is. This coordinates with PR 14 so only one place owns kill-sequencing; PR 16 removes the now-redundant trailing cleanup.

## Test
Ordered-recording fakes assert kill-index < worktree-removal-index. The full delete suite (hook left nil) is unaffected. Strict ratchet clean.