### PR TITLE
Extract viewLayerBased pane composition into per-pane methods

### DIFF
--- a/internal/app/app_view.go
+++ b/internal/app/app_view.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"runtime/debug"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -12,7 +11,6 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/ui/common"
-	"github.com/andyrewlee/amux/internal/ui/compositor"
 )
 
 const (
@@ -115,242 +113,16 @@ func (a *App) viewLayerBased() tea.View {
 	// Create canvas at screen dimensions
 	canvas := a.canvasFor(a.width, a.height)
 
-	// Dashboard pane (leftmost)
 	leftGutter := a.layout.LeftGutter()
 	topGutter := a.layout.TopGutter()
 	dashWidth := a.layout.DashboardWidth()
-	dashHeight := a.layout.Height()
-	dashContentWidth := dashWidth - 3
-	dashContentHeight := dashHeight - 2
-	if dashContentWidth < 1 {
-		dashContentWidth = 1
-	}
-	if dashContentHeight < 1 {
-		dashContentHeight = 1
-	}
-	dashContent := clampLines(a.dashboard.View(), dashContentWidth, dashContentHeight)
-	if dashDrawable := a.dashboardContent.get(dashContent, leftGutter+1, topGutter+1); dashDrawable != nil {
-		canvas.Compose(dashDrawable)
-	}
-	for _, border := range a.dashboardBorders.get(leftGutter, topGutter, dashWidth, dashHeight) {
-		canvas.Compose(border)
-	}
 
-	// Center pane
+	a.composeDashboardPane(canvas, leftGutter, topGutter)
 	if a.layout.ShowCenter() {
-		centerX := leftGutter + dashWidth + a.layout.GapX()
-		centerWidth := a.layout.CenterWidth()
-		centerHeight := a.layout.Height()
-
-		// Check if we can use VTermLayer for direct cell rendering
-		centerOwnsCursor := a.focusedPane == messages.PaneCenter && !blockingOverlayVisible
-		if termLayer := a.center.TerminalLayerWithCursorOwner(centerOwnsCursor); termLayer != nil && a.center.HasTabs() && !a.center.HasDiffViewer() {
-			// Get terminal viewport from center model (accounts for borders, tab bar, help lines)
-			termOffsetX, termOffsetY, termW, termH := a.center.TerminalViewport()
-			termX := centerX + termOffsetX
-			termY := topGutter + termOffsetY
-			if centerOwnsCursor {
-				termLayer = delegateTerminalCursor(termLayer, termX, termY, termW, termH, setTerminalCursor)
-			}
-
-			// Compose terminal layer first; chrome is drawn on top without clearing the content area.
-			positionedTermLayer := &compositor.PositionedVTermLayer{
-				VTermLayer: termLayer,
-				PosX:       termX,
-				PosY:       termY,
-				Width:      termW,
-				Height:     termH,
-			}
-			canvas.Compose(positionedTermLayer)
-
-			// Draw borders without touching the content area.
-			for _, border := range a.centerBorders.get(centerX, topGutter, centerWidth, centerHeight) {
-				canvas.Compose(border)
-			}
-
-			contentWidth := a.center.ContentWidth()
-			if contentWidth < 1 {
-				contentWidth = 1
-			}
-
-			// Tab bar (top of content area).
-			tabBar := clampLines(a.center.TabBarView(), contentWidth, termOffsetY-1)
-			if tabBarDrawable := a.centerTabBar.get(tabBar, termX, topGutter+1); tabBarDrawable != nil {
-				canvas.Compose(tabBarDrawable)
-			}
-
-			// Status line (directly below terminal content).
-			if status := clampLines(a.center.ActiveTerminalStatusLine(), contentWidth, 1); status != "" {
-				if statusDrawable := a.centerStatus.get(status, termX, termY+termH); statusDrawable != nil {
-					canvas.Compose(statusDrawable)
-				}
-			}
-
-			// Help lines at bottom of pane.
-			if helpLines := a.center.HelpLines(contentWidth); len(helpLines) > 0 {
-				helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
-				helpY := topGutter + centerHeight - 1 - len(helpLines)
-				if helpY > termY {
-					if helpDrawable := a.centerHelp.get(helpContent, termX, helpY); helpDrawable != nil {
-						canvas.Compose(helpDrawable)
-					}
-				}
-			}
-		} else {
-			// Fallback to string-based rendering with borders (no caching - content changes)
-			a.centerChrome.Invalidate()
-			var centerContent string
-			if a.center.HasTabs() {
-				centerContent = a.center.View()
-			} else {
-				centerContent = a.renderCenterPaneContent()
-			}
-			centerView := buildBorderedPane(centerContent, centerWidth, centerHeight)
-			centerDrawable := compositor.NewStringDrawable(clampPane(centerView, centerWidth, centerHeight), centerX, topGutter)
-			canvas.Compose(centerDrawable)
-		}
+		a.composeCenterPane(canvas, leftGutter, topGutter, dashWidth, blockingOverlayVisible, setTerminalCursor)
 	}
-
-	// Sidebar pane (rightmost)
 	if a.layout.ShowSidebar() {
-		sidebarX := leftGutter + a.layout.DashboardWidth()
-		if a.layout.ShowCenter() {
-			sidebarX += a.layout.GapX() + a.layout.CenterWidth()
-		}
-		if a.layout.ShowSidebar() {
-			sidebarX += a.layout.GapX()
-		}
-		sidebarWidth := a.layout.SidebarWidth()
-		sidebarHeight := a.layout.Height()
-		topPaneHeight, bottomPaneHeight := sidebarPaneHeights(sidebarHeight)
-		if bottomPaneHeight > 0 {
-			contentWidth := sidebarWidth - 4
-			if contentWidth < 1 {
-				contentWidth = 1
-			}
-
-			if topPaneHeight > 0 {
-				topContentHeight := topPaneHeight - 2
-				if topContentHeight < 1 {
-					topContentHeight = 1
-				}
-
-				// Sidebar tab bar (Changes/Project tabs)
-				tabBar := a.sidebar.TabBarView()
-				tabBarHeight := 0
-				if tabBar != "" {
-					tabBarHeight = 1
-					tabBarContent := clampLines(tabBar, contentWidth, 1)
-					tabBarY := topGutter + 1 // Inside the border
-					if tabBarDrawable := a.sidebarTopTabBar.get(tabBarContent, sidebarX+2, tabBarY); tabBarDrawable != nil {
-						canvas.Compose(tabBarDrawable)
-					}
-				}
-
-				// Sidebar content (below tab bar)
-				sidebarContentHeight := topContentHeight - tabBarHeight
-				if sidebarContentHeight < 1 {
-					sidebarContentHeight = 1
-				}
-				topContent := clampLines(a.sidebar.ContentView(), contentWidth, sidebarContentHeight)
-				if topDrawable := a.sidebarTopContent.get(topContent, sidebarX+2, topGutter+1+tabBarHeight); topDrawable != nil {
-					canvas.Compose(topDrawable)
-				}
-				for _, border := range a.sidebarTopBorders.get(sidebarX, topGutter, sidebarWidth, topPaneHeight) {
-					canvas.Compose(border)
-				}
-			}
-
-			bottomY := topGutter + topPaneHeight
-			bottomContentHeight := bottomPaneHeight - 2
-			if bottomContentHeight < 1 {
-				bottomContentHeight = 1
-			}
-
-			sidebarOwnsCursor := a.focusedPane == messages.PaneSidebarTerminal && !blockingOverlayVisible
-			if termLayer := a.sidebarTerminal.TerminalLayerWithCursorOwner(sidebarOwnsCursor); termLayer != nil {
-				originX, originY := a.sidebarTerminal.TerminalOrigin()
-				termW, termH := a.sidebarTerminal.TerminalSize()
-				if termW > contentWidth {
-					termW = contentWidth
-				}
-				if termH > bottomContentHeight {
-					termH = bottomContentHeight
-				}
-
-				// Tab bar (above terminal content) - compact single line
-				tabBar := a.sidebarTerminal.TabBarView()
-				tabBarHeight := 0
-				if tabBar != "" {
-					tabBarHeight = 1
-					tabBarContent := clampLines(tabBar, contentWidth, 1)
-					tabBarY := bottomY + 1 // Inside the border
-					if tabBarDrawable := a.sidebarBottomTabBar.get(tabBarContent, originX, tabBarY); tabBarDrawable != nil {
-						canvas.Compose(tabBarDrawable)
-					}
-				}
-
-				status := clampLines(a.sidebarTerminal.StatusLine(), contentWidth, 1)
-				helpLines := a.sidebarTerminal.HelpLines(contentWidth)
-				statusLines := 0
-				if status != "" {
-					statusLines = 1
-				}
-				maxHelpHeight := bottomContentHeight - statusLines - tabBarHeight
-				if maxHelpHeight < 0 {
-					maxHelpHeight = 0
-				}
-				if len(helpLines) > maxHelpHeight {
-					helpLines = helpLines[:maxHelpHeight]
-				}
-				maxTermHeight := bottomContentHeight - statusLines - len(helpLines) - tabBarHeight
-				if maxTermHeight < 0 {
-					maxTermHeight = 0
-				}
-				if termH > maxTermHeight {
-					termH = maxTermHeight
-				}
-				if sidebarOwnsCursor {
-					termLayer = delegateTerminalCursor(termLayer, originX, originY, termW, termH, setTerminalCursor)
-				}
-
-				positioned := &compositor.PositionedVTermLayer{
-					VTermLayer: termLayer,
-					PosX:       originX,
-					PosY:       originY,
-					Width:      termW,
-					Height:     termH,
-				}
-				canvas.Compose(positioned)
-
-				if status != "" {
-					if statusDrawable := a.sidebarBottomStatus.get(status, originX, originY+termH); statusDrawable != nil {
-						canvas.Compose(statusDrawable)
-					}
-				}
-
-				if len(helpLines) > 0 {
-					helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
-					helpY := originY + bottomContentHeight - len(helpLines) - tabBarHeight
-					if helpDrawable := a.sidebarBottomHelp.get(helpContent, originX, helpY); helpDrawable != nil {
-						canvas.Compose(helpDrawable)
-					}
-				} else if status == "" && bottomContentHeight > termH+tabBarHeight {
-					blank := strings.Repeat(" ", contentWidth)
-					if blankDrawable := a.sidebarBottomHelp.get(blank, originX, originY+bottomContentHeight-1-tabBarHeight); blankDrawable != nil {
-						canvas.Compose(blankDrawable)
-					}
-				}
-			} else {
-				bottomContent := clampLines(a.sidebarTerminal.View(), contentWidth, bottomContentHeight)
-				if bottomDrawable := a.sidebarBottomContent.get(bottomContent, sidebarX+2, bottomY+1); bottomDrawable != nil {
-					canvas.Compose(bottomDrawable)
-				}
-			}
-			for _, border := range a.sidebarBottomBorders.get(sidebarX, bottomY, sidebarWidth, bottomPaneHeight) {
-				canvas.Compose(border)
-			}
-		}
+		a.composeSidebarPane(canvas, leftGutter, topGutter, blockingOverlayVisible, setTerminalCursor)
 	}
 
 	// Overlay layers (dialogs, toasts, etc.)

--- a/internal/app/app_view_panes.go
+++ b/internal/app/app_view_panes.go
@@ -1,6 +1,278 @@
 package app
 
-import "github.com/andyrewlee/amux/internal/ui/compositor"
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/compositor"
+)
+
+// composeDashboardPane draws the leftmost dashboard pane (content + borders).
+func (a *App) composeDashboardPane(canvas *lipgloss.Canvas, leftGutter, topGutter int) {
+	dashWidth := a.layout.DashboardWidth()
+	dashHeight := a.layout.Height()
+	dashContentWidth := dashWidth - 3
+	dashContentHeight := dashHeight - 2
+	if dashContentWidth < 1 {
+		dashContentWidth = 1
+	}
+	if dashContentHeight < 1 {
+		dashContentHeight = 1
+	}
+	dashContent := clampLines(a.dashboard.View(), dashContentWidth, dashContentHeight)
+	if dashDrawable := a.dashboardContent.get(dashContent, leftGutter+1, topGutter+1); dashDrawable != nil {
+		canvas.Compose(dashDrawable)
+	}
+	for _, border := range a.dashboardBorders.get(leftGutter, topGutter, dashWidth, dashHeight) {
+		canvas.Compose(border)
+	}
+}
+
+// composeCenterPane draws the center agent pane, using a direct VTerm layer when
+// a terminal tab owns the pane and falling back to string rendering otherwise.
+func (a *App) composeCenterPane(canvas *lipgloss.Canvas, leftGutter, topGutter, dashWidth int, blockingOverlayVisible bool, setTerminalCursor func(x, y int)) {
+	centerX := leftGutter + dashWidth + a.layout.GapX()
+	centerWidth := a.layout.CenterWidth()
+	centerHeight := a.layout.Height()
+
+	// Check if we can use VTermLayer for direct cell rendering
+	centerOwnsCursor := a.focusedPane == messages.PaneCenter && !blockingOverlayVisible
+	termLayer := a.center.TerminalLayerWithCursorOwner(centerOwnsCursor)
+	if termLayer != nil && a.center.HasTabs() && !a.center.HasDiffViewer() {
+		a.composeCenterTerminalLayer(canvas, centerX, topGutter, centerWidth, centerHeight, termLayer, centerOwnsCursor, setTerminalCursor)
+		return
+	}
+	// Fallback to string-based rendering with borders (no caching - content changes)
+	a.centerChrome.Invalidate()
+	var centerContent string
+	if a.center.HasTabs() {
+		centerContent = a.center.View()
+	} else {
+		centerContent = a.renderCenterPaneContent()
+	}
+	centerView := buildBorderedPane(centerContent, centerWidth, centerHeight)
+	centerDrawable := compositor.NewStringDrawable(clampPane(centerView, centerWidth, centerHeight), centerX, topGutter)
+	canvas.Compose(centerDrawable)
+}
+
+// composeCenterTerminalLayer draws the center pane's direct VTerm layer plus its
+// chrome (borders, tab bar, status line, help lines).
+func (a *App) composeCenterTerminalLayer(canvas *lipgloss.Canvas, centerX, topGutter, centerWidth, centerHeight int, termLayer *compositor.VTermLayer, centerOwnsCursor bool, setTerminalCursor func(x, y int)) {
+	// Get terminal viewport from center model (accounts for borders, tab bar, help lines)
+	termOffsetX, termOffsetY, termW, termH := a.center.TerminalViewport()
+	termX := centerX + termOffsetX
+	termY := topGutter + termOffsetY
+	if centerOwnsCursor {
+		termLayer = delegateTerminalCursor(termLayer, termX, termY, termW, termH, setTerminalCursor)
+	}
+
+	// Compose terminal layer first; chrome is drawn on top without clearing the content area.
+	positionedTermLayer := &compositor.PositionedVTermLayer{
+		VTermLayer: termLayer,
+		PosX:       termX,
+		PosY:       termY,
+		Width:      termW,
+		Height:     termH,
+	}
+	canvas.Compose(positionedTermLayer)
+
+	// Draw borders without touching the content area.
+	for _, border := range a.centerBorders.get(centerX, topGutter, centerWidth, centerHeight) {
+		canvas.Compose(border)
+	}
+
+	contentWidth := a.center.ContentWidth()
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	// Tab bar (top of content area).
+	tabBar := clampLines(a.center.TabBarView(), contentWidth, termOffsetY-1)
+	if tabBarDrawable := a.centerTabBar.get(tabBar, termX, topGutter+1); tabBarDrawable != nil {
+		canvas.Compose(tabBarDrawable)
+	}
+
+	// Status line (directly below terminal content).
+	if status := clampLines(a.center.ActiveTerminalStatusLine(), contentWidth, 1); status != "" {
+		if statusDrawable := a.centerStatus.get(status, termX, termY+termH); statusDrawable != nil {
+			canvas.Compose(statusDrawable)
+		}
+	}
+
+	// Help lines at bottom of pane.
+	helpLines := a.center.HelpLines(contentWidth)
+	if len(helpLines) == 0 {
+		return
+	}
+	helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
+	helpY := topGutter + centerHeight - 1 - len(helpLines)
+	if helpY <= termY {
+		return
+	}
+	if helpDrawable := a.centerHelp.get(helpContent, termX, helpY); helpDrawable != nil {
+		canvas.Compose(helpDrawable)
+	}
+}
+
+// composeSidebarPane draws the rightmost sidebar (top changes/project pane and
+// the bottom terminal pane), delegating the bottom terminal content to
+// composeSidebarTerminalPane.
+func (a *App) composeSidebarPane(canvas *lipgloss.Canvas, leftGutter, topGutter int, blockingOverlayVisible bool, setTerminalCursor func(x, y int)) {
+	sidebarX := leftGutter + a.layout.DashboardWidth()
+	if a.layout.ShowCenter() {
+		sidebarX += a.layout.GapX() + a.layout.CenterWidth()
+	}
+	if a.layout.ShowSidebar() {
+		sidebarX += a.layout.GapX()
+	}
+	sidebarWidth := a.layout.SidebarWidth()
+	sidebarHeight := a.layout.Height()
+	topPaneHeight, bottomPaneHeight := sidebarPaneHeights(sidebarHeight)
+	if bottomPaneHeight <= 0 {
+		return
+	}
+	contentWidth := sidebarWidth - 4
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	if topPaneHeight > 0 {
+		a.composeSidebarTopPane(canvas, sidebarX, topGutter, sidebarWidth, topPaneHeight, contentWidth)
+	}
+
+	bottomY := topGutter + topPaneHeight
+	bottomContentHeight := bottomPaneHeight - 2
+	if bottomContentHeight < 1 {
+		bottomContentHeight = 1
+	}
+
+	a.composeSidebarTerminalPane(canvas, sidebarX, bottomY, contentWidth, bottomContentHeight, blockingOverlayVisible, setTerminalCursor)
+	for _, border := range a.sidebarBottomBorders.get(sidebarX, bottomY, sidebarWidth, bottomPaneHeight) {
+		canvas.Compose(border)
+	}
+}
+
+// composeSidebarTopPane draws the sidebar's top changes/project pane (tab bar,
+// content, and borders).
+func (a *App) composeSidebarTopPane(canvas *lipgloss.Canvas, sidebarX, topGutter, sidebarWidth, topPaneHeight, contentWidth int) {
+	topContentHeight := topPaneHeight - 2
+	if topContentHeight < 1 {
+		topContentHeight = 1
+	}
+
+	// Sidebar tab bar (Changes/Project tabs)
+	tabBar := a.sidebar.TabBarView()
+	tabBarHeight := 0
+	if tabBar != "" {
+		tabBarHeight = 1
+		tabBarContent := clampLines(tabBar, contentWidth, 1)
+		tabBarY := topGutter + 1 // Inside the border
+		if tabBarDrawable := a.sidebarTopTabBar.get(tabBarContent, sidebarX+2, tabBarY); tabBarDrawable != nil {
+			canvas.Compose(tabBarDrawable)
+		}
+	}
+
+	// Sidebar content (below tab bar)
+	sidebarContentHeight := topContentHeight - tabBarHeight
+	if sidebarContentHeight < 1 {
+		sidebarContentHeight = 1
+	}
+	topContent := clampLines(a.sidebar.ContentView(), contentWidth, sidebarContentHeight)
+	if topDrawable := a.sidebarTopContent.get(topContent, sidebarX+2, topGutter+1+tabBarHeight); topDrawable != nil {
+		canvas.Compose(topDrawable)
+	}
+	for _, border := range a.sidebarTopBorders.get(sidebarX, topGutter, sidebarWidth, topPaneHeight) {
+		canvas.Compose(border)
+	}
+}
+
+// composeSidebarTerminalPane draws the sidebar's bottom terminal pane content
+// (tab bar, terminal layer or string fallback, status, and help lines).
+func (a *App) composeSidebarTerminalPane(canvas *lipgloss.Canvas, sidebarX, bottomY, contentWidth, bottomContentHeight int, blockingOverlayVisible bool, setTerminalCursor func(x, y int)) {
+	sidebarOwnsCursor := a.focusedPane == messages.PaneSidebarTerminal && !blockingOverlayVisible
+	termLayer := a.sidebarTerminal.TerminalLayerWithCursorOwner(sidebarOwnsCursor)
+	if termLayer == nil {
+		bottomContent := clampLines(a.sidebarTerminal.View(), contentWidth, bottomContentHeight)
+		if bottomDrawable := a.sidebarBottomContent.get(bottomContent, sidebarX+2, bottomY+1); bottomDrawable != nil {
+			canvas.Compose(bottomDrawable)
+		}
+		return
+	}
+	originX, originY := a.sidebarTerminal.TerminalOrigin()
+	termW, termH := a.sidebarTerminal.TerminalSize()
+	if termW > contentWidth {
+		termW = contentWidth
+	}
+	if termH > bottomContentHeight {
+		termH = bottomContentHeight
+	}
+
+	// Tab bar (above terminal content) - compact single line
+	tabBar := a.sidebarTerminal.TabBarView()
+	tabBarHeight := 0
+	if tabBar != "" {
+		tabBarHeight = 1
+		tabBarContent := clampLines(tabBar, contentWidth, 1)
+		tabBarY := bottomY + 1 // Inside the border
+		if tabBarDrawable := a.sidebarBottomTabBar.get(tabBarContent, originX, tabBarY); tabBarDrawable != nil {
+			canvas.Compose(tabBarDrawable)
+		}
+	}
+
+	status := clampLines(a.sidebarTerminal.StatusLine(), contentWidth, 1)
+	helpLines := a.sidebarTerminal.HelpLines(contentWidth)
+	statusLines := 0
+	if status != "" {
+		statusLines = 1
+	}
+	maxHelpHeight := bottomContentHeight - statusLines - tabBarHeight
+	if maxHelpHeight < 0 {
+		maxHelpHeight = 0
+	}
+	if len(helpLines) > maxHelpHeight {
+		helpLines = helpLines[:maxHelpHeight]
+	}
+	maxTermHeight := bottomContentHeight - statusLines - len(helpLines) - tabBarHeight
+	if maxTermHeight < 0 {
+		maxTermHeight = 0
+	}
+	if termH > maxTermHeight {
+		termH = maxTermHeight
+	}
+	if sidebarOwnsCursor {
+		termLayer = delegateTerminalCursor(termLayer, originX, originY, termW, termH, setTerminalCursor)
+	}
+
+	positioned := &compositor.PositionedVTermLayer{
+		VTermLayer: termLayer,
+		PosX:       originX,
+		PosY:       originY,
+		Width:      termW,
+		Height:     termH,
+	}
+	canvas.Compose(positioned)
+
+	if status != "" {
+		if statusDrawable := a.sidebarBottomStatus.get(status, originX, originY+termH); statusDrawable != nil {
+			canvas.Compose(statusDrawable)
+		}
+	}
+
+	if len(helpLines) > 0 {
+		helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
+		helpY := originY + bottomContentHeight - len(helpLines) - tabBarHeight
+		if helpDrawable := a.sidebarBottomHelp.get(helpContent, originX, helpY); helpDrawable != nil {
+			canvas.Compose(helpDrawable)
+		}
+	} else if status == "" && bottomContentHeight > termH+tabBarHeight {
+		blank := strings.Repeat(" ", contentWidth)
+		if blankDrawable := a.sidebarBottomHelp.get(blank, originX, originY+bottomContentHeight-1-tabBarHeight); blankDrawable != nil {
+			canvas.Compose(blankDrawable)
+		}
+	}
+}
 
 // delegateTerminalCursor moves a terminal pane's in-snapshot cursor onto the
 // hardware cursor (via setCursor) when it is visible and in bounds, returning a


### PR DESCRIPTION
## What

`viewLayerBased` was a 277-line god-function (gocyclo 66) composing the entire screen — dashboard, center pane (VTermLayer vs string fallback), sidebar (changes pane + terminal pane with its own fallback), and cursor selection — with layout math, clamping, border composition, and cursor delegation for three independent panes interleaved. A sidebar-sizing change forced re-reading center logic, and the function blocked the ratchet for any view edit.

## Change (pure subtractive decomposition)

Decompose into `composeDashboardPane` / `composeCenterPane` (+ `composeCenterTerminalLayer`) / `composeSidebarPane` (+ `composeSidebarTopPane` + `composeSidebarTerminalPane`) in `app_view_panes.go`. `viewLayerBased` keeps the `tea.View` setup, the `terminalCursor` closure, canvas creation, the three compose calls, `composeOverlays`, and final cursor selection. Package-level helpers (`clampLines`, `buildBorderedPane`, `clampPane`, `sidebarPaneHeights`, `delegateTerminalCursor`) are reachable from the `*App`-receiver methods.

`viewLayerBased` drops to **gocyclo 15** and every new method is < 30, within funlen, and nestif-clean; both files stay under 500 lines.

## Verification

**Byte-identical render**: a golden capture of the harness `center`/`sidebar`/`monitor` render modes (via `Harness.Render()` → `viewLayerBased()`) is unchanged before vs after the refactor. Full `internal/app` suite passes.