### PR TITLE
Eagerly rescan tmux activity on agent tab start/reattach

### DIFF
--- a/internal/app/app_eager_scan_test.go
+++ b/internal/app/app_eager_scan_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+)
+
+// TestUpdate_TabReattachedSchedulesEagerScan proves a reattached agent triggers
+// an immediate activity rescan instead of waiting up to one ticker interval, and
+// that a second reattach while a scan is in flight only marks a rescan pending.
+func TestUpdate_TabReattachedSchedulesEagerScan(t *testing.T) {
+	app := &App{tmuxAvailable: true}
+
+	app.update(messages.TabReattached{WorkspaceID: "ws-a"})
+	if !app.tmuxActivityScanInFlight {
+		t.Fatal("expected an eager scan to be scheduled on TabReattached")
+	}
+	if app.tmuxActivityToken != 1 {
+		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivityToken)
+	}
+
+	// A second reattach while the first scan is in flight must coalesce: no new
+	// token, only a pending rescan.
+	app.update(messages.TabReattached{WorkspaceID: "ws-b"})
+	if app.tmuxActivityToken != 1 {
+		t.Fatalf("expected in-flight reattach to coalesce (token stays 1), got %d", app.tmuxActivityToken)
+	}
+	if !app.tmuxActivityRescanPending {
+		t.Fatal("expected in-flight second reattach to set rescan-pending")
+	}
+}
+
+// TestUpdate_TabCreatedSchedulesEagerScan proves a freshly created agent tab
+// schedules an immediate activity rescan.
+func TestUpdate_TabCreatedSchedulesEagerScan(t *testing.T) {
+	app := &App{
+		tmuxAvailable: true,
+		center:        center.New(nil),
+	}
+
+	app.update(messages.TabCreated{Name: "claude"})
+	if !app.tmuxActivityScanInFlight {
+		t.Fatal("expected an eager scan to be scheduled on TabCreated")
+	}
+	if app.tmuxActivityToken != 1 {
+		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivityToken)
+	}
+}
+
+// TestUpdate_TabReattachedNoScanWhenTmuxUnavailable proves the eager scan is
+// suppressed when tmux is unavailable, avoiding no-op churn.
+func TestUpdate_TabReattachedNoScanWhenTmuxUnavailable(t *testing.T) {
+	app := &App{tmuxAvailable: false}
+
+	app.update(messages.TabReattached{WorkspaceID: "ws-a"})
+	if app.tmuxActivityScanInFlight {
+		t.Fatal("expected no scan scheduled when tmux is unavailable")
+	}
+	if app.tmuxActivityToken != 0 {
+		t.Fatalf("expected scan token untouched, got %d", app.tmuxActivityToken)
+	}
+}

--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -211,6 +211,11 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := a.persistActiveWorkspaceTabs(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		// Eagerly rescan so a just-started agent's working indicator does not
+		// wait up to one ticker interval (~5s) to appear.
+		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case messages.TabClosed:
 		logging.Info("Tab closed: %d", msg.Index)
@@ -227,6 +232,11 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.TabReattached:
 		cmds = append(cmds, a.enforceAttachedAgentTabLimit()...)
 		cmds = append(cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
+		// Eagerly rescan so a reattached agent's working indicator does not
+		// wait up to one ticker interval (~5s) to appear.
+		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case messages.TabStateChanged:
 		cmds = append(cmds, a.persistWorkspaceTabs(msg.WorkspaceID))

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -61,6 +61,18 @@ func (a *App) triggerTmuxActivityScan() tea.Cmd {
 	}
 }
 
+// eagerScanTmuxActivity schedules an immediate activity rescan when tmux is
+// available, used on agent tab start/reattach so a freshly running agent does
+// not wait up to one full ticker interval (~5s) before its working indicator
+// can appear. It coalesces with any in-flight scan via scanTmuxActivityNow and
+// no-ops when tmux is unavailable to avoid churn.
+func (a *App) eagerScanTmuxActivity() tea.Cmd {
+	if !a.tmuxAvailable {
+		return nil
+	}
+	return a.scanTmuxActivityNow()
+}
+
 func (a *App) scanTmuxActivityNow() tea.Cmd {
 	if a.tmuxActivityScanInFlight {
 		a.tmuxActivityRescanPending = true


### PR DESCRIPTION
## What

Activity was re-scanned only on the 5s ticker, on `ProjectsLoaded`, and on tmux-available. So when an agent starts (or reattaches), the next tick could be up to ~5s away and the working spinner appeared late, even though the agent was actively generating.

## Change

Add `eagerScanTmuxActivity` (gated on `tmuxAvailable`, coalescing through `scanTmuxActivityNow`'s in-flight / rescan-pending machinery) and call it from the `messages.TabCreated` and `messages.TabReattached` handlers after the tab is `Running`. No new message type and no new throttle.

## Honest scope

This shaves the cadence **phase** — it avoids waiting up to one tick and burns one settle scan earlier. It does **not** guarantee a spinner within one scan, since fresh output still routes through the pane-delta hysteresis (fresh-tag baseline seed + the two-scan settle). It is a latency nicety, not a one-scan correctness win.

## Tests

- `TabCreated` and `TabReattached` each schedule a scan (in-flight set, token incremented).
- A second eager call while in flight only sets rescan-pending.
- An unavailable-tmux reattach schedules nothing.