### PR TITLE
Add demotion hysteresis to activity-scan reconciliation

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -136,7 +136,10 @@ type App struct {
 	tmuxInstallHint           string
 	tmuxActiveWorkspaceIDs    map[string]bool
 	sessionActivityStates     map[string]*activity.SessionState // Per-session hysteresis state
-	instanceID                string                            // Immutable after init; safe for read-only access from Cmd goroutines.
+	// activityMissBySession counts consecutive non-live activity observations per
+	// session so a single transient miss does not demote a working agent.
+	activityMissBySession map[string]int
+	instanceID            string // Immutable after init; safe for read-only access from Cmd goroutines.
 
 	// Workspace persistence debounce
 	dirtyWorkspaces      map[string]bool

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -239,7 +239,10 @@ func (a *App) fetchAndSyncActivitySessionStates(
 		return nil, nil, err
 	}
 	// Mutates infoBySession so IsRunningSession sees corrected statuses.
-	stoppedTabs := syncActivitySessionStates(infoBySession, sessions, svc, opts)
+	if a.activityMissBySession == nil {
+		a.activityMissBySession = make(map[string]int)
+	}
+	stoppedTabs := syncActivitySessionStates(infoBySession, sessions, svc, opts, a.activityMissBySession)
 	return sessions, stoppedTabs, nil
 }
 
@@ -318,11 +321,37 @@ func (a *App) tabSessionInfoByName() map[string]activity.SessionInfo {
 // ActiveWorkspaceIDsFromTags call (which filters via IsRunningSession) sees corrected
 // statuses. It returns TabSessionStatus messages for sessions whose status changed
 // from a running-like state to stopped.
+// activityDemotionMissThreshold is the number of consecutive non-live activity
+// observations required before a running session is demoted to stopped. A single
+// best-effort AllSessionStates call can miss a live session under load, so one
+// miss must not tear down a working background agent.
+const activityDemotionMissThreshold = 2
+
+// recordSessionMiss increments the consecutive-non-live counter for a session and,
+// once the hysteresis threshold is reached, marks it stopped. It returns the
+// (possibly updated) info and whether a stopped message should be emitted — true
+// only on the transition from a running-like status.
+func recordSessionMiss(missBySession map[string]int, sessionName string, info activity.SessionInfo) (activity.SessionInfo, bool) {
+	// A nil counter disables hysteresis (single-miss demotion). The production
+	// caller always passes a real map; some unit tests opt out to assert the
+	// per-observation decision directly.
+	if missBySession != nil {
+		missBySession[sessionName]++
+		if missBySession[sessionName] < activityDemotionMissThreshold {
+			return info, false
+		}
+	}
+	wasRunningLike := activity.IsRunningSession(info, true)
+	info.Status = "stopped"
+	return info, wasRunningLike
+}
+
 func syncActivitySessionStates(
 	infoBySession map[string]activity.SessionInfo,
 	sessions []activity.TaggedSession,
 	svc TmuxOps,
 	opts tmux.Options,
+	missBySession map[string]int,
 ) []messages.TabSessionStatus {
 	stoppedTabs := make([]messages.TabSessionStatus, 0)
 	if svc == nil || len(infoBySession) == 0 {
@@ -351,13 +380,13 @@ func syncActivitySessionStates(
 		if !ok {
 			continue
 		}
-		isRunningLikeStatus := activity.IsRunningSession(info, true)
 
 		state := allStates[sessionName] // zero value if missing (Exists=false)
 
 		if !state.Exists || !state.HasLivePane {
-			info.Status = "stopped"
-			if isRunningLikeStatus {
+			var emit bool
+			info, emit = recordSessionMiss(missBySession, sessionName, info)
+			if emit {
 				if wsID := strings.TrimSpace(info.WorkspaceID); wsID != "" {
 					stoppedTabs = append(stoppedTabs, messages.TabSessionStatus{
 						WorkspaceID: wsID,
@@ -366,23 +395,28 @@ func syncActivitySessionStates(
 					})
 				}
 			}
-		} else if strings.EqualFold(info.Status, "stopped") {
-			info.Status = "running"
+		} else {
+			// Live again: reset the miss counter and revive a previously-stopped
+			// session so it is no longer treated as dead.
+			delete(missBySession, sessionName)
+			if strings.EqualFold(info.Status, "stopped") {
+				info.Status = "running"
+			}
 		}
 		infoBySession[sessionName] = info
 	}
 
-	// Sessions that no longer appear in list-sessions are no longer running.
+	// Sessions that no longer appear in list-sessions are non-live this scan; the
+	// same hysteresis applies before demoting them.
 	for sessionName, info := range infoBySession {
 		if _, ok := checked[sessionName]; ok {
 			continue
 		}
-		isRunningLikeStatus := activity.IsRunningSession(info, true)
-		if isRunningLikeStatus {
-			info.Status = "stopped"
-			infoBySession[sessionName] = info
-			wsID := strings.TrimSpace(info.WorkspaceID)
-			if wsID != "" {
+		var emit bool
+		info, emit = recordSessionMiss(missBySession, sessionName, info)
+		infoBySession[sessionName] = info
+		if emit {
+			if wsID := strings.TrimSpace(info.WorkspaceID); wsID != "" {
 				stoppedTabs = append(stoppedTabs, messages.TabSessionStatus{
 					WorkspaceID: wsID,
 					SessionName: sessionName,

--- a/internal/app/app_tmux_activity_hysteresis_test.go
+++ b/internal/app/app_tmux_activity_hysteresis_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/app/activity"
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// TestSyncActivitySessionStates_DemotionHysteresis proves a running session is
+// not demoted on a single non-live observation and only demoted once the miss
+// threshold is reached — so a transient tmux glitch cannot tear down a working
+// background agent.
+func TestSyncActivitySessionStates_DemotionHysteresis(t *testing.T) {
+	const sessionName = "amux-ws-sess"
+	info := map[string]activity.SessionInfo{
+		sessionName: {Status: "running", WorkspaceID: "ws", IsChat: true},
+	}
+	sessions := []activity.TaggedSession{{Session: tmux.SessionActivity{Name: sessionName}}}
+	deadSvc := stubTmuxOps{allStates: map[string]tmux.SessionState{}} // not live
+	miss := map[string]int{}
+
+	r1 := syncActivitySessionStates(info, sessions, deadSvc, tmux.Options{}, miss)
+	if len(r1) != 0 {
+		t.Fatalf("first non-live observation must not demote, got %d stopped", len(r1))
+	}
+	if info[sessionName].Status != "running" {
+		t.Fatalf("first miss must keep status running, got %q", info[sessionName].Status)
+	}
+
+	r2 := syncActivitySessionStates(info, sessions, deadSvc, tmux.Options{}, miss)
+	if len(r2) != 1 {
+		t.Fatalf("second consecutive non-live observation must demote, got %d stopped", len(r2))
+	}
+	if info[sessionName].Status != "stopped" {
+		t.Fatalf("expected stopped after threshold, got %q", info[sessionName].Status)
+	}
+}
+
+// TestSyncActivitySessionStates_LiveResetsMissCounter proves a live observation
+// resets the per-session miss counter, so a session that flickers does not
+// accumulate misses toward demotion.
+func TestSyncActivitySessionStates_LiveResetsMissCounter(t *testing.T) {
+	const sessionName = "amux-ws-sess"
+	info := map[string]activity.SessionInfo{
+		sessionName: {Status: "running", WorkspaceID: "ws"},
+	}
+	sessions := []activity.TaggedSession{{Session: tmux.SessionActivity{Name: sessionName}}}
+	miss := map[string]int{}
+
+	deadSvc := stubTmuxOps{allStates: map[string]tmux.SessionState{}}
+	syncActivitySessionStates(info, sessions, deadSvc, tmux.Options{}, miss)
+	if miss[sessionName] != 1 {
+		t.Fatalf("expected 1 miss after one non-live observation, got %d", miss[sessionName])
+	}
+
+	liveSvc := stubTmuxOps{allStates: map[string]tmux.SessionState{
+		sessionName: {Exists: true, HasLivePane: true},
+	}}
+	syncActivitySessionStates(info, sessions, liveSvc, tmux.Options{}, miss)
+	if _, ok := miss[sessionName]; ok {
+		t.Fatalf("a live observation must reset the miss counter, still have %d", miss[sessionName])
+	}
+}

--- a/internal/app/app_tmux_activity_shared_scan_test.go
+++ b/internal/app/app_tmux_activity_shared_scan_test.go
@@ -52,6 +52,9 @@ func TestRunTmuxActivityScan_FollowerReconcilesStoppedTabsFromSharedSnapshot(t *
 				Tags: map[string]string{},
 			}},
 		},
+		// Pre-seed one prior non-live observation so this single scan reaches the
+		// demotion hysteresis threshold and still demotes the dead session.
+		activityMissBySession: map[string]int{"session-a": activityDemotionMissThreshold - 1},
 	}
 
 	infoBySession := map[string]activity.SessionInfo{

--- a/internal/app/app_tmux_activity_test.go
+++ b/internal/app/app_tmux_activity_test.go
@@ -121,6 +121,7 @@ func TestSyncActivitySessionStates_NilSvc(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		nil,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result with nil svc, got %d", len(result))
@@ -138,6 +139,7 @@ func TestSyncActivitySessionStates_EmptyInfoBySession(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result with empty infoBySession, got %d", len(result))
@@ -156,6 +158,7 @@ func TestSyncActivitySessionStates_AllSessionStatesError(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result on AllSessionStates error, got %d", len(result))
@@ -180,6 +183,7 @@ func TestSyncActivitySessionStates_RunningSessionDeadPane(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab, got %d", len(result))
@@ -205,6 +209,7 @@ func TestSyncActivitySessionStates_RunningSessionDisappeared(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab for disappeared session, got %d", len(result))
@@ -231,6 +236,7 @@ func TestSyncActivitySessionStates_StoppedSessionRevived(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no stopped emissions for revived session, got %d", len(result))
@@ -253,6 +259,7 @@ func TestSyncActivitySessionStates_AlreadyStoppedDisappeared(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no duplicate stopped emission, got %d", len(result))
@@ -272,6 +279,7 @@ func TestSyncActivitySessionStates_TaggedNotInInfo(t *testing.T) {
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "unknown"}}},
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no stopped emissions for unknown session, got %d", len(result))
@@ -291,6 +299,7 @@ func TestSyncActivitySessionStates_InfoNotInTaggedRunning(t *testing.T) {
 		[]activity.TaggedSession{}, // no tagged sessions
 		svc,
 		tmux.Options{},
+		nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab for orphan running session, got %d", len(result))

--- a/internal/app/app_tmux_activity_test.go
+++ b/internal/app/app_tmux_activity_test.go
@@ -120,8 +120,7 @@ func TestSyncActivitySessionStates_NilSvc(t *testing.T) {
 		map[string]activity.SessionInfo{"s": {Status: "running", WorkspaceID: "ws1"}},
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		nil,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result with nil svc, got %d", len(result))
@@ -138,8 +137,7 @@ func TestSyncActivitySessionStates_EmptyInfoBySession(t *testing.T) {
 		map[string]activity.SessionInfo{},
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result with empty infoBySession, got %d", len(result))
@@ -157,8 +155,7 @@ func TestSyncActivitySessionStates_AllSessionStatesError(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected empty result on AllSessionStates error, got %d", len(result))
@@ -182,8 +179,7 @@ func TestSyncActivitySessionStates_RunningSessionDeadPane(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab, got %d", len(result))
@@ -208,8 +204,7 @@ func TestSyncActivitySessionStates_RunningSessionDisappeared(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab for disappeared session, got %d", len(result))
@@ -235,8 +230,7 @@ func TestSyncActivitySessionStates_StoppedSessionRevived(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no stopped emissions for revived session, got %d", len(result))
@@ -258,8 +252,7 @@ func TestSyncActivitySessionStates_AlreadyStoppedDisappeared(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "s"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no duplicate stopped emission, got %d", len(result))
@@ -278,8 +271,7 @@ func TestSyncActivitySessionStates_TaggedNotInInfo(t *testing.T) {
 		info,
 		[]activity.TaggedSession{{Session: tmux.SessionActivity{Name: "unknown"}}},
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 0 {
 		t.Fatalf("expected no stopped emissions for unknown session, got %d", len(result))
@@ -298,8 +290,7 @@ func TestSyncActivitySessionStates_InfoNotInTaggedRunning(t *testing.T) {
 		info,
 		[]activity.TaggedSession{}, // no tagged sessions
 		svc,
-		tmux.Options{},
-		nil,
+		tmux.Options{}, nil,
 	)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 stopped tab for orphan running session, got %d", len(result))


### PR DESCRIPTION
## What

`syncActivitySessionStates` demoted a tab to `stopped` on a **single** non-live `AllSessionStates` result. That result comes from one best-effort tmux call, so a momentary load spike or hiccup is enough to trip it — and a `TabSessionStatus{stopped}` message destructively tears down the agent (`stopPTYReader` + `CloseAgent`). Net effect: one transient tmux glitch permanently kills a background workspace's working agent and its activity indicator until the user manually reattaches that exact tab — which, for a background workspace, never happens.

## Change

Require **N=2** consecutive non-live observations before emitting `stopped`:

- New per-session miss counter `App.activityMissBySession`, threaded into `syncActivitySessionStates`.
- Incremented on each non-live observation (both the in-list and not-seen branches) via a `recordSessionMiss` helper.
- Reset whenever the session is observed live.
- Nil-safe: a `nil` map disables hysteresis, keeping existing single-miss unit tests unchanged.

## Tests

- A single non-live observation does **not** demote.
- A second consecutive one **does**.
- A live observation resets the counter.

## Follow-up (noted)

Re-promotion on revival — emitting a `running` status the center consumes to re-flip a demoted tab while its agent is still live — is deferred. The anti-flap above is the load-bearing durable fix: it prevents the spurious teardown in the first place. Per-session miss-map pruning is ticket #29.