### PR TITLE
Surface branch-delete failures on workspace delete via a warning toast

### DIFF
--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -85,6 +85,9 @@ func (a *App) handleWorkspaceCreateFailed(msg messages.WorkspaceCreateFailed) te
 // handleWorkspaceDeleted handles the WorkspaceDeleted message.
 func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 	var cmds []tea.Cmd
+	if msg.Warning != "" {
+		cmds = append(cmds, a.toast.ShowWarning(msg.Warning))
+	}
 	if msg.Workspace != nil {
 		a.markWorkspaceDeleteInFlight(msg.Workspace, false)
 		// Drop the deleted workspace from the active set now rather than waiting

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -302,8 +302,10 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 		// but never kill sessions for a delete that failed and left the workspace.
 		s.killWorkspaceSessionsForDelete(wsID)
 
+		var warning string
 		if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
 			logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
+			warning = fmt.Sprintf("workspace deleted but branch %s was left behind: %v", ws.Branch, err)
 		}
 		if s.store != nil {
 			if err := s.store.Delete(ws.ID()); err != nil {
@@ -335,6 +337,7 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 		return messages.WorkspaceDeleted{
 			Project:   project,
 			Workspace: ws,
+			Warning:   warning,
 		}
 	}
 }

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -323,6 +323,7 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 					Project:   project,
 					Workspace: ws,
 					Err:       err,
+					Warning:   warning,
 				}
 			}
 		}

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -47,6 +47,7 @@ func TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess(t *testing.T) {
 
 	mock := &mockGitOps{
 		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
+		deleteBranch:    func(repoPath, branch string) error { return errors.New("branch checked out elsewhere") },
 	}
 	store := &failingDeleteStore{deleteErr: errors.New("metadata delete boom")}
 
@@ -63,6 +64,9 @@ func TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess(t *testing.T) {
 	}
 	if deleted.Err == nil {
 		t.Fatal("expected the store.Delete error to be preserved")
+	}
+	if deleted.Warning == "" {
+		t.Fatal("expected branch-delete warning to be preserved with metadata error")
 	}
 	if store.saved == nil || !store.saved.Archived {
 		t.Fatalf("expected surviving metadata to be archived, got %+v", store.saved)

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -107,3 +107,36 @@ func TestDeleteWorkspace_StoreDeleteAndArchiveFailureReportsFailure(t *testing.T
 		t.Fatalf("expected archive fallback to be attempted, got %+v", store.saved)
 	}
 }
+
+// TestDeleteWorkspace_BranchDeleteFailureSurfacesWarning proves a failed branch
+// delete is reported (not silently logged): the delete still succeeds but the
+// returned WorkspaceDeleted carries a Warning so the user is told the branch was
+// left behind.
+func TestDeleteWorkspace_BranchDeleteFailureSurfacesWarning(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
+		deleteBranch:    func(repoPath, branch string) error { return errors.New("branch checked out elsewhere") },
+	}
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	deleted, ok := msg.(messages.WorkspaceDeleted)
+	if !ok {
+		t.Fatalf("expected WorkspaceDeleted (delete still succeeds), got %T", msg)
+	}
+	if deleted.Warning == "" {
+		t.Fatal("expected a non-empty Warning when branch delete fails")
+	}
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -48,6 +48,9 @@ type WorkspaceDeleted struct {
 	Project   *data.Project
 	Workspace *data.Workspace
 	Err       error
+	// Warning is a non-fatal note (e.g. the branch could not be deleted). The
+	// workspace delete still succeeded; this is surfaced to the user as a toast.
+	Warning string
 }
 
 // WorkspaceDeleteFailed is sent when a workspace deletion fails


### PR DESCRIPTION
## Plan stack — PR 18/41 (ticket #19)

## Problem
When `DeleteBranch` failed during workspace delete, the error was silently logged at Warn with no user feedback. A persistently failing branch delete (e.g. branch checked out elsewhere) leaves an orphaned branch accumulating in the repo with the user never told — "delete workspace" silently leaves repo cruft.

## Change
- Add a `Warning string` field to `messages.WorkspaceDeleted` (mirroring `WorkspaceCreatedWithWarning`).
- On a `DeleteBranch` failure, keep the Warn log but also set `Warning` on the **successful** `WorkspaceDeleted` return (delete still succeeds).
- `handleWorkspaceDeleted` shows it as a warning toast.

(Per the ticket note, no `PruneWorktrees` git op — the stale path reaches `IsUnregisteredWorkspacePathError`, so the worktree is already unregistered.)

## Test
A `mockGitOps` whose `deleteBranch` fails yields `WorkspaceDeleted` with a non-empty `Warning` while the delete still succeeds; existing delete suite green; strict ratchet clean.