### PR TITLE
Guard handleProjectsLoaded with a load-generation token

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -139,12 +139,16 @@ type App struct {
 	instanceID                string                            // Immutable after init; safe for read-only access from Cmd goroutines.
 
 	// Workspace persistence debounce
-	dirtyWorkspaces       map[string]bool
-	deletingWorkspaceMu   sync.RWMutex
-	deletingWorkspaceIDs  map[string]bool
-	persistToken          int
-	localWorkspaceSaveMu  sync.Mutex
-	localWorkspaceSavesAt map[string]localWorkspaceSaveMarker
+	dirtyWorkspaces      map[string]bool
+	deletingWorkspaceMu  sync.RWMutex
+	deletingWorkspaceIDs map[string]bool
+	persistToken         int
+	// projectsLoadToken is the next load generation to issue; lastApplied is the
+	// highest applied, so handleProjectsLoaded can drop out-of-order reloads.
+	projectsLoadToken            int
+	lastAppliedProjectsLoadToken int
+	localWorkspaceSaveMu         sync.Mutex
+	localWorkspaceSavesAt        map[string]localWorkspaceSaveMarker
 
 	// Workspaces in creation flow (not yet loaded into projects list)
 	creatingWorkspaceIDs map[string]bool

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -17,6 +17,16 @@ import (
 
 // handleProjectsLoaded processes the ProjectsLoaded message.
 func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
+	// Drop a stale reload: under rapid/batch deletes multiple LoadProjects
+	// goroutines are in flight with no ordering, and an older one (started before
+	// a later delete's store.Delete completed) would otherwise overwrite a.projects
+	// and resurrect the deleted workspace. Zero-token messages apply (back-compat).
+	if msg.LoadToken != 0 && msg.LoadToken < a.lastAppliedProjectsLoadToken {
+		return nil
+	}
+	if msg.LoadToken > a.lastAppliedProjectsLoadToken {
+		a.lastAppliedProjectsLoadToken = msg.LoadToken
+	}
 	a.projects = msg.Projects
 	a.projectsLoaded = true
 	var cmds []tea.Cmd

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -14,7 +14,8 @@ func (a *App) loadProjects() tea.Cmd {
 	if a.workspaceService == nil {
 		return nil
 	}
-	return a.workspaceService.LoadProjects()
+	a.projectsLoadToken++
+	return a.workspaceService.LoadProjects(a.projectsLoadToken)
 }
 
 // rescanWorkspaces discovers git worktrees and updates the workspace store.

--- a/internal/app/app_projects_load_token_test.go
+++ b/internal/app/app_projects_load_token_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+	"github.com/andyrewlee/amux/internal/ui/sidebar"
+)
+
+// TestHandleProjectsLoaded_DropsStaleLoadToken proves an out-of-order reload is
+// dropped: under rapid deletes an older LoadProjects goroutine (started before a
+// later delete completed) could deliver last and resurrect the deleted workspace.
+func TestHandleProjectsLoaded_DropsStaleLoadToken(t *testing.T) {
+	app := &App{
+		dashboard:       dashboard.New(),
+		center:          center.New(nil),
+		sidebar:         sidebar.NewTabbedSidebar(),
+		sidebarTerminal: sidebar.NewTerminalModel(),
+	}
+	newer := []data.Project{{Name: "kept", Path: "/kept"}}
+	older := []data.Project{{Name: "kept", Path: "/kept"}, {Name: "deleted", Path: "/deleted"}}
+
+	app.handleProjectsLoaded(messages.ProjectsLoaded{Projects: newer, LoadToken: 5})
+	if len(app.projects) != 1 {
+		t.Fatalf("expected newer (higher-token) set applied, got %d projects", len(app.projects))
+	}
+
+	// A later-arriving but OLDER load (lower token) must be dropped.
+	app.handleProjectsLoaded(messages.ProjectsLoaded{Projects: older, LoadToken: 3})
+	if len(app.projects) != 1 {
+		t.Fatalf("stale lower-token load must be dropped, got %d projects", len(app.projects))
+	}
+
+	// A zero-token message still applies (back-compat with existing callers/tests).
+	app.handleProjectsLoaded(messages.ProjectsLoaded{Projects: older, LoadToken: 0})
+	if len(app.projects) != 2 {
+		t.Fatalf("zero-token load should apply, got %d projects", len(app.projects))
+	}
+}

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -14,10 +14,10 @@ import (
 )
 
 // LoadProjects loads all registered projects and their workspaces.
-func (s *workspaceService) LoadProjects() tea.Cmd {
+func (s *workspaceService) LoadProjects(loadToken int) tea.Cmd {
 	return func() tea.Msg {
 		if s == nil || s.registry == nil {
-			return messages.ProjectsLoaded{}
+			return messages.ProjectsLoaded{LoadToken: loadToken}
 		}
 		paths, err := s.registry.Projects()
 		if err != nil {
@@ -96,7 +96,7 @@ func (s *workspaceService) LoadProjects() tea.Cmd {
 			projects = append(projects, *project)
 		}
 
-		return messages.ProjectsLoaded{Projects: projects}
+		return messages.ProjectsLoaded{Projects: projects, LoadToken: loadToken}
 	}
 }
 

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -18,6 +18,11 @@ const (
 // ProjectsLoaded is sent when projects have been loaded/reloaded
 type ProjectsLoaded struct {
 	Projects []data.Project
+	// LoadToken identifies the load generation; handleProjectsLoaded drops a
+	// result older than the last applied one so out-of-order reloads (e.g. under
+	// rapid deletes) cannot resurrect a just-deleted workspace. Zero applies
+	// unconditionally (back-compat).
+	LoadToken int
 }
 
 // WorkspaceActivated is sent when a workspace is selected


### PR DESCRIPTION
## Plan stack — PR 21/41 (ticket #22)

## Problem
Each successful delete fires `loadProjects()`, and `handleProjectsLoaded` unconditionally overwrote `a.projects = msg.Projects`. `LoadProjects` runs as its own goroutine with no ordering, so under rapid/batch deletes multiple in-flight loads can deliver **out of order**: a reload that started before a later delete's `store.Delete` completed lists the deleted workspace, and if its `ProjectsLoaded` arrives last it overwrites `a.projects` and **the deleted workspace reappears**.

## Change
Add a `LoadToken` to `messages.ProjectsLoaded`, issue a monotonic `projectsLoadToken` in the `loadProjects` wrapper, stamp it at both `LoadProjects` return sites, and drop a stale result in `handleProjectsLoaded` (`LoadToken < lastApplied`) before applying — mirroring the established `persistToken`/`tmuxSyncToken` idiom. Zero-token messages still apply (back-compat).

## Test
A newer (higher-token) load then an older (lower-token) load leaves `a.projects` on the newer set; a zero-token message still applies. Existing projects-loaded + rescan tests green; strict ratchet clean.