### PR TITLE
Cap forward clock skew in ReadSnapshot

### DIFF
--- a/internal/app/activity/lease.go
+++ b/internal/app/activity/lease.go
@@ -29,6 +29,10 @@ const (
 	// SnapshotStaleAfter controls how long a shared activity snapshot is trusted
 	// after its timestamp before followers ignore it.
 	SnapshotStaleAfter = 10 * time.Second
+	// SnapshotFutureSkewTolerance caps how far in the future a shared snapshot
+	// timestamp may be (clock skew) before it is treated as stale rather than
+	// fresh, mirroring OwnerFutureSkewTolerance for the owner lease.
+	SnapshotFutureSkewTolerance = 2 * time.Second
 )
 
 // OwnerLease is the cross-instance activity-scan owner lease stored in tmux
@@ -117,13 +121,21 @@ func ReadSnapshot(opts tmux.Options, now time.Time, expectedEpoch int64) (map[st
 	if expectedEpoch > 0 && snapshotEpoch != expectedEpoch {
 		return nil, false, nil
 	}
-	if at.After(now) {
-		return parsed, true, nil
-	}
-	if now.Sub(at) > SnapshotStaleAfter {
+	if !snapshotFresh(at, now) {
 		return nil, false, nil
 	}
 	return parsed, true, nil
+}
+
+// snapshotFresh reports whether a snapshot timestamped at is fresh relative to
+// now, tolerating only small forward clock skew. A far-future timestamp (a peer
+// whose clock runs minutes/hours ahead) would otherwise pin every follower to a
+// stale active set indefinitely, ignoring SnapshotStaleAfter.
+func snapshotFresh(at, now time.Time) bool {
+	if at.After(now) {
+		return at.Sub(now) <= SnapshotFutureSkewTolerance
+	}
+	return now.Sub(at) <= SnapshotStaleAfter
 }
 
 // EncodeSnapshot serializes the active-workspace set with epoch and timestamp.

--- a/internal/app/activity/lease_test.go
+++ b/internal/app/activity/lease_test.go
@@ -1,0 +1,56 @@
+package activity
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSnapshotFresh covers the forward-skew cap that keeps a future-dated
+// snapshot from pinning followers to a stale active set forever.
+func TestSnapshotFresh(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	cases := []struct {
+		name string
+		at   time.Time
+		want bool
+	}{
+		{"far future rejected", now.Add(time.Minute), false},
+		{"small forward skew accepted", now.Add(time.Second), true},
+		{"recent past accepted", now.Add(-5 * time.Second), true},
+		{"stale past rejected", now.Add(-15 * time.Second), false},
+		{"exactly now accepted", now, true},
+		{"future at skew boundary accepted", now.Add(SnapshotFutureSkewTolerance), true},
+		{"future just past boundary rejected", now.Add(SnapshotFutureSkewTolerance + time.Millisecond), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := snapshotFresh(tc.at, now); got != tc.want {
+				t.Fatalf("snapshotFresh(%v, %v) = %v, want %v", tc.at, now, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSnapshotFresh_RoundTripThroughEncodeDecode drives a far-future timestamp
+// through EncodeSnapshot/DecodeSnapshot to confirm the decoded timestamp still
+// trips the skew cap (no loss of precision flips the freshness decision).
+func TestSnapshotFresh_RoundTripThroughEncodeDecode(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	future := now.Add(time.Minute)
+
+	encoded := EncodeSnapshot(map[string]bool{"ws-a": true}, 3, future)
+	parsed, epoch, at, ok := DecodeSnapshot(encoded)
+	if !ok {
+		t.Fatal("expected snapshot to decode")
+	}
+	if epoch != 3 {
+		t.Fatalf("expected epoch 3, got %d", epoch)
+	}
+	if !parsed["ws-a"] {
+		t.Fatalf("expected ws-a in decoded set, got %v", parsed)
+	}
+	if snapshotFresh(at, now) {
+		t.Fatalf("far-future decoded timestamp %v must be rejected as stale", at)
+	}
+}


### PR DESCRIPTION
## What

`ReadSnapshot` trusted any future-dated snapshot unconditionally (`if at.After(now) { return parsed, true }`) with **no skew cap** — inconsistent with `OwnerLeaseAlive`, which caps forward skew at `OwnerFutureSkewTolerance`. A peer whose clock is skewed minutes/hours ahead pinned every follower to its published active set forever, ignoring `SnapshotStaleAfter`, until the local clock caught up. Followers rendered stale active/idle status for as long as the skew lasted.

## Change

Replace the unconditional future-accept with a skew-bounded `snapshotFresh(at, now)` helper:

- A future timestamp is fresh only within `SnapshotFutureSkewTolerance` (2s, mirroring the owner lease).
- Otherwise it must be within `SnapshotStaleAfter` of the past.

Same-instance writes use `time.Now()` and stay well within tolerance, so there is no single-instance regression. Encode/decode are unchanged.

## Tests

Pure-helper coverage (no live tmux): `now+1m` rejected; `now+1s` and `now-5s` accepted; `now-15s` rejected; `at==now` accepted; both sides of the skew boundary. Plus a round-trip through `EncodeSnapshot`/`DecodeSnapshot` proving the decoded timestamp still trips the cap.