### PR TITLE
Add E2E delete-workspace teardown test (stub agent + real tmux)

### DIFF
--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -102,6 +102,53 @@ func workspaceIDForRepo(repo string) string {
 	return string(ws.ID())
 }
 
+// deleteSelectedWorkspace opens the delete-workspace dialog for the active
+// workspace via the leader sequence and confirms it. The confirm dialog defaults
+// to "No" (cursor on index 1), so "h" moves the selection to "Yes" before Enter.
+func deleteSelectedWorkspace(t *testing.T, session *PTYSession, timeout time.Duration) {
+	t.Helper()
+	sendPrefixCommand(t, session, "d")
+	waitForUIContains(t, session, "Delete Workspace", timeout)
+	if err := session.SendString("h"); err != nil {
+		t.Fatalf("select Yes in delete dialog: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if err := session.SendString("\r"); err != nil {
+		t.Fatalf("confirm delete: %v", err)
+	}
+}
+
+// waitForNoAgentSessions polls until no @amux agent sessions remain, proving the
+// deleted workspace's agent pane was actually torn down through the real handler.
+func waitForNoAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
+			"@amux":      "1",
+			"@amux_type": "agent",
+		}, opts)
+		if err == nil && len(sessions) == 0 {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for agent sessions to be torn down\n%s", tmuxSessionDebug(opts))
+}
+
+// waitForUIAbsent polls until needle disappears from the rendered screen.
+func waitForUIAbsent(t *testing.T, session *PTYSession, needle string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !stringsContains(session.ScreenASCII(), needle) {
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %q to disappear from the screen:\n%s", needle, session.ScreenASCII())
+}
+
 func waitForTerminalSessionCount(t *testing.T, opts tmux.Options, wsID string, count int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/internal/e2e/workspace_agent_test.go
+++ b/internal/e2e/workspace_agent_test.go
@@ -56,3 +56,60 @@ func TestWorkspaceCreateAgentTabStaysRunning(t *testing.T) {
 	assertAgentSessionsStayLive(t, opts, 8*time.Second)
 	assertScreenNeverContains(t, session, []string{"STOPPED", "DETACHED"}, 5*time.Second)
 }
+
+// TestWorkspaceDeleteTearsDownAgent drives a workspace delete through the real UI
+// while a fakeagent is live and asserts the full teardown contract: the agent's
+// tmux session is killed and the agent tab is removed. It fails if the delete
+// path stops tearing down the workspace's tmux sessions.
+func TestWorkspaceDeleteTearsDownAgent(t *testing.T) {
+	skipIfNoGit(t)
+	skipIfNoTmux(t)
+
+	home := t.TempDir()
+	repo := initRepo(t)
+	writeRegistry(t, home, repo)
+	writeConfig(t, home, false)
+	binDir := writeStubAssistant(t, home, "claude")
+	server := fmt.Sprintf("amux-e2e-%d", time.Now().UnixNano())
+	defer killTmuxServer(t, server)
+
+	env := sessionEnv(binDir, server)
+	env = append(env, "AMUX_TMUX_SYNC_INTERVAL=1s")
+	session, cleanup, err := StartPTYSession(PTYOptions{
+		Home: home,
+		Env:  env,
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	defer cleanup()
+
+	waitForUIContains(t, session, filepath.Base(repo), workspaceAgentTimeout)
+
+	createWorkspaceFromDashboard(t, session, "feature")
+	waitForUIContains(t, session, "feature", workspaceAgentTimeout)
+
+	// Select the newly created workspace (one row above "New") and activate it.
+	if err := session.SendString("k"); err != nil {
+		t.Fatalf("move to workspace row: %v", err)
+	}
+	if err := session.SendString("\r"); err != nil {
+		t.Fatalf("activate workspace: %v", err)
+	}
+	waitForUIContains(t, session, "[New agent]", workspaceAgentTimeout)
+
+	createAgentTab(t, session)
+	waitForUIContains(t, session, "claude", workspaceAgentTimeout)
+
+	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
+	waitForAgentSessions(t, opts, workspaceAgentTimeout)
+
+	// Delete the workspace through the real UI while the agent is live.
+	deleteSelectedWorkspace(t, session, workspaceAgentTimeout)
+
+	// The agent's tmux session must be torn down and the workspace must leave the
+	// dashboard (which also removes its agent tab from view).
+	waitForNoAgentSessions(t, opts, workspaceAgentTimeout)
+	waitForUIAbsent(t, session, "feature", workspaceAgentTimeout)
+	assertScreenNeverContains(t, session, []string{"feature"}, 3*time.Second)
+}


### PR DESCRIPTION
## What

No end-to-end test drove a workspace delete through the real UI and asserted the full teardown contract — the agent's tmux session killed and the agent tab removed. The delete path was only unit-tested with mocks; the real interaction between the delete handler and a live agent pane was never exercised (existing e2e covered create/stay-running and persistence, never delete).

## Change (test-only)

`TestWorkspaceDeleteTearsDownAgent` reuses the proven workspace-agent harness:

1. Create a `feature` workspace, start a stub agent, confirm its tmux session is live (`waitForAgentSessions`).
2. Delete the workspace via the leader sequence. `deleteSelectedWorkspace` opens the confirm dialog (`Ctrl+Space d` → "Delete Workspace") and confirms it — accounting for the **No-default** dialog: `h` moves the selection to "Yes" before Enter (a plain Enter would cancel).
3. Poll until **no agent tmux sessions remain** (`waitForNoAgentSessions`), and assert the workspace + its agent tab leaves the UI and does not resurrect.

Skip-guarded by `skipIfNoGit` + `skipIfNoTmux`; runs in the tmux-e2e CI matrix. The underlying kill primitives are validated against real tmux in the companion PR (#33); this test exercises them through the real delete handler.