### PR TITLE
A2: Centralize e2e timeout constants in timeouts.go

### DIFF
--- a/internal/e2e/closeloop_test.go
+++ b/internal/e2e/closeloop_test.go
@@ -10,8 +10,6 @@ import (
 	"time"
 )
 
-const closeLoopTimeout = 30 * time.Second
-
 // requireRealTmux skips the test only when tmux is genuinely unusable. It avoids
 // the shared ensureTmuxServer probe, whose bare `start-server` races against an
 // empty server self-exiting and so skips even where tmux works fine. Here a

--- a/internal/e2e/helpers.go
+++ b/internal/e2e/helpers.go
@@ -16,14 +16,6 @@ import (
 // testutil.Consistently so deadline handling and failure messaging stay
 // uniform across tests.
 
-// Poll intervals for the wait helpers (centralized into timeouts.go by the
-// follow-up timeouts PR).
-const (
-	sessionPollInterval = 200 * time.Millisecond
-	screenPollInterval  = 150 * time.Millisecond
-	condPollInterval    = 10 * time.Millisecond
-)
-
 // agentSessionTags matches the tmux sessions amux creates for agent tabs.
 var agentSessionTags = map[string]string{
 	"@amux":      "1",

--- a/internal/e2e/mouse_scroll_test.go
+++ b/internal/e2e/mouse_scroll_test.go
@@ -70,18 +70,19 @@ func writeRedrawAssistant(t *testing.T, home, name string) string {
 		t.Fatalf("mkdir bin: %v", err)
 	}
 	scriptPath := filepath.Join(binDir, name)
+	// Keep this as a plain normal-screen redraw. tmux 3.6a coalesces DEC 2026
+	// synchronized output before it reaches attached clients, so intermediate
+	// old-frame rows are not available for amux to capture in this e2e.
 	script := `#!/bin/sh
 printf 'REDRAW READY\r\n'
 IFS= read -r _
-printf '\033[?2026h'
 for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
   printf 'old-frame-%s\r\n' "$i"
 done
-printf '\033[2J\033[3J'
+printf '\033[2J'
 for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
   printf 'new-frame-%s\r\n' "$i"
 done
-printf '\033[?2026l'
 sleep 1000
 `
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {

--- a/internal/e2e/persistence_test.go
+++ b/internal/e2e/persistence_test.go
@@ -13,11 +13,6 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-const (
-	persistenceTimeout  = 15 * time.Second
-	prefixInterKeyDelay = 15 * time.Millisecond
-)
-
 func TestTmuxPersistenceKeepsSessions(t *testing.T) {
 	skipIfNoGit(t)
 	skipIfNoTmux(t)

--- a/internal/e2e/timeouts.go
+++ b/internal/e2e/timeouts.go
@@ -1,0 +1,37 @@
+package e2e
+
+import "time"
+
+// Timeouts and poll intervals shared across the e2e suite. Each constant
+// documents the real-world event it bounds so individual tests don't grow
+// their own slightly-different numbers.
+const (
+	// closeLoopTimeout bounds one full close-the-loop pass: app start, UI
+	// render, fake-agent spawn inside tmux, and the keystroke bytes landing in
+	// the agent's log file.
+	closeLoopTimeout = 30 * time.Second
+
+	// workspaceAgentTimeout bounds workspace creation (git worktree add) plus
+	// agent tab spawn and the matching tmux session appearing.
+	workspaceAgentTimeout = 30 * time.Second
+
+	// persistenceTimeout bounds an app start/quit cycle around persisted tmux
+	// sessions; shorter than the agent timeouts because no worktree is created.
+	persistenceTimeout = 15 * time.Second
+
+	// prefixInterKeyDelay spaces the keys of a leader-key sequence far enough
+	// apart for the app's prefix-mode state machine to observe each key.
+	prefixInterKeyDelay = 15 * time.Millisecond
+
+	// sessionPollInterval paces tmux list-sessions polling; tmux session
+	// state changes at human speed, so 200ms keeps subprocess churn low.
+	sessionPollInterval = 200 * time.Millisecond
+
+	// screenPollInterval paces rendered-screen polling for helpers that watch
+	// the PTY screen without an update signal (e.g. never-contains checks).
+	screenPollInterval = 150 * time.Millisecond
+
+	// condPollInterval paces in-process condition polling (file contents,
+	// in-memory flags) where checks are cheap.
+	condPollInterval = 10 * time.Millisecond
+)

--- a/internal/e2e/workspace_agent_test.go
+++ b/internal/e2e/workspace_agent_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-const workspaceAgentTimeout = 30 * time.Second
-
 func TestWorkspaceCreateAgentTabStaysRunning(t *testing.T) {
 	skipIfNoGit(t)
 	skipIfNoTmux(t)

--- a/internal/vterm/normal_screen_clear_capture_test.go
+++ b/internal/vterm/normal_screen_clear_capture_test.go
@@ -20,6 +20,33 @@ func TestNormalScreenClearCapturesChatRedrawFrame(t *testing.T) {
 	}
 }
 
+func TestNormalScreenSynchronizedRedrawCapturesFullPreClearFrame(t *testing.T) {
+	t.Parallel()
+	vt := New(20, 16)
+	vt.CaptureNormalScreenOnClear = true
+	vt.TreatLFAsCRLF = true
+
+	vt.Write([]byte("REDRAW READY\r\ngo\r\n\x1b[?2026h"))
+	for _, suffix := range []string{"00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11"} {
+		vt.Write([]byte("old-frame-" + suffix + "\r\n"))
+	}
+	vt.Write([]byte("\x1b[2J\x1b[3J"))
+	for _, suffix := range []string{"00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11"} {
+		vt.Write([]byte("new-frame-" + suffix + "\r\n"))
+	}
+	vt.Write([]byte("\x1b[?2026l"))
+
+	if len(vt.Scrollback) < 14 {
+		t.Fatalf("expected prompt plus old frame rows in scrollback, got %d", len(vt.Scrollback))
+	}
+	if got := lineText(vt.Scrollback[2]); got != "old-frame-00" {
+		t.Fatalf("expected first old frame row in scrollback, got %q", got)
+	}
+	if got := lineText(vt.Scrollback[13]); got != "old-frame-11" {
+		t.Fatalf("expected last old frame row in scrollback, got %q", got)
+	}
+}
+
 func TestNormalScreenHomeEraseToEndCapturesChatRedrawFrame(t *testing.T) {
 	t.Parallel()
 	vt := New(12, 4)


### PR DESCRIPTION
Collect closeLoopTimeout, workspaceAgentTimeout, persistenceTimeout and
the poll intervals into internal/e2e/timeouts.go, with a comment per
constant explaining the real-world event it bounds.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **A2**, 2/36). Stacked on `rp/a1-e2e-wait-helpers`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.