### PR TITLE
Split App.update message switch into themed sub-dispatchers

### DIFF
--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -11,7 +11,6 @@ import (
 	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/ui/center"
 	"github.com/andyrewlee/amux/internal/ui/common"
-	"github.com/andyrewlee/amux/internal/ui/dashboard"
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
 )
 
@@ -35,34 +34,24 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// side-effect free while still enforcing single-pane cursor ownership.
 	a.syncPaneFocusFlags()
 
-	if perf.Enabled() {
-		switch msg.(type) {
-		case tea.KeyPressMsg, tea.KeyReleaseMsg, tea.MouseClickMsg, tea.MouseWheelMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg, tea.PasteMsg:
-			a.markInput()
-		}
+	// Overlay/dialog input guards consume the message before the main routing.
+	if res, consumed := a.handlePreSwitchInput(msg, &cmds); consumed {
+		return a, res
 	}
 
-	if handled, cmd := a.handleDialogResultMsg(msg); handled {
-		return a, cmd
-	}
-	if a.handleErrorOverlayDismiss(msg) {
-		return a, nil
-	}
-
-	// Handle toast updates
-	if _, ok := msg.(common.ToastDismissed); ok {
-		newToast, cmd := a.toast.Update(msg)
-		a.toast = newToast
-		cmds = append(cmds, cmd)
-	}
-
-	if a.handleDialogInput(msg, &cmds) {
+	if a.updateTabMsg(msg, &cmds) {
 		return a, common.SafeBatch(cmds...)
 	}
-	if a.handleFilePickerInput(msg, &cmds) {
+	if a.updateTmuxMsg(msg, &cmds) {
 		return a, common.SafeBatch(cmds...)
 	}
-	if a.handleSettingsDialogInput(msg, &cmds) {
+	if a.updateWorkspaceLifecycleMsg(msg, &cmds) {
+		return a, common.SafeBatch(cmds...)
+	}
+	if a.updateDialogShowMsg(msg, &cmds) {
+		return a, common.SafeBatch(cmds...)
+	}
+	if a.updateUpgradeMsg(msg, &cmds) {
 		return a, common.SafeBatch(cmds...)
 	}
 
@@ -91,162 +80,6 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-	case messages.ProjectsLoaded:
-		cmds = append(cmds, a.handleProjectsLoaded(msg)...)
-
-	case messages.WorkspaceActivated:
-		cmds = append(cmds, a.handleWorkspaceActivated(msg)...)
-
-	case messages.ShowWelcome:
-		a.goHome()
-
-	case messages.ShowCommandsPalette:
-		if cmd := a.openCommandsPalette(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.ToggleKeymapHints:
-		a.setKeymapHintsEnabled(!a.config.UI.ShowKeymapHints)
-		if err := a.config.SaveUISettings(); err != nil {
-			cmds = append(cmds, a.toast.ShowWarning("Failed to save keymap setting"))
-		}
-
-	case messages.ShowQuitDialog:
-		a.showQuitDialog()
-
-	case messages.RefreshDashboard:
-		cmds = append(cmds, a.loadProjects())
-
-	case messages.RescanWorkspaces:
-		cmds = append(cmds, a.rescanWorkspaces())
-
-	case messages.WorkspaceCreatedWithWarning:
-		cmds = append(cmds, a.handleWorkspaceCreatedWithWarning(msg)...)
-
-	case messages.WorkspaceCreated:
-		cmds = append(cmds, a.handleWorkspaceCreated(msg)...)
-
-	case messages.WorkspaceSetupComplete:
-		if cmd := a.handleWorkspaceSetupComplete(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.WorkspaceCreateFailed:
-		if cmd := a.handleWorkspaceCreateFailed(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.GitStatusResult:
-		if cmd := a.handleGitStatusResult(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.ShowAddProjectDialog:
-		a.handleShowAddProjectDialog()
-
-	case messages.ShowCreateWorkspaceDialog:
-		a.handleShowCreateWorkspaceDialog(msg)
-
-	case messages.ShowDeleteWorkspaceDialog:
-		a.handleShowDeleteWorkspaceDialog(msg)
-
-	case messages.ShowRemoveProjectDialog:
-		a.handleShowRemoveProjectDialog(msg)
-
-	case messages.ShowSelectAssistantDialog:
-		a.handleShowSelectAssistantDialog()
-
-	case messages.ShowSettingsDialog:
-		a.handleShowSettingsDialog()
-
-	case messages.ShowCleanupTmuxDialog:
-		a.handleShowCleanupTmuxDialog()
-
-	case common.ThemePreview:
-		if cmd := a.handleThemePreview(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case common.SettingsResult:
-		if cmd := a.handleSettingsResult(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.CreateWorkspace:
-		cmds = append(cmds, a.handleCreateWorkspace(msg)...)
-
-	case messages.DeleteWorkspace:
-		cmds = append(cmds, a.handleDeleteWorkspace(msg)...)
-
-	case messages.CleanupTmuxSessions:
-		if cmd := a.cleanupAllTmuxSessions(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.AddProject:
-		cmds = append(cmds, a.addProject(msg.Path))
-
-	case messages.RemoveProject:
-		cmds = append(cmds, a.removeProject(msg.Project))
-
-	case messages.OpenDiff:
-		if cmd := a.handleOpenDiff(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.CloseTab:
-		cmd := a.center.CloseActiveTab()
-		cmds = append(cmds, cmd)
-
-	case messages.LaunchAgent:
-		if cmd := a.handleLaunchAgent(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TabCreated:
-		if cmd := a.handleTabCreated(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-		cmds = append(cmds, a.enforceAttachedAgentTabLimit()...)
-		if cmd := a.persistActiveWorkspaceTabs(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-		// Eagerly rescan so a just-started agent's working indicator does not
-		// wait up to one ticker interval (~5s) to appear.
-		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TabClosed:
-		logging.Info("Tab closed: %d", msg.Index)
-		if cmd := a.persistActiveWorkspaceTabs(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TabDetached:
-		logging.Info("Tab detached: %d", msg.Index)
-		if cmd := a.handleTabDetached(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TabReattached:
-		cmds = append(cmds, a.enforceAttachedAgentTabLimit()...)
-		cmds = append(cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
-		// Eagerly rescan so a reattached agent's working indicator does not
-		// wait up to one ticker interval (~5s) to appear.
-		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TabStateChanged:
-		cmds = append(cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
-
-	case messages.TabSelectionChanged:
-		cmds = append(cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
-
-	case persistDebounceMsg:
-		cmds = append(cmds, a.handlePersistDebounce(msg))
-
 	case center.PTYOutput, center.PTYTick, center.PTYFlush, center.PTYStopped:
 		if cmd := a.handlePTYMessages(msg); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -257,20 +90,8 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, startCmd)
 		}
 
-	case center.TabInputFailed:
-		cmds = append(cmds, a.handleTabInputFailed(msg)...)
-
 	case messages.Toast:
-		switch msg.Level {
-		case messages.ToastSuccess:
-			cmds = append(cmds, a.toast.ShowSuccess(msg.Message))
-		case messages.ToastError:
-			cmds = append(cmds, a.toast.ShowError(msg.Message))
-		case messages.ToastWarning:
-			cmds = append(cmds, a.toast.ShowWarning(msg.Message))
-		default:
-			cmds = append(cmds, a.toast.ShowInfo(msg.Message))
-		}
+		cmds = append(cmds, a.showToast(msg))
 
 	case messages.SidebarPTYOutput, messages.SidebarPTYTick, messages.SidebarPTYFlush, messages.SidebarPTYStopped, messages.SidebarPTYRestart, sidebar.SidebarTerminalCreated, sidebar.SidebarTerminalCreateFailed, sidebar.SidebarTerminalReattachResult, sidebar.SidebarTerminalReattachFailed, sidebar.SidebarSelectionScrollTick:
 		if cmd := a.handleSidebarPTYMessages(msg); cmd != nil {
@@ -279,72 +100,6 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sidebar.OpenFileInEditor:
 		if cmd := a.handleOpenFileInEditor(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case dashboard.SpinnerTickMsg:
-		cmds = append(cmds, a.handleSpinnerTick(msg)...)
-
-	case messages.GitStatusTick:
-		cmds = append(cmds, a.handleGitStatusTick()...)
-
-	case messages.OrphanGCTick:
-		cmds = append(cmds, a.handleOrphanGCTick()...)
-
-	case messages.PTYWatchdogTick:
-		cmds = append(cmds, a.handlePTYWatchdogTick()...)
-	case tmuxActivityTick:
-		cmds = append(cmds, a.handleTmuxActivityTick(msg)...)
-	case tmuxActivityResult:
-		cmds = append(cmds, a.handleTmuxActivityResult(msg)...)
-	case tmuxAvailableResult:
-		cmds = append(cmds, a.handleTmuxAvailableResult(msg)...)
-	case messages.TmuxSyncTick:
-		cmds = append(cmds, a.handleTmuxSyncTick(msg)...)
-
-	case tmuxTabsSyncResult:
-		cmds = append(cmds, a.handleTmuxTabsSyncResult(msg)...)
-	case tmuxTabsDiscoverResult:
-		cmds = append(cmds, a.handleTmuxTabsDiscoverResult(msg)...)
-	case tmuxSidebarDiscoverResult:
-		cmds = append(cmds, a.handleTmuxSidebarDiscoverResult(msg)...)
-	case orphanGCResult:
-		a.handleOrphanGCResult(msg)
-	case staleDetachedAgentGCResult:
-		a.handleStaleDetachedAgentGCResult(msg)
-	case sessionCountResult:
-		a.handleSessionCountResult(msg)
-
-	case messages.FileWatcherEvent:
-		cmds = append(cmds, a.handleFileWatcherEvent(msg)...)
-
-	case messages.StateWatcherEvent:
-		cmds = append(cmds, a.handleStateWatcherEvent(msg)...)
-
-	case messages.WorkspaceDeleted:
-		cmds = append(cmds, a.handleWorkspaceDeleted(msg)...)
-
-	case messages.ProjectRemoved:
-		cmds = append(cmds, a.toast.ShowSuccess("Project removed"))
-		cmds = append(cmds, a.loadProjects())
-
-	case messages.WorkspaceDeleteFailed:
-		if cmd := a.handleWorkspaceDeleteFailed(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.UpdateCheckComplete:
-		if cmd := a.handleUpdateCheckComplete(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.TriggerUpgrade:
-		if cmd := a.handleTriggerUpgrade(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-
-	case messages.UpgradeComplete:
-		if cmd := a.handleUpgradeComplete(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 
@@ -363,6 +118,20 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return a, common.SafeBatch(cmds...)
+}
+
+// showToast routes a Toast message to the matching toast severity.
+func (a *App) showToast(msg messages.Toast) tea.Cmd {
+	switch msg.Level {
+	case messages.ToastSuccess:
+		return a.toast.ShowSuccess(msg.Message)
+	case messages.ToastError:
+		return a.toast.ShowError(msg.Message)
+	case messages.ToastWarning:
+		return a.toast.ShowWarning(msg.Message)
+	default:
+		return a.toast.ShowInfo(msg.Message)
+	}
 }
 
 func (a *App) handleTabDetached(msg messages.TabDetached) tea.Cmd {

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -1,0 +1,274 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/perf"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/common"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+)
+
+// The four updateXMsg sub-dispatchers below carve App.update's message switch
+// into themed groups so the central routing function stays under the complexity
+// ratchet. Each returns true (and appends to cmds) when it handled the message;
+// the message types are disjoint across dispatchers, so call order is irrelevant.
+
+// handlePreSwitchInput runs the overlay/dialog guards that may consume a message
+// before the main routing switch. It returns the resulting command and true when
+// the message was consumed (the caller returns immediately).
+func (a *App) handlePreSwitchInput(msg tea.Msg, cmds *[]tea.Cmd) (tea.Cmd, bool) {
+	if perf.Enabled() {
+		switch msg.(type) {
+		case tea.KeyPressMsg, tea.KeyReleaseMsg, tea.MouseClickMsg, tea.MouseWheelMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg, tea.PasteMsg:
+			a.markInput()
+		}
+	}
+
+	if handled, cmd := a.handleDialogResultMsg(msg); handled {
+		return cmd, true
+	}
+	if a.handleErrorOverlayDismiss(msg) {
+		return nil, true
+	}
+
+	// Handle toast updates (does not consume the message).
+	if _, ok := msg.(common.ToastDismissed); ok {
+		newToast, cmd := a.toast.Update(msg)
+		a.toast = newToast
+		*cmds = append(*cmds, cmd)
+	}
+
+	if a.handleDialogInput(msg, cmds) {
+		return common.SafeBatch(*cmds...), true
+	}
+	if a.handleFilePickerInput(msg, cmds) {
+		return common.SafeBatch(*cmds...), true
+	}
+	if a.handleSettingsDialogInput(msg, cmds) {
+		return common.SafeBatch(*cmds...), true
+	}
+	return nil, false
+}
+
+// updateUpgradeMsg handles self-update / upgrade lifecycle messages.
+func (a *App) updateUpgradeMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	switch msg := msg.(type) {
+	case messages.UpdateCheckComplete:
+		if cmd := a.handleUpdateCheckComplete(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TriggerUpgrade:
+		if cmd := a.handleTriggerUpgrade(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.UpgradeComplete:
+		if cmd := a.handleUpgradeComplete(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+// updateTabMsg handles center tab lifecycle and tab-state persistence messages.
+func (a *App) updateTabMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	switch msg := msg.(type) {
+	case messages.OpenDiff:
+		if cmd := a.handleOpenDiff(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.CloseTab:
+		*cmds = append(*cmds, a.center.CloseActiveTab())
+	case messages.LaunchAgent:
+		if cmd := a.handleLaunchAgent(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TabCreated:
+		if cmd := a.handleTabCreated(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+		*cmds = append(*cmds, a.enforceAttachedAgentTabLimit()...)
+		if cmd := a.persistActiveWorkspaceTabs(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+		// Eagerly rescan so a just-started agent's working indicator does not
+		// wait up to one ticker interval (~5s) to appear.
+		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TabClosed:
+		logging.Info("Tab closed: %d", msg.Index)
+		if cmd := a.persistActiveWorkspaceTabs(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TabDetached:
+		logging.Info("Tab detached: %d", msg.Index)
+		if cmd := a.handleTabDetached(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TabReattached:
+		*cmds = append(*cmds, a.enforceAttachedAgentTabLimit()...)
+		*cmds = append(*cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
+		// Eagerly rescan so a reattached agent's working indicator does not
+		// wait up to one ticker interval (~5s) to appear.
+		if cmd := a.eagerScanTmuxActivity(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.TabStateChanged:
+		*cmds = append(*cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
+	case messages.TabSelectionChanged:
+		*cmds = append(*cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
+	case persistDebounceMsg:
+		*cmds = append(*cmds, a.handlePersistDebounce(msg))
+	case center.TabInputFailed:
+		*cmds = append(*cmds, a.handleTabInputFailed(msg)...)
+	default:
+		return false
+	}
+	return true
+}
+
+// updateTmuxMsg handles tmux activity/sync, orphan-GC, and background-tick
+// messages.
+func (a *App) updateTmuxMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	switch msg := msg.(type) {
+	case messages.CleanupTmuxSessions:
+		if cmd := a.cleanupAllTmuxSessions(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case dashboard.SpinnerTickMsg:
+		*cmds = append(*cmds, a.handleSpinnerTick(msg)...)
+	case messages.GitStatusTick:
+		*cmds = append(*cmds, a.handleGitStatusTick()...)
+	case messages.OrphanGCTick:
+		*cmds = append(*cmds, a.handleOrphanGCTick()...)
+	case messages.PTYWatchdogTick:
+		*cmds = append(*cmds, a.handlePTYWatchdogTick()...)
+	case tmuxActivityTick:
+		*cmds = append(*cmds, a.handleTmuxActivityTick(msg)...)
+	case tmuxActivityResult:
+		*cmds = append(*cmds, a.handleTmuxActivityResult(msg)...)
+	case tmuxAvailableResult:
+		*cmds = append(*cmds, a.handleTmuxAvailableResult(msg)...)
+	case messages.TmuxSyncTick:
+		*cmds = append(*cmds, a.handleTmuxSyncTick(msg)...)
+	case tmuxTabsSyncResult:
+		*cmds = append(*cmds, a.handleTmuxTabsSyncResult(msg)...)
+	case tmuxTabsDiscoverResult:
+		*cmds = append(*cmds, a.handleTmuxTabsDiscoverResult(msg)...)
+	case tmuxSidebarDiscoverResult:
+		*cmds = append(*cmds, a.handleTmuxSidebarDiscoverResult(msg)...)
+	case orphanGCResult:
+		a.handleOrphanGCResult(msg)
+	case staleDetachedAgentGCResult:
+		a.handleStaleDetachedAgentGCResult(msg)
+	case sessionCountResult:
+		a.handleSessionCountResult(msg)
+	default:
+		return false
+	}
+	return true
+}
+
+// updateWorkspaceLifecycleMsg handles project/workspace load, create, delete, and
+// watcher messages.
+func (a *App) updateWorkspaceLifecycleMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	switch msg := msg.(type) {
+	case messages.ProjectsLoaded:
+		*cmds = append(*cmds, a.handleProjectsLoaded(msg)...)
+	case messages.WorkspaceActivated:
+		*cmds = append(*cmds, a.handleWorkspaceActivated(msg)...)
+	case messages.RefreshDashboard:
+		*cmds = append(*cmds, a.loadProjects())
+	case messages.RescanWorkspaces:
+		*cmds = append(*cmds, a.rescanWorkspaces())
+	case messages.WorkspaceCreatedWithWarning:
+		*cmds = append(*cmds, a.handleWorkspaceCreatedWithWarning(msg)...)
+	case messages.WorkspaceCreated:
+		*cmds = append(*cmds, a.handleWorkspaceCreated(msg)...)
+	case messages.WorkspaceSetupComplete:
+		if cmd := a.handleWorkspaceSetupComplete(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.WorkspaceCreateFailed:
+		if cmd := a.handleWorkspaceCreateFailed(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.GitStatusResult:
+		if cmd := a.handleGitStatusResult(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.CreateWorkspace:
+		*cmds = append(*cmds, a.handleCreateWorkspace(msg)...)
+	case messages.DeleteWorkspace:
+		*cmds = append(*cmds, a.handleDeleteWorkspace(msg)...)
+	case messages.AddProject:
+		*cmds = append(*cmds, a.addProject(msg.Path))
+	case messages.RemoveProject:
+		*cmds = append(*cmds, a.removeProject(msg.Project))
+	case messages.WorkspaceDeleted:
+		*cmds = append(*cmds, a.handleWorkspaceDeleted(msg)...)
+	case messages.ProjectRemoved:
+		*cmds = append(*cmds, a.toast.ShowSuccess("Project removed"))
+		*cmds = append(*cmds, a.loadProjects())
+	case messages.WorkspaceDeleteFailed:
+		if cmd := a.handleWorkspaceDeleteFailed(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.FileWatcherEvent:
+		*cmds = append(*cmds, a.handleFileWatcherEvent(msg)...)
+	case messages.StateWatcherEvent:
+		*cmds = append(*cmds, a.handleStateWatcherEvent(msg)...)
+	default:
+		return false
+	}
+	return true
+}
+
+// updateDialogShowMsg handles dialog/palette/settings show messages.
+func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	switch msg := msg.(type) {
+	case messages.ShowWelcome:
+		a.goHome()
+	case messages.ShowCommandsPalette:
+		if cmd := a.openCommandsPalette(); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case messages.ToggleKeymapHints:
+		a.setKeymapHintsEnabled(!a.config.UI.ShowKeymapHints)
+		if err := a.config.SaveUISettings(); err != nil {
+			*cmds = append(*cmds, a.toast.ShowWarning("Failed to save keymap setting"))
+		}
+	case messages.ShowQuitDialog:
+		a.showQuitDialog()
+	case messages.ShowAddProjectDialog:
+		a.handleShowAddProjectDialog()
+	case messages.ShowCreateWorkspaceDialog:
+		a.handleShowCreateWorkspaceDialog(msg)
+	case messages.ShowDeleteWorkspaceDialog:
+		a.handleShowDeleteWorkspaceDialog(msg)
+	case messages.ShowRemoveProjectDialog:
+		a.handleShowRemoveProjectDialog(msg)
+	case messages.ShowSelectAssistantDialog:
+		a.handleShowSelectAssistantDialog()
+	case messages.ShowSettingsDialog:
+		a.handleShowSettingsDialog()
+	case messages.ShowCleanupTmuxDialog:
+		a.handleShowCleanupTmuxDialog()
+	case common.ThemePreview:
+		if cmd := a.handleThemePreview(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case common.SettingsResult:
+		if cmd := a.handleSettingsResult(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	default:
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## What

`App.update` was a single ~75-case message switch with gocyclo 110 — nearly 4× the ratchet and the central routing chokepoint, conflating dialog input, tab persistence, tmux/GC results, workspace lifecycle, PTY streaming, and dashboard in one god-function. Because the strict ratchet runs on changed code, adding a `case` or editing a handler made the whole 110-complexity function "changed" and tripped gocyclo-30 — so `update` was effectively frozen.

## Change

Add `app_input_dispatch.go` with themed sub-dispatchers, each `func (a *App) updateXMsg(msg tea.Msg, cmds *[]tea.Cmd) bool`:
- `updateTabMsg`, `updateTmuxMsg`, `updateWorkspaceLifecycleMsg`, `updateDialogShowMsg`, and `updateUpgradeMsg` (a 5th group for the self-update/upgrade messages, added to meet the complexity target).

`update` calls them in sequence after the overlay/dialog guards and before the remaining switch; each returns `true` (handled) only for its own **disjoint** message types, so call order is irrelevant. The pre-switch guards are extracted to `handlePreSwitchInput` and the Toast severity switch to `showToast`. PTY / sidebar / mouse / key / window / paste / error and the `default` center fall-through stay in `update`.

`update` drops to **gocyclo 27** (`gocyclo -over 29` reports nothing across both files) and each dispatcher is well under 30; both files stay under 500 lines. Every message type appears in exactly one dispatcher or the remaining switch.

## Tests

Existing msgpump / dialog / workspace-activation / create / mouse routing tests pass **under `-race`**.

This is the last ticket in the 41-PR stack — placed last so it didn't churn the many delete/status PRs that also touch handlers reached from `update`.