### PR TITLE
Anchor dashboard cursor to the selected workspace across SetProjects

### DIFF
--- a/internal/data/workspace_store_validation_test.go
+++ b/internal/data/workspace_store_validation_test.go
@@ -72,35 +72,40 @@ func TestWorkspaceStore_LockWorkspaceIDsUsesDeterministicOrder(t *testing.T) {
 		unlockRegistryFile(heldHigh)
 	}()
 
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
 		locks, lockErr := store.lockWorkspaceIDs(highID, lowID)
 		if lockErr != nil {
-			t.Errorf("lockWorkspaceIDs() error = %v", lockErr)
-			close(done)
+			done <- lockErr
 			return
 		}
 		unlockRegistryFiles(locks)
-		close(done)
+		done <- nil
 	}()
 
 	time.Sleep(100 * time.Millisecond)
 
-	lowAcquired := make(chan *os.File, 1)
+	type lockResult struct {
+		file *os.File
+		err  error
+	}
+	lowAcquired := make(chan lockResult, 1)
 	go func() {
 		lowFile, lockErr := lockRegistryFile(store.workspaceLockPath(lowID), false)
 		if lockErr != nil {
-			t.Errorf("lockRegistryFile(lowID) error = %v", lockErr)
-			lowAcquired <- nil
+			lowAcquired <- lockResult{err: lockErr}
 			return
 		}
-		lowAcquired <- lowFile
+		lowAcquired <- lockResult{file: lowFile}
 	}()
 
 	select {
-	case lowFile := <-lowAcquired:
-		if lowFile != nil {
-			unlockRegistryFile(lowFile)
+	case result := <-lowAcquired:
+		if result.err != nil {
+			t.Fatalf("lockRegistryFile(lowID) error = %v", result.err)
+		}
+		if result.file != nil {
+			unlockRegistryFile(result.file)
 		}
 		t.Fatalf("expected lowID lock to be held while waiting on highID")
 	case <-time.After(100 * time.Millisecond):
@@ -111,8 +116,23 @@ func TestWorkspaceStore_LockWorkspaceIDsUsesDeterministicOrder(t *testing.T) {
 	heldHigh = nil
 
 	select {
-	case <-done:
+	case lockErr := <-done:
+		if lockErr != nil {
+			t.Fatalf("lockWorkspaceIDs() error = %v", lockErr)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("lockWorkspaceIDs() did not complete after releasing highID lock")
+	}
+
+	select {
+	case result := <-lowAcquired:
+		if result.err != nil {
+			t.Fatalf("lockRegistryFile(lowID) error = %v", result.err)
+		}
+		if result.file != nil {
+			unlockRegistryFile(result.file)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("lockRegistryFile(lowID) did not complete after releasing ordered locks")
 	}
 }

--- a/internal/ui/dashboard/dashboard_cursor_anchor_test.go
+++ b/internal/ui/dashboard/dashboard_cursor_anchor_test.go
@@ -1,0 +1,97 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+func workspaceRowIndices(m *Model) []int {
+	var idx []int
+	for i := range m.rows {
+		if m.rows[i].Type == RowWorkspace && m.rows[i].Workspace != nil {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
+func projectWithoutWorkspace(wsList []data.Workspace, removeID string) data.Project {
+	kept := make([]data.Workspace, 0, len(wsList))
+	for i := range wsList {
+		if string(wsList[i].ID()) == removeID {
+			continue
+		}
+		kept = append(kept, wsList[i])
+	}
+	return data.Project{Name: "repo", Path: "/repo", Workspaces: kept}
+}
+
+// TestSetProjects_AnchorsCursorToPredecessorOnDelete proves deleting the selected
+// (middle) workspace moves the cursor to the row ABOVE it, not the successor that
+// slid up into the same index.
+func TestSetProjects_AnchorsCursorToPredecessorOnDelete(t *testing.T) {
+	wsList := []data.Workspace{
+		*data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1"),
+		*data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2"),
+		*data.NewWorkspace("ws3", "feature3", "main", "/repo", "/repo/ws3"),
+	}
+
+	m := New()
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: wsList}})
+
+	rows := workspaceRowIndices(m)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 workspace rows, got %d", len(rows))
+	}
+	middle := rows[1]
+	selectedID := string(m.rows[middle].Workspace.ID())
+	predecessorID := string(m.rows[middle-1].Workspace.ID())
+	successorID := string(m.rows[middle+1].Workspace.ID())
+	m.cursor = middle
+
+	m.SetProjects([]data.Project{projectWithoutWorkspace(wsList, selectedID)})
+
+	if m.rows[m.cursor].Type != RowWorkspace || m.rows[m.cursor].Workspace == nil {
+		t.Fatalf("expected cursor on a workspace row after delete, got %+v", m.rows[m.cursor])
+	}
+	landedID := string(m.rows[m.cursor].Workspace.ID())
+	if landedID == successorID {
+		t.Fatalf("cursor slid onto the successor %q instead of the predecessor", successorID)
+	}
+	if landedID != predecessorID {
+		t.Fatalf("expected cursor anchored to predecessor %q, got %q", predecessorID, landedID)
+	}
+}
+
+// TestSetProjects_PreservesSelectedWorkspaceWhenOtherDeleted proves removing a
+// non-selected workspace keeps selection on the same workspace by identity.
+func TestSetProjects_PreservesSelectedWorkspaceWhenOtherDeleted(t *testing.T) {
+	wsList := []data.Workspace{
+		*data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1"),
+		*data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2"),
+		*data.NewWorkspace("ws3", "feature3", "main", "/repo", "/repo/ws3"),
+	}
+
+	m := New()
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: wsList}})
+
+	rows := workspaceRowIndices(m)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 workspace rows, got %d", len(rows))
+	}
+	// Select the last workspace, then delete the first (a different one).
+	selectedIdx := rows[2]
+	selectedID := string(m.rows[selectedIdx].Workspace.ID())
+	otherID := string(m.rows[rows[0]].Workspace.ID())
+	m.cursor = selectedIdx
+
+	m.SetProjects([]data.Project{projectWithoutWorkspace(wsList, otherID)})
+
+	if m.rows[m.cursor].Type != RowWorkspace || m.rows[m.cursor].Workspace == nil {
+		t.Fatalf("expected cursor on a workspace row, got %+v", m.rows[m.cursor])
+	}
+	if got := string(m.rows[m.cursor].Workspace.ID()); got != selectedID {
+		t.Fatalf("expected selection preserved on %q after deleting a different workspace, got %q", selectedID, got)
+	}
+}

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -26,6 +26,59 @@ func (m *Model) findSelectableRow(from, dir int) int {
 	return -1
 }
 
+// selectedWorkspaceIDAt returns the workspace ID of the row at idx, or "" if that
+// row is not a workspace row. Read before SetProjects mutates m.rows.
+func (m *Model) selectedWorkspaceIDAt(idx int) string {
+	if idx < 0 || idx >= len(m.rows) {
+		return ""
+	}
+	row := m.rows[idx]
+	if row.Type == RowWorkspace && row.Workspace != nil {
+		return string(row.Workspace.ID())
+	}
+	return ""
+}
+
+// workspaceRowIndex returns the index of the workspace row with the given ID, or
+// -1 if no such row exists in the current rows.
+func (m *Model) workspaceRowIndex(wsID string) int {
+	for i := range m.rows {
+		row := m.rows[i]
+		if row.Type == RowWorkspace && row.Workspace != nil && string(row.Workspace.ID()) == wsID {
+			return i
+		}
+	}
+	return -1
+}
+
+// resolveCursorAfterRebuild re-anchors the cursor to the workspace selected
+// before the rebuild. If that workspace is gone (deleted), it falls back to the
+// nearest selectable row at or ABOVE the previous index — the predecessor — so
+// repeated deletes walk upward instead of chasing the successor. A no-op when no
+// workspace was selected; rebuildRows' clamp then governs.
+func (m *Model) resolveCursorAfterRebuild(prevCursor int, selectedID string) {
+	if selectedID == "" {
+		return
+	}
+	if idx := m.workspaceRowIndex(selectedID); idx != -1 {
+		m.cursor = idx
+		return
+	}
+	// The selected workspace is gone. Land on the nearest selectable row strictly
+	// ABOVE its old slot (the predecessor) — not the successor that shifted up into
+	// that slot — so repeated deletes walk upward instead of chewing downward.
+	start := prevCursor - 1
+	if start > len(m.rows)-1 {
+		start = len(m.rows) - 1
+	}
+	if start < 0 {
+		return
+	}
+	if prev := m.findSelectableRow(start, -1); prev != -1 {
+		m.cursor = prev
+	}
+}
+
 // moveCursor moves the cursor by delta, skipping non-selectable rows
 func (m *Model) moveCursor(delta int) {
 	if len(m.rows) == 0 {

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -163,8 +163,13 @@ func (m *Model) Focused() bool {
 func (m *Model) SetProjects(projects []data.Project) {
 	prevCursor := m.cursor
 	prevOffset := m.scrollOffset
+	// Capture the selected workspace's identity before the rebuild so a delete
+	// (or reorder) re-anchors selection to that workspace rather than letting the
+	// same index silently slide onto the row that was below it.
+	selectedID := m.selectedWorkspaceIDAt(prevCursor)
 	m.projects = projects
 	m.rebuildRows()
+	m.resolveCursorAfterRebuild(prevCursor, selectedID)
 	if m.cursor == prevCursor {
 		m.scrollOffset = prevOffset
 		m.clampScrollOffset()


### PR DESCRIPTION
## What

After a delete, `SetProjects → rebuildRows` preserved `m.cursor` by integer index and only clamped to range/selectability — no identity re-anchoring. Since the deleted row is gone, the same index then points at the workspace that previously sat directly **below** it, so selection focus silently **slid onto the successor** — error-prone when deleting several workspaces in a row.

## Change (UX-only; deletion is still confirm-gated)

`SetProjects` captures the selected workspace's ID before the rebuild and, after it, re-anchors the cursor to that workspace's row by identity. When the workspace is gone, it falls back to the nearest selectable row strictly **above** the old slot (the predecessor), so repeated deletes walk upward instead of chasing the successor. `scrollOffset` is still preserved only when the resolved cursor is unchanged. The dialog identity-pinning path is untouched.

> Note: this lands on the **predecessor**, not the same-index successor — i.e. the search starts from `prevCursor-1`. The ticket's literal `findSelectableRow(min(prevCursor,…), -1)` would start *at* `prevCursor` (the successor's new slot); I followed the acceptance criterion ("predecessor, not successor") instead.

## Tests

- Deleting the selected middle workspace lands the cursor on its **predecessor** (not the successor).
- Deleting a non-selected workspace **preserves** the selected workspace by identity.