### PR TITLE
B2: Move goHome out of view code into app_operations.go

### DIFF
--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -121,3 +121,27 @@ func (a *App) removeProject(project *data.Project) tea.Cmd {
 	}
 	return a.workspaceService.RemoveProject(project)
 }
+
+// goHome is the explicit "no active workspace" state transition: it clears the
+// active workspace and resets every pane that renders workspace-scoped state.
+// It runs only from message handlers (workspace deleted, project removed,
+// selection rebind), never from view code.
+func (a *App) goHome() {
+	a.showWelcome = true
+	a.activeWorkspace = nil
+	if a.center != nil {
+		a.center.SetWorkspace(nil)
+	}
+	if a.sidebar != nil {
+		a.sidebar.SetWorkspace(nil)
+		a.sidebar.SetGitStatus(nil)
+	}
+	if a.sidebarTerminal != nil {
+		_ = a.sidebarTerminal.SetWorkspace(nil)
+	}
+	if a.dashboard != nil {
+		a.dashboard.ClearActiveRoot()
+	}
+	a.centerBtnFocused = false
+	a.centerBtnIndex = 0
+}

--- a/internal/app/app_view_content.go
+++ b/internal/app/app_view_content.go
@@ -46,26 +46,6 @@ func (a *App) centerPaneContentOrigin() (x, y int) {
 	return a.layout.LeftGutter() + a.layout.DashboardWidth() + gapX + frameX/2, a.layout.TopGutter() + frameY/2
 }
 
-func (a *App) goHome() {
-	a.showWelcome = true
-	a.activeWorkspace = nil
-	if a.center != nil {
-		a.center.SetWorkspace(nil)
-	}
-	if a.sidebar != nil {
-		a.sidebar.SetWorkspace(nil)
-		a.sidebar.SetGitStatus(nil)
-	}
-	if a.sidebarTerminal != nil {
-		_ = a.sidebarTerminal.SetWorkspace(nil)
-	}
-	if a.dashboard != nil {
-		a.dashboard.ClearActiveRoot()
-	}
-	a.centerBtnFocused = false
-	a.centerBtnIndex = 0
-}
-
 // renderWorkspaceInfo renders information about the active workspace
 func (a *App) renderWorkspaceInfo() string {
 	ws := a.activeWorkspace


### PR DESCRIPTION
goHome mutates App state (clears activeWorkspace and resets every
workspace-scoped pane) but lived in app_view_content.go. It is an
explicit state transition called only from message handlers, so it now
lives with the other operations.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **B2**, 6/36). Stacked on `rp/b1-create-rollback-regression-test`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.