### PR TITLE
C1: Extract tmuxActivityState from the App god object

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -8,7 +8,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
@@ -120,26 +119,15 @@ type App struct {
 	prefixToken    int
 	prefixSequence []string
 
-	tmuxSyncToken             int
-	tmuxActivityToken         int
-	tmuxActivityScanInFlight  bool
-	tmuxActivityRescanPending bool
-	tmuxActivitySettled       bool
-	tmuxActivitySettledScans  int
-	tmuxActivityScannerOwner  bool
-	tmuxActivityOwnershipSet  bool
-	tmuxActivityOwnerEpoch    int64
-	tmuxOptions               tmux.Options
-	tmuxAvailable             bool
-	tmuxCheckDone             bool
-	projectsLoaded            bool
-	tmuxInstallHint           string
-	tmuxActiveWorkspaceIDs    map[string]bool
-	sessionActivityStates     map[string]*activity.SessionState // Per-session hysteresis state
-	// activityMissBySession counts consecutive non-live activity observations per
-	// session so a single transient miss does not demote a working agent.
-	activityMissBySession map[string]int
-	instanceID            string // Immutable after init; safe for read-only access from Cmd goroutines.
+	// tmuxActivity holds tmux activity-scan bookkeeping (tokens, coalescing,
+	// shared-scan ownership, per-session hysteresis).
+	tmuxActivity    tmuxActivityState
+	tmuxOptions     tmux.Options
+	tmuxAvailable   bool
+	tmuxCheckDone   bool
+	projectsLoaded  bool
+	tmuxInstallHint string
+	instanceID      string // Immutable after init; safe for read-only access from Cmd goroutines.
 
 	// Workspace persistence debounce
 	dirtyWorkspaces      map[string]bool

--- a/internal/app/app_eager_scan_test.go
+++ b/internal/app/app_eager_scan_test.go
@@ -14,20 +14,20 @@ func TestUpdate_TabReattachedSchedulesEagerScan(t *testing.T) {
 	app := &App{tmuxAvailable: true}
 
 	app.update(messages.TabReattached{WorkspaceID: "ws-a"})
-	if !app.tmuxActivityScanInFlight {
+	if !app.tmuxActivity.scanInFlight {
 		t.Fatal("expected an eager scan to be scheduled on TabReattached")
 	}
-	if app.tmuxActivityToken != 1 {
-		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 1 {
+		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivity.token)
 	}
 
 	// A second reattach while the first scan is in flight must coalesce: no new
 	// token, only a pending rescan.
 	app.update(messages.TabReattached{WorkspaceID: "ws-b"})
-	if app.tmuxActivityToken != 1 {
-		t.Fatalf("expected in-flight reattach to coalesce (token stays 1), got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 1 {
+		t.Fatalf("expected in-flight reattach to coalesce (token stays 1), got %d", app.tmuxActivity.token)
 	}
-	if !app.tmuxActivityRescanPending {
+	if !app.tmuxActivity.rescanPending {
 		t.Fatal("expected in-flight second reattach to set rescan-pending")
 	}
 }
@@ -41,11 +41,11 @@ func TestUpdate_TabCreatedSchedulesEagerScan(t *testing.T) {
 	}
 
 	app.update(messages.TabCreated{Name: "claude"})
-	if !app.tmuxActivityScanInFlight {
+	if !app.tmuxActivity.scanInFlight {
 		t.Fatal("expected an eager scan to be scheduled on TabCreated")
 	}
-	if app.tmuxActivityToken != 1 {
-		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 1 {
+		t.Fatalf("expected scan token incremented to 1, got %d", app.tmuxActivity.token)
 	}
 }
 
@@ -55,10 +55,10 @@ func TestUpdate_TabReattachedNoScanWhenTmuxUnavailable(t *testing.T) {
 	app := &App{tmuxAvailable: false}
 
 	app.update(messages.TabReattached{WorkspaceID: "ws-a"})
-	if app.tmuxActivityScanInFlight {
+	if app.tmuxActivity.scanInFlight {
 		t.Fatal("expected no scan scheduled when tmux is unavailable")
 	}
-	if app.tmuxActivityToken != 0 {
-		t.Fatalf("expected scan token untouched, got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 0 {
+		t.Fatalf("expected scan token untouched, got %d", app.tmuxActivity.token)
 	}
 }

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -8,7 +8,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
@@ -32,25 +31,24 @@ import (
 // component construction and ordering changes are exercised by harness runs.
 func newAppShell(cfg *config.Config) *App {
 	app := &App{
-		config:                 cfg,
-		layout:                 layout.NewManager(),
-		dashboard:              dashboard.New(),
-		center:                 center.New(cfg),
-		sidebar:                sidebar.NewTabbedSidebar(),
-		sidebarTerminal:        sidebar.NewTerminalModel(),
-		toast:                  common.NewToastModel(),
-		focusedPane:            messages.PaneDashboard,
-		keymap:                 DefaultKeyMap(),
-		dashboardChrome:        &compositor.ChromeCache{},
-		centerChrome:           &compositor.ChromeCache{},
-		sidebarChrome:          &compositor.ChromeCache{},
-		tmuxActiveWorkspaceIDs: make(map[string]bool),
-		sessionActivityStates:  make(map[string]*activity.SessionState),
-		dirtyWorkspaces:        make(map[string]bool),
-		deletingWorkspaceIDs:   make(map[string]bool),
-		localWorkspaceSavesAt:  make(map[string]localWorkspaceSaveMarker),
-		creatingWorkspaceIDs:   make(map[string]bool),
-		maxAttachedAgentTabs:   maxAttachedAgentTabsFromEnv(),
+		config:                cfg,
+		layout:                layout.NewManager(),
+		dashboard:             dashboard.New(),
+		center:                center.New(cfg),
+		sidebar:               sidebar.NewTabbedSidebar(),
+		sidebarTerminal:       sidebar.NewTerminalModel(),
+		toast:                 common.NewToastModel(),
+		focusedPane:           messages.PaneDashboard,
+		keymap:                DefaultKeyMap(),
+		dashboardChrome:       &compositor.ChromeCache{},
+		centerChrome:          &compositor.ChromeCache{},
+		sidebarChrome:         &compositor.ChromeCache{},
+		tmuxActivity:          newTmuxActivityState(),
+		dirtyWorkspaces:       make(map[string]bool),
+		deletingWorkspaceIDs:  make(map[string]bool),
+		localWorkspaceSavesAt: make(map[string]localWorkspaceSaveMarker),
+		creatingWorkspaceIDs:  make(map[string]bool),
+		maxAttachedAgentTabs:  maxAttachedAgentTabsFromEnv(),
 	}
 	app.styles = common.DefaultStyles()
 	// Propagate styles to all components (they may have been created with a
@@ -270,8 +268,8 @@ func (a *App) startPTYWatchdog() tea.Cmd {
 
 // startTmuxSyncTicker returns a command that ticks for tmux session reconciliation.
 func (a *App) startTmuxSyncTicker() tea.Cmd {
-	a.tmuxSyncToken++
-	token := a.tmuxSyncToken
+	a.tmuxActivity.syncToken++
+	token := a.tmuxActivity.syncToken
 	return common.SafeTick(a.tmuxSyncInterval(), func(time.Time) tea.Msg {
 		return messages.TmuxSyncTick{Token: token}
 	})

--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -15,11 +15,11 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 		return
 	}
 	activeWorkspaces := make(map[string]bool)
-	if !a.tmuxActivitySettled {
+	if !a.tmuxActivity.settled {
 		a.dashboard.SetActiveWorkspaces(activeWorkspaces)
 		return
 	}
-	for wsID := range a.tmuxActiveWorkspaceIDs {
+	for wsID := range a.tmuxActivity.activeWorkspaceIDs {
 		// A scan completing after a delete began must not re-publish the workspace
 		// as active; the delete-in-flight guard keeps the dashboard consistent.
 		if a.isWorkspaceDeleteInFlight(wsID) {

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -93,7 +93,7 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 		// Drop the deleted workspace from the active set now rather than waiting
 		// for the async loadProjects -> scan reconcile, so a killed-but-not-yet-
 		// reaped agent session cannot keep it shown as active by tag alone.
-		delete(a.tmuxActiveWorkspaceIDs, string(msg.Workspace.ID()))
+		delete(a.tmuxActivity.activeWorkspaceIDs, string(msg.Workspace.ID()))
 		a.syncActiveWorkspacesToDashboard()
 		// Navigate home only now that the delete is confirmed (moved off the
 		// up-front deleteWorkspace path so a failed delete leaves the user put).

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -40,9 +40,11 @@ func TestSyncActiveWorkspacesToDashboard_SkipsDeleteInFlight(t *testing.T) {
 	idA, idB := string(wsA.ID()), string(wsB.ID())
 
 	app := &App{
-		tmuxActivitySettled:    true,
-		tmuxActiveWorkspaceIDs: map[string]bool{idA: true, idB: true},
-		dashboard:              dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			settled:            true,
+			activeWorkspaceIDs: map[string]bool{idA: true, idB: true},
+		},
+		dashboard: dashboard.New(),
 	}
 	app.markWorkspaceDeleteInFlight(wsA, true)
 	app.syncActiveWorkspacesToDashboard()
@@ -56,10 +58,12 @@ func TestHandleWorkspaceDeleteFailedRequestsFreshActivityScan(t *testing.T) {
 	ws := &data.Workspace{Repo: "/repo", Root: "/repo/a"}
 	wsID := string(ws.ID())
 	app := &App{
-		tmuxActivitySettled:    true,
-		tmuxActiveWorkspaceIDs: map[string]bool{wsID: true},
-		tmuxAvailable:          true,
-		dashboard:              dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			settled:            true,
+			activeWorkspaceIDs: map[string]bool{wsID: true},
+		},
+		tmuxAvailable: true,
+		dashboard:     dashboard.New(),
 	}
 
 	app.markWorkspaceDeleteInFlight(ws, true)
@@ -75,7 +79,7 @@ func TestHandleWorkspaceDeleteFailedRequestsFreshActivityScan(t *testing.T) {
 	if got := dashboardActiveWorkspaceCount(app.dashboard); got != 0 {
 		t.Fatalf("expected cached active state to stay filtered until fresh scan, got %d", got)
 	}
-	if !app.tmuxActivityScanInFlight {
+	if !app.tmuxActivity.scanInFlight {
 		t.Fatal("expected failed delete to request a fresh tmux activity scan")
 	}
 }
@@ -86,21 +90,23 @@ func TestHandleWorkspaceDeleted_ClearsActiveWorkspace(t *testing.T) {
 	idDel, idKeep := string(wsDel.ID()), string(wsKeep.ID())
 
 	app := &App{
-		dashboard:              dashboard.New(),
-		center:                 center.New(nil),
-		sidebar:                sidebar.NewTabbedSidebar(),
-		sidebarTerminal:        sidebar.NewTerminalModel(),
-		tmuxActivitySettled:    true,
-		tmuxActiveWorkspaceIDs: map[string]bool{idDel: true, idKeep: true},
-		deletingWorkspaceIDs:   map[string]bool{idDel: true},
+		dashboard:       dashboard.New(),
+		center:          center.New(nil),
+		sidebar:         sidebar.NewTabbedSidebar(),
+		sidebarTerminal: sidebar.NewTerminalModel(),
+		tmuxActivity: tmuxActivityState{
+			settled:            true,
+			activeWorkspaceIDs: map[string]bool{idDel: true, idKeep: true},
+		},
+		deletingWorkspaceIDs: map[string]bool{idDel: true},
 	}
 
 	app.handleWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: wsDel})
 
-	if app.tmuxActiveWorkspaceIDs[idDel] {
+	if app.tmuxActivity.activeWorkspaceIDs[idDel] {
 		t.Fatal("expected deleted workspace cleared from the active set")
 	}
-	if !app.tmuxActiveWorkspaceIDs[idKeep] {
+	if !app.tmuxActivity.activeWorkspaceIDs[idKeep] {
 		t.Fatal("expected surviving workspace to remain in the active set")
 	}
 }

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -34,8 +34,8 @@ type tmuxActivityResult struct {
 // snapshotActivityStates creates a deep copy of session activity states for use in a goroutine.
 // This avoids concurrent map access between the Update loop and Cmd goroutines.
 func (a *App) snapshotActivityStates() map[string]*activity.SessionState {
-	snapshot := make(map[string]*activity.SessionState, len(a.sessionActivityStates))
-	for name, state := range a.sessionActivityStates {
+	snapshot := make(map[string]*activity.SessionState, len(a.tmuxActivity.sessionStates))
+	for name, state := range a.tmuxActivity.sessionStates {
 		// Copy the struct to avoid sharing pointers
 		stateCopy := *state
 		snapshot[name] = &stateCopy
@@ -44,19 +44,19 @@ func (a *App) snapshotActivityStates() map[string]*activity.SessionState {
 }
 
 func (a *App) startTmuxActivityTicker() tea.Cmd {
-	a.tmuxActivityToken++
+	a.tmuxActivity.token++
 	return a.scheduleTmuxActivityTick()
 }
 
 func (a *App) scheduleTmuxActivityTick() tea.Cmd {
-	token := a.tmuxActivityToken
+	token := a.tmuxActivity.token
 	return common.SafeTick(tmuxActivityInterval, func(time.Time) tea.Msg {
 		return tmuxActivityTick{Token: token}
 	})
 }
 
 func (a *App) triggerTmuxActivityScan() tea.Cmd {
-	token := a.tmuxActivityToken
+	token := a.tmuxActivity.token
 	return func() tea.Msg {
 		return tmuxActivityTick{Token: token}
 	}
@@ -75,14 +75,14 @@ func (a *App) eagerScanTmuxActivity() tea.Cmd {
 }
 
 func (a *App) scanTmuxActivityNow() tea.Cmd {
-	if a.tmuxActivityScanInFlight {
-		a.tmuxActivityRescanPending = true
+	if a.tmuxActivity.scanInFlight {
+		a.tmuxActivity.rescanPending = true
 		return nil
 	}
-	a.tmuxActivityScanInFlight = true
-	a.tmuxActivityRescanPending = false
-	a.tmuxActivityToken++
-	scanToken := a.tmuxActivityToken
+	a.tmuxActivity.scanInFlight = true
+	a.tmuxActivity.rescanPending = false
+	a.tmuxActivity.token++
+	scanToken := a.tmuxActivity.token
 	infoBySession := a.tabSessionInfoByName()
 	statesSnapshot := a.snapshotActivityStates()
 	opts := a.tmuxOptions
@@ -96,22 +96,22 @@ func (a *App) scanTmuxActivityNow() tea.Cmd {
 }
 
 func (a *App) handleTmuxActivityTick(msg tmuxActivityTick) []tea.Cmd {
-	if msg.Token != a.tmuxActivityToken {
+	if msg.Token != a.tmuxActivity.token {
 		return []tea.Cmd{a.scheduleTmuxActivityTick()}
 	}
 	if !a.tmuxAvailable {
 		return []tea.Cmd{a.scheduleTmuxActivityTick()}
 	}
-	if a.tmuxActivityScanInFlight {
-		a.tmuxActivityRescanPending = true
+	if a.tmuxActivity.scanInFlight {
+		a.tmuxActivity.rescanPending = true
 		return []tea.Cmd{a.scheduleTmuxActivityTick()}
 	}
-	a.tmuxActivityScanInFlight = true
-	a.tmuxActivityRescanPending = false
+	a.tmuxActivity.scanInFlight = true
+	a.tmuxActivity.rescanPending = false
 	// Increment token for this scan so out-of-order results are rejected.
 	// Each scan gets a unique token; only the most recent result is applied.
-	a.tmuxActivityToken++
-	scanToken := a.tmuxActivityToken
+	a.tmuxActivity.token++
+	scanToken := a.tmuxActivity.token
 	sessionInfo := a.tabSessionInfoByName()
 	statesSnapshot := a.snapshotActivityStates()
 	opts := a.tmuxOptions
@@ -253,10 +253,10 @@ func (a *App) fetchAndSyncActivitySessionStates(
 		return nil, nil, err
 	}
 	// Mutates infoBySession so IsRunningSession sees corrected statuses.
-	if a.activityMissBySession == nil {
-		a.activityMissBySession = make(map[string]int)
+	if a.tmuxActivity.missBySession == nil {
+		a.tmuxActivity.missBySession = make(map[string]int)
 	}
-	stoppedTabs := syncActivitySessionStates(infoBySession, sessions, svc, opts, a.activityMissBySession)
+	stoppedTabs := syncActivitySessionStates(infoBySession, sessions, svc, opts, a.tmuxActivity.missBySession)
 	return sessions, stoppedTabs, nil
 }
 
@@ -264,9 +264,9 @@ func (a *App) handleTmuxAvailableResult(msg tmuxAvailableResult) []tea.Cmd {
 	a.tmuxCheckDone = true
 	a.tmuxAvailable = msg.available
 	a.tmuxInstallHint = msg.installHint
-	a.tmuxActivitySettled = false
-	a.tmuxActivitySettledScans = 0
-	a.tmuxActiveWorkspaceIDs = make(map[string]bool)
+	a.tmuxActivity.settled = false
+	a.tmuxActivity.settledScans = 0
+	a.tmuxActivity.activeWorkspaceIDs = make(map[string]bool)
 	a.syncActiveWorkspacesToDashboard()
 	if !msg.available {
 		return []tea.Cmd{a.toast.ShowError("tmux not installed. " + msg.installHint)}

--- a/internal/app/app_tmux_activity_handle_result_test.go
+++ b/internal/app/app_tmux_activity_handle_result_test.go
@@ -10,18 +10,20 @@ import (
 
 func TestHandleTmuxActivityResult_OwnerTransitionErrorResetsHysteresis(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:        5,
-		tmuxActivityScanInFlight: true,
-		tmuxActivityOwnershipSet: true,
-		tmuxActivityScannerOwner: false,
-		tmuxActivityOwnerEpoch:   1,
-		sessionActivityStates: map[string]*activity.SessionState{
-			"stale-session": {},
+		tmuxActivity: tmuxActivityState{
+			token:        5,
+			scanInFlight: true,
+			ownershipSet: true,
+			scannerOwner: false,
+			ownerEpoch:   1,
+			sessionStates: map[string]*activity.SessionState{
+				"stale-session": {},
+			},
+			settled:            true,
+			settledScans:       2,
+			activeWorkspaceIDs: map[string]bool{"ws-stale": true},
 		},
-		tmuxActivitySettled:      true,
-		tmuxActivitySettledScans: 2,
-		tmuxActiveWorkspaceIDs:   map[string]bool{"ws-stale": true},
-		dashboard:                dashboard.New(),
+		dashboard: dashboard.New(),
 	}
 	app.syncActiveWorkspacesToDashboard()
 
@@ -32,11 +34,11 @@ func TestHandleTmuxActivityResult_OwnerTransitionErrorResetsHysteresis(t *testin
 		ScannerEpoch: 2,
 		Err:          errors.New("owner scan failed"),
 	})
-	if len(app.sessionActivityStates) != 0 {
-		t.Fatalf("expected hysteresis reset on owner transition despite scan error, got %v", app.sessionActivityStates)
+	if len(app.tmuxActivity.sessionStates) != 0 {
+		t.Fatalf("expected hysteresis reset on owner transition despite scan error, got %v", app.tmuxActivity.sessionStates)
 	}
-	if len(app.tmuxActiveWorkspaceIDs) != 0 {
-		t.Fatalf("expected stale active-workspace map cleared on owner transition, got %v", app.tmuxActiveWorkspaceIDs)
+	if len(app.tmuxActivity.activeWorkspaceIDs) != 0 {
+		t.Fatalf("expected stale active-workspace map cleared on owner transition, got %v", app.tmuxActivity.activeWorkspaceIDs)
 	}
 	if got := dashboardActiveWorkspaceCount(app.dashboard); got != 0 {
 		t.Fatalf("expected dashboard activity cleared on owner transition, got %d", got)
@@ -52,14 +54,14 @@ func TestHandleTmuxActivityResult_OwnerTransitionErrorResetsHysteresis(t *testin
 			"new-session": {},
 		},
 	})
-	if len(app.sessionActivityStates) != 1 {
-		t.Fatalf("expected only fresh owner state after recovery scan, got %v", app.sessionActivityStates)
+	if len(app.tmuxActivity.sessionStates) != 1 {
+		t.Fatalf("expected only fresh owner state after recovery scan, got %v", app.tmuxActivity.sessionStates)
 	}
-	if _, ok := app.sessionActivityStates["stale-session"]; ok {
-		t.Fatalf("expected stale pre-transition state to remain cleared, got %v", app.sessionActivityStates)
+	if _, ok := app.tmuxActivity.sessionStates["stale-session"]; ok {
+		t.Fatalf("expected stale pre-transition state to remain cleared, got %v", app.tmuxActivity.sessionStates)
 	}
-	if !app.tmuxActiveWorkspaceIDs["ws-new"] {
-		t.Fatalf("expected recovered owner activity to apply, got %v", app.tmuxActiveWorkspaceIDs)
+	if !app.tmuxActivity.activeWorkspaceIDs["ws-new"] {
+		t.Fatalf("expected recovered owner activity to apply, got %v", app.tmuxActivity.activeWorkspaceIDs)
 	}
 }
 
@@ -72,16 +74,18 @@ func TestHandleTmuxActivityResult_OwnerTransitionResetsSettlement(t *testing.T) 
 	dash := dashboard.New()
 	dash.SetActiveWorkspaces(map[string]bool{"ws-old": true})
 	app := &App{
-		tmuxActivityToken:        7,
-		tmuxActivityScanInFlight: true,
-		tmuxActivityOwnershipSet: true,
-		tmuxActivityScannerOwner: false,
-		tmuxActivityOwnerEpoch:   1,
-		sessionActivityStates:    map[string]*activity.SessionState{},
-		tmuxActivitySettled:      true,
-		tmuxActivitySettledScans: 2,
-		tmuxActiveWorkspaceIDs:   map[string]bool{"ws-old": true},
-		dashboard:                dash,
+		tmuxActivity: tmuxActivityState{
+			token:              7,
+			scanInFlight:       true,
+			ownershipSet:       true,
+			scannerOwner:       false,
+			ownerEpoch:         1,
+			sessionStates:      map[string]*activity.SessionState{},
+			settled:            true,
+			settledScans:       2,
+			activeWorkspaceIDs: map[string]bool{"ws-old": true},
+		},
+		dashboard: dash,
 	}
 
 	// Follower->owner transition (epoch bump). The owner scan succeeds and reports
@@ -95,19 +99,19 @@ func TestHandleTmuxActivityResult_OwnerTransitionResetsSettlement(t *testing.T) 
 		ActiveWorkspaceIDs: map[string]bool{"ws-new": true},
 		UpdatedStates:      map[string]*activity.SessionState{},
 	})
-	if app.tmuxActivitySettled {
+	if app.tmuxActivity.settled {
 		t.Fatal("expected settlement reset on owner transition")
 	}
-	if app.tmuxActivitySettledScans != 1 {
-		t.Fatalf("expected settle scans to restart at 1 after the transition scan, got %d", app.tmuxActivitySettledScans)
+	if app.tmuxActivity.settledScans != 1 {
+		t.Fatalf("expected settle scans to restart at 1 after the transition scan, got %d", app.tmuxActivity.settledScans)
 	}
 	if got := dashboardActiveWorkspaceCount(dash); got != 0 {
 		t.Fatalf("expected transient active set withheld while unsettled, got %d", got)
 	}
 
 	// Second successful owner scan re-settles and republishes the active set.
-	app.tmuxActivityToken = 8
-	app.tmuxActivityScanInFlight = true
+	app.tmuxActivity.token = 8
+	app.tmuxActivity.scanInFlight = true
 	app.handleTmuxActivityResult(tmuxActivityResult{
 		Token:              8,
 		RoleKnown:          true,
@@ -116,7 +120,7 @@ func TestHandleTmuxActivityResult_OwnerTransitionResetsSettlement(t *testing.T) 
 		ActiveWorkspaceIDs: map[string]bool{"ws-new": true},
 		UpdatedStates:      map[string]*activity.SessionState{},
 	})
-	if !app.tmuxActivitySettled {
+	if !app.tmuxActivity.settled {
 		t.Fatal("expected owner to re-settle after two successful scans")
 	}
 	if got := dashboardActiveWorkspaceCount(dash); got != 1 {

--- a/internal/app/app_tmux_activity_prefilter_test.go
+++ b/internal/app/app_tmux_activity_prefilter_test.go
@@ -17,13 +17,13 @@ func TestTmuxActivityScan_PrefilterErrorStillAllowsStaleFallback(t *testing.T) {
 	ops.prefilterErr = errors.New("prefilter unavailable")
 	ops.lastOutputAge = activity.OutputWindow + time.Second
 
-	app.sessionActivityStates[ops.sessionName] = &activity.SessionState{
+	app.tmuxActivity.sessionStates[ops.sessionName] = &activity.SessionState{
 		Initialized: true,
 		Score:       activity.ScoreThreshold - 2,
 	}
 
 	runImmediateTmuxActivityScan(t, app)
-	if !app.tmuxActiveWorkspaceIDs[wsID] {
+	if !app.tmuxActivity.activeWorkspaceIDs[wsID] {
 		t.Fatalf("expected workspace %s active via stale-tag fallback when prefilter is unavailable", wsID)
 	}
 }

--- a/internal/app/app_tmux_activity_prune_test.go
+++ b/internal/app/app_tmux_activity_prune_test.go
@@ -12,12 +12,14 @@ import (
 // bounding the growth of sessionActivityStates.
 func TestApplyTmuxActivityPayload_PrunesRemovedStates(t *testing.T) {
 	app := &App{
-		sessionActivityStates: map[string]*activity.SessionState{
-			"keep": {Score: activity.ScoreThreshold},
-			"drop": {Score: activity.ScoreThreshold},
+		tmuxActivity: tmuxActivityState{
+			sessionStates: map[string]*activity.SessionState{
+				"keep": {Score: activity.ScoreThreshold},
+				"drop": {Score: activity.ScoreThreshold},
+			},
+			activeWorkspaceIDs: map[string]bool{},
 		},
-		tmuxActiveWorkspaceIDs: map[string]bool{},
-		dashboard:              dashboard.New(),
+		dashboard: dashboard.New(),
 	}
 
 	app.applyTmuxActivityPayload(tmuxActivityResult{
@@ -28,10 +30,10 @@ func TestApplyTmuxActivityPayload_PrunesRemovedStates(t *testing.T) {
 		RemovedStates: []string{"drop"},
 	})
 
-	if _, ok := app.sessionActivityStates["drop"]; ok {
+	if _, ok := app.tmuxActivity.sessionStates["drop"]; ok {
 		t.Fatal("expected pruned session state to be deleted")
 	}
-	state, ok := app.sessionActivityStates["keep"]
+	state, ok := app.tmuxActivity.sessionStates["keep"]
 	if !ok {
 		t.Fatal("expected kept session state to remain")
 	}
@@ -46,9 +48,11 @@ func TestApplyTmuxActivityPayload_PrunesRemovedStates(t *testing.T) {
 // lists pruned (omitted-from-updatedStates) sessions.
 func TestApplyTmuxActivityPayload_RemoveRunsAfterMerge(t *testing.T) {
 	app := &App{
-		sessionActivityStates:  map[string]*activity.SessionState{},
-		tmuxActiveWorkspaceIDs: map[string]bool{},
-		dashboard:              dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			sessionStates:      map[string]*activity.SessionState{},
+			activeWorkspaceIDs: map[string]bool{},
+		},
+		dashboard: dashboard.New(),
 	}
 
 	app.applyTmuxActivityPayload(tmuxActivityResult{
@@ -59,7 +63,7 @@ func TestApplyTmuxActivityPayload_RemoveRunsAfterMerge(t *testing.T) {
 		RemovedStates: []string{"x"},
 	})
 
-	if _, ok := app.sessionActivityStates["x"]; ok {
+	if _, ok := app.tmuxActivity.sessionStates["x"]; ok {
 		t.Fatal("expected removal to run after merge (delete wins)")
 	}
 }

--- a/internal/app/app_tmux_activity_result.go
+++ b/internal/app/app_tmux_activity_result.go
@@ -12,12 +12,12 @@ import (
 )
 
 func (a *App) handleTmuxActivityResult(msg tmuxActivityResult) []tea.Cmd {
-	if msg.Token != a.tmuxActivityToken {
+	if msg.Token != a.tmuxActivity.token {
 		// Stale result from an older scan; ignore to avoid overwriting newer state.
 		return nil
 	}
 
-	a.tmuxActivityScanInFlight = false
+	a.tmuxActivity.scanInFlight = false
 	a.updateTmuxActivityOwnershipState(msg)
 
 	var cmds []tea.Cmd
@@ -33,8 +33,8 @@ func (a *App) handleTmuxActivityResult(msg tmuxActivityResult) []tea.Cmd {
 		}
 	}
 
-	if a.tmuxActivityRescanPending && a.tmuxAvailable {
-		a.tmuxActivityRescanPending = false
+	if a.tmuxActivity.rescanPending && a.tmuxAvailable {
+		a.tmuxActivity.rescanPending = false
 		if scanCmd := a.scanTmuxActivityNow(); scanCmd != nil {
 			cmds = append(cmds, scanCmd)
 		}
@@ -47,14 +47,14 @@ func (a *App) updateTmuxActivityOwnershipState(msg tmuxActivityResult) {
 		return
 	}
 
-	previousRoleSet := a.tmuxActivityOwnershipSet
-	previousOwner := a.tmuxActivityScannerOwner
-	previousEpoch := a.tmuxActivityOwnerEpoch
+	previousRoleSet := a.tmuxActivity.ownershipSet
+	previousOwner := a.tmuxActivity.scannerOwner
+	previousEpoch := a.tmuxActivity.ownerEpoch
 
-	a.tmuxActivityOwnershipSet = true
-	a.tmuxActivityScannerOwner = msg.ScannerOwner
+	a.tmuxActivity.ownershipSet = true
+	a.tmuxActivity.scannerOwner = msg.ScannerOwner
 	if msg.ScannerEpoch > 0 {
-		a.tmuxActivityOwnerEpoch = msg.ScannerEpoch
+		a.tmuxActivity.ownerEpoch = msg.ScannerEpoch
 	}
 
 	if !previousRoleSet || previousOwner != msg.ScannerOwner || (msg.ScannerEpoch > 0 && previousEpoch != msg.ScannerEpoch) {
@@ -62,7 +62,7 @@ func (a *App) updateTmuxActivityOwnershipState(msg tmuxActivityResult) {
 		if msg.ScannerOwner {
 			role = "owner"
 		}
-		logging.Info("tmux activity role=%s epoch=%d instance=%s", role, a.tmuxActivityOwnerEpoch, strings.TrimSpace(a.instanceID))
+		logging.Info("tmux activity role=%s epoch=%d instance=%s", role, a.tmuxActivity.ownerEpoch, strings.TrimSpace(a.instanceID))
 	}
 
 	if !isTmuxActivityOwnerTransition(previousRoleSet, previousOwner, previousEpoch, msg) {
@@ -71,10 +71,10 @@ func (a *App) updateTmuxActivityOwnershipState(msg tmuxActivityResult) {
 
 	// Reset local hysteresis when entering owner mode so we never reuse state
 	// created under an older owner epoch.
-	a.sessionActivityStates = make(map[string]*activity.SessionState)
+	a.tmuxActivity.sessionStates = make(map[string]*activity.SessionState)
 	// Clear follower/shared activity immediately. If the first owner scan fails,
 	// stale follower markers should not remain visible.
-	a.tmuxActiveWorkspaceIDs = make(map[string]bool)
+	a.tmuxActivity.activeWorkspaceIDs = make(map[string]bool)
 	// Re-enter the unsettled state so this transient empty set is not published as
 	// authoritative. While !settled, syncActiveWorkspacesToDashboard short-circuits
 	// to an empty publish that the dashboard treats as "not yet known" rather than a
@@ -82,8 +82,8 @@ func (a *App) updateTmuxActivityOwnershipState(msg tmuxActivityResult) {
 	// the handoff and the new owner's first scans. applyTmuxActivityPayload re-settles
 	// after tmuxActivitySettleScans successful owner scans, repopulating indicators.
 	// Mirrors the tmux-availability reset in scanTmuxActivity.
-	a.tmuxActivitySettled = false
-	a.tmuxActivitySettledScans = 0
+	a.tmuxActivity.settled = false
+	a.tmuxActivity.settledScans = 0
 	a.syncActiveWorkspacesToDashboard()
 }
 
@@ -122,19 +122,19 @@ func (a *App) applyTmuxActivityPayload(msg tmuxActivityResult) tea.Cmd {
 	}
 	// Merge updated hysteresis states back on the main thread.
 	for name, state := range msg.UpdatedStates {
-		a.sessionActivityStates[name] = state
+		a.tmuxActivity.sessionStates[name] = state
 	}
 	// Prune states the scan dropped after they went unseen long enough; this
 	// bounds the otherwise monotonic growth of sessionActivityStates (deleted
 	// workspaces' sessions never reappear in the scan). Delete after the merge so
 	// a same-scan re-add cannot be undone.
 	for _, name := range msg.RemovedStates {
-		delete(a.sessionActivityStates, name)
+		delete(a.tmuxActivity.sessionStates, name)
 	}
-	a.tmuxActiveWorkspaceIDs = msg.ActiveWorkspaceIDs
-	a.tmuxActivitySettledScans++
-	if a.tmuxActivitySettledScans >= tmuxActivitySettleScans {
-		a.tmuxActivitySettled = true
+	a.tmuxActivity.activeWorkspaceIDs = msg.ActiveWorkspaceIDs
+	a.tmuxActivity.settledScans++
+	if a.tmuxActivity.settledScans >= tmuxActivitySettleScans {
+		a.tmuxActivity.settled = true
 	}
 	a.syncActiveWorkspacesToDashboard()
 	return a.dashboard.StartSpinnerIfNeeded()

--- a/internal/app/app_tmux_activity_settle_test.go
+++ b/internal/app/app_tmux_activity_settle_test.go
@@ -18,11 +18,13 @@ func dashboardActiveWorkspaceCount(m *dashboard.Model) int {
 
 func TestHandleTmuxActivityResult_SettlesAfterTwoSuccessfulScans(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:        1,
-		tmuxActivityScanInFlight: true,
-		sessionActivityStates:    make(map[string]*activity.SessionState),
-		tmuxActiveWorkspaceIDs:   make(map[string]bool),
-		dashboard:                dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			token:              1,
+			scanInFlight:       true,
+			sessionStates:      make(map[string]*activity.SessionState),
+			activeWorkspaceIDs: make(map[string]bool),
+		},
+		dashboard: dashboard.New(),
 	}
 
 	app.handleTmuxActivityResult(tmuxActivityResult{
@@ -30,25 +32,25 @@ func TestHandleTmuxActivityResult_SettlesAfterTwoSuccessfulScans(t *testing.T) {
 		ActiveWorkspaceIDs: map[string]bool{"ws1": true},
 		UpdatedStates:      map[string]*activity.SessionState{},
 	})
-	if app.tmuxActivitySettled {
+	if app.tmuxActivity.settled {
 		t.Fatal("expected activity to remain unsettled after first successful scan")
 	}
-	if app.tmuxActivitySettledScans != 1 {
-		t.Fatalf("expected settled scan count=1, got %d", app.tmuxActivitySettledScans)
+	if app.tmuxActivity.settledScans != 1 {
+		t.Fatalf("expected settled scan count=1, got %d", app.tmuxActivity.settledScans)
 	}
 
-	app.tmuxActivityToken = 2
-	app.tmuxActivityScanInFlight = true
+	app.tmuxActivity.token = 2
+	app.tmuxActivity.scanInFlight = true
 	app.handleTmuxActivityResult(tmuxActivityResult{
 		Token:              2,
 		ActiveWorkspaceIDs: map[string]bool{"ws1": true},
 		UpdatedStates:      map[string]*activity.SessionState{},
 	})
-	if !app.tmuxActivitySettled {
+	if !app.tmuxActivity.settled {
 		t.Fatal("expected activity to settle after second successful scan")
 	}
-	if app.tmuxActivitySettledScans != 2 {
-		t.Fatalf("expected settled scan count=2, got %d", app.tmuxActivitySettledScans)
+	if app.tmuxActivity.settledScans != 2 {
+		t.Fatalf("expected settled scan count=2, got %d", app.tmuxActivity.settledScans)
 	}
 }
 
@@ -56,23 +58,25 @@ func TestHandleTmuxAvailableResult_ResetsActivitySettlement(t *testing.T) {
 	dash := dashboard.New()
 	dash.SetActiveWorkspaces(map[string]bool{"ws-old": true})
 	app := &App{
-		tmuxAvailable:            true,
-		tmuxActivitySettled:      true,
-		tmuxActivitySettledScans: 5,
-		tmuxActiveWorkspaceIDs:   map[string]bool{"ws-old": true},
-		dashboard:                dash,
-		toast:                    common.NewToastModel(),
+		tmuxAvailable: true,
+		tmuxActivity: tmuxActivityState{
+			settled:            true,
+			settledScans:       5,
+			activeWorkspaceIDs: map[string]bool{"ws-old": true},
+		},
+		dashboard: dash,
+		toast:     common.NewToastModel(),
 	}
 
 	_ = app.handleTmuxAvailableResult(tmuxAvailableResult{available: true})
-	if app.tmuxActivitySettled {
+	if app.tmuxActivity.settled {
 		t.Fatal("expected settled flag reset on tmux availability result")
 	}
-	if app.tmuxActivitySettledScans != 0 {
-		t.Fatalf("expected settled scan count reset to 0, got %d", app.tmuxActivitySettledScans)
+	if app.tmuxActivity.settledScans != 0 {
+		t.Fatalf("expected settled scan count reset to 0, got %d", app.tmuxActivity.settledScans)
 	}
-	if len(app.tmuxActiveWorkspaceIDs) != 0 {
-		t.Fatalf("expected active workspace map reset, got %v", app.tmuxActiveWorkspaceIDs)
+	if len(app.tmuxActivity.activeWorkspaceIDs) != 0 {
+		t.Fatalf("expected active workspace map reset, got %v", app.tmuxActivity.activeWorkspaceIDs)
 	}
 	if got := dashboardActiveWorkspaceCount(dash); got != 0 {
 		t.Fatalf("expected dashboard active workspace state reset, got %d", got)

--- a/internal/app/app_tmux_activity_shared_scan_test.go
+++ b/internal/app/app_tmux_activity_shared_scan_test.go
@@ -54,7 +54,9 @@ func TestRunTmuxActivityScan_FollowerReconcilesStoppedTabsFromSharedSnapshot(t *
 		},
 		// Pre-seed one prior non-live observation so this single scan reaches the
 		// demotion hysteresis threshold and still demotes the dead session.
-		activityMissBySession: map[string]int{"session-a": activityDemotionMissThreshold - 1},
+		tmuxActivity: tmuxActivityState{
+			missBySession: map[string]int{"session-a": activityDemotionMissThreshold - 1},
+		},
 	}
 
 	infoBySession := map[string]activity.SessionInfo{
@@ -246,8 +248,7 @@ func TestRunTmuxActivityScan_OwnerResolutionErrorLeavesRoleUnknown(t *testing.T)
 
 func TestHandleTmuxActivityResult_AppliesStoppedTabsWhenSkipApply(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:        7,
-		tmuxActivityScanInFlight: true,
+		tmuxActivity: tmuxActivityState{token: 7, scanInFlight: true},
 	}
 
 	expected := messages.TabSessionStatus{
@@ -263,7 +264,7 @@ func TestHandleTmuxActivityResult_AppliesStoppedTabsWhenSkipApply(t *testing.T) 
 	if len(cmds) != 1 {
 		t.Fatalf("expected stopped-tab command to be enqueued, got %d cmds", len(cmds))
 	}
-	if app.tmuxActivityScanInFlight {
+	if app.tmuxActivity.scanInFlight {
 		t.Fatal("expected scan in-flight flag to be cleared")
 	}
 
@@ -279,8 +280,7 @@ func TestHandleTmuxActivityResult_AppliesStoppedTabsWhenSkipApply(t *testing.T) 
 
 func TestHandleTmuxActivityResult_AppliesStoppedTabsWhenErrSet(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:        8,
-		tmuxActivityScanInFlight: true,
+		tmuxActivity: tmuxActivityState{token: 8, scanInFlight: true},
 	}
 
 	expected := messages.TabSessionStatus{
@@ -296,7 +296,7 @@ func TestHandleTmuxActivityResult_AppliesStoppedTabsWhenErrSet(t *testing.T) {
 	if len(cmds) != 1 {
 		t.Fatalf("expected stopped-tab command to be enqueued despite scan error, got %d cmds", len(cmds))
 	}
-	if app.tmuxActivityScanInFlight {
+	if app.tmuxActivity.scanInFlight {
 		t.Fatal("expected scan in-flight flag to be cleared")
 	}
 	msg := cmds[0]()

--- a/internal/app/app_tmux_activity_state.go
+++ b/internal/app/app_tmux_activity_state.go
@@ -1,0 +1,44 @@
+package app
+
+import "github.com/andyrewlee/amux/internal/app/activity"
+
+// tmuxActivityState groups the tmux activity-scan bookkeeping that previously
+// lived as loose fields on App: ticker/dedup tokens, scan-coalescing flags,
+// shared-scan ownership, and per-session activity hysteresis. It is mutated
+// only from App.Update handlers (single writer).
+type tmuxActivityState struct {
+	// syncToken dedups tmux session-reconcile ticker generations (TmuxSyncTick).
+	syncToken int
+	// token dedups activity ticker generations (tmuxActivityTick).
+	token int
+	// scanInFlight and rescanPending coalesce overlapping scan requests: a
+	// request that arrives mid-scan marks rescanPending instead of spawning a
+	// second scan.
+	scanInFlight  bool
+	rescanPending bool
+	// settled and settledScans track post-startup scan settling: activity is
+	// not trusted until a few consecutive scans agree.
+	settled      bool
+	settledScans int
+	// scannerOwner, ownershipSet and ownerEpoch hold shared-scan leadership
+	// state: one amux instance scans on behalf of all instances on the host.
+	scannerOwner bool
+	ownershipSet bool
+	ownerEpoch   int64
+	// activeWorkspaceIDs is the latest set of workspace IDs with active agent
+	// sessions, as published by the most recent scan.
+	activeWorkspaceIDs map[string]bool
+	// sessionStates holds per-session activity hysteresis state.
+	sessionStates map[string]*activity.SessionState
+	// missBySession counts consecutive non-live activity observations per
+	// session so a single transient miss does not demote a working agent.
+	missBySession map[string]int
+}
+
+func newTmuxActivityState() tmuxActivityState {
+	return tmuxActivityState{
+		activeWorkspaceIDs: make(map[string]bool),
+		sessionStates:      make(map[string]*activity.SessionState),
+		missBySession:      make(map[string]int),
+	}
+}

--- a/internal/app/app_tmux_activity_test.go
+++ b/internal/app/app_tmux_activity_test.go
@@ -54,43 +54,44 @@ func (s stubTmuxOps) CapturePaneTail(string, int, tmux.Options) (string, bool) {
 func (s stubTmuxOps) ContentHash(string) [16]byte                              { return [16]byte{} }
 
 func TestScanTmuxActivityNow_QueuesWhenInFlight(t *testing.T) {
-	app := &App{tmuxActivityScanInFlight: true}
+	app := &App{tmuxActivity: tmuxActivityState{scanInFlight: true}}
 	cmd := app.scanTmuxActivityNow()
 	if cmd != nil {
 		t.Fatal("expected nil cmd when scan already in flight")
 	}
-	if !app.tmuxActivityRescanPending {
+	if !app.tmuxActivity.rescanPending {
 		t.Fatal("expected pending rescan to be queued")
 	}
 }
 
 func TestHandleTmuxActivityTick_QueuesWhenInFlight(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:        7,
-		tmuxAvailable:            true,
-		tmuxActivityScanInFlight: true,
+		tmuxActivity:  tmuxActivityState{token: 7, scanInFlight: true},
+		tmuxAvailable: true,
 	}
 	cmds := app.handleTmuxActivityTick(tmuxActivityTick{Token: 7})
 	if len(cmds) != 1 {
 		t.Fatalf("expected only ticker reschedule while in flight, got %d cmds", len(cmds))
 	}
-	if !app.tmuxActivityRescanPending {
+	if !app.tmuxActivity.rescanPending {
 		t.Fatal("expected pending rescan to be queued")
 	}
-	if app.tmuxActivityToken != 7 {
-		t.Fatalf("expected token unchanged while in flight, got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 7 {
+		t.Fatalf("expected token unchanged while in flight, got %d", app.tmuxActivity.token)
 	}
 }
 
 func TestHandleTmuxActivityResult_ConsumesPendingRescan(t *testing.T) {
 	app := &App{
-		tmuxActivityToken:         2,
-		tmuxAvailable:             true,
-		tmuxActivityScanInFlight:  true,
-		tmuxActivityRescanPending: true,
-		sessionActivityStates:     make(map[string]*activity.SessionState),
-		tmuxActiveWorkspaceIDs:    make(map[string]bool),
-		dashboard:                 dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			token:              2,
+			scanInFlight:       true,
+			rescanPending:      true,
+			sessionStates:      make(map[string]*activity.SessionState),
+			activeWorkspaceIDs: make(map[string]bool),
+		},
+		tmuxAvailable: true,
+		dashboard:     dashboard.New(),
 	}
 	cmds := app.handleTmuxActivityResult(tmuxActivityResult{
 		Token:              2,
@@ -100,13 +101,13 @@ func TestHandleTmuxActivityResult_ConsumesPendingRescan(t *testing.T) {
 	if len(cmds) == 0 {
 		t.Fatal("expected pending rescan command to be enqueued")
 	}
-	if app.tmuxActivityToken != 3 {
-		t.Fatalf("expected next scan token to be allocated, got %d", app.tmuxActivityToken)
+	if app.tmuxActivity.token != 3 {
+		t.Fatalf("expected next scan token to be allocated, got %d", app.tmuxActivity.token)
 	}
-	if !app.tmuxActivityScanInFlight {
+	if !app.tmuxActivity.scanInFlight {
 		t.Fatal("expected follow-up scan to be marked in flight")
 	}
-	if app.tmuxActivityRescanPending {
+	if app.tmuxActivity.rescanPending {
 		t.Fatal("expected pending flag to be cleared")
 	}
 }
@@ -428,13 +429,15 @@ func newActivityTestAppWithScriptedTmux(contentByScan []string) (*App, string) {
 				"codex": {},
 			},
 		},
-		projects:               []data.Project{project},
-		tmuxService:            tmuxOps,
-		tmuxOptions:            tmux.Options{},
-		tmuxAvailable:          true,
-		dashboard:              dashboard.New(),
-		sessionActivityStates:  make(map[string]*activity.SessionState),
-		tmuxActiveWorkspaceIDs: make(map[string]bool),
+		projects:      []data.Project{project},
+		tmuxService:   tmuxOps,
+		tmuxOptions:   tmux.Options{},
+		tmuxAvailable: true,
+		dashboard:     dashboard.New(),
+		tmuxActivity: tmuxActivityState{
+			sessionStates:      make(map[string]*activity.SessionState),
+			activeWorkspaceIDs: make(map[string]bool),
+		},
 	}
 	return app, wsID
 }
@@ -467,7 +470,7 @@ func TestTmuxActivityScan_KnownFreshUnchangedRemainsInactiveAcrossScans(t *testi
 
 	for i := 0; i < 5; i++ {
 		runImmediateTmuxActivityScan(t, app)
-		if app.tmuxActiveWorkspaceIDs[wsID] {
+		if app.tmuxActivity.activeWorkspaceIDs[wsID] {
 			t.Fatalf("scan %d: expected workspace %s to remain inactive on unchanged output", i+1, wsID)
 		}
 	}
@@ -481,17 +484,17 @@ func TestTmuxActivityScan_KnownFreshConsecutiveDeltasBecomeActive(t *testing.T) 
 	})
 
 	runImmediateTmuxActivityScan(t, app)
-	if app.tmuxActiveWorkspaceIDs[wsID] {
+	if app.tmuxActivity.activeWorkspaceIDs[wsID] {
 		t.Fatalf("expected workspace %s inactive after baseline scan", wsID)
 	}
 
 	runImmediateTmuxActivityScan(t, app)
-	if app.tmuxActiveWorkspaceIDs[wsID] {
+	if app.tmuxActivity.activeWorkspaceIDs[wsID] {
 		t.Fatalf("expected workspace %s inactive after first delta scan", wsID)
 	}
 
 	runImmediateTmuxActivityScan(t, app)
-	if !app.tmuxActiveWorkspaceIDs[wsID] {
+	if !app.tmuxActivity.activeWorkspaceIDs[wsID] {
 		t.Fatalf("expected workspace %s active after second consecutive delta", wsID)
 	}
 }

--- a/internal/app/app_tmux_gc_detached_test.go
+++ b/internal/app/app_tmux_gc_detached_test.go
@@ -74,11 +74,10 @@ func TestGcStaleDetachedAgentSessions_RunsWhenFollower(t *testing.T) {
 		rows: []tmux.SessionTagValues{},
 	}
 	app := &App{
-		tmuxAvailable:            true,
-		instanceID:               "instance-a",
-		tmuxActivityOwnershipSet: true,
-		tmuxActivityScannerOwner: false,
-		tmuxService:              ops,
+		tmuxAvailable: true,
+		instanceID:    "instance-a",
+		tmuxActivity:  tmuxActivityState{ownershipSet: true, scannerOwner: false},
+		tmuxService:   ops,
 	}
 	cmd := app.gcStaleDetachedAgentSessions()
 	if cmd == nil {

--- a/internal/app/app_tmux_sync.go
+++ b/internal/app/app_tmux_sync.go
@@ -15,7 +15,7 @@ import (
 // 2) status sync for known tabs.
 // The default 7s tick interval and per-command 5s timeout bound worst-case latency.
 func (a *App) handleTmuxSyncTick(msg messages.TmuxSyncTick) []tea.Cmd {
-	if msg.Token != a.tmuxSyncToken {
+	if msg.Token != a.tmuxActivity.syncToken {
 		return nil
 	}
 	var cmds []tea.Cmd


### PR DESCRIPTION
Move the 13 tmux activity-scan bookkeeping fields (sync/activity dedup
tokens, scan-coalescing flags, shared-scan ownership, per-session
hysteresis maps) into their own struct with a constructor. Mechanical
a.fieldX -> a.tmuxActivity.fieldX rewrite; no behavior change.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **C1**, 8/36). Stacked on `rp/b3-sync-flag-tests`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.