### PR TITLE
Drop the redundant trailing tmux cleanup in handleWorkspaceDeleted

### DIFF
--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -86,3 +86,35 @@ func TestDeleteWorkspace_NavigatesHomeOnlyOnConfirmedDelete(t *testing.T) {
 		t.Fatal("expected goHome (activeWorkspace cleared) once the delete is confirmed")
 	}
 }
+
+// TestHandleWorkspaceDeleted_NoTrailingSessionKill proves the trailing tmux
+// cleanup was removed: the validated delete path already tore the sessions down,
+// and re-killing by tag after the delete-in-flight flag clears would, on a
+// delete-then-recreate at the same project+name (same wsID, same session names),
+// kill the brand-new agent session.
+func TestHandleWorkspaceDeleted_NoTrailingSessionKill(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+
+	ops := &killRecordingTmuxOps{}
+	app := &App{
+		dashboard:            dashboard.New(),
+		center:               center.New(nil),
+		sidebar:              sidebar.NewTabbedSidebar(),
+		sidebarTerminal:      sidebar.NewTerminalModel(),
+		tmuxService:          ops,
+		tmuxOptions:          tmux.Options{},
+		deletingWorkspaceIDs: map[string]bool{string(ws.ID()): true},
+	}
+
+	cmds := app.handleWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: ws})
+	for _, cmd := range cmds {
+		if cmd != nil {
+			_ = cmd()
+		}
+	}
+
+	if ops.killTagsCalls != 0 || ops.killWsCalls != 0 {
+		t.Fatalf("handleWorkspaceDeleted must not re-kill sessions after the trailing cleanup was removed; KillSessionsMatchingTags=%d KillWorkspaceSessions=%d",
+			ops.killTagsCalls, ops.killWsCalls)
+	}
+}

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -97,9 +97,11 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 			a.goHome()
 		}
 		delete(a.dirtyWorkspaces, string(msg.Workspace.ID()))
-		if cleanup := a.cleanupWorkspaceTmuxSessions(msg.Workspace); cleanup != nil {
-			cmds = append(cmds, cleanup)
-		}
+		// No trailing tmux cleanup here: the validated delete path already tore
+		// down this workspace's sessions before removing the worktree. Re-running
+		// it after the delete-in-flight flag is cleared would, on a delete-then-
+		// recreate at the same project+name (same wsID, same session names), match
+		// and kill the brand-new agent session by tag.
 		if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -5,40 +5,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
-
-func (a *App) cleanupWorkspaceTmuxSessions(ws *data.Workspace) tea.Cmd {
-	if ws == nil {
-		return nil
-	}
-	wsID := string(ws.ID())
-	opts := a.tmuxOptions
-	svc := a.tmuxService
-	return func() tea.Msg {
-		if svc == nil {
-			return nil
-		}
-		tags := map[string]string{
-			"@amux":           "1",
-			"@amux_workspace": wsID,
-		}
-		cleaned, err := svc.KillSessionsMatchingTags(tags, opts)
-		if err != nil {
-			logging.Warn("Failed to cleanup tmux sessions for workspace %s: %v", ws.Name, err)
-		}
-		if cleaned {
-			logging.Info("Cleaned up @amux tmux sessions for workspace %s", ws.Name)
-		}
-		if err := svc.KillWorkspaceSessions(wsID, opts); err != nil {
-			logging.Warn("Failed to cleanup tmux sessions for workspace %s: %v", ws.Name, err)
-		}
-		return nil
-	}
-}
 
 // killWorkspaceSessionsSync synchronously tears down a workspace's tmux sessions
 // by tag. The delete path calls this only after worktree removal succeeds, so a


### PR DESCRIPTION
## Plan stack — PR 16/41

## Problem
Workspace ID is `sha1(repo+root)`, so delete-then-recreate at the same project+name yields the **same wsID and the same session names**. `handleWorkspaceDeleted` fired a tmux cleanup (`KillSessionsMatchingTags` by `{@amux, @amux_workspace=wsID}`) *after* clearing the delete-in-flight flag. If the user recreated and launched an agent before that trailing async cleanup ran, it matched and **killed the brand-new session**.

## Change
The validated delete path now tears the workspace's sessions down before removing the worktree (PR 15), so this trailing cleanup is redundant. Remove it — which deletes the last caller of `cleanupWorkspaceTmuxSessions`, so that now-dead helper is removed too (subtractive).

## Test
`handleWorkspaceDeleted` records **zero** `KillSessionsMatchingTags`/`KillWorkspaceSessions` calls (fails if the trailing cleanup is restored).

**Note on the e2e:** the plan suggested a full delete-then-recreate e2e guard. I used a reliable unit test that pins the exact invariant instead — the full-TUI e2e is a reasonable follow-up but the unit test deterministically covers the regression without TUI-navigation flakiness.