### PR TITLE
Log tab-actor stall + direct-send degradation

### DIFF
--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
@@ -37,8 +38,11 @@ type Model struct {
 	tabActorReady         uint32
 	tabActorHeartbeat     int64
 	tabActorRedrawPending uint32
-	flushLoadSampleAt     time.Time
-	cachedBusyTabCount    int
+	// tabActorStalled gates a single stall/recovery log per episode so the
+	// otherwise-silent degradation to synchronous direct-send is observable.
+	tabActorStalled    uint32
+	flushLoadSampleAt  time.Time
+	cachedBusyTabCount int
 
 	// Layout
 	width           int
@@ -166,6 +170,11 @@ func (m *Model) isTabActorReady() bool {
 	}
 	if time.Since(time.Unix(0, lastBeat)) > tabActorStallTimeout {
 		atomic.StoreUint32(&m.tabActorReady, 0)
+		// CAS-gate so a stall logs exactly once per episode even though the hot
+		// read path calls this on every keystroke/scroll/write.
+		if atomic.CompareAndSwapUint32(&m.tabActorStalled, 0, 1) {
+			logging.Warn("tab actor stalled (>%s since last heartbeat); falling back to direct send", tabActorStallTimeout)
+		}
 		return false
 	}
 	return true
@@ -174,6 +183,9 @@ func (m *Model) isTabActorReady() bool {
 func (m *Model) setTabActorReady() {
 	atomic.StoreInt64(&m.tabActorHeartbeat, time.Now().UnixNano())
 	atomic.StoreUint32(&m.tabActorReady, 1)
+	// Clear any prior stall episode without logging a recovery: this is a fresh
+	// (re)attach, not a heartbeat-driven recovery.
+	atomic.StoreUint32(&m.tabActorStalled, 0)
 }
 
 func (m *Model) noteTabActorHeartbeat() {
@@ -189,6 +201,10 @@ func (m *Model) noteTabActorHeartbeat() {
 	}
 	if atomic.LoadUint32(&m.tabActorReady) == 0 {
 		atomic.StoreUint32(&m.tabActorReady, 1)
+	}
+	// A heartbeat after a stall episode is a genuine recovery; log it once.
+	if atomic.CompareAndSwapUint32(&m.tabActorStalled, 1, 0) {
+		logging.Info("tab actor recovered")
 	}
 }
 

--- a/internal/ui/center/model_actor_stall_test.go
+++ b/internal/ui/center/model_actor_stall_test.go
@@ -1,0 +1,71 @@
+package center
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+// TestTabActorStall_LogsOnceAndRecovers proves the actor-stall degradation (which
+// silently routes input/scroll/writes through the slower synchronous direct-send
+// path) logs exactly once per episode, and a heartbeat logs a single recovery.
+func TestTabActorStall_LogsOnceAndRecovers(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelDebug); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	m := &Model{}
+	m.setTabActorReady()
+	// Force the heartbeat older than the stall timeout.
+	atomic.StoreInt64(&m.tabActorHeartbeat, time.Now().Add(-2*tabActorStallTimeout).UnixNano())
+
+	for i := 0; i < 5; i++ {
+		if m.isTabActorReady() {
+			t.Fatal("expected actor to read as not-ready while stalled")
+		}
+	}
+
+	// Recovery: a heartbeat flips ready back and logs exactly one recovery; a
+	// second heartbeat must not re-log.
+	m.noteTabActorHeartbeat()
+	m.noteTabActorHeartbeat()
+
+	logging.Close()
+	if got := countLogLines(t, dir, "tab actor stalled"); got != 1 {
+		t.Fatalf("expected exactly one stall Warn, got %d", got)
+	}
+	if got := countLogLines(t, dir, "tab actor recovered"); got != 1 {
+		t.Fatalf("expected exactly one recovery Info, got %d", got)
+	}
+}
+
+// TestSetTabActorReady_ClearsStallWithoutRecoveryLog proves a fresh (re)attach
+// clears a prior stall episode silently — no spurious "recovered" line.
+func TestSetTabActorReady_ClearsStallWithoutRecoveryLog(t *testing.T) {
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelDebug); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	m := &Model{}
+	m.setTabActorReady()
+	atomic.StoreInt64(&m.tabActorHeartbeat, time.Now().Add(-2*tabActorStallTimeout).UnixNano())
+	if m.isTabActorReady() {
+		t.Fatal("expected stalled actor to read not-ready")
+	}
+
+	// A fresh attach resets readiness and the stall flag, but must not log a
+	// heartbeat-style recovery.
+	m.setTabActorReady()
+	m.noteTabActorHeartbeat()
+
+	logging.Close()
+	if got := countLogLines(t, dir, "tab actor recovered"); got != 0 {
+		t.Fatalf("expected no recovery Info after a fresh attach cleared the stall, got %d", got)
+	}
+}


### PR DESCRIPTION
## What

`isTabActorReady()` demotes the actor to not-ready when the heartbeat is older than `tabActorStallTimeout` (10s) with **no log**. The whole input/scroll/write path keys off `isTabActorReady()` (~21 call sites): when it flips false, keystrokes/scrolls/PTY writes silently route through the slower synchronous direct-send fallback while holding `tab.mu` on the UI goroutine. The PTY-reader stall path already logs; the actor-stall path was the only silent degradation, so "the UI got janky after a heavy build" was undetectable from logs.

## Change

- Add a `tabActorStalled` atomic and CAS-gate a single log per episode: a `Warn` at the stall transition, an `Info` when a heartbeat recovers.
- `setTabActorReady` clears the flag **without** logging (a fresh attach is not a heartbeat recovery).
- The hot read path stays lock-free — once stalled, the `tabActorReady==0` early-return bails before the stall check.

Depends on #1 for visibility at the default level. Pure observability of a rare, self-recovering degraded mode.

## Tests

- A stalled heartbeat read multiple times logs exactly one stall Warn.
- A heartbeat then logs exactly one recovery Info (a second does not re-log).
- A fresh `setTabActorReady` clears the stall without a spurious recovery line.