### PR TITLE
A4: Bound supervisor.Stop with a timeout and log stuck workers

### DIFF
--- a/internal/e2e/mouse_scroll_test.go
+++ b/internal/e2e/mouse_scroll_test.go
@@ -73,12 +73,15 @@ func writeRedrawAssistant(t *testing.T, home, name string) string {
 	// Keep this as a plain normal-screen redraw. tmux 3.6a coalesces DEC 2026
 	// synchronized output before it reaches attached clients, so intermediate
 	// old-frame rows are not available for amux to capture in this e2e.
+	// The short pause lets older tmux releases flush the old frame to attached
+	// clients before the clear arrives.
 	script := `#!/bin/sh
 printf 'REDRAW READY\r\n'
 IFS= read -r _
 for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
   printf 'old-frame-%s\r\n' "$i"
 done
+sleep 0.1
 printf '\033[2J'
 for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
   printf 'new-frame-%s\r\n' "$i"

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sort"
 	"sync"
 	"time"
 
@@ -66,18 +67,25 @@ func WithSleep(fn func(time.Duration)) Option {
 	}
 }
 
+// StopTimeout bounds how long Stop waits for workers to exit. A worker that
+// ignores context cancellation must not be able to wedge app shutdown.
+const StopTimeout = 5 * time.Second
+
 // Supervisor manages worker lifecycles with restart policies.
 type Supervisor struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 	onError func(name string, err error)
+
+	mu      sync.Mutex
+	running map[string]int
 }
 
 // New creates a supervisor bound to the parent context.
 func New(parent context.Context) *Supervisor {
 	ctx, cancel := context.WithCancel(parent)
-	return &Supervisor{ctx: ctx, cancel: cancel}
+	return &Supervisor{ctx: ctx, cancel: cancel, running: make(map[string]int)}
 }
 
 // Context returns the supervisor context.
@@ -85,13 +93,60 @@ func (s *Supervisor) Context() context.Context {
 	return s.ctx
 }
 
-// Stop cancels all workers and waits for them to exit.
+// Stop cancels all workers and waits up to StopTimeout for them to exit,
+// logging which workers failed to stop in time.
 func (s *Supervisor) Stop() {
 	if s == nil {
 		return
 	}
+	s.StopWithTimeout(StopTimeout)
+}
+
+// StopWithTimeout cancels all workers and waits up to timeout for them to
+// exit. On timeout it logs the workers still running and returns false.
+func (s *Supervisor) StopWithTimeout(timeout time.Duration) bool {
+	if s == nil {
+		return true
+	}
 	s.cancel()
-	s.wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		logging.Error("supervisor: timed out after %s waiting for workers to exit: %v", timeout, s.runningWorkers())
+		return false
+	}
+}
+
+// runningWorkers returns the names of workers that have not exited yet.
+func (s *Supervisor) runningWorkers() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	names := make([]string, 0, len(s.running))
+	for name, count := range s.running {
+		if count > 0 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *Supervisor) markRunning(name string, delta int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running == nil {
+		s.running = make(map[string]int)
+	}
+	s.running[name] += delta
+	if s.running[name] <= 0 {
+		delete(s.running, name)
+	}
 }
 
 // SetErrorHandler registers a handler for worker errors.
@@ -124,8 +179,10 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 	}
 
 	s.wg.Add(1)
+	s.markRunning(name, 1)
 	go func() {
 		defer s.wg.Done()
+		defer s.markRunning(name, -1)
 		restarts := 0
 		backoff := cfg.backoff
 		for {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -401,3 +401,44 @@ func TestSupervisor_ConcurrentStart(t *testing.T) {
 		t.Errorf("expected 10 workers started, got %d", count)
 	}
 }
+
+func TestSupervisor_StopWithTimeoutStuckWorker(t *testing.T) {
+	ctx := context.Background()
+	s := New(ctx)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	s.Start("stuck", func(ctx context.Context) error {
+		started <- struct{}{}
+		<-release // ignores ctx cancellation
+		return nil
+	}, WithRestartPolicy(RestartNever))
+	s.Start("polite", func(ctx context.Context) error {
+		started <- struct{}{}
+		<-ctx.Done()
+		return nil
+	}, WithRestartPolicy(RestartNever))
+	// Both workers must be inside their run functions before Stop cancels the
+	// context, otherwise the supervisor loop exits before ever calling them.
+	<-started
+	<-started
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- s.StopWithTimeout(100 * time.Millisecond)
+	}()
+
+	select {
+	case clean := <-done:
+		if clean {
+			t.Fatalf("expected StopWithTimeout to report a stuck worker")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("StopWithTimeout hung on a stuck worker")
+	}
+
+	if got := s.runningWorkers(); len(got) != 1 || got[0] != "stuck" {
+		t.Fatalf("expected only the stuck worker to remain, got %v", got)
+	}
+	close(release)
+}


### PR DESCRIPTION
Stop now waits up to 5s (StopWithTimeout) and logs which workers failed
to exit, so a worker that ignores context cancellation cannot wedge app
shutdown. Includes a stuck-worker test.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **A4**, 4/36). Stacked on `rp/a3-harness-shares-wiring`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.