### PR TITLE
A1: Consolidate e2e wait/poll helpers onto testutil.Eventually

### DIFF
--- a/internal/e2e/fakeagent_test.go
+++ b/internal/e2e/fakeagent_test.go
@@ -98,9 +98,7 @@ func TestFakeAgentRecordsRawCarriageReturn(t *testing.T) {
 		defer mu.Unlock()
 		return bytes.Contains(out.Bytes(), []byte("FAKEAGENT READY"))
 	}
-	if !waitForCond(bannerSeen, 5*time.Second) {
-		t.Fatal("fake agent never signaled readiness")
-	}
+	waitForCond(t, bannerSeen, 5*time.Second, "fake agent never signaled readiness")
 
 	// Deliver text + a literal CR the way amux delivers agent input. In raw mode
 	// the agent must record 0x0D, not a line-discipline-translated NL.
@@ -113,33 +111,4 @@ func TestFakeAgentRecordsRawCarriageReturn(t *testing.T) {
 	if !ok {
 		t.Fatalf("fake agent did not record raw bytes\n got: % x\nwant: % x", got, want)
 	}
-}
-
-// waitForCond polls cond until it is true or the timeout elapses.
-func waitForCond(cond func() bool, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return cond()
-}
-
-// waitForFileBytes polls path until it contains want, returning the last-read
-// contents and whether want was found.
-func waitForFileBytes(path string, want []byte, timeout time.Duration) ([]byte, bool) {
-	var last []byte
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if b, err := os.ReadFile(path); err == nil {
-			last = b
-			if bytes.Contains(b, want) {
-				return b, true
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return last, false
 }

--- a/internal/e2e/helpers.go
+++ b/internal/e2e/helpers.go
@@ -1,0 +1,250 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/testutil"
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// Shared wait/poll helpers for the e2e suite, built on testutil.Eventually /
+// testutil.Consistently so deadline handling and failure messaging stay
+// uniform across tests.
+
+// Poll intervals for the wait helpers (centralized into timeouts.go by the
+// follow-up timeouts PR).
+const (
+	sessionPollInterval = 200 * time.Millisecond
+	screenPollInterval  = 150 * time.Millisecond
+	condPollInterval    = 10 * time.Millisecond
+)
+
+// agentSessionTags matches the tmux sessions amux creates for agent tabs.
+var agentSessionTags = map[string]string{
+	"@amux":      "1",
+	"@amux_type": "agent",
+}
+
+// lazyString defers rendering of debug output until a wait helper actually
+// fails, so timeout messages show the state observed at the deadline rather
+// than at call time.
+type lazyString func() string
+
+func (f lazyString) String() string { return f() }
+
+func waitForUIContains(t *testing.T, session *PTYSession, needle string, timeout time.Duration) {
+	t.Helper()
+	if err := session.WaitForContains(needle, timeout); err != nil {
+		t.Fatalf("waiting for %q: %v", needle, err)
+	}
+}
+
+// waitForUIAbsent polls until needle disappears from the rendered screen.
+func waitForUIAbsent(t *testing.T, session *PTYSession, needle string, timeout time.Duration) {
+	t.Helper()
+	if err := session.WaitForAbsent(needle, timeout); err != nil {
+		t.Fatalf("waiting for %q to disappear: %v", needle, err)
+	}
+}
+
+// waitForCond polls cond until it returns true, failing the test with the
+// formatted message on timeout.
+func waitForCond(t *testing.T, cond func() bool, timeout time.Duration, msgf string, args ...any) {
+	t.Helper()
+	testutil.Eventually(t, timeout, condPollInterval, cond, msgf, args...)
+}
+
+// waitForFileBytes polls path until it contains want, returning the last-read
+// contents and whether want was found.
+func waitForFileBytes(path string, want []byte, timeout time.Duration) ([]byte, bool) {
+	var last []byte
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil {
+			last = b
+			if bytes.Contains(b, want) {
+				return b, true
+			}
+		}
+		time.Sleep(condPollInterval)
+	}
+	return last, false
+}
+
+func waitForAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) []string {
+	t.Helper()
+	var sessions []string
+	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
+		got, err := tmux.ListSessionsMatchingTags(agentSessionTags, opts)
+		if err != nil || len(got) == 0 {
+			return false
+		}
+		sessions = got
+		return true
+	}, "timeout waiting for agent sessions\n%s", lazyString(func() string { return tmuxSessionDebug(opts) }))
+	return sessions
+}
+
+// waitForNoAgentSessions polls until no @amux agent sessions remain, proving the
+// deleted workspace's agent pane was actually torn down through the real handler.
+func waitForNoAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) {
+	t.Helper()
+	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
+		sessions, err := tmux.ListSessionsMatchingTags(agentSessionTags, opts)
+		return err == nil && len(sessions) == 0
+	}, "timeout waiting for agent sessions to be torn down\n%s", lazyString(func() string { return tmuxSessionDebug(opts) }))
+}
+
+func waitForTerminalSessionCount(t *testing.T, opts tmux.Options, wsID string, count int, timeout time.Duration) {
+	t.Helper()
+	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
+		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
+			"@amux":           "1",
+			"@amux_type":      "terminal",
+			"@amux_workspace": wsID,
+		}, opts)
+		return err == nil && len(sessions) == count
+	}, "timeout waiting for %d terminal sessions for workspace %s", count, wsID)
+}
+
+func waitForAssistantSessions(t *testing.T, opts tmux.Options, want map[string]bool, timeout time.Duration) map[string][]string {
+	t.Helper()
+	var result map[string][]string
+	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
+		rows, err := tmux.SessionsWithTags(agentSessionTags, []string{"@amux_assistant"}, opts)
+		if err != nil {
+			return false
+		}
+		byAssistant := make(map[string][]string)
+		for _, row := range rows {
+			assistant := strings.TrimSpace(row.Tags["@amux_assistant"])
+			if assistant == "" {
+				continue
+			}
+			byAssistant[assistant] = append(byAssistant[assistant], row.Name)
+		}
+		for assistant := range want {
+			if len(byAssistant[assistant]) == 0 {
+				return false
+			}
+		}
+		result = byAssistant
+		return true
+	}, "timeout waiting for assistant sessions: %v\n%s", want, lazyString(func() string { return tmuxSessionDebug(opts) }))
+	return result
+}
+
+func waitForSessionTypes(t *testing.T, opts tmux.Options, want map[string]bool, timeout time.Duration) {
+	t.Helper()
+	prefix := tmux.SessionName("amux") + "-"
+	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
+		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{"@amux": "1"}, opts)
+		if err != nil {
+			// Tag listing can fail transiently on older tmux; fall back to a
+			// session-name prefix count so the wait still terminates.
+			return hasSessionsWithPrefix(t, opts, prefix, len(want))
+		}
+		if len(sessions) == 0 {
+			return false
+		}
+		types := map[string]bool{}
+		for _, session := range sessions {
+			value, err := tmux.SessionTagValue(session, "@amux_type", opts)
+			if err != nil {
+				continue
+			}
+			types[strings.TrimSpace(value)] = true
+		}
+		for typ := range want {
+			if !types[typ] {
+				return false
+			}
+		}
+		return true
+	}, "timeout waiting for tmux session types %v", want)
+}
+
+func assertAgentSessionsStayLive(t *testing.T, opts tmux.Options, duration time.Duration) {
+	t.Helper()
+	testutil.Consistently(t, duration, sessionPollInterval, func() string {
+		sessions, err := tmux.ListSessionsMatchingTags(agentSessionTags, opts)
+		if err != nil {
+			return "" // transient tmux error: keep watching
+		}
+		if len(sessions) == 0 {
+			return "expected at least one agent session to stay alive"
+		}
+		for _, name := range sessions {
+			state, err := tmux.SessionStateFor(name, opts)
+			if err != nil {
+				continue
+			}
+			if state.Exists && state.HasLivePane {
+				return ""
+			}
+		}
+		return fmt.Sprintf("agent sessions not live: %v", sessions)
+	})
+}
+
+func assertScreenNeverContains(t *testing.T, session *PTYSession, needles []string, duration time.Duration) {
+	t.Helper()
+	testutil.Consistently(t, duration, screenPollInterval, func() string {
+		screen := session.ScreenASCII()
+		for _, needle := range needles {
+			if stringsContains(screen, needle) {
+				return fmt.Sprintf("unexpected screen text %q\n\nScreen:\n%s", needle, screen)
+			}
+		}
+		return ""
+	})
+}
+
+func hasSessionsWithPrefix(t *testing.T, opts tmux.Options, prefix string, minCount int) bool {
+	t.Helper()
+	sessions, err := tmux.ListSessions(opts)
+	if err != nil {
+		return false
+	}
+	count := 0
+	for _, name := range sessions {
+		if strings.HasPrefix(name, prefix) {
+			count++
+		}
+	}
+	return count >= minCount
+}
+
+func tmuxSessionDebug(opts tmux.Options) string {
+	rows, err := tmux.SessionsWithTags(map[string]string{}, []string{
+		"@amux",
+		"@amux_type",
+		"@amux_assistant",
+		"@amux_workspace",
+		"@amux_tab",
+	}, opts)
+	if err != nil {
+		return fmt.Sprintf("tmux sessions: error=%v", err)
+	}
+	if len(rows) == 0 {
+		return "tmux sessions: none"
+	}
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		lines = append(lines, fmt.Sprintf(
+			"%s amux=%q type=%q assistant=%q workspace=%q tab=%q",
+			row.Name,
+			row.Tags["@amux"],
+			row.Tags["@amux_type"],
+			row.Tags["@amux_assistant"],
+			row.Tags["@amux_workspace"],
+			row.Tags["@amux_tab"],
+		))
+	}
+	return "tmux sessions:\n" + strings.Join(lines, "\n")
+}

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -1,13 +1,10 @@
 package e2e
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
-	"github.com/andyrewlee/amux/internal/tmux"
 )
 
 func createWorkspaceFromDashboard(t *testing.T, session *PTYSession, name string) {
@@ -24,70 +21,6 @@ func createWorkspaceFromDashboard(t *testing.T, session *PTYSession, name string
 	}
 	if err := session.SendString("\r"); err != nil {
 		t.Fatalf("confirm workspace name: %v", err)
-	}
-}
-
-func waitForAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) []string {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
-			"@amux":      "1",
-			"@amux_type": "agent",
-		}, opts)
-		if err == nil && len(sessions) > 0 {
-			return sessions
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for agent sessions\n%s", tmuxSessionDebug(opts))
-	return nil
-}
-
-func assertAgentSessionsStayLive(t *testing.T, opts tmux.Options, duration time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(duration)
-	for time.Now().Before(deadline) {
-		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
-			"@amux":      "1",
-			"@amux_type": "agent",
-		}, opts)
-		if err != nil {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		if len(sessions) == 0 {
-			t.Fatalf("expected at least one agent session to stay alive")
-		}
-		live := false
-		for _, name := range sessions {
-			state, err := tmux.SessionStateFor(name, opts)
-			if err != nil {
-				continue
-			}
-			if state.Exists && state.HasLivePane {
-				live = true
-				break
-			}
-		}
-		if !live {
-			t.Fatalf("agent sessions not live: %v", sessions)
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-}
-
-func assertScreenNeverContains(t *testing.T, session *PTYSession, needles []string, duration time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(duration)
-	for time.Now().Before(deadline) {
-		screen := session.ScreenASCII()
-		for _, needle := range needles {
-			if stringsContains(screen, needle) {
-				t.Fatalf("unexpected screen text %q\n\nScreen:\n%s", needle, screen)
-			}
-		}
-		time.Sleep(150 * time.Millisecond)
 	}
 }
 
@@ -116,117 +49,4 @@ func deleteSelectedWorkspace(t *testing.T, session *PTYSession, timeout time.Dur
 	if err := session.SendString("\r"); err != nil {
 		t.Fatalf("confirm delete: %v", err)
 	}
-}
-
-// waitForNoAgentSessions polls until no @amux agent sessions remain, proving the
-// deleted workspace's agent pane was actually torn down through the real handler.
-func waitForNoAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
-			"@amux":      "1",
-			"@amux_type": "agent",
-		}, opts)
-		if err == nil && len(sessions) == 0 {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for agent sessions to be torn down\n%s", tmuxSessionDebug(opts))
-}
-
-// waitForUIAbsent polls until needle disappears from the rendered screen.
-func waitForUIAbsent(t *testing.T, session *PTYSession, needle string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if !stringsContains(session.ScreenASCII(), needle) {
-			return
-		}
-		time.Sleep(150 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for %q to disappear from the screen:\n%s", needle, session.ScreenASCII())
-}
-
-func waitForTerminalSessionCount(t *testing.T, opts tmux.Options, wsID string, count int, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{
-			"@amux":           "1",
-			"@amux_type":      "terminal",
-			"@amux_workspace": wsID,
-		}, opts)
-		if err == nil && len(sessions) == count {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for %d terminal sessions for workspace %s", count, wsID)
-}
-
-func waitForAssistantSessions(t *testing.T, opts tmux.Options, want map[string]bool, timeout time.Duration) map[string][]string {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		rows, err := tmux.SessionsWithTags(map[string]string{
-			"@amux":      "1",
-			"@amux_type": "agent",
-		}, []string{"@amux_assistant"}, opts)
-		if err != nil {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		byAssistant := make(map[string][]string)
-		for _, row := range rows {
-			assistant := strings.TrimSpace(row.Tags["@amux_assistant"])
-			if assistant == "" {
-				continue
-			}
-			byAssistant[assistant] = append(byAssistant[assistant], row.Name)
-		}
-		ok := true
-		for assistant := range want {
-			if len(byAssistant[assistant]) == 0 {
-				ok = false
-				break
-			}
-		}
-		if ok {
-			return byAssistant
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for assistant sessions: %v\n%s", want, tmuxSessionDebug(opts))
-	return nil
-}
-
-func tmuxSessionDebug(opts tmux.Options) string {
-	rows, err := tmux.SessionsWithTags(map[string]string{}, []string{
-		"@amux",
-		"@amux_type",
-		"@amux_assistant",
-		"@amux_workspace",
-		"@amux_tab",
-	}, opts)
-	if err != nil {
-		return fmt.Sprintf("tmux sessions: error=%v", err)
-	}
-	if len(rows) == 0 {
-		return "tmux sessions: none"
-	}
-	lines := make([]string, 0, len(rows))
-	for _, row := range rows {
-		lines = append(lines, fmt.Sprintf(
-			"%s amux=%q type=%q assistant=%q workspace=%q tab=%q",
-			row.Name,
-			row.Tags["@amux"],
-			row.Tags["@amux_type"],
-			row.Tags["@amux_assistant"],
-			row.Tags["@amux_workspace"],
-			row.Tags["@amux_tab"],
-		))
-	}
-	return "tmux sessions:\n" + strings.Join(lines, "\n")
 }

--- a/internal/e2e/persistence_test.go
+++ b/internal/e2e/persistence_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -125,68 +124,6 @@ func sendPrefixSequence(t *testing.T, session *PTYSession, keys ...string) {
 		}
 		time.Sleep(prefixInterKeyDelay)
 	}
-}
-
-func waitForSessionTypes(t *testing.T, opts tmux.Options, want map[string]bool, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	prefix := tmux.SessionName("amux") + "-"
-	for time.Now().Before(deadline) {
-		sessions, err := tmux.ListSessionsMatchingTags(map[string]string{"@amux": "1"}, opts)
-		if err != nil {
-			if hasSessionsWithPrefix(t, opts, prefix, len(want)) {
-				return
-			}
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		if len(sessions) == 0 {
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		types := map[string]bool{}
-		for _, session := range sessions {
-			value, err := tmux.SessionTagValue(session, "@amux_type", opts)
-			if err != nil {
-				continue
-			}
-			types[strings.TrimSpace(value)] = true
-		}
-		ok := true
-		for typ := range want {
-			if !types[typ] {
-				ok = false
-				break
-			}
-		}
-		if ok {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for tmux session types %v", want)
-}
-
-func waitForUIContains(t *testing.T, session *PTYSession, needle string, timeout time.Duration) {
-	t.Helper()
-	if err := session.WaitForContains(needle, timeout); err != nil {
-		t.Fatalf("waiting for %q: %v", needle, err)
-	}
-}
-
-func hasSessionsWithPrefix(t *testing.T, opts tmux.Options, prefix string, minCount int) bool {
-	t.Helper()
-	sessions, err := tmux.ListSessions(opts)
-	if err != nil {
-		return false
-	}
-	count := 0
-	for _, name := range sessions {
-		if strings.HasPrefix(name, prefix) {
-			count++
-		}
-	}
-	return count >= minCount
 }
 
 func writeRegistry(t *testing.T, home, repo string) {

--- a/internal/testutil/wait.go
+++ b/internal/testutil/wait.go
@@ -26,6 +26,20 @@ func Eventually(t *testing.T, timeout, interval time.Duration, cond func() bool,
 	}
 }
 
+// Consistently polls check for the full duration at the given interval,
+// failing the test the first time check returns a non-empty failure message.
+// It is the inverse of Eventually: the condition must hold the whole time.
+func Consistently(t *testing.T, duration, interval time.Duration, check func() string) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if msg := check(); msg != "" {
+			t.Fatalf("%s", msg)
+		}
+		time.Sleep(interval)
+	}
+}
+
 // WaitForAtomic polls load until it reports a value >= want or timeout elapses,
 // failing the test on timeout. load typically reads an atomic counter.
 func WaitForAtomic[T cmp.Ordered](t *testing.T, load func() T, want T, timeout time.Duration) {


### PR DESCRIPTION
Move waitForUIContains/waitForAgentSessions/waitForNoAgentSessions/
waitForCond/assertAgentSessionsStayLive and friends from per-test files
into a shared non-_test internal/e2e/helpers.go, implemented on
testutil.Eventually plus a new testutil.Consistently for the
stays-true-for-duration assertions. Pure test refactor.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **A1**, 1/36). Stacked on `main`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.