### PR TITLE
A3: Harness builds its App through the real constructor path

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -25,6 +25,47 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
 )
 
+// newAppShell constructs an App with its UI components built and wired in the
+// same order the real app uses, but with no services attached: no supervisor,
+// no watchers, no tmux/git/update services, and no background commands. New
+// layers the services on top; the headless harness uses the shell directly so
+// component construction and ordering changes are exercised by harness runs.
+func newAppShell(cfg *config.Config) *App {
+	app := &App{
+		config:                 cfg,
+		layout:                 layout.NewManager(),
+		dashboard:              dashboard.New(),
+		center:                 center.New(cfg),
+		sidebar:                sidebar.NewTabbedSidebar(),
+		sidebarTerminal:        sidebar.NewTerminalModel(),
+		toast:                  common.NewToastModel(),
+		focusedPane:            messages.PaneDashboard,
+		keymap:                 DefaultKeyMap(),
+		dashboardChrome:        &compositor.ChromeCache{},
+		centerChrome:           &compositor.ChromeCache{},
+		sidebarChrome:          &compositor.ChromeCache{},
+		tmuxActiveWorkspaceIDs: make(map[string]bool),
+		sessionActivityStates:  make(map[string]*activity.SessionState),
+		dirtyWorkspaces:        make(map[string]bool),
+		deletingWorkspaceIDs:   make(map[string]bool),
+		localWorkspaceSavesAt:  make(map[string]localWorkspaceSaveMarker),
+		creatingWorkspaceIDs:   make(map[string]bool),
+		maxAttachedAgentTabs:   maxAttachedAgentTabsFromEnv(),
+	}
+	app.styles = common.DefaultStyles()
+	// Propagate styles to all components (they may have been created with a
+	// different current theme).
+	app.dashboard.SetStyles(app.styles)
+	app.sidebar.SetStyles(app.styles)
+	app.sidebarTerminal.SetStyles(app.styles)
+	app.center.SetStyles(app.styles)
+	app.toast.SetStyles(app.styles)
+	if cfg != nil {
+		app.setKeymapHintsEnabled(cfg.UI.ShowKeymapHints)
+	}
+	return app
+}
+
 // New creates a new App instance.
 func New(version, commit, date string) (*App, error) {
 	cfg, err := config.DefaultConfig()
@@ -83,46 +124,29 @@ func New(version, commit, date string) (*App, error) {
 		stateWatcher = nil
 	}
 
+	// Apply saved theme before creating components and styles.
+	common.SetCurrentTheme(common.ThemeID(cfg.UI.Theme))
+
 	ctx := context.Background()
-	app := &App{
-		config:                 cfg,
-		workspaceService:       workspaceService,
-		gitStatus:              gitStatus,
-		tmuxService:            tmuxSvc,
-		updateService:          updateSvc,
-		fileWatcher:            fileWatcher,
-		fileWatcherCh:          fileWatcherCh,
-		fileWatcherErr:         fileWatcherErr,
-		stateWatcher:           stateWatcher,
-		stateWatcherCh:         stateWatcherCh,
-		stateWatcherErr:        stateWatcherErr,
-		layout:                 layout.NewManager(),
-		dashboard:              dashboard.New(),
-		center:                 center.New(cfg),
-		sidebar:                sidebar.NewTabbedSidebar(),
-		sidebarTerminal:        sidebar.NewTerminalModel(),
-		toast:                  common.NewToastModel(),
-		focusedPane:            messages.PaneDashboard,
-		showWelcome:            true,
-		keymap:                 DefaultKeyMap(),
-		dashboardChrome:        &compositor.ChromeCache{},
-		centerChrome:           &compositor.ChromeCache{},
-		sidebarChrome:          &compositor.ChromeCache{},
-		version:                version,
-		commit:                 commit,
-		buildDate:              date,
-		externalMsgs:           make(chan tea.Msg, externalMsgBuffer),
-		externalCritical:       make(chan tea.Msg, externalCriticalBuffer),
-		ctx:                    ctx,
-		tmuxOptions:            tmuxOpts,
-		tmuxActiveWorkspaceIDs: make(map[string]bool),
-		sessionActivityStates:  make(map[string]*activity.SessionState),
-		dirtyWorkspaces:        make(map[string]bool),
-		deletingWorkspaceIDs:   make(map[string]bool),
-		localWorkspaceSavesAt:  make(map[string]localWorkspaceSaveMarker),
-		creatingWorkspaceIDs:   make(map[string]bool),
-		maxAttachedAgentTabs:   maxAttachedAgentTabsFromEnv(),
-	}
+	app := newAppShell(cfg)
+	app.workspaceService = workspaceService
+	app.gitStatus = gitStatus
+	app.tmuxService = tmuxSvc
+	app.updateService = updateSvc
+	app.fileWatcher = fileWatcher
+	app.fileWatcherCh = fileWatcherCh
+	app.fileWatcherErr = fileWatcherErr
+	app.stateWatcher = stateWatcher
+	app.stateWatcherCh = stateWatcherCh
+	app.stateWatcherErr = stateWatcherErr
+	app.showWelcome = true
+	app.version = version
+	app.commit = commit
+	app.buildDate = date
+	app.externalMsgs = make(chan tea.Msg, externalMsgBuffer)
+	app.externalCritical = make(chan tea.Msg, externalCriticalBuffer)
+	app.ctx = ctx
+	app.tmuxOptions = tmuxOpts
 	app.instanceID = newInstanceID()
 	app.supervisor = supervisor.New(ctx)
 	app.installSupervisorErrorHandler()
@@ -131,16 +155,6 @@ func New(version, commit, date string) (*App, error) {
 	app.sidebarTerminal.SetMsgSink(app.enqueueExternalMsg)
 	app.center.SetInstanceID(app.instanceID)
 	app.sidebarTerminal.SetInstanceID(app.instanceID)
-	// Apply saved theme before creating styles
-	common.SetCurrentTheme(common.ThemeID(cfg.UI.Theme))
-	app.styles = common.DefaultStyles()
-	// Propagate styles to all components (they were created with default theme)
-	app.dashboard.SetStyles(app.styles)
-	app.sidebar.SetStyles(app.styles)
-	app.sidebarTerminal.SetStyles(app.styles)
-	app.center.SetStyles(app.styles)
-	app.toast.SetStyles(app.styles)
-	app.setKeymapHintsEnabled(cfg.UI.ShowKeymapHints)
 	// Propagate tmux config to components
 	app.center.SetTmuxOptions(tmuxOpts)
 	app.sidebarTerminal.SetTmuxOptions(tmuxOpts)

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -10,10 +10,6 @@ import (
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/center"
-	"github.com/andyrewlee/amux/internal/ui/common"
-	"github.com/andyrewlee/amux/internal/ui/compositor"
-	"github.com/andyrewlee/amux/internal/ui/dashboard"
-	"github.com/andyrewlee/amux/internal/ui/layout"
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
@@ -93,23 +89,31 @@ func newMonitorHarness(cfg *config.Config, opts HarnessOptions) *Harness {
 	return h
 }
 
-func newCenterHarness(cfg *config.Config, opts HarnessOptions) *Harness {
-	centerModel := center.New(cfg)
-	centerModel.SetShowKeymapHints(opts.ShowKeymapHints)
+// newHarnessApp builds a services-off App through the real constructor path
+// (newAppShell), so the harness exercises the same component construction and
+// wiring order as the production app, then applies harness geometry/focus.
+func newHarnessApp(cfg *config.Config, opts HarnessOptions, focused messages.PaneType) *App {
+	app := newAppShell(cfg)
+	app.setKeymapHintsEnabled(opts.ShowKeymapHints)
+	app.width = opts.Width
+	app.height = opts.Height
+	app.focusedPane = focused
+	app.layout.Resize(opts.Width, opts.Height)
+	return app
+}
 
-	dash := dashboard.New()
-	dash.SetShowKeymapHints(opts.ShowKeymapHints)
-	sideTerm := sidebar.NewTerminalModel()
-	sideTerm.SetShowKeymapHints(opts.ShowKeymapHints)
-
-	layoutMgr := layout.NewManager()
-	layoutMgr.Resize(opts.Width, opts.Height)
-
-	ws := &data.Workspace{
+func harnessWorkspace() *data.Workspace {
+	return &data.Workspace{
 		Name: "primary",
 		Repo: "/repo/primary",
 		Root: "/repo/primary/ws",
 	}
+}
+
+func newCenterHarness(cfg *config.Config, opts HarnessOptions) *Harness {
+	app := newHarnessApp(cfg, opts, messages.PaneCenter)
+
+	ws := harnessWorkspace()
 	project := data.Project{Name: "primary", Path: ws.Repo}
 
 	tabs := make([]*center.Tab, 0, opts.Tabs)
@@ -123,34 +127,13 @@ func newCenterHarness(cfg *config.Config, opts HarnessOptions) *Harness {
 			Terminal:  term,
 			Running:   true,
 		}
-		centerModel.AddTab(tab)
+		app.center.AddTab(tab)
 		tabs = append(tabs, tab)
 	}
-	centerModel.SetWorkspace(ws)
+	app.center.SetWorkspace(ws)
 
-	dash.SetProjects([]data.Project{project})
+	app.dashboard.SetProjects([]data.Project{project})
 
-	tabbedSidebar := sidebar.NewTabbedSidebar()
-	tabbedSidebar.SetShowKeymapHints(opts.ShowKeymapHints)
-
-	app := &App{
-		config:          cfg,
-		layout:          layoutMgr,
-		dashboard:       dash,
-		center:          centerModel,
-		sidebar:         tabbedSidebar,
-		sidebarTerminal: sideTerm,
-		styles:          common.DefaultStyles(),
-		width:           opts.Width,
-		height:          opts.Height,
-		toast:           common.NewToastModel(),
-		focusedPane:     messages.PaneCenter,
-		dashboardChrome: &compositor.ChromeCache{},
-		centerChrome:    &compositor.ChromeCache{},
-		sidebarChrome:   &compositor.ChromeCache{},
-	}
-
-	app.layout.Resize(opts.Width, opts.Height)
 	app.updateLayout()
 
 	return &Harness{
@@ -166,49 +149,16 @@ func newCenterHarness(cfg *config.Config, opts HarnessOptions) *Harness {
 }
 
 func newSidebarHarness(cfg *config.Config, opts HarnessOptions) *Harness {
-	centerModel := center.New(cfg)
-	centerModel.SetShowKeymapHints(opts.ShowKeymapHints)
+	app := newHarnessApp(cfg, opts, messages.PaneSidebarTerminal)
 
-	dash := dashboard.New()
-	dash.SetShowKeymapHints(opts.ShowKeymapHints)
-	side := sidebar.NewTabbedSidebar()
-	side.SetShowKeymapHints(opts.ShowKeymapHints)
-	sideTerm := sidebar.NewTerminalModel()
-	sideTerm.SetShowKeymapHints(opts.ShowKeymapHints)
-
-	layoutMgr := layout.NewManager()
-	layoutMgr.Resize(opts.Width, opts.Height)
-
-	ws := &data.Workspace{
-		Name: "primary",
-		Repo: "/repo/primary",
-		Root: "/repo/primary/ws",
-	}
+	ws := harnessWorkspace()
 	project := data.Project{Name: "primary", Path: ws.Repo}
 
-	dash.SetProjects([]data.Project{project})
+	app.dashboard.SetProjects([]data.Project{project})
 
-	app := &App{
-		config:          cfg,
-		layout:          layoutMgr,
-		dashboard:       dash,
-		center:          centerModel,
-		sidebar:         side,
-		sidebarTerminal: sideTerm,
-		styles:          common.DefaultStyles(),
-		width:           opts.Width,
-		height:          opts.Height,
-		toast:           common.NewToastModel(),
-		focusedPane:     messages.PaneSidebarTerminal,
-		dashboardChrome: &compositor.ChromeCache{},
-		centerChrome:    &compositor.ChromeCache{},
-		sidebarChrome:   &compositor.ChromeCache{},
-	}
-
-	app.layout.Resize(opts.Width, opts.Height)
 	app.updateLayout()
 
-	sideTerm.AddTerminalForHarness(ws)
+	app.sidebarTerminal.AddTerminalForHarness(ws)
 
 	return &Harness{
 		app:          app,
@@ -218,7 +168,7 @@ func newSidebarHarness(cfg *config.Config, opts HarnessOptions) *Harness {
 		newlineEvery: opts.NewlineEvery,
 		payloadBuf:   make([]byte, 0, opts.PayloadBytes+32),
 		spinner:      []byte{'|', '/', '-', '\\'},
-		sidebarTerm:  sideTerm,
+		sidebarTerm:  app.sidebarTerminal,
 	}
 }
 


### PR DESCRIPTION
Extract newAppShell — component construction, wiring and styling in the
same order New uses, with no services attached — and make the headless
harness use it instead of hand-building the App. Init-order changes in
the real app are now exercised by harness runs; render goldens verified
byte-identical via make harness-presets.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **A3**, 3/36). Stacked on `rp/a2-e2e-timeouts`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.