### PR TITLE
Clear reattachInFlight when a tab is reconciled to stopped

### DIFF
--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -213,6 +213,11 @@ func (m *Model) updateTabSessionStatus(msg messages.TabSessionStatus) (*Model, t
 	tab.mu.Lock()
 	tab.Running = false
 	tab.Detached = false
+	// Clear the in-flight reattach guard too: this is the only stop/detach
+	// transition that did not, leaving a tab wedged if a stopped message lands
+	// while a reattach is in flight (all reattach gates bail on this flag, so the
+	// user could no longer reattach a tab that now shows stopped).
+	tab.reattachInFlight = false
 	tab.mu.Unlock()
 	tab.resetActivityANSIState()
 	return m, common.SafeBatch(func() tea.Msg {

--- a/internal/ui/center/model_stopped_reattach_test.go
+++ b/internal/ui/center/model_stopped_reattach_test.go
@@ -1,0 +1,48 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// TestUpdateTabSessionStatus_StoppedClearsReattachInFlight proves a stopped
+// reconcile from the activity scan clears reattachInFlight, so a tab that goes
+// stopped while a reattach was in flight is not left wedged (every reattach gate
+// bails on that flag).
+func TestUpdateTabSessionStatus_StoppedClearsReattachInFlight(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	tab := &Tab{
+		ID:               TabID("tab-stopped-reattach"),
+		Assistant:        "claude",
+		Workspace:        ws,
+		SessionName:      "amux-ws-sess",
+		Running:          true,
+		reattachInFlight: true,
+		Agent:            &appPty.Agent{Workspace: ws, Session: "amux-ws-sess"},
+	}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+
+	m.updateTabSessionStatus(messages.TabSessionStatus{
+		Status:      "stopped",
+		WorkspaceID: wsID,
+		SessionName: "amux-ws-sess",
+	})
+
+	tab.mu.Lock()
+	inFlight, running, detached := tab.reattachInFlight, tab.Running, tab.Detached
+	tab.mu.Unlock()
+	if inFlight {
+		t.Fatal("expected reattachInFlight=false after a stopped reconcile")
+	}
+	if running {
+		t.Fatal("expected Running=false after a stopped reconcile")
+	}
+	if detached {
+		t.Fatal("expected Detached=false after a stopped reconcile")
+	}
+}


### PR DESCRIPTION
## Plan stack — PR 22/41 (ticket #23)

## Problem
`updateTabSessionStatus` (handler for the activity scan's `TabSessionStatus{stopped}`) set `Running=false`/`Detached=false` but **never cleared `tab.reattachInFlight`** — the only stop/detach transition that fails to. If a stopped message arrives while a reattach is in flight (e.g. a restore placeholder tab created with `reattachInFlight=true`), the tab is **wedged**: `ReattachActiveTab`, the auto-reattach gate, and wheel auto-reattach all bail on `reattachInFlight`, so the user can no longer reattach a tab that now shows stopped.

## Change
One line: clear `tab.reattachInFlight = false` in the same lock block.

## Test
A stopped reconcile of a tab with `reattachInFlight=true` leaves it not-in-flight, not-Running, not-Detached (fails before the change). Foundational for #24 and #25. Lint + center suite green.