### PR TITLE
C2: Type the App's dedup tokens

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -133,11 +133,11 @@ type App struct {
 	dirtyWorkspaces      map[string]bool
 	deletingWorkspaceMu  sync.RWMutex
 	deletingWorkspaceIDs map[string]bool
-	persistToken         int
+	persistToken         persistToken
 	// projectsLoadToken is the next load generation to issue; lastApplied is the
 	// highest applied, so handleProjectsLoaded can drop out-of-order reloads.
-	projectsLoadToken            int
-	lastAppliedProjectsLoadToken int
+	projectsLoadToken            projectsLoadToken
+	lastAppliedProjectsLoadToken projectsLoadToken
 	localWorkspaceSaveMu         sync.Mutex
 	localWorkspaceSavesAt        map[string]localWorkspaceSaveMarker
 

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -21,11 +21,12 @@ func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
 	// goroutines are in flight with no ordering, and an older one (started before
 	// a later delete's store.Delete completed) would otherwise overwrite a.projects
 	// and resurrect the deleted workspace. Zero-token messages apply (back-compat).
-	if msg.LoadToken != 0 && msg.LoadToken < a.lastAppliedProjectsLoadToken {
+	loadToken := projectsLoadToken(msg.LoadToken)
+	if loadToken != 0 && loadToken < a.lastAppliedProjectsLoadToken {
 		return nil
 	}
-	if msg.LoadToken > a.lastAppliedProjectsLoadToken {
-		a.lastAppliedProjectsLoadToken = msg.LoadToken
+	if loadToken > a.lastAppliedProjectsLoadToken {
+		a.lastAppliedProjectsLoadToken = loadToken
 	}
 	a.projects = msg.Projects
 	a.projectsLoaded = true

--- a/internal/app/app_persistence.go
+++ b/internal/app/app_persistence.go
@@ -47,7 +47,7 @@ func (a *App) persistAllWorkspacesNow() {
 
 // persistDebounceMsg is sent after the debounce period to trigger actual save.
 type persistDebounceMsg struct {
-	token int
+	token persistToken
 }
 
 // persistWorkspaceTabs marks a workspace dirty and schedules a debounced save.

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -15,11 +15,11 @@ import (
 )
 
 type tmuxActivityTick struct {
-	Token int
+	Token activityScanToken
 }
 
 type tmuxActivityResult struct {
-	Token              int
+	Token              activityScanToken
 	ActiveWorkspaceIDs map[string]bool
 	UpdatedStates      map[string]*activity.SessionState // Updated hysteresis states to merge
 	RemovedStates      []string                          // Session states pruned this scan (delete on merge)
@@ -126,7 +126,7 @@ func (a *App) handleTmuxActivityTick(msg tmuxActivityTick) []tea.Cmd {
 }
 
 func (a *App) runTmuxActivityScan(
-	scanToken int,
+	scanToken activityScanToken,
 	infoBySession map[string]activity.SessionInfo,
 	statesSnapshot map[string]*activity.SessionState,
 	opts tmux.Options,

--- a/internal/app/app_tmux_activity_state.go
+++ b/internal/app/app_tmux_activity_state.go
@@ -10,7 +10,7 @@ type tmuxActivityState struct {
 	// syncToken dedups tmux session-reconcile ticker generations (TmuxSyncTick).
 	syncToken int
 	// token dedups activity ticker generations (tmuxActivityTick).
-	token int
+	token activityScanToken
 	// scanInFlight and rescanPending coalesce overlapping scan requests: a
 	// request that arrives mid-scan marks rescanPending instead of spawning a
 	// second scan.

--- a/internal/app/app_tokens.go
+++ b/internal/app/app_tokens.go
@@ -1,0 +1,18 @@
+package app
+
+// Distinct types for the App's dedup/generation counters, so the compiler
+// rejects cross-assignment between unrelated token streams (e.g. comparing an
+// activity-scan token against a persist token). Each token increments when a
+// new generation is issued; handlers drop messages carrying a stale token.
+
+// activityScanToken identifies a tmux activity ticker/scan generation.
+type activityScanToken int
+
+// projectsLoadToken identifies a projects-load generation; out-of-order
+// reloads are dropped by comparing against the last applied token. The token
+// crosses the messages package boundary as a plain int
+// (messages.ProjectsLoaded.LoadToken).
+type projectsLoadToken int
+
+// persistToken identifies a workspace-persist debounce generation.
+type persistToken int

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -14,10 +14,10 @@ import (
 )
 
 // LoadProjects loads all registered projects and their workspaces.
-func (s *workspaceService) LoadProjects(loadToken int) tea.Cmd {
+func (s *workspaceService) LoadProjects(loadToken projectsLoadToken) tea.Cmd {
 	return func() tea.Msg {
 		if s == nil || s.registry == nil {
-			return messages.ProjectsLoaded{LoadToken: loadToken}
+			return messages.ProjectsLoaded{LoadToken: int(loadToken)}
 		}
 		paths, err := s.registry.Projects()
 		if err != nil {
@@ -101,7 +101,7 @@ func (s *workspaceService) LoadProjects(loadToken int) tea.Cmd {
 			projects = append(projects, *project)
 		}
 
-		return messages.ProjectsLoaded{Projects: projects, LoadToken: loadToken}
+		return messages.ProjectsLoaded{Projects: projects, LoadToken: int(loadToken)}
 	}
 }
 


### PR DESCRIPTION
Distinct activityScanToken / projectsLoadToken / persistToken types so
the compiler rejects cross-assignment between unrelated generation
counters. messages.ProjectsLoaded keeps a plain int at the package
boundary with explicit conversions.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **C2**, 9/36). Stacked on `rp/c1-tmux-activity-state`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.