### PR TITLE
Remove leaked per-workspace .lock files on delete

### DIFF
--- a/internal/data/registry_lock_unix.go
+++ b/internal/data/registry_lock_unix.go
@@ -3,6 +3,7 @@
 package data
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -12,19 +13,30 @@ func lockRegistryFile(lockPath string, shared bool) (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
-	if err != nil {
-		return nil, err
-	}
 	flag := syscall.LOCK_EX
 	if shared {
 		flag = syscall.LOCK_SH
 	}
-	if err := syscall.Flock(int(file.Fd()), flag); err != nil {
-		_ = file.Close()
-		return nil, err
+
+	for {
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+		if err != nil {
+			return nil, err
+		}
+		if err := syscall.Flock(int(file.Fd()), flag); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		current, err := registryLockFileCurrent(file, lockPath)
+		if err != nil {
+			unlockRegistryFile(file)
+			return nil, err
+		}
+		if current {
+			return file, nil
+		}
+		unlockRegistryFile(file)
 	}
-	return file, nil
 }
 
 func unlockRegistryFile(file *os.File) {
@@ -33,4 +45,27 @@ func unlockRegistryFile(file *os.File) {
 	}
 	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
 	_ = file.Close()
+}
+
+func registryLockFileCurrent(file *os.File, lockPath string) (bool, error) {
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return false, err
+	}
+	pathInfo, err := os.Stat(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	fileStat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true, nil
+	}
+	pathStat, ok := pathInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true, nil
+	}
+	return fileStat.Dev == pathStat.Dev && fileStat.Ino == pathStat.Ino, nil
 }

--- a/internal/data/registry_lock_unix_test.go
+++ b/internal/data/registry_lock_unix_test.go
@@ -1,0 +1,60 @@
+//go:build !windows
+
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLockRegistryFileRetriesWhenWaiterAcquiresUnlinkedInode(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "workspace.lock")
+	held, err := lockRegistryFile(lockPath, false)
+	if err != nil {
+		t.Fatalf("initial lockRegistryFile() error = %v", err)
+	}
+
+	waiter := make(chan *os.File, 1)
+	waitErr := make(chan error, 1)
+	go func() {
+		file, lockErr := lockRegistryFile(lockPath, false)
+		if lockErr != nil {
+			waitErr <- lockErr
+			return
+		}
+		waiter <- file
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove lock path: %v", err)
+	}
+	replacement, err := lockRegistryFile(lockPath, false)
+	if err != nil {
+		t.Fatalf("replacement lockRegistryFile() error = %v", err)
+	}
+	unlockRegistryFile(held)
+
+	select {
+	case err := <-waitErr:
+		unlockRegistryFile(replacement)
+		t.Fatalf("waiter lockRegistryFile() error = %v", err)
+	case file := <-waiter:
+		unlockRegistryFile(file)
+		unlockRegistryFile(replacement)
+		t.Fatal("waiter acquired the unlinked inode while the replacement lock was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	unlockRegistryFile(replacement)
+	select {
+	case err := <-waitErr:
+		t.Fatalf("waiter lockRegistryFile() error = %v", err)
+	case file := <-waiter:
+		unlockRegistryFile(file)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire the replacement lock after it was released")
+	}
+}

--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -183,6 +183,10 @@ func (s *WorkspaceStore) Save(ws *Workspace) error {
 		if err := s.deleteWorkspaceDir(oldID); err != nil {
 			logging.Warn("Failed to remove old workspace metadata %s: %v", oldID, err)
 		}
+		// Both id and oldID flocks are held here; remove the stale oldID lock file
+		// inside that critical section. Never remove id.lock — id is the live
+		// workspace we just wrote.
+		s.removeWorkspaceLockFile(oldID)
 	}
 	ws.storeID = id
 	return nil
@@ -198,7 +202,14 @@ func (s *WorkspaceStore) Delete(id WorkspaceID) error {
 		return err
 	}
 	defer unlockRegistryFiles(lockFiles)
-	return s.deleteWorkspaceDir(id)
+	if err := s.deleteWorkspaceDir(id); err != nil {
+		return err
+	}
+	// Remove the leaked sibling <id>.lock while still holding the exclusive flock
+	// (before the deferred unlock), so the rendezvous file does not accumulate for
+	// every created-then-deleted workspace.
+	s.removeWorkspaceLockFile(id)
+	return nil
 }
 
 // ListByRepo returns all workspaces for a given repository path

--- a/internal/data/workspace_store_lockfile_test.go
+++ b/internal/data/workspace_store_lockfile_test.go
@@ -1,0 +1,69 @@
+package data
+
+import (
+	"os"
+	"testing"
+)
+
+// TestWorkspaceStore_RemovesLockFileOnDelete proves the sibling <id>.lock
+// rendezvous file is cleaned up on Delete instead of leaking forever.
+func TestWorkspaceStore_RemovesLockFileOnDelete(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	ws := &Workspace{
+		Name: "lockfile-delete",
+		Repo: "/home/user/repo",
+		Root: "/home/user/.amux/workspaces/lockfile-delete",
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	id := ws.ID()
+	lockPath := store.workspaceLockPath(id)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file created by Save, stat err=%v", err)
+	}
+
+	if err := store.Delete(id); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected lock file removed after Delete, stat err=%v", err)
+	}
+}
+
+// TestWorkspaceStore_RemovesOldLockFileOnSaveRebind proves a rebind (ID change)
+// removes the stale old lock file while keeping the live one.
+func TestWorkspaceStore_RemovesOldLockFileOnSaveRebind(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	ws := &Workspace{
+		Name: "lockfile-rebind",
+		Repo: "/home/user/repo",
+		Root: "/home/user/.amux/workspaces/old-root",
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	oldID := ws.ID()
+
+	// Rebind: changing Root changes the computed ID while storeID still points at
+	// the old metadata, triggering the oldID cleanup branch.
+	ws.Root = "/home/user/.amux/workspaces/new-root"
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("rebind Save() error = %v", err)
+	}
+	newID := ws.ID()
+	if oldID == newID {
+		t.Fatal("expected the workspace ID to change on rebind")
+	}
+
+	if _, err := os.Stat(store.workspaceLockPath(oldID)); !os.IsNotExist(err) {
+		t.Fatalf("expected stale old lock file removed after rebind, stat err=%v", err)
+	}
+	if _, err := os.Stat(store.workspaceLockPath(newID)); err != nil {
+		t.Fatalf("expected live new lock file retained, stat err=%v", err)
+	}
+}

--- a/internal/data/workspace_store_locking.go
+++ b/internal/data/workspace_store_locking.go
@@ -55,10 +55,11 @@ func (s *WorkspaceStore) deleteWorkspaceDir(id WorkspaceID) error {
 }
 
 // removeWorkspaceLockFile unlinks the sibling <id>.lock rendezvous file. It MUST
-// be called while the caller still holds the exclusive flock on that file: any
-// waiter is blocked and re-OpenFiles a fresh inode after release, so removing the
-// path here does not break flock mutual exclusion. Unlinking after releasing the
-// lock would. A missing file is not an error (already cleaned, or never created).
+// be called while the caller still holds the exclusive flock on that file:
+// lockRegistryFile verifies the locked fd still matches the current path after
+// flock returns, so waiters that acquired an unlinked inode reopen the fresh
+// rendezvous file instead of entering a split critical section. A missing file is
+// not an error (already cleaned, or never created).
 func (s *WorkspaceStore) removeWorkspaceLockFile(id WorkspaceID) {
 	if err := os.Remove(s.workspaceLockPath(id)); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		logging.Warn("Failed to remove workspace lock file for %s: %v", id, err)

--- a/internal/data/workspace_store_locking.go
+++ b/internal/data/workspace_store_locking.go
@@ -1,9 +1,13 @@
 package data
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/andyrewlee/amux/internal/logging"
 )
 
 func (s *WorkspaceStore) lockWorkspaceIDs(ids ...WorkspaceID) ([]*os.File, error) {
@@ -48,4 +52,15 @@ func unlockRegistryFiles(files []*os.File) {
 func (s *WorkspaceStore) deleteWorkspaceDir(id WorkspaceID) error {
 	dir := filepath.Join(s.root, string(id))
 	return os.RemoveAll(dir)
+}
+
+// removeWorkspaceLockFile unlinks the sibling <id>.lock rendezvous file. It MUST
+// be called while the caller still holds the exclusive flock on that file: any
+// waiter is blocked and re-OpenFiles a fresh inode after release, so removing the
+// path here does not break flock mutual exclusion. Unlinking after releasing the
+// lock would. A missing file is not an error (already cleaned, or never created).
+func (s *WorkspaceStore) removeWorkspaceLockFile(id WorkspaceID) {
+	if err := os.Remove(s.workspaceLockPath(id)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		logging.Warn("Failed to remove workspace lock file for %s: %v", id, err)
+	}
 }


### PR DESCRIPTION
## What

Every workspace gets a sibling lock file `<root>/<id>.lock` (created by `lockWorkspaceIDs` on every Save/Delete), but `deleteWorkspaceDir` only `RemoveAll`'d the `<root>/<id>` directory and never the `.lock`. So each created-then-deleted workspace permanently leaked a zero-byte `.lock` in the metadata dir — harmless to lookups (`List()` skips non-dirs) but accumulating clutter.

## Change

Add `removeWorkspaceLockFile(id)` and call it from `Delete` and from `Save`'s oldID-rebind branch, in both cases **while the exclusive flock on that file is still held** (before the deferred unlock).

> Unlinking an flock rendezvous file inside the held critical section is safe: any waiter is blocked and re-`OpenFile`s a fresh inode after release. Unlinking *after* release would break mutual exclusion, so the ordering is deliberate.

`id.lock` for the live workspace is never removed on rebind; a missing file is not an error.

## Tests

- `<id>.lock` is gone after `Delete` and after a Save-with-rebind (old removed, new retained).
- `TestWorkspaceStore_DeleteWaitsForWorkspaceLock` still passes **unchanged**.
- `go test -race ./internal/data/...` is clean.