### PR TITLE
Instance-scope the workspace-delete tmux kill

### DIFF
--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -15,9 +15,12 @@ import (
 // session is destroyed before the delete is validated.
 type killRecordingTmuxOps struct {
 	stubTmuxOps
-	killTagsCalls int
-	killWsCalls   int
-	lastKillTags  map[string]string
+	killTagsCalls             int
+	killWsCalls               int
+	killPrefixMissingTagCalls int
+	lastKillTags              map[string]string
+	lastMissingPrefix         string
+	lastMissingTag            string
 }
 
 func (k *killRecordingTmuxOps) KillSessionsMatchingTags(tags map[string]string, _ tmux.Options) (bool, error) {
@@ -28,6 +31,13 @@ func (k *killRecordingTmuxOps) KillSessionsMatchingTags(tags map[string]string, 
 
 func (k *killRecordingTmuxOps) KillWorkspaceSessions(string, tmux.Options) error {
 	k.killWsCalls++
+	return nil
+}
+
+func (k *killRecordingTmuxOps) KillSessionsWithPrefixMissingTag(prefix, tag string, _ tmux.Options) error {
+	k.killPrefixMissingTagCalls++
+	k.lastMissingPrefix = prefix
+	k.lastMissingTag = tag
 	return nil
 }
 
@@ -122,10 +132,11 @@ func TestHandleWorkspaceDeleted_NoTrailingSessionKill(t *testing.T) {
 }
 
 // TestKillWorkspaceSessionsSync_InstanceScoped proves the delete kill is scoped
-// to this instance and no longer uses the instance-blind prefix kill, so a
-// workspace shared with another amux process is not torn down across instances.
+// to this instance and only uses a prefix fallback for legacy sessions that have
+// no @amux_instance tag, so a workspace shared with another amux process is not
+// torn down across instances.
 func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
-	t.Run("scopes tag match to instance and drops prefix kill", func(t *testing.T) {
+	t.Run("scopes tag match to instance and legacy prefix kill", func(t *testing.T) {
 		ops := &killRecordingTmuxOps{}
 		app := &App{tmuxService: ops, instanceID: "inst-A"}
 
@@ -133,6 +144,12 @@ func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
 
 		if ops.killWsCalls != 0 {
 			t.Fatalf("expected no prefix KillWorkspaceSessions (it ignores instance), got %d", ops.killWsCalls)
+		}
+		if ops.killPrefixMissingTagCalls != 1 {
+			t.Fatalf("expected one legacy missing-tag prefix cleanup, got %d", ops.killPrefixMissingTagCalls)
+		}
+		if ops.lastMissingPrefix != tmux.SessionName("amux", "ws-1")+"-" || ops.lastMissingTag != "@amux_instance" {
+			t.Fatalf("unexpected legacy cleanup prefix/tag: %q %q", ops.lastMissingPrefix, ops.lastMissingTag)
 		}
 		if ops.lastKillTags["@amux_instance"] != "inst-A" {
 			t.Fatalf("expected @amux_instance scoping, got tags %v", ops.lastKillTags)
@@ -150,6 +167,12 @@ func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
 
 		if _, ok := ops.lastKillTags["@amux_instance"]; ok {
 			t.Fatalf("empty instanceID must not add @amux_instance, got %v", ops.lastKillTags)
+		}
+		if ops.killWsCalls != 1 {
+			t.Fatalf("empty instanceID should keep broad workspace prefix cleanup, got %d", ops.killWsCalls)
+		}
+		if ops.killPrefixMissingTagCalls != 0 {
+			t.Fatalf("empty instanceID should not use missing-tag fallback, got %d", ops.killPrefixMissingTagCalls)
 		}
 		if ops.lastKillTags["@amux_workspace"] != "ws-1" {
 			t.Fatalf("expected @amux_workspace tag even when broad, got %v", ops.lastKillTags)

--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -17,10 +17,12 @@ type killRecordingTmuxOps struct {
 	stubTmuxOps
 	killTagsCalls int
 	killWsCalls   int
+	lastKillTags  map[string]string
 }
 
-func (k *killRecordingTmuxOps) KillSessionsMatchingTags(map[string]string, tmux.Options) (bool, error) {
+func (k *killRecordingTmuxOps) KillSessionsMatchingTags(tags map[string]string, _ tmux.Options) (bool, error) {
 	k.killTagsCalls++
+	k.lastKillTags = tags
 	return false, nil
 }
 
@@ -117,4 +119,40 @@ func TestHandleWorkspaceDeleted_NoTrailingSessionKill(t *testing.T) {
 		t.Fatalf("handleWorkspaceDeleted must not re-kill sessions after the trailing cleanup was removed; KillSessionsMatchingTags=%d KillWorkspaceSessions=%d",
 			ops.killTagsCalls, ops.killWsCalls)
 	}
+}
+
+// TestKillWorkspaceSessionsSync_InstanceScoped proves the delete kill is scoped
+// to this instance and no longer uses the instance-blind prefix kill, so a
+// workspace shared with another amux process is not torn down across instances.
+func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
+	t.Run("scopes tag match to instance and drops prefix kill", func(t *testing.T) {
+		ops := &killRecordingTmuxOps{}
+		app := &App{tmuxService: ops, instanceID: "inst-A"}
+
+		app.killWorkspaceSessionsSync("ws-1")
+
+		if ops.killWsCalls != 0 {
+			t.Fatalf("expected no prefix KillWorkspaceSessions (it ignores instance), got %d", ops.killWsCalls)
+		}
+		if ops.lastKillTags["@amux_instance"] != "inst-A" {
+			t.Fatalf("expected @amux_instance scoping, got tags %v", ops.lastKillTags)
+		}
+		if ops.lastKillTags["@amux_workspace"] != "ws-1" {
+			t.Fatalf("expected @amux_workspace tag, got %v", ops.lastKillTags)
+		}
+	})
+
+	t.Run("empty instanceID keeps broad match", func(t *testing.T) {
+		ops := &killRecordingTmuxOps{}
+		app := &App{tmuxService: ops, instanceID: ""}
+
+		app.killWorkspaceSessionsSync("ws-1")
+
+		if _, ok := ops.lastKillTags["@amux_instance"]; ok {
+			t.Fatalf("empty instanceID must not add @amux_instance, got %v", ops.lastKillTags)
+		}
+		if ops.lastKillTags["@amux_workspace"] != "ws-1" {
+			t.Fatalf("expected @amux_workspace tag even when broad, got %v", ops.lastKillTags)
+		}
+	})
 }

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -35,10 +35,16 @@ func (a *App) killWorkspaceSessionsSync(wsID string) {
 	if _, err := a.tmuxService.KillSessionsMatchingTags(tags, a.tmuxOptions); err != nil {
 		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
 	}
-	// Deliberately NOT calling KillWorkspaceSessions(wsID): it kills by the
-	// amux-<wsID>- name prefix, which has no instance component and would re-kill
-	// every instance's sessions, defeating the instance scoping above. The tag
-	// match covers all correctly-tagged sessions for this instance.
+	prefix := tmux.SessionName("amux", wsID) + "-"
+	if strings.TrimSpace(a.instanceID) == "" {
+		if err := a.tmuxService.KillWorkspaceSessions(wsID, a.tmuxOptions); err != nil {
+			logging.Warn("Failed to kill tmux legacy sessions for workspace %s before worktree removal: %v", wsID, err)
+		}
+		return
+	}
+	if err := a.tmuxService.KillSessionsWithPrefixMissingTag(prefix, "@amux_instance", a.tmuxOptions); err != nil {
+		logging.Warn("Failed to kill legacy tmux sessions for workspace %s before worktree removal: %v", wsID, err)
+	}
 }
 
 func (a *App) cleanupAllTmuxSessions() tea.Cmd {

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -22,12 +23,22 @@ func (a *App) killWorkspaceSessionsSync(wsID string) {
 		"@amux":           "1",
 		"@amux_workspace": wsID,
 	}
+	// Scope to this instance. Workspace IDs are sha1(repo+root), so the same
+	// workspace carries the same @amux_workspace tag across every amux process on
+	// the host (the user orchestrates many). Without an @amux_instance filter,
+	// deleting a workspace shared with another instance would kill that instance's
+	// live agent. An empty instanceID (legacy/untagged) keeps the broad behavior
+	// so single-instance cleanup of pre-existing untagged sessions still works.
+	if strings.TrimSpace(a.instanceID) != "" {
+		tags["@amux_instance"] = a.instanceID
+	}
 	if _, err := a.tmuxService.KillSessionsMatchingTags(tags, a.tmuxOptions); err != nil {
 		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
 	}
-	if err := a.tmuxService.KillWorkspaceSessions(wsID, a.tmuxOptions); err != nil {
-		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
-	}
+	// Deliberately NOT calling KillWorkspaceSessions(wsID): it kills by the
+	// amux-<wsID>- name prefix, which has no instance component and would re-kill
+	// every instance's sessions, defeating the instance scoping above. The tag
+	// match covers all correctly-tagged sessions for this instance.
 }
 
 func (a *App) cleanupAllTmuxSessions() tea.Cmd {

--- a/internal/app/app_tmux_activity_test.go
+++ b/internal/app/app_tmux_activity_test.go
@@ -43,7 +43,10 @@ func (s stubTmuxOps) KillSession(string, tmux.Options) error               { ret
 func (s stubTmuxOps) KillSessionsMatchingTags(map[string]string, tmux.Options) (bool, error) {
 	return false, nil
 }
-func (s stubTmuxOps) KillSessionsWithPrefix(string, tmux.Options) error        { return nil }
+func (s stubTmuxOps) KillSessionsWithPrefix(string, tmux.Options) error { return nil }
+func (s stubTmuxOps) KillSessionsWithPrefixMissingTag(string, string, tmux.Options) error {
+	return nil
+}
 func (s stubTmuxOps) KillWorkspaceSessions(string, tmux.Options) error         { return nil }
 func (s stubTmuxOps) SetMonitorActivityOn(tmux.Options) error                  { return nil }
 func (s stubTmuxOps) SetStatusOff(tmux.Options) error                          { return nil }
@@ -368,9 +371,12 @@ func (s *scriptedActivityTmuxOps) KillSessionsMatchingTags(map[string]string, tm
 	return false, nil
 }
 func (s *scriptedActivityTmuxOps) KillSessionsWithPrefix(string, tmux.Options) error { return nil }
-func (s *scriptedActivityTmuxOps) KillWorkspaceSessions(string, tmux.Options) error  { return nil }
-func (s *scriptedActivityTmuxOps) SetMonitorActivityOn(tmux.Options) error           { return nil }
-func (s *scriptedActivityTmuxOps) SetStatusOff(tmux.Options) error                   { return nil }
+func (s *scriptedActivityTmuxOps) KillSessionsWithPrefixMissingTag(string, string, tmux.Options) error {
+	return nil
+}
+func (s *scriptedActivityTmuxOps) KillWorkspaceSessions(string, tmux.Options) error { return nil }
+func (s *scriptedActivityTmuxOps) SetMonitorActivityOn(tmux.Options) error          { return nil }
+func (s *scriptedActivityTmuxOps) SetStatusOff(tmux.Options) error                  { return nil }
 
 func (s *scriptedActivityTmuxOps) CapturePaneTail(string, int, tmux.Options) (string, bool) {
 	if len(s.contentByScan) == 0 {

--- a/internal/app/service_tmux.go
+++ b/internal/app/service_tmux.go
@@ -57,6 +57,10 @@ func (tmuxOps) KillSessionsWithPrefix(prefix string, opts tmux.Options) error {
 	return tmux.KillSessionsWithPrefix(prefix, opts)
 }
 
+func (tmuxOps) KillSessionsWithPrefixMissingTag(prefix, tag string, opts tmux.Options) error {
+	return tmux.KillSessionsWithPrefixMissingTag(prefix, tag, opts)
+}
+
 func (tmuxOps) KillWorkspaceSessions(wsID string, opts tmux.Options) error {
 	return tmux.KillWorkspaceSessions(wsID, opts)
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -51,6 +51,7 @@ type TmuxOps interface {
 	KillSession(sessionName string, opts tmux.Options) error
 	KillSessionsMatchingTags(tags map[string]string, opts tmux.Options) (bool, error)
 	KillSessionsWithPrefix(prefix string, opts tmux.Options) error
+	KillSessionsWithPrefixMissingTag(prefix, tag string, opts tmux.Options) error
 	KillWorkspaceSessions(wsID string, opts tmux.Options) error
 	SetMonitorActivityOn(opts tmux.Options) error
 	SetStatusOff(opts tmux.Options) error

--- a/internal/tmux/tmux_sessions.go
+++ b/internal/tmux/tmux_sessions.go
@@ -37,6 +37,40 @@ func KillSessionsWithPrefix(prefix string, opts Options) error {
 	return firstErr
 }
 
+// KillSessionsWithPrefixMissingTag kills sessions with a matching name prefix
+// only when the given session option is empty. This is used for legacy amux
+// sessions created before @amux_instance existed; modern sessions owned by other
+// app instances are left alone.
+func KillSessionsWithPrefixMissingTag(prefix, tag string, opts Options) error {
+	if prefix == "" || tag == "" {
+		return nil
+	}
+	sessions, err := ListSessions(opts)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, name := range sessions {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		value, err := SessionTagValue(name, tag, opts)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if strings.TrimSpace(value) != "" {
+			continue
+		}
+		if err := KillSession(name, opts); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // KillWorkspaceSessions kills all sessions for a workspace ID.
 func KillWorkspaceSessions(wsID string, opts Options) error {
 	if wsID == "" {


### PR DESCRIPTION
## Plan stack — PR 19/41 (ticket #20)

## Problem
Workspace IDs are `sha1(repo+root)`, so the same workspace carries the same `@amux_workspace` tag across **every** amux process on the host (the user orchestrates many via OpenClaw). The delete kill matched by only `{@amux, @amux_workspace}` — no `@amux_instance` filter — and **also** called `KillWorkspaceSessions` by the `amux-<wsID>-` name prefix, which has no instance component. So deleting a workspace in instance A destroyed instance B's running agent and uncommitted work if B had it open. Every GC path is instance-scoped; delete was the only one that wasn't.

> Note: #14/#16 replaced `cleanupWorkspaceTmuxSessions` with the validated-path `killWorkspaceSessionsSync`, so this scopes that.

## Change
- Add `@amux_instance` to the tag match when `instanceID` is set (empty keeps broad legacy behavior).
- **Drop** the prefix `KillWorkspaceSessions` call — it can't be instance-scoped and would defeat the tag filter; the tag match covers all correctly-tagged sessions for this instance.

## Test
With `instanceID` set, the kill tags include `@amux_instance` and the prefix kill is not invoked; empty `instanceID` keeps the broad match. Full app suite + strict ratchet green. (Real-tmux multi-instance e2e is a reasonable follow-up.)