### PR TITLE
Serialize per-repo git worktree/branch mutations

### DIFF
--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -147,13 +147,10 @@ func (s *workspaceService) CreateWorkspace(project *data.Project, name, base str
 			}
 		}
 
-		createUnlock := s.lockRepoGit(project.Path)
-		createErr := s.gitOps.CreateWorkspace(project.Path, workspacePath, branch, base)
-		createUnlock()
-		if createErr != nil {
+		if err := s.createWorkspaceLocked(project.Path, workspacePath, branch, base); err != nil {
 			return messages.WorkspaceCreateFailed{
 				Workspace: ws,
-				Err:       createErr,
+				Err:       err,
 			}
 		}
 
@@ -181,6 +178,13 @@ func (s *workspaceService) CreateWorkspace(project *data.Project, name, base str
 		// Return immediately for async setup
 		return messages.WorkspaceCreated{Workspace: ws}
 	}
+}
+
+func (s *workspaceService) createWorkspaceLocked(repoPath, workspacePath, branch, base string) error {
+	unlock := s.lockRepoGit(repoPath)
+	defer unlock()
+
+	return s.gitOps.CreateWorkspace(repoPath, workspacePath, branch, base)
 }
 
 // RunSetupAsync runs setup scripts asynchronously and returns a WorkspaceSetupComplete message.

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -147,10 +147,13 @@ func (s *workspaceService) CreateWorkspace(project *data.Project, name, base str
 			}
 		}
 
-		if err := s.gitOps.CreateWorkspace(project.Path, workspacePath, branch, base); err != nil {
+		createUnlock := s.lockRepoGit(project.Path)
+		createErr := s.gitOps.CreateWorkspace(project.Path, workspacePath, branch, base)
+		createUnlock()
+		if createErr != nil {
 			return messages.WorkspaceCreateFailed{
 				Workspace: ws,
-				Err:       err,
+				Err:       createErr,
 			}
 		}
 
@@ -275,37 +278,9 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("validate_managed_root", fmt.Errorf("workspace root %s is outside managed project root", ws.Root))
 		}
 
-		if err := s.gitOps.RemoveWorkspace(projectPath, ws.Root); err != nil {
-			if !git.IsUnregisteredWorkspacePathError(err) {
-				if workspacePathGone(ws.Root) {
-					s.killWorkspaceSessionsForDelete(wsID)
-				}
-				return fail("remove_worktree", err)
-			}
-			if _, statErr := os.Stat(ws.Root); os.IsNotExist(statErr) {
-				s.killWorkspaceSessionsForDelete(wsID)
-				return fail("remove_worktree", err)
-			} else if statErr != nil {
-				return fail("remove_worktree", errors.Join(err, statErr))
-			}
-			if !isManagedWorkspaceChildPathForProject(s.workspacesRoot, project, ws.Root) {
-				return fail("remove_worktree", err)
-			}
-			if cleanupErr := cleanupStaleWorkspacePath(ws.Root); cleanupErr != nil {
-				return fail("remove_worktree", errors.Join(err, cleanupErr))
-			}
-			logging.Warn("workspace delete stale cleanup workspace_id=%s workspace_root=%s remove_error=%v", wsID, ws.Root, err)
-		}
-
-		// The worktree removal has succeeded or an owned stale path was cleaned up.
-		// Tear down any remaining workspace tmux sessions before metadata deletion,
-		// but never kill sessions for a delete that failed and left the workspace.
-		s.killWorkspaceSessionsForDelete(wsID)
-
-		var warning string
-		if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
-			logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
-			warning = fmt.Sprintf("workspace deleted but branch %s was left behind: %v", ws.Branch, err)
+		warning, failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail)
+		if failMsg != nil {
+			return failMsg
 		}
 		if s.store != nil {
 			if err := s.store.Delete(ws.ID()); err != nil {
@@ -364,6 +339,66 @@ func (s *workspaceService) archiveDeletedWorkspaceMetadata(ws *data.Workspace) e
 	if err := s.store.Save(&archived); err != nil {
 		return fmt.Errorf("archive deleted workspace metadata: %w", err)
 	}
+	return nil
+}
+
+// removeWorktreeAndBranchLocked runs the git mutations (worktree remove + branch
+// delete) under the per-repo lock so concurrent same-repo deletes do not contend
+// on .git locks. It returns a non-fatal branch-delete warning and a failure
+// message that is non-nil only when the worktree removal hard-failed; the caller
+// then returns it and skips metadata removal.
+func (s *workspaceService) removeWorktreeAndBranchLocked(
+	project *data.Project, ws *data.Workspace, projectPath, wsID string,
+	fail func(stage string, err error) tea.Msg,
+) (warning string, failMsg tea.Msg) {
+	unlock := s.lockRepoGit(projectPath)
+	defer unlock()
+
+	if err := s.gitOps.RemoveWorkspace(projectPath, ws.Root); err != nil {
+		if failMsg := s.handleStaleRemoveError(project, ws, wsID, err, fail); failMsg != nil {
+			return "", failMsg
+		}
+	}
+
+	// The worktree removal has succeeded or an owned stale path was cleaned up.
+	// Tear down any remaining workspace tmux sessions before metadata deletion,
+	// but never kill sessions for a delete that failed and left the workspace.
+	s.killWorkspaceSessionsForDelete(wsID)
+
+	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
+		logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
+		warning = fmt.Sprintf("workspace deleted but branch %s was left behind: %v", ws.Branch, err)
+	}
+	return warning, nil
+}
+
+// handleStaleRemoveError resolves a RemoveWorkspace error. It returns a non-nil
+// failure message when the removal genuinely failed, or nil when an unregistered
+// worktree path was reconciled by a managed stale-path cleanup.
+func (s *workspaceService) handleStaleRemoveError(
+	project *data.Project, ws *data.Workspace, wsID string, err error,
+	fail func(stage string, err error) tea.Msg,
+) tea.Msg {
+	if !git.IsUnregisteredWorkspacePathError(err) {
+		if workspacePathGone(ws.Root) {
+			s.killWorkspaceSessionsForDelete(wsID)
+		}
+		return fail("remove_worktree", err)
+	}
+	if _, statErr := os.Stat(ws.Root); statErr != nil {
+		if os.IsNotExist(statErr) {
+			s.killWorkspaceSessionsForDelete(wsID)
+			return fail("remove_worktree", err)
+		}
+		return fail("remove_worktree", errors.Join(err, statErr))
+	}
+	if !isManagedWorkspaceChildPathForProject(s.workspacesRoot, project, ws.Root) {
+		return fail("remove_worktree", err)
+	}
+	if cleanupErr := cleanupStaleWorkspacePath(ws.Root); cleanupErr != nil {
+		return fail("remove_worktree", errors.Join(err, cleanupErr))
+	}
+	logging.Warn("workspace delete stale cleanup workspace_id=%s workspace_root=%s remove_error=%v", wsID, ws.Root, err)
 	return nil
 }
 

--- a/internal/app/workspace_service_create_pending_test.go
+++ b/internal/app/workspace_service_create_pending_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
 )
@@ -71,6 +73,48 @@ func TestCreateWorkspaceGitFailureIncludesPendingWorkspace(t *testing.T) {
 	}
 	if !errors.Is(failed.Err, gitErr) {
 		t.Fatalf("expected git error, got %v", failed.Err)
+	}
+}
+
+func TestCreateWorkspacePanicReleasesRepoGitLock(t *testing.T) {
+	project := data.NewProject("/tmp/repo")
+	svc := newWorkspaceService(nil, nil, nil, "/tmp/workspaces")
+
+	createCalls := 0
+	secondErr := errors.New("second create reached")
+	svc.gitOps = &mockGitOps{
+		createWorkspace: func(repoPath, workspacePath, branch, base string) error {
+			createCalls++
+			if createCalls == 1 {
+				panic("git worktree add panicked")
+			}
+			return secondErr
+		},
+	}
+
+	msg := svc.CreateWorkspace(project, "feature", "main")()
+	if failed, ok := msg.(messages.WorkspaceCreateFailed); !ok {
+		t.Fatalf("expected WorkspaceCreateFailed, got %T", msg)
+	} else if failed.Err == nil {
+		t.Fatal("expected panic recovery error, got nil")
+	}
+
+	done := make(chan tea.Msg, 1)
+	go func() {
+		done <- svc.CreateWorkspace(project, "feature-two", "main")()
+	}()
+
+	select {
+	case msg := <-done:
+		failed, ok := msg.(messages.WorkspaceCreateFailed)
+		if !ok {
+			t.Fatalf("expected WorkspaceCreateFailed, got %T", msg)
+		}
+		if !errors.Is(failed.Err, secondErr) {
+			t.Fatalf("expected second create error, got %v", failed.Err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("second create blocked, repo git lock was not released")
 	}
 }
 

--- a/internal/app/workspace_service_delete_concurrent_test.go
+++ b/internal/app/workspace_service_delete_concurrent_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// TestDeleteWorkspace_ConcurrentSameRepoDeletesAllSucceed fires three real
+// `git worktree remove` deletes for the same repository concurrently. Without
+// the per-repo git lock they contend on .git locks (index.lock / packed-refs)
+// and one intermittently fails as WorkspaceDeleteFailed; the lock serializes the
+// mutations so all three succeed.
+func TestDeleteWorkspace_ConcurrentSameRepoDeletesAllSucceed(t *testing.T) {
+	skipIfNoGit(t)
+
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGit(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	workspacesRoot := filepath.Join(tmp, "workspaces")
+	const n = 3
+	workspaces := make([]*data.Workspace, n)
+	for i := range workspaces {
+		name := fmt.Sprintf("feature-%d", i)
+		wsPath := filepath.Join(workspacesRoot, "repo", name)
+		runGit(t, repo, "worktree", "add", "-b", name, wsPath, "main")
+		workspaces[i] = data.NewWorkspace(name, name, "main", repo, wsPath)
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	project := data.NewProject(repo)
+
+	results := make([]tea.Msg, n)
+	var wg sync.WaitGroup
+	for i := range workspaces {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = svc.DeleteWorkspace(project, workspaces[i])()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, msg := range results {
+		if failed, ok := msg.(messages.WorkspaceDeleteFailed); ok {
+			t.Fatalf("workspace %d failed under concurrent same-repo delete: %v", i, failed.Err)
+		}
+		if _, ok := msg.(messages.WorkspaceDeleted); !ok {
+			t.Fatalf("workspace %d: expected WorkspaceDeleted, got %T", i, msg)
+		}
+	}
+}

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"sync"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
@@ -53,6 +54,20 @@ type workspaceService struct {
 	// only after worktree removal succeeds, so failed deletes leave live sessions
 	// intact.
 	killWorkspaceSessions func(wsID string)
+	// repoGitLocks serializes git worktree/branch mutations per repository (keyed
+	// by normalized project path) so concurrent create/delete of workspaces in the
+	// same repo do not contend on .git locks (index.lock / packed-refs).
+	repoGitLocks sync.Map
+}
+
+// lockRepoGit acquires the per-repo git mutation lock and returns the unlock
+// closure. Callers must hold it only around git CLI mutations, not over the
+// flock-serialized metadata store.
+func (s *workspaceService) lockRepoGit(repoPath string) func() {
+	actual, _ := s.repoGitLocks.LoadOrStore(data.NormalizePath(repoPath), &sync.Mutex{})
+	mu, _ := actual.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 // isDeleteInFlight reports whether the workspace is mid-delete. It is nil-safe so


### PR DESCRIPTION
## Plan stack — PR 20/41 (ticket #21)

## Problem
`DeleteWorkspace` runs `git worktree remove` and `git branch -D` against the project repo inside a `tea.Cmd` goroutine with no mutex serializing git ops per repo. Deleting several workspaces of the **same project** in rapid succession runs concurrent git mutations against one `.git`, contending on `index.lock`/`packed-refs` and intermittently failing one of the batch as `WorkspaceDeleteFailed` — a confusing partial failure the user must re-trigger.

## Change
- Add a per-repo git lock (`repoGitLocks sync.Map` keyed by normalized project path) + `lockRepoGit` helper.
- Extract the git-mutation section of `DeleteWorkspace` into `removeWorktreeAndBranchLocked`, which holds the lock around `RemoveWorkspace` + `DeleteBranch` only — **not** `store.Delete` (already flock-serialized). This also drops `DeleteWorkspace` well under the funlen cap. The stale-remove error handling is further extracted to `handleStaleRemoveError` (nestif).
- Acquire the same lock around `CreateWorkspace`'s git call so create/delete in one repo don't contend.

## Test
Three **concurrent real** `git worktree remove` deletes for the same repo all return `WorkspaceDeleted` (passes 3× under `-race`). Strict ratchet clean.