### PR TITLE
Log throttled PTY output-overflow drops in center + sidebar

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -21,8 +21,8 @@ const overflowLogThrottle = 2 * time.Second
 // throttled overflow Warn should be emitted now (the caller logs outside the
 // lock). It returns the aggregated dropped-byte total to report when logNow is
 // true. The caller must hold tab.mu.
-func (t *Tab) noteOverflowDropLocked(overflow int) (logNow bool, total int) {
-	t.overflowDroppedSinceLog += overflow
+func (t *Tab) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
+	t.overflowDroppedSinceLog += droppedBytes
 	now := time.Now()
 	if t.lastOverflowLogAt.IsZero() || now.Sub(t.lastOverflowLogAt) >= overflowLogThrottle {
 		total = t.overflowDroppedSinceLog
@@ -126,7 +126,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				tab.ptyNoiseTrailing = nil
 				tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
 			}
-			overflowLogNow, overflowDroppedTotal := tab.noteOverflowDropLocked(overflow)
+			overflowLogNow, overflowDroppedTotal := tab.noteOverflowDropLocked(retainedStart)
 			tab.mu.Unlock()
 			if overflowLogNow {
 				logging.Warn("PTY output overflow for tab %s: dropped %d bytes (buffer cap %d)", tab.ID, overflowDroppedTotal, ptyMaxBufferedBytes)

--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -6,12 +6,32 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
+
+// overflowLogThrottle bounds how often a sustained PTY overflow logs.
+const overflowLogThrottle = 2 * time.Second
+
+// noteOverflowDropLocked accumulates dropped overflow bytes and reports whether a
+// throttled overflow Warn should be emitted now (the caller logs outside the
+// lock). It returns the aggregated dropped-byte total to report when logNow is
+// true. The caller must hold tab.mu.
+func (t *Tab) noteOverflowDropLocked(overflow int) (logNow bool, total int) {
+	t.overflowDroppedSinceLog += overflow
+	now := time.Now()
+	if t.lastOverflowLogAt.IsZero() || now.Sub(t.lastOverflowLogAt) >= overflowLogThrottle {
+		total = t.overflowDroppedSinceLog
+		t.overflowDroppedSinceLog = 0
+		t.lastOverflowLogAt = now
+		return true, total
+	}
+	return false, 0
+}
 
 // updatePTYOutput handles PTYOutput.
 func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
@@ -106,7 +126,11 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				tab.ptyNoiseTrailing = nil
 				tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
 			}
+			overflowLogNow, overflowDroppedTotal := tab.noteOverflowDropLocked(overflow)
 			tab.mu.Unlock()
+			if overflowLogNow {
+				logging.Warn("PTY output overflow for tab %s: dropped %d bytes (buffer cap %d)", tab.ID, overflowDroppedTotal, ptyMaxBufferedBytes)
+			}
 		}
 		perf.Count("pty_output_bytes", int64(len(msg.Data)))
 		now := time.Now()

--- a/internal/ui/center/model_overflow_log_test.go
+++ b/internal/ui/center/model_overflow_log_test.go
@@ -1,0 +1,95 @@
+package center
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// TestNoteOverflowDropLocked_ThrottlesAndAggregates pins the throttle window and
+// byte-aggregation contract independent of the log writer.
+func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
+	tab := &Tab{}
+
+	logNow, total := tab.noteOverflowDropLocked(100)
+	if !logNow || total != 100 {
+		t.Fatalf("first drop should log immediately with its total, got logNow=%v total=%d", logNow, total)
+	}
+	if ln, _ := tab.noteOverflowDropLocked(50); ln {
+		t.Fatal("second drop within the throttle window should be suppressed")
+	}
+	if ln, _ := tab.noteOverflowDropLocked(25); ln {
+		t.Fatal("third drop within the throttle window should be suppressed")
+	}
+	// Simulate the throttle window elapsing.
+	tab.lastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
+	logNow, total = tab.noteOverflowDropLocked(10)
+	if !logNow {
+		t.Fatal("a drop after the throttle window should log")
+	}
+	if total != 85 {
+		t.Fatalf("expected aggregated 50+25+10=85 dropped bytes, got %d", total)
+	}
+}
+
+// TestUpdatePTYOutput_OverflowEmitsThrottledWarn drives the real overflow path
+// and asserts exactly one Warn is written at the default level even though two
+// overflows occur back to back.
+func TestUpdatePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelWarn); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	m := New(cfg)
+	ws := &data.Workspace{Name: "ws", Repo: "/repo", Root: "/repo"}
+	m.SetWorkspace(ws)
+	wsID := string(ws.ID())
+	tab := &Tab{ID: TabID("overflow-tab"), Workspace: ws, Terminal: vterm.New(80, 24), Running: true}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+
+	overflowChunk := bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+4096)
+	_ = m.updatePTYOutput(PTYOutput{WorkspaceID: wsID, TabID: tab.ID, Data: overflowChunk})
+	// A second overflow immediately after must be throttled (no second Warn).
+	_ = m.updatePTYOutput(PTYOutput{WorkspaceID: wsID, TabID: tab.ID, Data: bytes.Repeat([]byte("y"), ptyMaxBufferedBytes+4096)})
+
+	logging.Close()
+	if got := countLogLines(t, dir, "PTY output overflow"); got != 1 {
+		t.Fatalf("expected exactly one throttled overflow Warn, got %d", got)
+	}
+}
+
+func countLogLines(t *testing.T, dir, needle string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "amux-*.log"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("no log file written in %s (err=%v)", dir, err)
+	}
+	count := 0
+	for _, p := range matches {
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			t.Fatalf("read log: %v", readErr)
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.Contains(line, needle) {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/internal/ui/center/model_overflow_log_test.go
+++ b/internal/ui/center/model_overflow_log_test.go
@@ -73,23 +73,62 @@ func TestUpdatePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
 	}
 }
 
+func TestUpdatePTYOutput_OverflowWarnReportsActualTrimmedBytes(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelWarn); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	m := New(cfg)
+	ws := &data.Workspace{Name: "ws", Repo: "/repo", Root: "/repo"}
+	m.SetWorkspace(ws)
+	wsID := string(ws.ID())
+	tab := &Tab{ID: TabID("overflow-tab"), Workspace: ws, Terminal: vterm.New(80, 24), Running: true}
+	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.activeTabByWorkspace[wsID] = 0
+
+	controlSeq := []byte("\x1b[>1;10;0c")
+	chunk := append([]byte{}, controlSeq...)
+	chunk = append(chunk, bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+1-len(controlSeq))...)
+	_ = m.updatePTYOutput(PTYOutput{WorkspaceID: wsID, TabID: tab.ID, Data: chunk})
+
+	logging.Close()
+	logText := readLogText(t, dir)
+	if !strings.Contains(logText, "dropped 10 bytes") {
+		t.Fatalf("expected overflow Warn to report dropped 10 bytes, log:\n%s", logText)
+	}
+}
+
 func countLogLines(t *testing.T, dir, needle string) int {
+	t.Helper()
+	logText := readLogText(t, dir)
+	count := 0
+	for _, line := range strings.Split(logText, "\n") {
+		if strings.Contains(line, needle) {
+			count++
+		}
+	}
+	return count
+}
+
+func readLogText(t *testing.T, dir string) string {
 	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(dir, "amux-*.log"))
 	if err != nil || len(matches) == 0 {
 		t.Fatalf("no log file written in %s (err=%v)", dir, err)
 	}
-	count := 0
+	var out strings.Builder
 	for _, p := range matches {
 		b, readErr := os.ReadFile(p)
 		if readErr != nil {
 			t.Fatalf("read log: %v", readErr)
 		}
-		for _, line := range strings.Split(string(b), "\n") {
-			if strings.Contains(line, needle) {
-				count++
-			}
-		}
+		out.Write(b)
 	}
-	return count
+	return out.String()
 }

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -66,32 +66,36 @@ type Tab struct {
 	readerActive     bool // Guard to ensure only one PTY read loop per tab
 	// Buffer PTY output to avoid rendering partial screen updates.
 
-	pendingOutput            []byte
-	pendingOutputBytes       int
-	catchUpPendingOutput     bool
-	catchUpTargetBytes       uint64
-	ptyBytesReceived         uint64
-	ptyBytesSettled          uint64
-	ptyNoiseTrailing         []byte
-	flushScheduled           bool
-	lastOutputAt             time.Time
-	lastVisibleOutput        time.Time
-	pendingVisibleOutput     bool
-	pendingVisibleSeq        uint64
-	activityDigest           [16]byte
-	activityDigestInit       bool
-	lastActivityTagAt        time.Time
-	activityANSIState        ansiActivityState
-	lastInputTagAt           time.Time
-	lastUserInputAt          time.Time
-	bootstrapActivity        bool
-	bootstrapLastOutputAt    time.Time
-	flushPendingSince        time.Time
-	postWriteVisibleState    uint32
-	lastPromptInputAt        time.Time
-	lastPromptSubmitAt       time.Time
-	pendingSubmitPasteEcho   string
-	overflowTrimCarry        vterm.ParserCarryState
+	pendingOutput          []byte
+	pendingOutputBytes     int
+	catchUpPendingOutput   bool
+	catchUpTargetBytes     uint64
+	ptyBytesReceived       uint64
+	ptyBytesSettled        uint64
+	ptyNoiseTrailing       []byte
+	flushScheduled         bool
+	lastOutputAt           time.Time
+	lastVisibleOutput      time.Time
+	pendingVisibleOutput   bool
+	pendingVisibleSeq      uint64
+	activityDigest         [16]byte
+	activityDigestInit     bool
+	lastActivityTagAt      time.Time
+	activityANSIState      ansiActivityState
+	lastInputTagAt         time.Time
+	lastUserInputAt        time.Time
+	bootstrapActivity      bool
+	bootstrapLastOutputAt  time.Time
+	flushPendingSince      time.Time
+	postWriteVisibleState  uint32
+	lastPromptInputAt      time.Time
+	lastPromptSubmitAt     time.Time
+	pendingSubmitPasteEcho string
+	overflowTrimCarry      vterm.ParserCarryState
+	// Throttle + accumulator for the overflow-drop Warn so a sustained overflow
+	// logs at most once per overflowLogThrottle with the aggregated byte count.
+	lastOverflowLogAt        time.Time
+	overflowDroppedSinceLog  int
 	parserResetPending       bool
 	actorWritesPending       int
 	actorQueuedBytes         int

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -57,6 +57,10 @@ type TerminalState struct {
 	flushScheduled    bool
 	lastOutputAt      time.Time
 	flushPendingSince time.Time
+	// Throttle + accumulator for the overflow-drop Warn (at most one per
+	// overflowLogThrottle with the aggregated dropped-byte count).
+	lastOverflowLogAt       time.Time
+	overflowDroppedSinceLog int
 
 	// Selection state
 	Selection          common.SelectionState

--- a/internal/ui/sidebar/terminal_overflow_log_test.go
+++ b/internal/ui/sidebar/terminal_overflow_log_test.go
@@ -1,0 +1,87 @@
+package sidebar
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// TestNoteOverflowDropLocked_ThrottlesAndAggregates pins the throttle window and
+// byte-aggregation contract independent of the log writer.
+func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
+	ts := &TerminalState{}
+
+	logNow, total := ts.noteOverflowDropLocked(100)
+	if !logNow || total != 100 {
+		t.Fatalf("first drop should log immediately with its total, got logNow=%v total=%d", logNow, total)
+	}
+	if ln, _ := ts.noteOverflowDropLocked(50); ln {
+		t.Fatal("second drop within the throttle window should be suppressed")
+	}
+	if ln, _ := ts.noteOverflowDropLocked(25); ln {
+		t.Fatal("third drop within the throttle window should be suppressed")
+	}
+	ts.lastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
+	logNow, total = ts.noteOverflowDropLocked(10)
+	if !logNow {
+		t.Fatal("a drop after the throttle window should log")
+	}
+	if total != 85 {
+		t.Fatalf("expected aggregated 50+25+10=85 dropped bytes, got %d", total)
+	}
+}
+
+// TestHandlePTYOutput_OverflowEmitsThrottledWarn drives the real sidebar overflow
+// path and asserts exactly one Warn is written even though two overflows occur.
+func TestHandlePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelWarn); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	m := NewTerminalModel()
+	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
+	wsID := string(ws.ID())
+	tabID := TerminalTabID("term-overflow")
+	state := &TerminalState{VTerm: vterm.New(80, 24)}
+	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+
+	overflowChunk := bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+4096)
+	_ = m.handlePTYOutput(messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: overflowChunk})
+	_ = m.handlePTYOutput(messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: bytes.Repeat([]byte("y"), ptyMaxBufferedBytes+4096)})
+
+	logging.Close()
+	if got := countLogLines(t, dir, "Sidebar PTY output overflow"); got != 1 {
+		t.Fatalf("expected exactly one throttled overflow Warn, got %d", got)
+	}
+}
+
+func countLogLines(t *testing.T, dir, needle string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "amux-*.log"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("no log file written in %s (err=%v)", dir, err)
+	}
+	count := 0
+	for _, p := range matches {
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			t.Fatalf("read log: %v", readErr)
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.Contains(line, needle) {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/internal/ui/sidebar/terminal_overflow_log_test.go
+++ b/internal/ui/sidebar/terminal_overflow_log_test.go
@@ -65,23 +65,57 @@ func TestHandlePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
 	}
 }
 
+func TestHandlePTYOutput_OverflowWarnReportsActualTrimmedBytes(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelWarn); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	m := NewTerminalModel()
+	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
+	wsID := string(ws.ID())
+	tabID := TerminalTabID("term-overflow")
+	state := &TerminalState{VTerm: vterm.New(80, 24)}
+	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+
+	controlSeq := []byte("\x1b[>1;10;0c")
+	chunk := append([]byte{}, controlSeq...)
+	chunk = append(chunk, bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+1-len(controlSeq))...)
+	_ = m.handlePTYOutput(messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: chunk})
+
+	logging.Close()
+	logText := readLogText(t, dir)
+	if !strings.Contains(logText, "dropped 10 bytes") {
+		t.Fatalf("expected overflow Warn to report dropped 10 bytes, log:\n%s", logText)
+	}
+}
+
 func countLogLines(t *testing.T, dir, needle string) int {
+	t.Helper()
+	logText := readLogText(t, dir)
+	count := 0
+	for _, line := range strings.Split(logText, "\n") {
+		if strings.Contains(line, needle) {
+			count++
+		}
+	}
+	return count
+}
+
+func readLogText(t *testing.T, dir string) string {
 	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(dir, "amux-*.log"))
 	if err != nil || len(matches) == 0 {
 		t.Fatalf("no log file written in %s (err=%v)", dir, err)
 	}
-	count := 0
+	var out strings.Builder
 	for _, p := range matches {
 		b, readErr := os.ReadFile(p)
 		if readErr != nil {
 			t.Fatalf("read log: %v", readErr)
 		}
-		for _, line := range strings.Split(string(b), "\n") {
-			if strings.Contains(line, needle) {
-				count++
-			}
-		}
+		out.Write(b)
 	}
-	return count
+	return out.String()
 }

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -19,8 +19,8 @@ const overflowLogThrottle = 2 * time.Second
 // noteOverflowDropLocked accumulates dropped overflow bytes and reports whether a
 // throttled overflow Warn should be emitted now (caller logs outside the lock),
 // returning the aggregated dropped-byte total. The caller must hold ts.mu.
-func (ts *TerminalState) noteOverflowDropLocked(overflow int) (logNow bool, total int) {
-	ts.overflowDroppedSinceLog += overflow
+func (ts *TerminalState) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
+	ts.overflowDroppedSinceLog += droppedBytes
 	now := time.Now()
 	if ts.lastOverflowLogAt.IsZero() || now.Sub(ts.lastOverflowLogAt) >= overflowLogThrottle {
 		total = ts.overflowDroppedSinceLog
@@ -68,7 +68,7 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 		if retainedStart > prevPendingLen {
 			ts.ptyNoiseTrailing = nil
 		}
-		overflowLogNow, overflowDroppedTotal := ts.noteOverflowDropLocked(overflow)
+		overflowLogNow, overflowDroppedTotal := ts.noteOverflowDropLocked(retainedStart)
 		ts.mu.Unlock()
 		if overflowLogNow {
 			logging.Warn("Sidebar PTY output overflow for workspace %s tab %s: dropped %d bytes (buffer cap %d)", wsID, tabID, overflowDroppedTotal, ptyMaxBufferedBytes)

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -13,6 +13,24 @@ import (
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
+// overflowLogThrottle bounds how often a sustained PTY overflow logs.
+const overflowLogThrottle = 2 * time.Second
+
+// noteOverflowDropLocked accumulates dropped overflow bytes and reports whether a
+// throttled overflow Warn should be emitted now (caller logs outside the lock),
+// returning the aggregated dropped-byte total. The caller must hold ts.mu.
+func (ts *TerminalState) noteOverflowDropLocked(overflow int) (logNow bool, total int) {
+	ts.overflowDroppedSinceLog += overflow
+	now := time.Now()
+	if ts.lastOverflowLogAt.IsZero() || now.Sub(ts.lastOverflowLogAt) >= overflowLogThrottle {
+		total = ts.overflowDroppedSinceLog
+		ts.overflowDroppedSinceLog = 0
+		ts.lastOverflowLogAt = now
+		return true, total
+	}
+	return false, 0
+}
+
 // handlePTYOutput buffers incoming PTY data and schedules a flush.
 func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	wsID := msg.WorkspaceID
@@ -50,7 +68,11 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 		if retainedStart > prevPendingLen {
 			ts.ptyNoiseTrailing = nil
 		}
+		overflowLogNow, overflowDroppedTotal := ts.noteOverflowDropLocked(overflow)
 		ts.mu.Unlock()
+		if overflowLogNow {
+			logging.Warn("Sidebar PTY output overflow for workspace %s tab %s: dropped %d bytes (buffer cap %d)", wsID, tabID, overflowDroppedTotal, ptyMaxBufferedBytes)
+		}
 	}
 	ts.lastOutputAt = time.Now()
 	if !ts.flushScheduled {


### PR DESCRIPTION
## What

When a tab's `pendingOutput` exceeds `ptyMaxBufferedBytes` (8 MiB center / 4 MiB sidebar) the oldest bytes are discarded, but the only signal was two `perf.Count` calls — no-ops unless `AMUX_PROFILE` is set. Dropping agent output is a user-visible correctness event (a gap or truncated transcript) yet left **zero trace at the default log level**, so "the agent's output got cut off / scrollback is missing a chunk" was undiagnosable.

## Change

Emit a throttled `logging.Warn` on overflow in both panes:

- A `noteOverflowDropLocked` helper accumulates dropped bytes under the existing lock and reports whether the ~2s throttle window has elapsed.
- The Warn is emitted **outside** the lock with the aggregated byte total, so a sustained overflow logs **at most once per window** rather than per chunk.
- Both `perf.Count` calls are preserved.
- Extracting the helper keeps the already-oversized `updatePTYOutput` from growing into the funlen ratchet.

Depends on #1 (`AMUX_LOG_LEVEL`) so the Warn is visible at the default level.

## Tests

- The throttle/aggregation contract is pinned directly (`noteOverflowDropLocked`: first drop logs, subsequent within window suppressed, post-window logs aggregated total).
- The real overflow path is driven end to end in both panes — two back-to-back >cap writes produce **exactly one** Warn at the default level.