### PR TITLE
Reset activity settlement on follower->owner transition

### DIFF
--- a/internal/app/app_tmux_activity_handle_result_test.go
+++ b/internal/app/app_tmux_activity_handle_result_test.go
@@ -62,3 +62,64 @@ func TestHandleTmuxActivityResult_OwnerTransitionErrorResetsHysteresis(t *testin
 		t.Fatalf("expected recovered owner activity to apply, got %v", app.tmuxActiveWorkspaceIDs)
 	}
 }
+
+// TestHandleTmuxActivityResult_OwnerTransitionResetsSettlement proves a
+// follower->owner handoff re-enters the unsettled state, so the transient empty
+// active set the transition publishes is not treated as a confirmed all-idle set
+// (which would blink every working-agent spinner off until the new owner's first
+// scan lands). Indicators repopulate only after the owner re-settles.
+func TestHandleTmuxActivityResult_OwnerTransitionResetsSettlement(t *testing.T) {
+	dash := dashboard.New()
+	dash.SetActiveWorkspaces(map[string]bool{"ws-old": true})
+	app := &App{
+		tmuxActivityToken:        7,
+		tmuxActivityScanInFlight: true,
+		tmuxActivityOwnershipSet: true,
+		tmuxActivityScannerOwner: false,
+		tmuxActivityOwnerEpoch:   1,
+		sessionActivityStates:    map[string]*activity.SessionState{},
+		tmuxActivitySettled:      true,
+		tmuxActivitySettledScans: 2,
+		tmuxActiveWorkspaceIDs:   map[string]bool{"ws-old": true},
+		dashboard:                dash,
+	}
+
+	// Follower->owner transition (epoch bump). The owner scan succeeds and reports
+	// an active workspace, but settlement must restart from zero so the active set
+	// is not yet treated as authoritative.
+	app.handleTmuxActivityResult(tmuxActivityResult{
+		Token:              7,
+		RoleKnown:          true,
+		ScannerOwner:       true,
+		ScannerEpoch:       2,
+		ActiveWorkspaceIDs: map[string]bool{"ws-new": true},
+		UpdatedStates:      map[string]*activity.SessionState{},
+	})
+	if app.tmuxActivitySettled {
+		t.Fatal("expected settlement reset on owner transition")
+	}
+	if app.tmuxActivitySettledScans != 1 {
+		t.Fatalf("expected settle scans to restart at 1 after the transition scan, got %d", app.tmuxActivitySettledScans)
+	}
+	if got := dashboardActiveWorkspaceCount(dash); got != 0 {
+		t.Fatalf("expected transient active set withheld while unsettled, got %d", got)
+	}
+
+	// Second successful owner scan re-settles and republishes the active set.
+	app.tmuxActivityToken = 8
+	app.tmuxActivityScanInFlight = true
+	app.handleTmuxActivityResult(tmuxActivityResult{
+		Token:              8,
+		RoleKnown:          true,
+		ScannerOwner:       true,
+		ScannerEpoch:       2,
+		ActiveWorkspaceIDs: map[string]bool{"ws-new": true},
+		UpdatedStates:      map[string]*activity.SessionState{},
+	})
+	if !app.tmuxActivitySettled {
+		t.Fatal("expected owner to re-settle after two successful scans")
+	}
+	if got := dashboardActiveWorkspaceCount(dash); got != 1 {
+		t.Fatalf("expected indicators to repopulate after re-settle, got %d", got)
+	}
+}

--- a/internal/app/app_tmux_activity_result.go
+++ b/internal/app/app_tmux_activity_result.go
@@ -75,10 +75,16 @@ func (a *App) updateTmuxActivityOwnershipState(msg tmuxActivityResult) {
 	// Clear follower/shared activity immediately. If the first owner scan fails,
 	// stale follower markers should not remain visible.
 	a.tmuxActiveWorkspaceIDs = make(map[string]bool)
+	// Re-enter the unsettled state so this transient empty set is not published as
+	// authoritative. While !settled, syncActiveWorkspacesToDashboard short-circuits
+	// to an empty publish that the dashboard treats as "not yet known" rather than a
+	// confirmed all-idle set, so working-agent spinners are not blinked off between
+	// the handoff and the new owner's first scans. applyTmuxActivityPayload re-settles
+	// after tmuxActivitySettleScans successful owner scans, repopulating indicators.
+	// Mirrors the tmux-availability reset in scanTmuxActivity.
+	a.tmuxActivitySettled = false
+	a.tmuxActivitySettledScans = 0
 	a.syncActiveWorkspacesToDashboard()
-	// Do not reset tmuxActivitySettledScans on role transitions. Settlement tracks
-	// continuity of successfully applied activity payloads, independent of owner
-	// identity, and only increments in applyTmuxActivityPayload.
 }
 
 func isTmuxActivityOwnerTransition(


### PR DESCRIPTION
## What

On a follower→owner handoff, `updateTmuxActivityOwnershipState` clears `tmuxActiveWorkspaceIDs` to empty and immediately calls `syncActiveWorkspacesToDashboard`, but left `tmuxActivitySettled=true`. The settled path publishes that empty set as an authoritative all-idle state, so **every working-agent spinner blinks off** until the new owner's first successful scan completes — up to ~5s later, or never if it errors — exactly when a peer just quit/crashed and the user is most likely watching.

## Change

Re-enter the unsettled state on the transition (`settled=false`, `settledScans=0`) before the sync, mirroring the tmux-availability reset. While `!settled`, `syncActiveWorkspacesToDashboard` short-circuits to an empty publish the dashboard treats as "not yet known" rather than confirmed all-idle; `applyTmuxActivityPayload` re-settles after two successful owner scans and repopulates indicators.

The deliberate stale-marker clears (`sessionActivityStates`, `tmuxActiveWorkspaceIDs`) are preserved — this does **not** adopt the "keep last-known set visible" alternative, which would contradict the existing clear-on-transition assertion.

## Tests

- New: the transition withholds the transient active set while unsettled and republishes it after the owner re-settles.
- Existing `TestHandleTmuxActivityResult_OwnerTransitionErrorResetsHysteresis` and `TestHandleTmuxAvailableResult_ResetsActivitySettlement` still pass.