### PR TITLE
Extract updatePTYFlush actor enqueue + send-failure rollback into helpers

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -209,8 +209,6 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 			writeOutput := false
 			hasMoreBuffered := false
 			visibleSeq := uint64(0)
-			tagSessionName := ""
-			var tagTimestamp int64
 			parserResetPending := false
 			actorWritesPending := 0
 			tab.mu.Lock()
@@ -273,143 +271,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 				tab.mu.Unlock()
 			}
 			if writeOutput && len(chunk) > 0 {
-				if m.isTabActorReady() {
-					prevPending := 0
-					prevEpoch := uint64(0)
-					prevCarry := vterm.ParserCarryState{}
-					var nextCarry vterm.ParserCarryState
-					prevNoiseTrailing := []byte(nil)
-					nextNoiseTrailing := []byte(nil)
-					tab.mu.Lock()
-					if tab.Terminal != nil {
-						prevPending = tab.actorWritesPending
-						prevEpoch = tab.actorWriteEpoch
-						prevCarry = tab.actorQueuedCarry
-						prevNoiseTrailing = append(prevNoiseTrailing, tab.actorQueuedNoiseTrailing...)
-						seedCarry := tab.Terminal.ParserCarryState()
-						if prevPending > 0 {
-							seedCarry = prevCarry
-						}
-						previewTrailing := append([]byte(nil), tab.ptyNoiseTrailing...)
-						if prevPending > 0 {
-							previewTrailing = append(previewTrailing[:0], tab.actorQueuedNoiseTrailing...)
-						}
-						filteredPreview := ptyio.FilterKnownPTYNoiseStream(chunk, &previewTrailing)
-						nextCarry = vterm.AdvanceParserCarryState(seedCarry, filteredPreview)
-						nextNoiseTrailing = append(nextNoiseTrailing, previewTrailing...)
-						tab.actorWritesPending = prevPending + 1
-						tab.actorQueuedBytes += len(chunk)
-						tab.actorQueuedCarry = nextCarry
-						tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], nextNoiseTrailing...)
-					}
-					tab.mu.Unlock()
-					if !m.sendTabEvent(tabEvent{
-						tab:             tab,
-						workspaceID:     msg.WorkspaceID,
-						tabID:           msg.TabID,
-						kind:            tabEventWriteOutput,
-						output:          chunk,
-						writeEpoch:      prevEpoch,
-						catchUp:         catchUp,
-						hasMoreBuffered: hasMoreBuffered,
-						visibleSeq:      visibleSeq,
-					}) {
-						rebuffered := false
-						dropWrite := false
-						syncFallbackChunkSize := 0
-						tab.mu.Lock()
-						if tab.actorWriteEpoch == prevEpoch && tab.actorWritesPending > 0 {
-							tab.actorWritesPending--
-							if tab.actorQueuedBytes >= len(chunk) {
-								tab.actorQueuedBytes -= len(chunk)
-							} else {
-								tab.actorQueuedBytes = 0
-							}
-							if tab.isClosed() {
-								dropWrite = true
-							} else if tab.actorWritesPending > 0 {
-								rebuffered = true
-								tab.actorQueuedCarry = prevCarry
-								tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], prevNoiseTrailing...)
-								restored := make([]byte, 0, len(chunk)+len(tab.pendingOutput))
-								restored = append(restored, chunk...)
-								restored = append(restored, tab.pendingOutput...)
-								tab.pendingOutput = restored
-								tab.pendingOutputBytes = len(tab.pendingOutput)
-							} else if catchUp && len(chunk) > ptyFlushChunkSizeActive {
-								syncFallbackChunkSize = ptyFlushChunkSizeActive
-								tab.actorQueuedCarry = prevCarry
-								tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], prevNoiseTrailing...)
-								restored := make([]byte, 0, len(chunk)-syncFallbackChunkSize+len(tab.pendingOutput))
-								restored = append(restored, chunk[syncFallbackChunkSize:]...)
-								restored = append(restored, tab.pendingOutput...)
-								tab.pendingOutput = restored
-								tab.pendingOutputBytes = len(tab.pendingOutput)
-								hasMoreBuffered = len(tab.pendingOutput) > 0
-							}
-						} else if tab.actorWriteEpoch != prevEpoch || tab.isClosed() {
-							dropWrite = true
-						}
-						tab.mu.Unlock()
-						if syncFallbackChunkSize > 0 {
-							chunk = chunk[:syncFallbackChunkSize]
-						}
-						if !rebuffered && !dropWrite {
-							processedBytes := len(chunk)
-							filteredLen := 0
-							filterApplied := false
-							suppressRedraw := false
-							tab.mu.Lock()
-							if tab.Terminal != nil {
-								filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
-								filterApplied = true
-								tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
-								tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.ptyNoiseTrailing...)
-							}
-							tab.mu.Unlock()
-							if !suppressRedraw {
-								cmds = append(cmds, m.scheduleChatCursorRefresh(tab, msg.WorkspaceID, time.Now()))
-							}
-							perf.Count("pty_flush_bytes_processed", int64(processedBytes))
-							if filterApplied {
-								filteredBytes := processedBytes - filteredLen
-								if filteredBytes > 0 {
-									perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
-								}
-							}
-						}
-					}
-				} else {
-					processedBytes := len(chunk)
-					filteredLen := 0
-					filterApplied := false
-					suppressRedraw := false
-					tab.mu.Lock()
-					if tab.Terminal != nil {
-						filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
-						filterApplied = true
-					}
-					tab.mu.Unlock()
-					if !suppressRedraw {
-						cmds = append(cmds, m.scheduleChatCursorRefresh(tab, msg.WorkspaceID, time.Now()))
-					}
-					perf.Count("pty_flush_bytes_processed", int64(processedBytes))
-					if filterApplied {
-						filteredBytes := processedBytes - filteredLen
-						if filteredBytes > 0 {
-							perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
-						}
-					}
-				}
-				if tagSessionName != "" {
-					opts := m.tmuxOpts
-					sessionName := tagSessionName
-					timestamp := strconv.FormatInt(tagTimestamp, 10)
-					cmds = append(cmds, func() tea.Msg {
-						_ = tmux.SetSessionTagValue(sessionName, tmux.TagLastOutputAt, timestamp, opts)
-						return nil
-					})
-				}
+				cmds = append(cmds, m.dispatchFlushChunk(tab, msg, chunk, hasMoreBuffered, visibleSeq, catchUp)...)
 			}
 			tab.mu.Lock()
 			catchUpStillActive := tab.catchUpActiveLocked()
@@ -435,6 +297,103 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 		}
 	}
 	return common.SafeBatch(cmds...)
+}
+
+// dispatchFlushChunk delivers a flush chunk either through the tab actor (the
+// fast path) or via a synchronous apply, handling actor enqueue, send-failure
+// rollback, the synchronous apply, and publishing the last-output activity tag.
+// It returns the commands to batch (cursor refresh + tag write).
+func (m *Model) dispatchFlushChunk(tab *Tab, msg PTYFlush, chunk []byte, hasMoreBuffered bool, visibleSeq uint64, catchUp bool) []tea.Cmd {
+	var cmds []tea.Cmd
+	tagSessionName := ""
+	var tagTimestamp int64
+	if m.isTabActorReady() {
+		cmds, tagSessionName, tagTimestamp = m.dispatchFlushChunkViaActor(tab, msg, chunk, hasMoreBuffered, visibleSeq, catchUp)
+	} else {
+		var cmd tea.Cmd
+		cmd, tagSessionName, tagTimestamp = m.applyFlushChunkSync(tab, msg.WorkspaceID, chunk, hasMoreBuffered, visibleSeq, false)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if tagSessionName != "" {
+		opts := m.tmuxOpts
+		sessionName := tagSessionName
+		timestamp := strconv.FormatInt(tagTimestamp, 10)
+		cmds = append(cmds, func() tea.Msg {
+			_ = tmux.SetSessionTagValue(sessionName, tmux.TagLastOutputAt, timestamp, opts)
+			return nil
+		})
+	}
+	return cmds
+}
+
+// dispatchFlushChunkViaActor enqueues the chunk and sends it to the tab actor.
+// A successful send returns no commands (the actor applies it asynchronously).
+// A failed send is rolled back; if the rollback leaves the chunk to apply, it is
+// applied synchronously here. Returns any cursor-refresh command and the activity
+// tag to publish.
+func (m *Model) dispatchFlushChunkViaActor(tab *Tab, msg PTYFlush, chunk []byte, hasMoreBuffered bool, visibleSeq uint64, catchUp bool) (cmds []tea.Cmd, tagSessionName string, tagTimestamp int64) {
+	prevEpoch, prevCarry, prevNoiseTrailing := enqueueActorWrite(tab, chunk)
+	if m.sendTabEvent(tabEvent{
+		tab:             tab,
+		workspaceID:     msg.WorkspaceID,
+		tabID:           msg.TabID,
+		kind:            tabEventWriteOutput,
+		output:          chunk,
+		writeEpoch:      prevEpoch,
+		catchUp:         catchUp,
+		hasMoreBuffered: hasMoreBuffered,
+		visibleSeq:      visibleSeq,
+	}) {
+		return nil, "", 0
+	}
+	var rebuffered, dropWrite bool
+	chunk, hasMoreBuffered, rebuffered, dropWrite = recoverFailedActorSend(
+		tab, chunk, prevEpoch, prevCarry, prevNoiseTrailing, catchUp, hasMoreBuffered,
+	)
+	if rebuffered || dropWrite {
+		return nil, "", 0
+	}
+	cmd, tagSessionName, tagTimestamp := m.applyFlushChunkSync(tab, msg.WorkspaceID, chunk, hasMoreBuffered, visibleSeq, true)
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return cmds, tagSessionName, tagTimestamp
+}
+
+// applyFlushChunkSync writes a flush chunk to the terminal on the UI goroutine
+// (the synchronous fallback used when the actor is not ready, or after an actor
+// send-failure rollback that leaves the chunk to apply directly). When
+// updateActorCarry is set (post-rollback actor path) it also snapshots the actor
+// queued carry/noise so a later actor write resumes from the applied state. It
+// returns an optional cursor-refresh command and the activity tag to publish.
+func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, hasMoreBuffered bool, visibleSeq uint64, updateActorCarry bool) (cmd tea.Cmd, tagSessionName string, tagTimestamp int64) {
+	processedBytes := len(chunk)
+	filteredLen := 0
+	filterApplied := false
+	suppressRedraw := false
+	tab.mu.Lock()
+	if tab.Terminal != nil {
+		filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
+		filterApplied = true
+		if updateActorCarry {
+			tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
+			tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.ptyNoiseTrailing...)
+		}
+	}
+	tab.mu.Unlock()
+	if !suppressRedraw {
+		cmd = m.scheduleChatCursorRefresh(tab, workspaceID, time.Now())
+	}
+	perf.Count("pty_flush_bytes_processed", int64(processedBytes))
+	if filterApplied {
+		filteredBytes := processedBytes - filteredLen
+		if filteredBytes > 0 {
+			perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
+		}
+	}
+	return cmd, tagSessionName, tagTimestamp
 }
 
 // applyPTYChunkLocked filters chunk for known PTY noise, writes it to the

--- a/internal/ui/center/tab_actor_write.go
+++ b/internal/ui/center/tab_actor_write.go
@@ -7,6 +7,7 @@ import (
 	"github.com/andyrewlee/amux/internal/safego"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/ptyio"
+	"github.com/andyrewlee/amux/internal/vterm"
 )
 
 func (m *Model) handleWriteOutput(ev tabEvent) {
@@ -86,6 +87,111 @@ func (m *Model) applyActorWriteLocked(tab *Tab, ev tabEvent, processedBytes int)
 		requestFlush = finalizeActorWriteLocked(tab)
 	}
 	return filteredLen, filterApplied, suppressRedraw, requestFlush, tagSessionName, tagTimestamp
+}
+
+// enqueueActorWrite optimistically advances the actor-write accounting for a
+// chunk about to be dispatched to the tab actor: it captures the prior epoch,
+// queued carry, and queued noise trailing (returned so a failed send can roll
+// back), advances the queued parser carry/noise across the chunk, and bumps the
+// pending/queued counters. It manages tab.mu itself and makes no mutation when
+// tab.Terminal == nil (the symmetric apply side bails the same way).
+func enqueueActorWrite(tab *Tab, chunk []byte) (prevEpoch uint64, prevCarry vterm.ParserCarryState, prevNoiseTrailing []byte) {
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if tab.Terminal == nil {
+		return 0, vterm.ParserCarryState{}, nil
+	}
+	prevPending := tab.actorWritesPending
+	prevEpoch = tab.actorWriteEpoch
+	prevCarry = tab.actorQueuedCarry
+	prevNoiseTrailing = append(prevNoiseTrailing, tab.actorQueuedNoiseTrailing...)
+	seedCarry := tab.Terminal.ParserCarryState()
+	if prevPending > 0 {
+		seedCarry = prevCarry
+	}
+	previewTrailing := append([]byte(nil), tab.ptyNoiseTrailing...)
+	if prevPending > 0 {
+		previewTrailing = append(previewTrailing[:0], tab.actorQueuedNoiseTrailing...)
+	}
+	filteredPreview := ptyio.FilterKnownPTYNoiseStream(chunk, &previewTrailing)
+	nextCarry := vterm.AdvanceParserCarryState(seedCarry, filteredPreview)
+	nextNoiseTrailing := append([]byte(nil), previewTrailing...)
+	tab.actorWritesPending = prevPending + 1
+	tab.actorQueuedBytes += len(chunk)
+	tab.actorQueuedCarry = nextCarry
+	tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], nextNoiseTrailing...)
+	return prevEpoch, prevCarry, prevNoiseTrailing
+}
+
+// recoverFailedActorSend rolls back an actor-write enqueue when sendTabEvent
+// could not deliver the chunk. It undoes the pending/queued bump and decides what
+// the caller should do: rebuffer the chunk ahead of pendingOutput (another write
+// is still in flight), drop it (epoch advanced or tab closed), or fall back to a
+// synchronous apply (optionally truncated to the active chunk size in catch-up).
+// It manages tab.mu itself and returns the chunk to apply synchronously, the
+// (possibly updated) hasMoreBuffered, and whether the write was rebuffered or
+// dropped (either of which means the caller must not apply it).
+func recoverFailedActorSend(
+	tab *Tab,
+	chunk []byte,
+	prevEpoch uint64,
+	prevCarry vterm.ParserCarryState,
+	prevNoiseTrailing []byte,
+	catchUp bool,
+	hasMoreBuffered bool,
+) (chunkToApply []byte, hasMore, rebuffered, dropWrite bool) {
+	hasMore = hasMoreBuffered
+	syncFallbackChunkSize := 0
+	tab.mu.Lock()
+	switch {
+	case tab.actorWriteEpoch == prevEpoch && tab.actorWritesPending > 0:
+		tab.actorWritesPending--
+		if tab.actorQueuedBytes >= len(chunk) {
+			tab.actorQueuedBytes -= len(chunk)
+		} else {
+			tab.actorQueuedBytes = 0
+		}
+		switch {
+		case tab.isClosed():
+			dropWrite = true
+		case tab.actorWritesPending > 0:
+			rebuffered = true
+			tab.restoreActorCarryLocked(prevCarry, prevNoiseTrailing)
+			tab.prependPendingOutputLocked(chunk)
+		case catchUp && len(chunk) > ptyFlushChunkSizeActive:
+			syncFallbackChunkSize = ptyFlushChunkSizeActive
+			tab.restoreActorCarryLocked(prevCarry, prevNoiseTrailing)
+			tab.prependPendingOutputLocked(chunk[syncFallbackChunkSize:])
+			hasMore = len(tab.pendingOutput) > 0
+		}
+	case tab.actorWriteEpoch != prevEpoch || tab.isClosed():
+		dropWrite = true
+	}
+	tab.mu.Unlock()
+	chunkToApply = chunk
+	if syncFallbackChunkSize > 0 {
+		chunkToApply = chunk[:syncFallbackChunkSize]
+	}
+	return chunkToApply, hasMore, rebuffered, dropWrite
+}
+
+// restoreActorCarryLocked restores the actor queued parser carry / noise trailing
+// to a previously captured state (used when rolling back a failed actor send).
+// Caller holds tab.mu.
+func (tab *Tab) restoreActorCarryLocked(prevCarry vterm.ParserCarryState, prevNoiseTrailing []byte) {
+	tab.actorQueuedCarry = prevCarry
+	tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], prevNoiseTrailing...)
+}
+
+// prependPendingOutputLocked restores chunk to the front of pendingOutput so a
+// rolled-back write is re-flushed before newer buffered output. Caller holds
+// tab.mu.
+func (tab *Tab) prependPendingOutputLocked(chunk []byte) {
+	restored := make([]byte, 0, len(chunk)+len(tab.pendingOutput))
+	restored = append(restored, chunk...)
+	restored = append(restored, tab.pendingOutput...)
+	tab.pendingOutput = restored
+	tab.pendingOutputBytes = len(tab.pendingOutput)
 }
 
 // finalizeActorWriteLocked snapshots the parser carry/noise state after the last


### PR DESCRIPTION
## What

`updatePTYFlush` was the worst maintainability hotspot in the streaming path (gocyclo 55 vs ratchet 30, ~266 lines), with deeply nested lock/unlock dances mutating six interdependent actor-write fields inline. The actor enqueue and the send-failure rollback (rebuffer / drop / sync-fallback) were inlined here while the symmetric apply side already lived in clean helpers in `tab_actor_write.go` — so the most timing-sensitive code was the hardest to reason about, and any edit risked the gocyclo ratchet.

## Change (behavior-preserving extraction)

Field updates and lock ownership are byte-identical to the inlined blocks:

- **`enqueueActorWrite`** (manages its own `tab.mu`; no mutation when `Terminal==nil`) captures `prevEpoch`/`prevCarry`/`prevNoiseTrailing` and advances the queued carry/noise + pending counters.
- **`recoverFailedActorSend`** (manages its own `tab.mu`) undoes the enqueue and returns the chunk to apply, updated `hasMoreBuffered`, and `rebuffered`/`drop` flags. Its inner branch is a `switch` (nestif) with `restoreActorCarryLocked` / `prependPendingOutputLocked` helpers for the repeated rollback steps.
- **`dispatchFlushChunk` / `dispatchFlushChunkViaActor` / `applyFlushChunkSync`** split the actor-vs-synchronous apply (deduping the two near-identical apply blocks) and the activity-tag publish out of `updatePTYFlush`.

`updatePTYFlush` drops to **gocyclo 29** and within funlen 120/60; both files stay under 500 lines.

## Verification

The full `internal/ui/center` suite (existing flush/catchUp/rollback coverage) passes **under `-race`** with no behavior change; e2e still compiles. Verified via the `make` ratchet targets with the pinned golangci-lint.

> Signature note: the rollback helper omits the unused `prevPending` the spec listed, to avoid a dead parameter.