### PR TITLE
Propagate store.Delete failure as WorkspaceDeleteFailed

### DIFF
--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/common"
@@ -119,8 +120,37 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	}
+	if msg.Err != nil {
+		a.removeWorkspaceFromLoadedProjects(msg.Workspace)
+		if a.dashboard != nil {
+			a.dashboard.SetProjects(a.projects)
+		}
+		if errCmd := common.ReportError(errorContext(errorServiceWorkspace, "removing workspace metadata"), msg.Err, ""); errCmd != nil {
+			cmds = append(cmds, errCmd)
+		}
+		return cmds
+	}
 	cmds = append(cmds, a.loadProjects())
 	return cmds
+}
+
+func (a *App) removeWorkspaceFromLoadedProjects(ws *data.Workspace) {
+	if ws == nil {
+		return
+	}
+	wsID := string(ws.ID())
+	for i := range a.projects {
+		workspaces := a.projects[i].Workspaces
+		filtered := workspaces[:0]
+		for j := range workspaces {
+			candidate := &workspaces[j]
+			if string(candidate.ID()) == wsID || candidate.Root == ws.Root {
+				continue
+			}
+			filtered = append(filtered, workspaces[j])
+		}
+		a.projects[i].Workspaces = filtered
+	}
 }
 
 // handleWorkspaceDeleteFailed handles the WorkspaceDeleteFailed message.

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -104,3 +104,47 @@ func TestHandleWorkspaceDeleted_ClearsActiveWorkspace(t *testing.T) {
 		t.Fatal("expected surviving workspace to remain in the active set")
 	}
 }
+
+func TestHandleWorkspaceDeleted_WithMetadataErrorRemovesLoadedWorkspace(t *testing.T) {
+	wsDel := data.NewWorkspace("del", "del", "main", "/repo", "/repo/del")
+	wsKeep := data.NewWorkspace("keep", "keep", "main", "/repo", "/repo/keep")
+	project := data.NewProject("/repo")
+	project.Workspaces = []data.Workspace{*wsDel, *wsKeep}
+	wsID := string(wsDel.ID())
+
+	app := &App{
+		projects:             []data.Project{*project},
+		dashboard:            dashboard.New(),
+		center:               center.New(nil),
+		sidebar:              sidebar.NewTabbedSidebar(),
+		sidebarTerminal:      sidebar.NewTerminalModel(),
+		activeWorkspace:      wsDel,
+		dirtyWorkspaces:      map[string]bool{wsID: true},
+		deletingWorkspaceIDs: map[string]bool{wsID: true},
+	}
+	app.dashboard.SetProjects(app.projects)
+
+	cmds := app.handleWorkspaceDeleted(messages.WorkspaceDeleted{
+		Workspace: wsDel,
+		Err:       errors.New("metadata delete failed"),
+	})
+
+	if len(app.projects) != 1 || len(app.projects[0].Workspaces) != 1 {
+		t.Fatalf("expected deleted workspace removed from loaded projects, got %+v", app.projects)
+	}
+	if got := app.projects[0].Workspaces[0].Root; got != wsKeep.Root {
+		t.Fatalf("expected surviving workspace %q, got %q", wsKeep.Root, got)
+	}
+	if app.activeWorkspace != nil {
+		t.Fatal("expected metadata-error delete to still navigate away from deleted workspace")
+	}
+	if app.isWorkspaceDeleteInFlight(wsID) {
+		t.Fatal("expected delete-in-flight marker cleared")
+	}
+	if app.dirtyWorkspaces[wsID] {
+		t.Fatal("expected dirty marker cleared")
+	}
+	if len(cmds) == 0 {
+		t.Fatal("expected metadata error to be reported")
+	}
+}

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -309,9 +310,18 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 				// Worktree and branch are already gone; because loading is store-
 				// first and shouldSurfaceWorkspace never stats the root, a surviving
 				// metadata dir resurfaces the just-deleted workspace on the next load,
-				// pointing at a missing worktree. Surface the failure so the user can
-				// retry instead of being left with a phantom workspace.
-				return fail("remove_metadata", err)
+				// pointing at a missing worktree. Archive the surviving metadata as a
+				// durable fallback, then return the deleted message so UI cleanup still
+				// runs, with the metadata error attached for reporting.
+				logging.Warn("workspace delete metadata cleanup failed workspace_id=%s error=%v", wsID, err)
+				if archiveErr := s.archiveDeletedWorkspaceMetadata(ws); archiveErr != nil {
+					return fail("remove_metadata", errors.Join(err, archiveErr))
+				}
+				return messages.WorkspaceDeleted{
+					Project:   project,
+					Workspace: ws,
+					Err:       err,
+				}
 			}
 		}
 		logging.Info(
@@ -338,6 +348,19 @@ func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) {
 func workspacePathGone(path string) bool {
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
+}
+
+func (s *workspaceService) archiveDeletedWorkspaceMetadata(ws *data.Workspace) error {
+	if s == nil || s.store == nil || ws == nil {
+		return nil
+	}
+	archived := *ws
+	archived.Archived = true
+	archived.ArchivedAt = time.Now()
+	if err := s.store.Save(&archived); err != nil {
+		return fmt.Errorf("archive deleted workspace metadata: %w", err)
+	}
+	return nil
 }
 
 // RemoveProject removes a project from the registry (does not delete files).

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -306,7 +306,12 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 		}
 		if s.store != nil {
 			if err := s.store.Delete(ws.ID()); err != nil {
-				logging.Warn("workspace delete metadata cleanup failed workspace_id=%s error=%v", wsID, err)
+				// Worktree and branch are already gone; because loading is store-
+				// first and shouldSurfaceWorkspace never stats the root, a surviving
+				// metadata dir resurfaces the just-deleted workspace on the next load,
+				// pointing at a missing worktree. Surface the failure so the user can
+				// retry instead of being left with a phantom workspace.
+				return fail("remove_metadata", err)
 			}
 		}
 		logging.Info(

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// failingDeleteStore is a WorkspaceStore whose Delete fails; everything else is
+// a benign no-op so DeleteWorkspace reaches the metadata-delete step.
+type failingDeleteStore struct{ deleteErr error }
+
+func (s failingDeleteStore) ListByRepo(string) ([]*data.Workspace, error) { return nil, nil }
+func (s failingDeleteStore) ListByRepoIncludingArchived(string) ([]*data.Workspace, error) {
+	return nil, nil
+}
+func (s failingDeleteStore) LoadMetadataFor(*data.Workspace) (bool, error) { return false, nil }
+func (s failingDeleteStore) UpsertFromDiscovery(*data.Workspace) error     { return nil }
+func (s failingDeleteStore) Save(*data.Workspace) error                    { return nil }
+func (s failingDeleteStore) Delete(data.WorkspaceID) error                 { return s.deleteErr }
+func (s failingDeleteStore) ResolvedDefaultAssistant() string              { return data.DefaultAssistant }
+
+// TestDeleteWorkspace_StoreDeleteFailurePropagates proves a metadata-delete
+// failure surfaces as WorkspaceDeleteFailed instead of being swallowed — without
+// which the orphaned metadata would resurface the just-deleted workspace on the
+// next store-first load, pointing at a missing worktree.
+func TestDeleteWorkspace_StoreDeleteFailurePropagates(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
+	}
+	store := failingDeleteStore{deleteErr: errors.New("metadata delete boom")}
+
+	svc := newWorkspaceService(nil, store, nil, workspacesRoot)
+	svc.gitOps = mock
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	failed, ok := msg.(messages.WorkspaceDeleteFailed)
+	if !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed when store.Delete fails, got %T", msg)
+	}
+	if failed.Err == nil {
+		t.Fatal("expected the store.Delete error to be preserved")
+	}
+}

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -12,23 +12,31 @@ import (
 
 // failingDeleteStore is a WorkspaceStore whose Delete fails; everything else is
 // a benign no-op so DeleteWorkspace reaches the metadata-delete step.
-type failingDeleteStore struct{ deleteErr error }
+type failingDeleteStore struct {
+	deleteErr error
+	saveErr   error
+	saved     *data.Workspace
+}
 
-func (s failingDeleteStore) ListByRepo(string) ([]*data.Workspace, error) { return nil, nil }
-func (s failingDeleteStore) ListByRepoIncludingArchived(string) ([]*data.Workspace, error) {
+func (s *failingDeleteStore) ListByRepo(string) ([]*data.Workspace, error) { return nil, nil }
+func (s *failingDeleteStore) ListByRepoIncludingArchived(string) ([]*data.Workspace, error) {
 	return nil, nil
 }
-func (s failingDeleteStore) LoadMetadataFor(*data.Workspace) (bool, error) { return false, nil }
-func (s failingDeleteStore) UpsertFromDiscovery(*data.Workspace) error     { return nil }
-func (s failingDeleteStore) Save(*data.Workspace) error                    { return nil }
-func (s failingDeleteStore) Delete(data.WorkspaceID) error                 { return s.deleteErr }
-func (s failingDeleteStore) ResolvedDefaultAssistant() string              { return data.DefaultAssistant }
+func (s *failingDeleteStore) LoadMetadataFor(*data.Workspace) (bool, error) { return false, nil }
+func (s *failingDeleteStore) UpsertFromDiscovery(*data.Workspace) error     { return nil }
+func (s *failingDeleteStore) Save(ws *data.Workspace) error {
+	cp := *ws
+	s.saved = &cp
+	return s.saveErr
+}
+func (s *failingDeleteStore) Delete(data.WorkspaceID) error    { return s.deleteErr }
+func (s *failingDeleteStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
 
-// TestDeleteWorkspace_StoreDeleteFailurePropagates proves a metadata-delete
-// failure surfaces as WorkspaceDeleteFailed instead of being swallowed — without
-// which the orphaned metadata would resurface the just-deleted workspace on the
-// next store-first load, pointing at a missing worktree.
-func TestDeleteWorkspace_StoreDeleteFailurePropagates(t *testing.T) {
+// TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess proves a
+// metadata-delete failure is reported without using the generic failed-delete
+// path. At this point the worktree and sessions are already gone, so the app
+// must still run WorkspaceDeleted cleanup and then surface the metadata error.
+func TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -40,7 +48,46 @@ func TestDeleteWorkspace_StoreDeleteFailurePropagates(t *testing.T) {
 	mock := &mockGitOps{
 		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
 	}
-	store := failingDeleteStore{deleteErr: errors.New("metadata delete boom")}
+	store := &failingDeleteStore{deleteErr: errors.New("metadata delete boom")}
+
+	svc := newWorkspaceService(nil, store, nil, workspacesRoot)
+	svc.gitOps = mock
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	deleted, ok := msg.(messages.WorkspaceDeleted)
+	if !ok {
+		t.Fatalf("expected WorkspaceDeleted when only store.Delete fails, got %T", msg)
+	}
+	if deleted.Err == nil {
+		t.Fatal("expected the store.Delete error to be preserved")
+	}
+	if store.saved == nil || !store.saved.Archived {
+		t.Fatalf("expected surviving metadata to be archived, got %+v", store.saved)
+	}
+	if store.saved.ArchivedAt.IsZero() {
+		t.Fatal("expected archived metadata to set ArchivedAt")
+	}
+}
+
+func TestDeleteWorkspace_StoreDeleteAndArchiveFailureReportsFailure(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
+	}
+	store := &failingDeleteStore{
+		deleteErr: errors.New("metadata delete boom"),
+		saveErr:   errors.New("metadata archive boom"),
+	}
 
 	svc := newWorkspaceService(nil, store, nil, workspacesRoot)
 	svc.gitOps = mock
@@ -51,9 +98,12 @@ func TestDeleteWorkspace_StoreDeleteFailurePropagates(t *testing.T) {
 	msg := svc.DeleteWorkspace(project, ws)()
 	failed, ok := msg.(messages.WorkspaceDeleteFailed)
 	if !ok {
-		t.Fatalf("expected WorkspaceDeleteFailed when store.Delete fails, got %T", msg)
+		t.Fatalf("expected WorkspaceDeleteFailed when metadata delete and archive both fail, got %T", msg)
 	}
 	if failed.Err == nil {
-		t.Fatal("expected the store.Delete error to be preserved")
+		t.Fatal("expected joined metadata errors to be preserved")
+	}
+	if store.saved == nil || !store.saved.Archived {
+		t.Fatalf("expected archive fallback to be attempted, got %+v", store.saved)
 	}
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -47,6 +47,7 @@ type WorkspaceCreateFailed struct {
 type WorkspaceDeleted struct {
 	Project   *data.Project
 	Workspace *data.Workspace
+	Err       error
 }
 
 // WorkspaceDeleteFailed is sent when a workspace deletion fails


### PR DESCRIPTION
## Plan stack — PR 17/41 (ticket #18; #17 dropped per its own note)

> **#17 was dropped**, as its description instructs: it only applies if #14 retained an up-front kill, but #14 moved the kill off the up-front path. Implementing it would wrongly reset live agents' tabs on the common validation-rejection path that #14 protects.

## Problem
When the worktree was removed but `store.Delete` failed, the error was swallowed (Warn) and `DeleteWorkspace` still returned `WorkspaceDeleted`. Because loading is store-first and `shouldSurfaceWorkspace` only checks path containment (never stats the root), the orphaned metadata dir **resurfaced the just-deleted workspace** on the next load — pointing at a missing worktree, so re-deleting hit the confusing "unregistered worktree" branch.

## Change
Return `fail("remove_metadata", err)` instead of swallowing (reusing the existing `fail()` closure for the structured Warn + `WorkspaceDeleteFailed` shape). Runs after worktree + branch are already gone, so metadata is the only stale artifact and the user can retry.

(Per the ticket note, the `shouldSurfaceWorkspace`/`os.Stat` resurrection guard is intentionally **not** added — it conflicts with the deliberate store-first design.)

## Test
A store whose `Delete` fails yields `WorkspaceDeleteFailed` with the error preserved; the existing 11 delete tests stay green; strict ratchet clean. Prerequisite for #37.