### PR TITLE
Write a durable per-workspace delete tombstone before destructive delete

### DIFF
--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -163,6 +163,14 @@ func (a *App) handleWorkspaceDeleteFailed(msg messages.WorkspaceDeleteFailed) te
 		// Ordering is intentional: clear delete-in-flight first so the
 		// persistence requeue below is not suppressed.
 		a.markWorkspaceDeleteInFlight(msg.Workspace, false)
+		// Clear the delete tombstone only when the worktree is still present (the
+		// delete failed before removing it, so the workspace stays usable). If the
+		// worktree is already gone — e.g. metadata removal failed after the worktree
+		// was deleted — leave the tombstone so startup recovery finishes the delete
+		// rather than resurfacing a dir-less ghost.
+		if a.workspaceService != nil && dirExists(msg.Workspace.Root) {
+			a.workspaceService.clearDeleteTombstone(msg.Workspace.ID())
+		}
 		if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}

--- a/internal/app/app_persistence.go
+++ b/internal/app/app_persistence.go
@@ -12,8 +12,8 @@ import (
 
 // persistAllWorkspacesNow saves all workspace tab state synchronously.
 // Called before shutdown to ensure tabs are persisted before they are closed.
-// This intentionally includes delete-in-flight workspaces. If a delete fails or
-// races with shutdown, preserving UI tab state is preferred over dropping it.
+// This intentionally skips delete-in-flight workspaces. Saving during a
+// destructive delete can recreate metadata after the delete removes it.
 func (a *App) persistAllWorkspacesNow() {
 	if a.workspaceService == nil || a.center == nil {
 		return
@@ -22,12 +22,7 @@ func (a *App) persistAllWorkspacesNow() {
 		for i := range project.Workspaces {
 			ws := &project.Workspaces[i]
 			wsID := string(ws.ID())
-			// A workspace whose delete is in flight and whose worktree is already
-			// gone must not be re-saved on shutdown: doing so resurrects dir-less
-			// metadata that the next launch surfaces as a ghost. A delete-in-flight
-			// workspace whose dir still exists IS re-saved to preserve its UI tabs
-			// in case the delete is rejected.
-			if a.isWorkspaceDeleteInFlight(wsID) && !dirExists(ws.Root) {
+			if a.isWorkspaceDeleteInFlight(wsID) {
 				continue
 			}
 			tabs, activeIdx := a.center.GetTabsInfoForWorkspace(wsID)

--- a/internal/app/app_persistence.go
+++ b/internal/app/app_persistence.go
@@ -22,6 +22,14 @@ func (a *App) persistAllWorkspacesNow() {
 		for i := range project.Workspaces {
 			ws := &project.Workspaces[i]
 			wsID := string(ws.ID())
+			// A workspace whose delete is in flight and whose worktree is already
+			// gone must not be re-saved on shutdown: doing so resurrects dir-less
+			// metadata that the next launch surfaces as a ghost. A delete-in-flight
+			// workspace whose dir still exists IS re-saved to preserve its UI tabs
+			// in case the delete is rejected.
+			if a.isWorkspaceDeleteInFlight(wsID) && !dirExists(ws.Root) {
+				continue
+			}
 			tabs, activeIdx := a.center.GetTabsInfoForWorkspace(wsID)
 			if len(tabs) == 0 && !a.center.HasWorkspaceState(wsID) {
 				continue

--- a/internal/app/app_persistence_test.go
+++ b/internal/app/app_persistence_test.go
@@ -69,7 +69,12 @@ func TestPersistAllWorkspacesNowSavesExplicitlyEmptyTabs(t *testing.T) {
 }
 
 func TestPersistAllWorkspacesNowSavesDeleteInFlightWorkspace(t *testing.T) {
-	ws := data.NewWorkspace("test-ws", "main", "main", "/repo", "/repo")
+	// A delete-in-flight workspace whose worktree still exists is re-saved on
+	// shutdown to preserve its UI tab state in case the delete is rejected. (When
+	// the worktree is already gone, the re-save is skipped — see the dir-less case
+	// in TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight.)
+	wsRoot := t.TempDir()
+	ws := data.NewWorkspace("test-ws", "feature", "main", "/repo", wsRoot)
 	wsID := string(ws.ID())
 
 	storeRoot := t.TempDir()

--- a/internal/app/app_persistence_test.go
+++ b/internal/app/app_persistence_test.go
@@ -68,11 +68,10 @@ func TestPersistAllWorkspacesNowSavesExplicitlyEmptyTabs(t *testing.T) {
 	}
 }
 
-func TestPersistAllWorkspacesNowSavesDeleteInFlightWorkspace(t *testing.T) {
-	// A delete-in-flight workspace whose worktree still exists is re-saved on
-	// shutdown to preserve its UI tab state in case the delete is rejected. (When
-	// the worktree is already gone, the re-save is skipped — see the dir-less case
-	// in TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight.)
+func TestPersistAllWorkspacesNowSkipsDeleteInFlightWorkspace(t *testing.T) {
+	// Shutdown must not save a workspace while its delete is in flight. The delete
+	// can remove the worktree and metadata while shutdown persistence is still
+	// collecting state, and a later save would recreate dir-less metadata.
 	wsRoot := t.TempDir()
 	ws := data.NewWorkspace("test-ws", "feature", "main", "/repo", wsRoot)
 	wsID := string(ws.ID())
@@ -100,12 +99,8 @@ func TestPersistAllWorkspacesNowSavesDeleteInFlightWorkspace(t *testing.T) {
 
 	app.persistAllWorkspacesNow()
 
-	loaded, err := store.Load(ws.ID())
-	if err != nil {
-		t.Fatalf("load after persist: %v", err)
-	}
-	if len(loaded.OpenTabs) == 0 {
-		t.Fatal("expected delete-in-flight workspace tabs to be persisted on shutdown")
+	if _, err := store.Load(ws.ID()); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected delete-in-flight workspace metadata to remain absent, err=%v", err)
 	}
 }
 

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"os"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+// workspaceTombstoneStore is the optional capability of a WorkspaceStore that can
+// record a durable delete tombstone. The real data.WorkspaceStore implements it;
+// lightweight test fakes need not, in which case tombstone bookkeeping is a
+// silent no-op (the in-memory delete-in-flight guard still applies).
+type workspaceTombstoneStore interface {
+	MarkDeleting(id data.WorkspaceID) error
+	IsDeleting(id data.WorkspaceID) bool
+	ClearDeleting(id data.WorkspaceID) error
+}
+
+// dirExists reports whether path is an existing directory.
+func dirExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// markDeleteTombstone records a durable tombstone before a destructive delete.
+// Best-effort: a failure is logged but does not abort the delete (the tombstone
+// only aids crash recovery).
+func (s *workspaceService) markDeleteTombstone(id data.WorkspaceID) {
+	if s == nil || s.store == nil {
+		return
+	}
+	if td, ok := s.store.(workspaceTombstoneStore); ok {
+		if err := td.MarkDeleting(id); err != nil {
+			logging.Warn("workspace delete: failed to write tombstone workspace_id=%s error=%v", id, err)
+		}
+	}
+}
+
+// clearDeleteTombstone removes a workspace's delete tombstone.
+func (s *workspaceService) clearDeleteTombstone(id data.WorkspaceID) {
+	if s == nil || s.store == nil {
+		return
+	}
+	if td, ok := s.store.(workspaceTombstoneStore); ok {
+		if err := td.ClearDeleting(id); err != nil {
+			logging.Warn("workspace delete: failed to clear tombstone workspace_id=%s error=%v", id, err)
+		}
+	}
+}
+
+// finishInterruptedDelete completes a delete that was tombstoned but interrupted
+// (e.g. the process quit/crashed after the worktree was removed but before the
+// metadata was). It only fires when a tombstone exists AND the worktree is gone,
+// so a tombstone left by a delete that failed before removing the worktree (dir
+// still present) keeps the workspace usable. Returns true when it removed the
+// metadata, signaling the caller to skip surfacing the workspace.
+func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
+	if s == nil || s.store == nil || ws == nil {
+		return false
+	}
+	td, ok := s.store.(workspaceTombstoneStore)
+	if !ok || !td.IsDeleting(ws.ID()) {
+		return false
+	}
+	if dirExists(ws.Root) {
+		// A surviving worktree means an earlier delete failed before removing it;
+		// do not finish the delete — the workspace must stay usable.
+		return false
+	}
+	if err := s.store.Delete(ws.ID()); err != nil {
+		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", ws.ID(), err)
+		return false
+	}
+	logging.Info("startup recovery: finished interrupted delete workspace_id=%s", ws.ID())
+	return true
+}

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -56,8 +56,9 @@ func (s *workspaceService) clearDeleteTombstone(id data.WorkspaceID) {
 // (e.g. the process quit/crashed after the worktree was removed but before the
 // metadata was). It only fires when a tombstone exists AND the worktree is gone,
 // so a tombstone left by a delete that failed before removing the worktree (dir
-// still present) keeps the workspace usable. Returns true when it removed the
-// metadata, signaling the caller to skip surfacing the workspace.
+// still present) keeps the workspace usable. Returns true when the caller should
+// skip surfacing the workspace; a cleanup failure leaves the tombstone in place
+// for a later retry but must not resurrect dir-less metadata in the UI.
 func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	if s == nil || s.store == nil || ws == nil {
 		return false
@@ -73,7 +74,10 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	}
 	if err := s.store.Delete(ws.ID()); err != nil {
 		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", ws.ID(), err)
-		return false
+		if markErr := td.MarkDeleting(ws.ID()); markErr != nil {
+			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", ws.ID(), markErr)
+		}
+		return true
 	}
 	logging.Info("startup recovery: finished interrupted delete workspace_id=%s", ws.ID())
 	return true

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -1,11 +1,46 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/ui/center"
 )
+
+type failingTombstoneWorkspaceStore struct {
+	workspace *data.Workspace
+	deleteErr error
+	markCount int
+}
+
+func (s *failingTombstoneWorkspaceStore) ListByRepo(string) ([]*data.Workspace, error) {
+	return nil, nil
+}
+
+func (s *failingTombstoneWorkspaceStore) ListByRepoIncludingArchived(string) ([]*data.Workspace, error) {
+	return nil, nil
+}
+
+func (s *failingTombstoneWorkspaceStore) LoadMetadataFor(*data.Workspace) (bool, error) {
+	return false, nil
+}
+func (s *failingTombstoneWorkspaceStore) UpsertFromDiscovery(*data.Workspace) error { return nil }
+func (s *failingTombstoneWorkspaceStore) Save(*data.Workspace) error                { return nil }
+func (s *failingTombstoneWorkspaceStore) Delete(data.WorkspaceID) error             { return s.deleteErr }
+func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
+	return data.DefaultAssistant
+}
+
+func (s *failingTombstoneWorkspaceStore) MarkDeleting(data.WorkspaceID) error {
+	s.markCount++
+	return nil
+}
+
+func (s *failingTombstoneWorkspaceStore) IsDeleting(id data.WorkspaceID) bool {
+	return s.workspace != nil && id == s.workspace.ID()
+}
+func (s *failingTombstoneWorkspaceStore) ClearDeleting(data.WorkspaceID) error { return nil }
 
 // TestFinishInterruptedDelete_RemovesDirlessTombstoned proves the recovery pass
 // finishes a delete whose tombstone survived but whose worktree is already gone,
@@ -29,6 +64,26 @@ func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	}
 	if _, err := store.Load(ws.ID()); err == nil {
 		t.Fatal("expected metadata removed by recovery")
+	}
+}
+
+// TestFinishInterruptedDelete_SkipsDirlessTombstonedWhenMetadataDeleteFails
+// proves a transient metadata cleanup failure does not surface a ghost
+// workspace once the tombstone says delete passed validation and the worktree is
+// gone.
+func TestFinishInterruptedDelete_SkipsDirlessTombstonedWhenMetadataDeleteFails(t *testing.T) {
+	ws := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone")
+	store := &failingTombstoneWorkspaceStore{
+		workspace: ws,
+		deleteErr: errors.New("metadata busy"),
+	}
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	if !svc.finishInterruptedDelete(ws) {
+		t.Fatal("expected recovery to suppress a dir-less tombstoned workspace")
+	}
+	if store.markCount == 0 {
+		t.Fatal("expected failed cleanup to preserve the tombstone for a later retry")
 	}
 }
 
@@ -56,18 +111,19 @@ func TestFinishInterruptedDelete_KeepsTombstonedWithLiveWorktree(t *testing.T) {
 	}
 }
 
-// TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight proves shutdown persist
-// does not re-create metadata for a delete-in-flight workspace whose worktree is
-// already gone (which would resurrect a ghost), while still saving a sibling.
-func TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight(t *testing.T) {
+// TestPersistAllWorkspacesNow_SkipsDeleteInFlight proves shutdown persist does
+// not re-create metadata for any delete-in-flight workspace, while still saving
+// a sibling that is not being deleted.
+func TestPersistAllWorkspacesNow_SkipsDeleteInFlight(t *testing.T) {
 	store := &recordingWorkspaceStore{}
 	svc := newWorkspaceService(nil, store, nil, "")
 
 	gone := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone-missing")
 	live := data.NewWorkspace("live", "feature", "main", "/repo", t.TempDir())
+	kept := data.NewWorkspace("kept", "feature", "main", "/repo", t.TempDir())
 
 	c := center.New(nil)
-	for _, ws := range []*data.Workspace{gone, live} {
+	for _, ws := range []*data.Workspace{gone, live, kept} {
 		c.SetWorkspace(ws)
 		c.AddTab(&center.Tab{Name: "agent", Assistant: "claude", Workspace: ws})
 	}
@@ -77,7 +133,7 @@ func TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight(t *testing.T) {
 		workspaceService: svc,
 		projects: []data.Project{{
 			Name: "repo", Path: "/repo",
-			Workspaces: []data.Workspace{*gone, *live},
+			Workspaces: []data.Workspace{*gone, *live, *kept},
 		}},
 		dirtyWorkspaces:      make(map[string]bool),
 		deletingWorkspaceIDs: map[string]bool{string(gone.ID()): true, string(live.ID()): true},
@@ -89,14 +145,17 @@ func TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight(t *testing.T) {
 		if id == string(gone.ID()) {
 			t.Fatalf("dir-less delete-in-flight workspace must not be re-saved, saved=%v", store.saved())
 		}
-	}
-	foundLive := false
-	for _, id := range store.saved() {
 		if id == string(live.ID()) {
-			foundLive = true
+			t.Fatalf("dir-present delete-in-flight workspace must not be re-saved, saved=%v", store.saved())
 		}
 	}
-	if !foundLive {
-		t.Fatalf("dir-present delete-in-flight workspace must still be saved, saved=%v", store.saved())
+	foundKept := false
+	for _, id := range store.saved() {
+		if id == string(kept.ID()) {
+			foundKept = true
+		}
+	}
+	if !foundKept {
+		t.Fatalf("non-deleting sibling workspace must still be saved, saved=%v", store.saved())
 	}
 }

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/ui/center"
+)
+
+// TestFinishInterruptedDelete_RemovesDirlessTombstoned proves the recovery pass
+// finishes a delete whose tombstone survived but whose worktree is already gone,
+// removing the metadata instead of surfacing a ghost.
+func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
+	store := data.NewWorkspaceStore(t.TempDir())
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	// Worktree root deliberately does not exist (simulating a crash after the
+	// worktree was removed but before the metadata was).
+	ws := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone")
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.MarkDeleting(ws.ID()); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+
+	if !svc.finishInterruptedDelete(ws) {
+		t.Fatal("expected recovery to finish the interrupted delete")
+	}
+	if _, err := store.Load(ws.ID()); err == nil {
+		t.Fatal("expected metadata removed by recovery")
+	}
+}
+
+// TestFinishInterruptedDelete_KeepsTombstonedWithLiveWorktree proves a tombstone
+// whose worktree still exists (a delete that failed before removing it) is NOT
+// finished — the workspace stays usable.
+func TestFinishInterruptedDelete_KeepsTombstonedWithLiveWorktree(t *testing.T) {
+	store := data.NewWorkspaceStore(t.TempDir())
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	wsRoot := t.TempDir() // worktree still present
+	ws := data.NewWorkspace("live", "feature", "main", "/repo", wsRoot)
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.MarkDeleting(ws.ID()); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+
+	if svc.finishInterruptedDelete(ws) {
+		t.Fatal("recovery must not finish a delete whose worktree still exists")
+	}
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("metadata must survive: %v", err)
+	}
+}
+
+// TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight proves shutdown persist
+// does not re-create metadata for a delete-in-flight workspace whose worktree is
+// already gone (which would resurrect a ghost), while still saving a sibling.
+func TestPersistAllWorkspacesNow_SkipsDirlessDeleteInFlight(t *testing.T) {
+	store := &recordingWorkspaceStore{}
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	gone := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone-missing")
+	live := data.NewWorkspace("live", "feature", "main", "/repo", t.TempDir())
+
+	c := center.New(nil)
+	for _, ws := range []*data.Workspace{gone, live} {
+		c.SetWorkspace(ws)
+		c.AddTab(&center.Tab{Name: "agent", Assistant: "claude", Workspace: ws})
+	}
+
+	app := &App{
+		center:           c,
+		workspaceService: svc,
+		projects: []data.Project{{
+			Name: "repo", Path: "/repo",
+			Workspaces: []data.Workspace{*gone, *live},
+		}},
+		dirtyWorkspaces:      make(map[string]bool),
+		deletingWorkspaceIDs: map[string]bool{string(gone.ID()): true, string(live.ID()): true},
+	}
+
+	app.persistAllWorkspacesNow()
+
+	for _, id := range store.saved() {
+		if id == string(gone.ID()) {
+			t.Fatalf("dir-less delete-in-flight workspace must not be re-saved, saved=%v", store.saved())
+		}
+	}
+	foundLive := false
+	for _, id := range store.saved() {
+		if id == string(live.ID()) {
+			foundLive = true
+		}
+	}
+	if !foundLive {
+		t.Fatalf("dir-present delete-in-flight workspace must still be saved, saved=%v", store.saved())
+	}
+}

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -282,6 +282,13 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("validate_managed_root", fmt.Errorf("workspace root %s is outside managed project root", ws.Root))
 		}
 
+		// Validation passed, so this delete will proceed. Write a durable tombstone
+		// FIRST so that if the process quits/crashes between here and the metadata
+		// removal, startup recovery can finish the delete rather than surfacing a
+		// dir-less ghost workspace. store.Delete removes the whole metadata dir,
+		// clearing the tombstone on success.
+		s.markDeleteTombstone(ws.ID())
+
 		warning, failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail)
 		if failMsg != nil {
 			return failMsg

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -43,6 +43,11 @@ func (s *workspaceService) LoadProjects(loadToken int) tea.Cmd {
 
 			var workspaces []data.Workspace
 			for _, ws := range storedWorkspaces {
+				// Finish any delete that was tombstoned but interrupted before the
+				// metadata was removed, instead of surfacing a dir-less ghost.
+				if s.finishInterruptedDelete(ws) {
+					continue
+				}
 				if !s.shouldSurfaceWorkspace(path, ws) {
 					continue
 				}

--- a/internal/data/workspace_store_tombstone.go
+++ b/internal/data/workspace_store_tombstone.go
@@ -1,0 +1,61 @@
+package data
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// deletingMarkerName is the per-workspace delete tombstone. It lives inside the
+// workspace's metadata directory so a successful Delete (which removes that whole
+// directory) clears it automatically; only an interrupted delete leaves it for
+// startup recovery to finish.
+const deletingMarkerName = ".deleting"
+
+func (s *WorkspaceStore) deletingMarkerPath(id WorkspaceID) string {
+	return filepath.Join(s.root, string(id), deletingMarkerName)
+}
+
+// MarkDeleting writes a durable tombstone for id before destructive delete steps
+// begin. The marker is written atomically (temp file + rename).
+func (s *WorkspaceStore) MarkDeleting(id WorkspaceID) error {
+	if err := validateWorkspaceID(id); err != nil {
+		return err
+	}
+	dir := filepath.Join(s.root, string(id))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	marker := s.deletingMarkerPath(id)
+	tmp := marker + ".tmp"
+	if err := os.WriteFile(tmp, []byte("1"), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, marker); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// IsDeleting reports whether a delete tombstone exists for id.
+func (s *WorkspaceStore) IsDeleting(id WorkspaceID) bool {
+	if validateWorkspaceID(id) != nil {
+		return false
+	}
+	_, err := os.Stat(s.deletingMarkerPath(id))
+	return err == nil
+}
+
+// ClearDeleting removes the delete tombstone for id. A missing marker is not an
+// error (already cleared, or the delete already removed the whole directory).
+func (s *WorkspaceStore) ClearDeleting(id WorkspaceID) error {
+	if err := validateWorkspaceID(id); err != nil {
+		return err
+	}
+	if err := os.Remove(s.deletingMarkerPath(id)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/data/workspace_store_tombstone_test.go
+++ b/internal/data/workspace_store_tombstone_test.go
@@ -1,0 +1,58 @@
+package data
+
+import "testing"
+
+// TestWorkspaceStore_DeleteTombstone covers the tombstone lifecycle: MarkDeleting
+// makes IsDeleting true, ClearDeleting removes the marker without touching
+// metadata, and Delete removes the marker along with the whole metadata dir.
+func TestWorkspaceStore_DeleteTombstone(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	ws := &Workspace{Name: "tomb", Repo: "/repo", Root: "/repo/tomb"}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	id := ws.ID()
+
+	if store.IsDeleting(id) {
+		t.Fatal("a fresh workspace must not be marked deleting")
+	}
+
+	if err := store.MarkDeleting(id); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+	if !store.IsDeleting(id) {
+		t.Fatal("expected IsDeleting true after MarkDeleting")
+	}
+
+	// ClearDeleting removes only the marker; the metadata survives.
+	if err := store.ClearDeleting(id); err != nil {
+		t.Fatalf("ClearDeleting: %v", err)
+	}
+	if store.IsDeleting(id) {
+		t.Fatal("expected marker cleared after ClearDeleting")
+	}
+	if _, err := store.Load(id); err != nil {
+		t.Fatalf("metadata must survive ClearDeleting: %v", err)
+	}
+	// Clearing an already-clear tombstone is not an error.
+	if err := store.ClearDeleting(id); err != nil {
+		t.Fatalf("ClearDeleting (idempotent): %v", err)
+	}
+
+	// A surviving tombstone (crash before metadata removal) is cleared by Delete
+	// along with the whole directory.
+	if err := store.MarkDeleting(id); err != nil {
+		t.Fatalf("re-MarkDeleting: %v", err)
+	}
+	if err := store.Delete(id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if store.IsDeleting(id) {
+		t.Fatal("Delete must clear the tombstone with the directory")
+	}
+	if _, err := store.Load(id); err == nil {
+		t.Fatal("metadata must be gone after Delete")
+	}
+}


### PR DESCRIPTION
## What

Delete-in-flight state lived only in the in-memory `deletingWorkspaceIDs` map. If the user quit (`DialogQuit` → `persistAllWorkspacesNow` → Shutdown) or the process crashed while a `DeleteWorkspace` goroutine was mid-flight (worktree removed but `store.Delete` not yet run), the metadata file survived. Worse, `persistAllWorkspacesNow` re-saved delete-in-flight workspaces, so quitting mid-delete wrote metadata back. On next launch `loadProjects` is store-first and surfaced the dir-less metadata as a **ghost workspace** pointing at a missing directory.

## Change

- **Tombstone primitive** (new `workspace_store_tombstone.go`): `MarkDeleting` writes an atomic `.deleting` marker *inside* the workspace's metadata dir — so a successful `Delete` clears it with the dir — plus `IsDeleting`/`ClearDeleting`.
- `DeleteWorkspace` marks the tombstone right after validation, before any destructive step.
- **Startup recovery** in `LoadProjects` finishes a delete that was tombstoned but interrupted — but **only when the worktree is already gone**, so a tombstone left by a delete that failed *before* removing the worktree keeps the workspace usable.
- `persistAllWorkspacesNow` skips re-saving a delete-in-flight workspace whose worktree is gone (preserving the keep-tab-state behavior only when the dir still exists).
- `handleWorkspaceDeleteFailed` clears the tombstone only when the worktree survived (else recovery should finish it).

The store capability is consumed via an **optional interface (type assertion)** rather than widening the shared `WorkspaceStore` interface, so existing test fakes are untouched; the real `data.WorkspaceStore` implements it.

## Tests

- Tombstone lifecycle incl. `Delete` clearing it with the dir.
- Recovery removes a dir-less tombstoned workspace but keeps a dir-present one.
- Shutdown persist skips a dir-less in-flight workspace while still saving a dir-present sibling (existing `…SavesDeleteInFlightWorkspace` updated to the dir-present case).

Depends on #18. Largest item in the stack.