### PR TITLE
E1: Extract shared ptyio.State for the center/sidebar PTY stacks

### DIFF
--- a/internal/ui/center/model_activity_test.go
+++ b/internal/ui/center/model_activity_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -122,10 +123,12 @@ func TestIsTabActiveUsesVisibleOutputOnly(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws,
-		Running:           true,
-		lastOutputAt:      now.Add(-1 * time.Second),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: now.Add(-1 * time.Second),
+		},
 		lastVisibleOutput: time.Time{},
 	}
 	if m.IsTabActive(tab) {
@@ -137,10 +140,12 @@ func TestIsTabActiveIgnoresBufferedOutputWithoutVisibleDelta(t *testing.T) {
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws,
-		Running:           true,
-		pendingOutput:     []byte("buffered"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 		lastVisibleOutput: time.Time{},
 	}
 	if m.IsTabActive(tab) {

--- a/internal/ui/center/model_activity_test.go
+++ b/internal/ui/center/model_activity_test.go
@@ -1,12 +1,12 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func newTestModel() *Model {

--- a/internal/ui/center/model_actor_ready_test.go
+++ b/internal/ui/center/model_actor_ready_test.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"context"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -33,14 +34,16 @@ func TestUpdatePTYFlush_StaleActorHeartbeatForcesParserResetFallback(t *testing.
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                 TabID("tab-1"),
-		Assistant:          "codex",
-		Workspace:          ws,
-		Terminal:           vterm.New(80, 24),
-		Running:            true,
-		pendingOutput:      []byte("visible"),
-		lastOutputAt:       time.Now().Add(-time.Second),
-		flushPendingSince:  time.Now().Add(-time.Second),
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput:     []byte("visible"),
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+		},
 		parserResetPending: true,
 		actorWritesPending: 1,
 	}
@@ -56,10 +59,10 @@ func TestUpdatePTYFlush_StaleActorHeartbeatForcesParserResetFallback(t *testing.
 	if tab.actorWritesPending != 0 {
 		t.Fatalf("expected stale actor flush to clear actorWritesPending, got %d", tab.actorWritesPending)
 	}
-	if len(tab.pendingOutput) == 0 {
+	if len(tab.PendingOutput) == 0 {
 		t.Fatal("expected pending output to remain queued for the follow-up flush")
 	}
-	if !tab.flushScheduled {
+	if !tab.FlushScheduled {
 		t.Fatal("expected follow-up flush to be scheduled after stale actor fallback")
 	}
 }

--- a/internal/ui/center/model_actor_ready_test.go
+++ b/internal/ui/center/model_actor_ready_test.go
@@ -2,10 +2,11 @@ package center
 
 import (
 	"context"
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 
 	tea "charm.land/bubbletea/v2"
 

--- a/internal/ui/center/model_cursor_refresh.go
+++ b/internal/ui/center/model_cursor_refresh.go
@@ -33,7 +33,7 @@ func nextChatCursorRefreshDelayLocked(tab *Tab, now time.Time) (time.Duration, b
 		}
 	}
 	if isTabCursorOutputActiveLocked(tab, now) {
-		if remaining := tabActiveWindow - now.Sub(tab.lastOutputAt); remaining > 0 &&
+		if remaining := tabActiveWindow - now.Sub(tab.LastOutputAt); remaining > 0 &&
 			(!pending || remaining < delay) {
 			delay = remaining
 			pending = true
@@ -47,9 +47,9 @@ func invalidateCursorSnapshotCacheLocked(tab *Tab) {
 	if tab == nil {
 		return
 	}
-	tab.cachedSnap = nil
-	tab.cachedVersion = 0
-	tab.cachedShowCursor = false
+	tab.CachedSnap = nil
+	tab.CachedVersion = 0
+	tab.CachedShowCursor = false
 	tab.cachedRecentLocalInput = false
 	tab.cachedRestrictCursor = false
 }
@@ -68,7 +68,7 @@ func resetChatCursorActivityStateLocked(tab *Tab) {
 	tab.stableCursorVersion = 0
 	tab.lastRestrictedVersion = 0
 	tab.pendingIdleCursorRelearn = false
-	tab.lastOutputAt = time.Time{}
+	tab.LastOutputAt = time.Time{}
 	tab.lastUserInputAt = time.Time{}
 	tab.lastPromptInputAt = time.Time{}
 	tab.lastPromptSubmitAt = time.Time{}

--- a/internal/ui/center/model_cursor_refresh_test.go
+++ b/internal/ui/center/model_cursor_refresh_test.go
@@ -1,11 +1,11 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_cursor_refresh_test.go
+++ b/internal/ui/center/model_cursor_refresh_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -20,7 +21,9 @@ func TestUpdatePTYCursorRefresh_SchedulesWhileCursorTimersPending(t *testing.T) 
 		Running:           true,
 		lastVisibleOutput: time.Now(),
 		lastPromptInputAt: time.Now(),
-		cachedSnap:        &compositor.VTermSnapshot{},
+		State: ptyio.State{
+			CachedSnap: &compositor.VTermSnapshot{},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -28,7 +31,7 @@ func TestUpdatePTYCursorRefresh_SchedulesWhileCursorTimersPending(t *testing.T) 
 	if cmd == nil {
 		t.Fatal("expected cursor refresh tick to be scheduled while cursor timers are pending")
 	}
-	if tab.cachedSnap != nil {
+	if tab.CachedSnap != nil {
 		t.Fatal("expected cursor refresh to invalidate cached snapshot")
 	}
 	if tab.cursorRefreshGen == 0 {
@@ -85,7 +88,9 @@ func TestUpdatePTYCursorRefresh_RequestPreservesPendingTimer(t *testing.T) {
 		Terminal:          vterm.New(80, 24),
 		Running:           true,
 		lastVisibleOutput: now,
-		cachedSnap:        &compositor.VTermSnapshot{},
+		State: ptyio.State{
+			CachedSnap: &compositor.VTermSnapshot{},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -100,7 +105,7 @@ func TestUpdatePTYCursorRefresh_RequestPreservesPendingTimer(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected refresh request to reuse the existing pending timer")
 	}
-	if tab.cachedSnap != nil {
+	if tab.CachedSnap != nil {
 		t.Fatal("expected refresh request to invalidate cached snapshot")
 	}
 	if tab.cursorRefreshGen != firstGen {
@@ -119,11 +124,13 @@ func TestUpdatePTYCursorRefresh_InvalidatesCachedSnapshotForNonChatTabs(t *testi
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:         TabID("tab-cursor-refresh-non-chat"),
-		Assistant:  "bash",
-		Workspace:  ws,
-		Terminal:   vterm.New(80, 24),
-		cachedSnap: &compositor.VTermSnapshot{},
+		ID:        TabID("tab-cursor-refresh-non-chat"),
+		Assistant: "bash",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		State: ptyio.State{
+			CachedSnap: &compositor.VTermSnapshot{},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -131,7 +138,7 @@ func TestUpdatePTYCursorRefresh_InvalidatesCachedSnapshotForNonChatTabs(t *testi
 	if cmd != nil {
 		t.Fatal("expected non-chat cursor refresh not to schedule chat timers")
 	}
-	if tab.cachedSnap != nil {
+	if tab.CachedSnap != nil {
 		t.Fatal("expected non-chat cursor refresh to invalidate cached snapshot")
 	}
 }

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -112,7 +112,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 			// The tmux snapshot is now the source of truth for the restored frame.
 			// Any preserved local PTY backlog may already be represented there and
 			// would duplicate on the next flush if we kept it alive.
-			tab.pendingOutput = nil
+			tab.PendingOutput = nil
 			ptyio.RestorePaneCapture(
 				tab.Terminal,
 				msg.ScrollbackCapture,

--- a/internal/ui/center/model_input_lifecycle_flush_test.go
+++ b/internal/ui/center/model_input_lifecycle_flush_test.go
@@ -2,10 +2,10 @@ package center
 
 import (
 	"bytes"
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_input_lifecycle_flush_test.go
+++ b/internal/ui/center/model_input_lifecycle_flush_test.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"bytes"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -13,13 +14,15 @@ func TestUpdatePTYFlush_UsesLargerChunkForActiveTab(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-active"),
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastOutputAt:      time.Now().Add(-time.Second),
-		flushPendingSince: time.Now().Add(-time.Second),
-		pendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17),
+		ID:        TabID("tab-active"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -27,7 +30,7 @@ func TestUpdatePTYFlush_UsesLargerChunkForActiveTab(t *testing.T) {
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
-	if got, want := len(tab.pendingOutput), 17; got != want {
+	if got, want := len(tab.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d", got, want)
 	}
 }
@@ -37,13 +40,15 @@ func TestUpdatePTYFlush_CatchUpWithoutActorKeepsActiveChunkCap(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17),
+		ID:        TabID("tab-active-catch-up"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   ptyFlushChunkSizeActive + 17,
 		ptyBytesReceived:     ptyFlushChunkSizeActive + 17,
@@ -54,7 +59,7 @@ func TestUpdatePTYFlush_CatchUpWithoutActorKeepsActiveChunkCap(t *testing.T) {
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
 
-	if got, want := len(tab.pendingOutput), 17; got != want {
+	if got, want := len(tab.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d after synchronous catch-up flush", got, want)
 	}
 }
@@ -68,13 +73,15 @@ func TestUpdatePTYFlush_FastForwardsCatchUpActiveTabViaActor(t *testing.T) {
 	wsID := string(ws.ID())
 	payload := bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17)
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up-actor"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        append([]byte(nil), payload...),
+		ID:        TabID("tab-active-catch-up-actor"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     append([]byte(nil), payload...),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
@@ -100,7 +107,7 @@ func TestUpdatePTYFlush_FastForwardsCatchUpActiveTabViaActor(t *testing.T) {
 		t.Fatalf("expected actor-backed catch-up flush to queue a write event")
 	}
 
-	if got := len(tab.pendingOutput); got != 0 {
+	if got := len(tab.PendingOutput); got != 0 {
 		t.Fatalf("pending output = %d, want 0 after actor catch-up flush", got)
 	}
 }
@@ -114,13 +121,15 @@ func TestUpdatePTYFlush_CatchUpUsesBoundedActorChunk(t *testing.T) {
 	wsID := string(ws.ID())
 	payload := bytes.Repeat([]byte("x"), ptyFlushChunkSizeCatchUp+17)
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up-bounded"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        append([]byte(nil), payload...),
+		ID:        TabID("tab-active-catch-up-bounded"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     append([]byte(nil), payload...),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
@@ -146,7 +155,7 @@ func TestUpdatePTYFlush_CatchUpUsesBoundedActorChunk(t *testing.T) {
 		t.Fatalf("expected bounded catch-up flush to queue a write event")
 	}
 
-	if got, want := len(tab.pendingOutput), 17; got != want {
+	if got, want := len(tab.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d after bounded actor catch-up flush", got, want)
 	}
 }
@@ -160,13 +169,15 @@ func TestUpdatePTYFlush_PendingCatchUpOverridesStaleFlushMessage(t *testing.T) {
 	wsID := string(ws.ID())
 	payload := bytes.Repeat([]byte("x"), ptyFlushChunkSizeCatchUp+17)
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up-stale-flush"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        append([]byte(nil), payload...),
+		ID:        TabID("tab-active-catch-up-stale-flush"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     append([]byte(nil), payload...),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
@@ -189,7 +200,7 @@ func TestUpdatePTYFlush_PendingCatchUpOverridesStaleFlushMessage(t *testing.T) {
 		t.Fatalf("expected stale flush message to honor latched catch-up state")
 	}
 
-	if got, want := len(tab.pendingOutput), 17; got != want {
+	if got, want := len(tab.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d after latched catch-up flush", got, want)
 	}
 }
@@ -202,12 +213,14 @@ func TestUpdatePTYFlush_StaleCatchUpMessageDoesNotRelatchAfterBacklogDrains(t *t
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-active-catch-up-stale-relatch"),
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastOutputAt:      time.Now().Add(-time.Second),
-		flushPendingSince: time.Now().Add(-time.Second),
+		ID:        TabID("tab-active-catch-up-stale-relatch"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -218,9 +231,9 @@ func TestUpdatePTYFlush_StaleCatchUpMessageDoesNotRelatchAfterBacklogDrains(t *t
 		t.Fatalf("expected stale catch-up message with empty backlog not to relatch catch-up state")
 	}
 
-	tab.pendingOutput = bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17)
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = time.Now().Add(-time.Second)
+	tab.PendingOutput = bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17)
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = time.Now().Add(-time.Second)
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
@@ -245,13 +258,15 @@ func TestUpdatePTYFlush_UsesBaseChunkForInactiveTab(t *testing.T) {
 		Running:   true,
 	}
 	inactive := &Tab{
-		ID:                TabID("tab-inactive"),
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastOutputAt:      time.Now().Add(-time.Second),
-		flushPendingSince: time.Now().Add(-time.Second),
-		pendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSize+17),
+		ID:        TabID("tab-inactive"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSize+17),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{active, inactive}
 	m.activeTabByWorkspace[wsID] = 0
@@ -259,7 +274,7 @@ func TestUpdatePTYFlush_UsesBaseChunkForInactiveTab(t *testing.T) {
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: inactive.ID})
 
-	if got, want := len(inactive.pendingOutput), 17; got != want {
+	if got, want := len(inactive.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d", got, want)
 	}
 }
@@ -275,13 +290,15 @@ func TestUpdatePTYFlush_CatchUpHintIgnoredWhenTabIsNoLongerActive(t *testing.T) 
 		Running:   true,
 	}
 	inactive := &Tab{
-		ID:                   TabID("tab-inactive-catch-up"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        bytes.Repeat([]byte("x"), ptyFlushChunkSize+17),
+		ID:        TabID("tab-inactive-catch-up"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSize+17),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   ptyFlushChunkSize + 17,
 		ptyBytesReceived:     ptyFlushChunkSize + 17,
@@ -292,7 +309,7 @@ func TestUpdatePTYFlush_CatchUpHintIgnoredWhenTabIsNoLongerActive(t *testing.T) 
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: inactive.ID})
 
-	if got, want := len(inactive.pendingOutput), 17; got != want {
+	if got, want := len(inactive.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d when catch-up tab is inactive", got, want)
 	}
 	if inactive.catchUpPendingOutput {
@@ -310,13 +327,15 @@ func TestUpdatePTYFlush_CatchUpFallsBackToActiveChunkWhenActorQueueIsFull(t *tes
 	wsID := string(ws.ID())
 	payload := bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17)
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up-queue-full"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        append([]byte(nil), payload...),
+		ID:        TabID("tab-active-catch-up-queue-full"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     append([]byte(nil), payload...),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
@@ -327,13 +346,13 @@ func TestUpdatePTYFlush_CatchUpFallsBackToActiveChunkWhenActorQueueIsFull(t *tes
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
 
-	if got, want := len(tab.pendingOutput), 17; got != want {
+	if got, want := len(tab.PendingOutput), 17; got != want {
 		t.Fatalf("pending output = %d, want %d after queue-full catch-up fallback", got, want)
 	}
 	if tab.actorWritesPending != 0 {
 		t.Fatalf("expected no actor writes pending after queue-full catch-up fallback, got %d", tab.actorWritesPending)
 	}
-	if !tab.flushScheduled {
+	if !tab.FlushScheduled {
 		t.Fatalf("expected queue-full catch-up fallback to schedule another flush")
 	}
 	if !tab.catchUpPendingOutput {
@@ -354,13 +373,15 @@ func TestUpdatePTYFlush_CatchUpClearsAfterInitialBacklogPass(t *testing.T) {
 	initialBacklog := bytes.Repeat([]byte("x"), ptyFlushChunkSizeCatchUp)
 	steadyState := bytes.Repeat([]byte("y"), ptyFlushChunkSizeActive+17)
 	tab := &Tab{
-		ID:                   TabID("tab-active-catch-up-clears"),
-		Workspace:            ws,
-		Terminal:             vterm.New(80, 24),
-		Running:              true,
-		lastOutputAt:         time.Now().Add(-time.Second),
-		flushPendingSince:    time.Now().Add(-time.Second),
-		pendingOutput:        append(append([]byte(nil), initialBacklog...), steadyState...),
+		ID:        TabID("tab-active-catch-up-clears"),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      time.Now().Add(-time.Second),
+			FlushPendingSince: time.Now().Add(-time.Second),
+			PendingOutput:     append(append([]byte(nil), initialBacklog...), steadyState...),
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   uint64(len(initialBacklog)),
 		ptyBytesReceived:     uint64(len(initialBacklog) + len(steadyState)),

--- a/internal/ui/center/model_input_lifecycle_pane_capture_test.go
+++ b/internal/ui/center/model_input_lifecycle_pane_capture_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"strings"
 	"testing"
 
@@ -67,13 +68,15 @@ func TestUpdatePtyTabReattachResult_LoadsPaneCaptureIntoVisibleScreen(t *testing
 	term := vterm.New(20, 2)
 	term.LoadPaneCapture([]byte("old history\nstale one\nstale two\n"))
 	tab := &Tab{
-		ID:            TabID("tab-reattach-pane-capture"),
-		Assistant:     "codex",
-		Workspace:     ws,
-		Terminal:      term,
-		pendingOutput: []byte("buffered"),
+		ID:        TabID("tab-reattach-pane-capture"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 	}
-	tab.pendingOutputBytes = len(tab.pendingOutput)
+	tab.pendingOutputBytes = len(tab.PendingOutput)
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
@@ -101,8 +104,8 @@ func TestUpdatePtyTabReattachResult_LoadsPaneCaptureIntoVisibleScreen(t *testing
 	if got := tab.Terminal.Screen[1][0].Rune; got != 's' {
 		t.Fatalf("expected second visible row to start with screen data, got %q", got)
 	}
-	if len(tab.pendingOutput) != 0 || tab.pendingOutputBytes != 0 {
-		t.Fatalf("expected full-pane restore to clear preserved PTY backlog, got %q (%d bytes)", tab.pendingOutput, tab.pendingOutputBytes)
+	if len(tab.PendingOutput) != 0 || tab.pendingOutputBytes != 0 {
+		t.Fatalf("expected full-pane restore to clear preserved PTY backlog, got %q (%d bytes)", tab.PendingOutput, tab.pendingOutputBytes)
 	}
 }
 
@@ -187,13 +190,15 @@ func TestUpdatePtyTabReattachResult_NonAuthoritativeEmptyCapturePreservesExistin
 	term := vterm.New(20, 2)
 	term.LoadPaneCapture([]byte("old history\nstale one\nstale two\n"))
 	tab := &Tab{
-		ID:            TabID("tab-reattach-snapshot-fallback"),
-		Assistant:     "codex",
-		Workspace:     ws,
-		Terminal:      term,
-		pendingOutput: []byte("buffered"),
+		ID:        TabID("tab-reattach-snapshot-fallback"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 	}
-	tab.pendingOutputBytes = len(tab.pendingOutput)
+	tab.pendingOutputBytes = len(tab.PendingOutput)
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
@@ -216,8 +221,8 @@ func TestUpdatePtyTabReattachResult_NonAuthoritativeEmptyCapturePreservesExistin
 	if got := tab.Terminal.Screen[0][0].Rune; got != 's' {
 		t.Fatalf("expected existing visible frame to remain untouched, got %q", got)
 	}
-	if len(tab.pendingOutput) != len([]byte("buffered")) || tab.pendingOutputBytes != len([]byte("buffered")) {
-		t.Fatalf("expected non-authoritative fallback to preserve PTY backlog, got %q (%d bytes)", tab.pendingOutput, tab.pendingOutputBytes)
+	if len(tab.PendingOutput) != len([]byte("buffered")) || tab.pendingOutputBytes != len([]byte("buffered")) {
+		t.Fatalf("expected non-authoritative fallback to preserve PTY backlog, got %q (%d bytes)", tab.PendingOutput, tab.pendingOutputBytes)
 	}
 }
 
@@ -340,15 +345,17 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 	tabID := TabID("tab-existing-pane-capture")
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
-			ID:            tabID,
-			Name:          "codex",
-			Assistant:     "codex",
-			Workspace:     ws,
-			Terminal:      term,
-			pendingOutput: []byte("buffered"),
+			ID:        tabID,
+			Name:      "codex",
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			State: ptyio.State{
+				PendingOutput: []byte("buffered"),
+			},
 		},
 	}
-	m.tabsByWorkspace[wsID][0].pendingOutputBytes = len(m.tabsByWorkspace[wsID][0].pendingOutput)
+	m.tabsByWorkspace[wsID][0].pendingOutputBytes = len(m.tabsByWorkspace[wsID][0].PendingOutput)
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace:         ws,
@@ -378,8 +385,8 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 	if got := tab.Terminal.Screen[1][0].Rune; got != 's' {
 		t.Fatalf("expected second visible row to start with screen data, got %q", got)
 	}
-	if len(tab.pendingOutput) != 0 || tab.pendingOutputBytes != 0 {
-		t.Fatalf("expected full-pane restore to clear preserved PTY backlog, got %q (%d bytes)", tab.pendingOutput, tab.pendingOutputBytes)
+	if len(tab.PendingOutput) != 0 || tab.pendingOutputBytes != 0 {
+		t.Fatalf("expected full-pane restore to clear preserved PTY backlog, got %q (%d bytes)", tab.PendingOutput, tab.pendingOutputBytes)
 	}
 }
 

--- a/internal/ui/center/model_input_lifecycle_pane_capture_test.go
+++ b/internal/ui/center/model_input_lifecycle_pane_capture_test.go
@@ -1,9 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"strings"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/vterm"

--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -22,12 +22,12 @@ const overflowLogThrottle = 2 * time.Second
 // lock). It returns the aggregated dropped-byte total to report when logNow is
 // true. The caller must hold tab.mu.
 func (t *Tab) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
-	t.overflowDroppedSinceLog += droppedBytes
+	t.OverflowDroppedSinceLog += droppedBytes
 	now := time.Now()
-	if t.lastOverflowLogAt.IsZero() || now.Sub(t.lastOverflowLogAt) >= overflowLogThrottle {
-		total = t.overflowDroppedSinceLog
-		t.overflowDroppedSinceLog = 0
-		t.lastOverflowLogAt = now
+	if t.LastOverflowLogAt.IsZero() || now.Sub(t.LastOverflowLogAt) >= overflowLogThrottle {
+		total = t.OverflowDroppedSinceLog
+		t.OverflowDroppedSinceLog = 0
+		t.LastOverflowLogAt = now
 		return true, total
 	}
 	return false, 0
@@ -41,26 +41,26 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 		m.tracePTYOutput(tab, msg.Data)
 		data := msg.Data
 		tab.mu.Lock()
-		if tab.overflowTrimCarry != (vterm.ParserCarryState{}) {
-			data, tab.overflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, tab.overflowTrimCarry)
+		if tab.OverflowTrimCarry != (vterm.ParserCarryState{}) {
+			data, tab.OverflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, tab.OverflowTrimCarry)
 			tab.activityANSIState = ansiActivityText
 		}
 		tab.mu.Unlock()
-		prevPendingLen := len(tab.pendingOutput)
+		prevPendingLen := len(tab.PendingOutput)
 		activityData := data
 		activityState := ansiActivityText
 		activityStateSet := false
-		tab.pendingOutput = append(tab.pendingOutput, data...)
+		tab.PendingOutput = append(tab.PendingOutput, data...)
 		tab.mu.Lock()
-		tab.pendingOutputBytes = len(tab.pendingOutput)
+		tab.pendingOutputBytes = len(tab.PendingOutput)
 		tab.ptyBytesReceived += uint64(len(data))
 		tab.mu.Unlock()
-		if len(tab.pendingOutput) > ptyMaxBufferedBytes {
-			overflow := len(tab.pendingOutput) - ptyMaxBufferedBytes
+		if len(tab.PendingOutput) > ptyMaxBufferedBytes {
+			overflow := len(tab.PendingOutput) - ptyMaxBufferedBytes
 			perf.Count("pty_output_drop_bytes", int64(overflow))
 			perf.Count("pty_output_drop", 1)
 			seed := vterm.ParserCarryState{}
-			combinedLen := len(tab.pendingOutput)
+			combinedLen := len(tab.PendingOutput)
 			resetNow := false
 			if m.isTabActorReady() {
 				tab.mu.Lock()
@@ -91,7 +91,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 						tab.parserResetPending = false
 						tab.actorQueuedCarry = vterm.ParserCarryState{}
 						tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
-						tab.ptyNoiseTrailing = nil
+						tab.NoiseTrailing = nil
 					} else {
 						seed = tab.Terminal.ParserCarryState()
 					}
@@ -100,7 +100,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				}
 				tab.mu.Unlock()
 			}
-			retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(tab.pendingOutput, overflow, seed)
+			retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(tab.PendingOutput, overflow, seed)
 			retainedStart := combinedLen - len(retained)
 			chunkStart := prevPendingLen
 			if retainedStart > chunkStart {
@@ -111,7 +111,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 					activityData = data[dropFromMsg:]
 				}
 			}
-			tab.pendingOutput = append([]byte(nil), retained...)
+			tab.PendingOutput = append([]byte(nil), retained...)
 			activityPrefixLen := len(retained) - len(activityData)
 			if activityPrefixLen < 0 {
 				activityPrefixLen = 0
@@ -119,11 +119,11 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 			_, activityState = hasVisiblePTYOutput(retained[:activityPrefixLen], ansiActivityText)
 			activityStateSet = true
 			tab.mu.Lock()
-			tab.pendingOutputBytes = len(tab.pendingOutput)
+			tab.pendingOutputBytes = len(tab.PendingOutput)
 			tab.settlePTYBytesLocked(overflow)
-			tab.overflowTrimCarry = overflowCarry
+			tab.OverflowTrimCarry = overflowCarry
 			if resetNow && retainedStart > chunkStart {
-				tab.ptyNoiseTrailing = nil
+				tab.NoiseTrailing = nil
 				tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
 			}
 			overflowLogNow, overflowDroppedTotal := tab.noteOverflowDropLocked(retainedStart)
@@ -134,7 +134,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 		}
 		perf.Count("pty_output_bytes", int64(len(msg.Data)))
 		now := time.Now()
-		tab.lastOutputAt = now
+		tab.LastOutputAt = now
 		if m.isChatTab(tab) {
 			tab.mu.Lock()
 			if tab.bootstrapActivity &&
@@ -155,9 +155,9 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				tab.mu.Unlock()
 			}
 		}
-		if !tab.flushScheduled {
-			tab.flushScheduled = true
-			tab.flushPendingSince = tab.lastOutputAt
+		if !tab.FlushScheduled {
+			tab.FlushScheduled = true
+			tab.FlushPendingSince = tab.LastOutputAt
 			quiet, _ := m.flushTiming(tab, m.isActiveTab(msg.WorkspaceID, msg.TabID))
 			tabID := msg.TabID // Capture for closure
 			cmds = append(cmds, common.SafeTick(quiet, func(t time.Time) tea.Msg {
@@ -183,10 +183,10 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 		catchUp := isActive && tab.catchUpActiveLocked()
 		tab.mu.Unlock()
 		now := time.Now()
-		quietFor := now.Sub(tab.lastOutputAt)
+		quietFor := now.Sub(tab.LastOutputAt)
 		pendingFor := time.Duration(0)
-		if !tab.flushPendingSince.IsZero() {
-			pendingFor = now.Sub(tab.flushPendingSince)
+		if !tab.FlushPendingSince.IsZero() {
+			pendingFor = now.Sub(tab.FlushPendingSince)
 		}
 		quiet, maxInterval := m.flushTiming(tab, isActive)
 		if quietFor < quiet && pendingFor < maxInterval {
@@ -195,16 +195,16 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 				delay = time.Millisecond
 			}
 			tabID := msg.TabID
-			tab.flushScheduled = true
+			tab.FlushScheduled = true
 			cmds = append(cmds, common.SafeTick(delay, func(t time.Time) tea.Msg {
 				return PTYFlush{WorkspaceID: msg.WorkspaceID, TabID: tabID, CatchUp: catchUp}
 			}))
 			return common.SafeBatch(cmds...)
 		}
 
-		tab.flushScheduled = false
-		tab.flushPendingSince = time.Time{}
-		if len(tab.pendingOutput) > 0 {
+		tab.FlushScheduled = false
+		tab.FlushPendingSince = time.Time{}
+		if len(tab.PendingOutput) > 0 {
 			var chunk []byte
 			writeOutput := false
 			hasMoreBuffered := false
@@ -215,7 +215,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 			if tab.Terminal != nil {
 				parserResetPending = tab.parserResetPending
 				actorWritesPending = tab.actorWritesPending
-				chunkSize := len(tab.pendingOutput)
+				chunkSize := len(tab.PendingOutput)
 				maxChunk := ptyFlushChunkSize
 				if isActive {
 					maxChunk = ptyFlushChunkSizeActive
@@ -229,11 +229,11 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 					chunkSize = maxChunk
 				}
 				if !parserResetPending && chunkSize > 0 {
-					chunk = append(chunk, tab.pendingOutput[:chunkSize]...)
-					copy(tab.pendingOutput, tab.pendingOutput[chunkSize:])
-					tab.pendingOutput = tab.pendingOutput[:len(tab.pendingOutput)-chunkSize]
-					tab.pendingOutputBytes = len(tab.pendingOutput)
-					hasMoreBuffered = len(tab.pendingOutput) > 0
+					chunk = append(chunk, tab.PendingOutput[:chunkSize]...)
+					copy(tab.PendingOutput, tab.PendingOutput[chunkSize:])
+					tab.PendingOutput = tab.PendingOutput[:len(tab.PendingOutput)-chunkSize]
+					tab.pendingOutputBytes = len(tab.PendingOutput)
+					hasMoreBuffered = len(tab.PendingOutput) > 0
 					visibleSeq = tab.pendingVisibleSeq
 					writeOutput = true
 				}
@@ -241,8 +241,8 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 			tab.mu.Unlock()
 			if parserResetPending {
 				if actorWritesPending > 0 && m.isTabActorReady() {
-					tab.flushScheduled = true
-					tab.flushPendingSince = time.Now()
+					tab.FlushScheduled = true
+					tab.FlushPendingSince = time.Now()
 					delay, _ := m.flushTiming(tab, m.isActiveTab(msg.WorkspaceID, msg.TabID))
 					if delay < time.Millisecond {
 						delay = time.Millisecond
@@ -259,7 +259,7 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 						tab.settlePTYBytesLocked(tab.actorQueuedBytes)
 						tab.actorQueuedBytes = 0
 						tab.actorWriteEpoch++
-						tab.ptyNoiseTrailing = nil
+						tab.NoiseTrailing = nil
 					}
 					tab.Terminal.ResetParserState()
 					tab.activityANSIState = ansiActivityText
@@ -276,14 +276,14 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 			tab.mu.Lock()
 			catchUpStillActive := tab.catchUpActiveLocked()
 			tab.mu.Unlock()
-			if len(tab.pendingOutput) == 0 {
-				tab.pendingOutput = tab.pendingOutput[:0]
+			if len(tab.PendingOutput) == 0 {
+				tab.PendingOutput = tab.PendingOutput[:0]
 				tab.mu.Lock()
 				tab.pendingOutputBytes = 0
 				tab.mu.Unlock()
 			} else {
-				tab.flushScheduled = true
-				tab.flushPendingSince = time.Now()
+				tab.FlushScheduled = true
+				tab.FlushPendingSince = time.Now()
 				tabID := msg.TabID
 				quietNext, _ := m.flushTiming(tab, isActive)
 				delay := quietNext
@@ -379,7 +379,7 @@ func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, 
 		filterApplied = true
 		if updateActorCarry {
 			tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
-			tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.ptyNoiseTrailing...)
+			tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.NoiseTrailing...)
 		}
 	}
 	tab.mu.Unlock()
@@ -402,7 +402,7 @@ func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, 
 // tab.Terminal != nil. It returns the filtered byte count, whether the
 // post-write redraw should be suppressed, and the activity tag to publish.
 func (m *Model) applyPTYChunkLocked(tab *Tab, chunk []byte, hasMoreBuffered bool, visibleSeq uint64) (filteredLen int, suppressRedraw bool, tagSessionName string, tagTimestamp int64) {
-	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &tab.ptyNoiseTrailing)
+	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &tab.NoiseTrailing)
 	filteredLen = len(filtered)
 	if len(filtered) > 0 {
 		flushDone := perf.Time("pty_flush")

--- a/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
@@ -2,9 +2,10 @@ package center
 
 import (
 	"bytes"
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/vterm"

--- a/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"bytes"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -22,7 +23,9 @@ func TestUpdatePTYFlush_StaleCatchUpMessageIgnoredAfterReattachReset(t *testing.
 		Workspace:            ws,
 		Terminal:             vterm.New(80, 24),
 		catchUpPendingOutput: true,
-		pendingOutput:        []byte("old buffered output"),
+		State: ptyio.State{
+			PendingOutput: []byte("old buffered output"),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -37,9 +40,9 @@ func TestUpdatePTYFlush_StaleCatchUpMessageIgnoredAfterReattachReset(t *testing.
 	})
 
 	payload := bytes.Repeat([]byte("x"), ptyFlushChunkSizeCatchUp+17)
-	tab.pendingOutput = append([]byte(nil), payload...)
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = time.Now().Add(-time.Second)
+	tab.PendingOutput = append([]byte(nil), payload...)
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = time.Now().Add(-time.Second)
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
 

--- a/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -49,14 +50,16 @@ func TestUpdatePtyTabReattachResult_ResetsStableCursor(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		stableCursorSet:   true,
-		stableCursorX:     7,
-		stableCursorY:     20,
-		lastOutputAt:      time.Now(),
+		ID:              TabID("tab-1"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        vterm.New(80, 24),
+		stableCursorSet: true,
+		stableCursorX:   7,
+		stableCursorY:   20,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastUserInputAt:   time.Now(),
 		lastPromptInputAt: time.Now(),
 		lastVisibleOutput: time.Now(),
@@ -86,7 +89,7 @@ func TestUpdatePtyTabReattachResult_ResetsStableCursor(t *testing.T) {
 	if !tab.lastVisibleOutput.IsZero() {
 		t.Fatal("expected visible-activity state to clear on reattach")
 	}
-	if !tab.lastOutputAt.IsZero() {
+	if !tab.LastOutputAt.IsZero() {
 		t.Fatal("expected recent output state to clear on reattach")
 	}
 }
@@ -98,11 +101,13 @@ func TestUpdatePtyTabReattachResult_PreservesParserCarryOnExistingTerminal(t *te
 	term := vterm.New(80, 24)
 	term.Write([]byte{0x1b})
 	tab := &Tab{
-		ID:            TabID("tab-reattach-carry"),
-		Assistant:     "codex",
-		Workspace:     ws,
-		Terminal:      term,
-		pendingOutput: []byte("[31mHello"),
+		ID:        TabID("tab-reattach-carry"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		State: ptyio.State{
+			PendingOutput: []byte("[31mHello"),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -124,7 +129,7 @@ func TestUpdatePtyTabReattachResult_PreservesParserCarryOnExistingTerminal(t *te
 	if got := tab.actorQueuedCarry; got != (vterm.ParserCarryState{Mode: vterm.ParserCarryEscape}) {
 		t.Fatalf("expected actor queued carry to match preserved parser carry, got %+v", got)
 	}
-	if got := string(tab.pendingOutput); got != "[31mHello" {
+	if got := string(tab.PendingOutput); got != "[31mHello" {
 		t.Fatalf("expected buffered continuation bytes to survive reattach, got %q", got)
 	}
 }
@@ -139,7 +144,9 @@ func TestUpdatePtyTabReattachResult_ClearsCatchUpPendingOutput(t *testing.T) {
 		Workspace:            ws,
 		Terminal:             vterm.New(80, 24),
 		catchUpPendingOutput: true,
-		pendingOutput:        []byte("buffered"),
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -193,7 +200,9 @@ func TestHandlePtyTabCreated_ExistingClearsCatchUpPendingOutput(t *testing.T) {
 		Workspace:            ws,
 		Terminal:             vterm.New(80, 24),
 		catchUpPendingOutput: true,
-		pendingOutput:        []byte("buffered"),
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -219,11 +228,13 @@ func TestHandlePtyTabCreated_ExistingPreservesParserCarry(t *testing.T) {
 	term := vterm.New(80, 24)
 	term.Write([]byte{0x1b})
 	tab := &Tab{
-		ID:            TabID("tab-created-carry"),
-		Assistant:     "codex",
-		Workspace:     ws,
-		Terminal:      term,
-		pendingOutput: []byte("[31mHello"),
+		ID:        TabID("tab-created-carry"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		State: ptyio.State{
+			PendingOutput: []byte("[31mHello"),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -247,7 +258,7 @@ func TestHandlePtyTabCreated_ExistingPreservesParserCarry(t *testing.T) {
 	if got := tab.actorQueuedCarry; got != (vterm.ParserCarryState{Mode: vterm.ParserCarryEscape}) {
 		t.Fatalf("expected actor queued carry to match preserved parser carry, got %+v", got)
 	}
-	if got := string(tab.pendingOutput); got != "[31mHello" {
+	if got := string(tab.PendingOutput); got != "[31mHello" {
 		t.Fatalf("expected buffered continuation bytes to survive existing create path, got %q", got)
 	}
 }
@@ -287,14 +298,16 @@ func TestHandlePtyTabCreated_ExistingResetsStableCursor(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		stableCursorSet:   true,
-		stableCursorX:     7,
-		stableCursorY:     20,
-		lastOutputAt:      time.Now(),
+		ID:              TabID("tab-1"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        vterm.New(80, 24),
+		stableCursorSet: true,
+		stableCursorX:   7,
+		stableCursorY:   20,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastUserInputAt:   time.Now(),
 		lastPromptInputAt: time.Now(),
 		lastVisibleOutput: time.Now(),
@@ -326,7 +339,7 @@ func TestHandlePtyTabCreated_ExistingResetsStableCursor(t *testing.T) {
 	if !tab.lastVisibleOutput.IsZero() {
 		t.Fatal("expected visible-activity state to clear on existing tab create path")
 	}
-	if !tab.lastOutputAt.IsZero() {
+	if !tab.LastOutputAt.IsZero() {
 		t.Fatal("expected recent output state to clear on existing tab create path")
 	}
 }
@@ -340,7 +353,9 @@ func TestUpdatePTYStopped_ResetsActivityANSIState(t *testing.T) {
 		Assistant:         "codex",
 		Workspace:         ws,
 		activityANSIState: ansiActivityOSC,
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -352,8 +367,8 @@ func TestUpdatePTYStopped_ResetsActivityANSIState(t *testing.T) {
 	if tab.activityANSIState != ansiActivityText {
 		t.Fatalf("expected activityANSIState reset to text on PTY stop, got %v", tab.activityANSIState)
 	}
-	if tab.overflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
-		t.Fatalf("expected overflowTrimCarry preserved on PTY stop, got %+v", tab.overflowTrimCarry)
+	if tab.OverflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
+		t.Fatalf("expected overflowTrimCarry preserved on PTY stop, got %+v", tab.OverflowTrimCarry)
 	}
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -361,8 +376,8 @@ func TestUpdatePTYStopped_ResetsActivityANSIState(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("31mHello"),
 	})
-	if string(tab.pendingOutput) != "Hello" {
-		t.Fatalf("expected post-stop continuation to trim to visible text, got %q", tab.pendingOutput)
+	if string(tab.PendingOutput) != "Hello" {
+		t.Fatalf("expected post-stop continuation to trim to visible text, got %q", tab.PendingOutput)
 	}
 }
 
@@ -375,7 +390,9 @@ func TestUpdatePTYRestart_ResetsActivityANSIState(t *testing.T) {
 		Assistant:         "codex",
 		Workspace:         ws,
 		activityANSIState: ansiActivityCSI,
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -387,8 +404,8 @@ func TestUpdatePTYRestart_ResetsActivityANSIState(t *testing.T) {
 	if tab.activityANSIState != ansiActivityText {
 		t.Fatalf("expected activityANSIState reset to text on PTY restart, got %v", tab.activityANSIState)
 	}
-	if tab.overflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
-		t.Fatalf("expected overflowTrimCarry preserved on PTY restart, got %+v", tab.overflowTrimCarry)
+	if tab.OverflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
+		t.Fatalf("expected overflowTrimCarry preserved on PTY restart, got %+v", tab.OverflowTrimCarry)
 	}
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -396,8 +413,8 @@ func TestUpdatePTYRestart_ResetsActivityANSIState(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("31mHello"),
 	})
-	if string(tab.pendingOutput) != "Hello" {
-		t.Fatalf("expected post-restart continuation to trim to visible text, got %q", tab.pendingOutput)
+	if string(tab.PendingOutput) != "Hello" {
+		t.Fatalf("expected post-restart continuation to trim to visible text, got %q", tab.PendingOutput)
 	}
 }
 
@@ -406,10 +423,12 @@ func TestUpdatePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-da-stop"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		ID:        TabID("tab-da-stop"),
+		Assistant: "codex",
+		Workspace: ws,
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -420,8 +439,8 @@ func TestUpdatePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 		Data:        []byte("[>1;10;0cvisible"),
 	})
 
-	if string(tab.pendingOutput) != "visible" {
-		t.Fatalf("expected secondary DA continuation trimmed after stop, got %q", tab.pendingOutput)
+	if string(tab.PendingOutput) != "visible" {
+		t.Fatalf("expected secondary DA continuation trimmed after stop, got %q", tab.PendingOutput)
 	}
 }
 
@@ -430,10 +449,12 @@ func TestUpdatePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-da-restart"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		ID:        TabID("tab-da-restart"),
+		Assistant: "codex",
+		Workspace: ws,
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -444,7 +465,7 @@ func TestUpdatePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 		Data:        []byte("[>1;10;0cvisible"),
 	})
 
-	if string(tab.pendingOutput) != "visible" {
-		t.Fatalf("expected secondary DA continuation trimmed after restart, got %q", tab.pendingOutput)
+	if string(tab.PendingOutput) != "visible" {
+		t.Fatalf("expected secondary DA continuation trimmed after restart, got %q", tab.PendingOutput)
 	}
 }

--- a/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
@@ -1,12 +1,12 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/messages"
 	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -24,8 +24,8 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 		termAlive := tab.Agent != nil && tab.Agent.Terminal != nil && !tab.Agent.Terminal.IsClosed()
 		m.stopPTYReader(tab)
 		tab.mu.Lock()
-		if tab.Terminal != nil && len(tab.ptyNoiseTrailing) > 0 {
-			trailing := ptyio.DrainKnownPTYNoiseTrailing(&tab.ptyNoiseTrailing)
+		if tab.Terminal != nil && len(tab.NoiseTrailing) > 0 {
+			trailing := ptyio.DrainKnownPTYNoiseTrailing(&tab.NoiseTrailing)
 			flushDone := perf.Time("pty_flush")
 			tab.Terminal.Write(trailing)
 			flushDone()
@@ -47,18 +47,18 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			shouldRestart := true
 			var backoff time.Duration
 			tab.mu.Lock()
-			if tab.ptyRestartSince.IsZero() || time.Since(tab.ptyRestartSince) > ptyRestartWindow {
-				tab.ptyRestartSince = time.Now()
-				tab.ptyRestartCount = 0
+			if tab.RestartSince.IsZero() || time.Since(tab.RestartSince) > ptyRestartWindow {
+				tab.RestartSince = time.Now()
+				tab.RestartCount = 0
 			}
-			tab.ptyRestartCount++
-			if tab.ptyRestartCount > ptyRestartMax {
+			tab.RestartCount++
+			if tab.RestartCount > ptyRestartMax {
 				shouldRestart = false
 				tab.Running = false
 				tab.Detached = true
-				tab.ptyRestartBackoff = 0
+				tab.RestartBackoff = 0
 			} else {
-				backoff = tab.ptyRestartBackoff
+				backoff = tab.RestartBackoff
 				if backoff <= 0 {
 					backoff = 200 * time.Millisecond
 				} else {
@@ -67,7 +67,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 						backoff = 5 * time.Second
 					}
 				}
-				tab.ptyRestartBackoff = backoff
+				tab.RestartBackoff = backoff
 			}
 			tab.mu.Unlock()
 			if shouldRestart {
@@ -87,9 +87,9 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			tab.mu.Lock()
 			tab.Running = false
 			tab.Detached = true
-			tab.ptyRestartBackoff = 0
-			tab.ptyRestartCount = 0
-			tab.ptyRestartSince = time.Time{}
+			tab.RestartBackoff = 0
+			tab.RestartCount = 0
+			tab.RestartSince = time.Time{}
 			tab.mu.Unlock()
 			logging.Info("PTY stopped for tab %s, marking detached: %v", msg.TabID, msg.Err)
 			cmds = append(cmds, func() tea.Msg {
@@ -110,7 +110,7 @@ func (m *Model) updatePTYRestart(msg PTYRestart) tea.Cmd {
 	tab.resetActivityANSIState()
 	if tab.Agent == nil || tab.Agent.Terminal == nil || tab.Agent.Terminal.IsClosed() {
 		tab.mu.Lock()
-		tab.ptyRestartBackoff = 0
+		tab.RestartBackoff = 0
 		tab.mu.Unlock()
 		return nil
 	}

--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"bytes"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -179,11 +180,13 @@ func TestUpdatePTYOutput_ResetsActivityStateAfterOverflowCarryTrim(t *testing.T)
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Running:           true,
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		Running:   true,
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		},
 		activityANSIState: ansiActivityCSI,
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -195,11 +198,11 @@ func TestUpdatePTYOutput_ResetsActivityStateAfterOverflowCarryTrim(t *testing.T)
 		Data:        []byte("31mX"),
 	})
 
-	if string(tab.pendingOutput) != "X" {
-		t.Fatalf("expected overflow carry trim to retain visible suffix, got %q", tab.pendingOutput)
+	if string(tab.PendingOutput) != "X" {
+		t.Fatalf("expected overflow carry trim to retain visible suffix, got %q", tab.PendingOutput)
 	}
-	if tab.overflowTrimCarry != (vterm.ParserCarryState{}) {
-		t.Fatalf("expected overflow trim carry cleared, got %+v", tab.overflowTrimCarry)
+	if tab.OverflowTrimCarry != (vterm.ParserCarryState{}) {
+		t.Fatalf("expected overflow trim carry cleared, got %+v", tab.OverflowTrimCarry)
 	}
 	if tab.activityANSIState != ansiActivityText {
 		t.Fatalf("expected activity ANSI state reset to text, got %v", tab.activityANSIState)
@@ -240,8 +243,8 @@ func TestUpdatePTYOutput_EndsBootstrapAfterQuietGap(t *testing.T) {
 		t.Fatal("expected bootstrapActivity to end after quiet gap before new output")
 	}
 
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 	if tab.lastVisibleOutput.IsZero() {
@@ -272,8 +275,8 @@ func TestUpdatePTYFlush_TagsVisibleScreenDelta(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("visible output"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
@@ -288,8 +291,8 @@ func TestUpdatePTYFlush_TagsVisibleScreenDelta(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("\nmore visible output"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 	if tab.lastVisibleOutput.IsZero() {
 		t.Fatalf("expected second visible delta flush to set lastVisibleOutput")
@@ -323,8 +326,8 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("stable"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 	firstVisible := tab.lastVisibleOutput
@@ -341,8 +344,8 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("\rstable"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
@@ -365,12 +368,14 @@ func TestUpdatePTYFlush_RebuffersChunkAfterActorFallbackWithOlderPendingWrites(t
 	prevCarry := vterm.ParserCarryState{Mode: vterm.ParserCarryCSIParam}
 	chunk := []byte("1mX\nproc(1) malloc")
 	tab := &Tab{
-		ID:                       TabID("tab-1"),
-		Assistant:                "codex",
-		Workspace:                ws,
-		Terminal:                 vterm.New(80, 24),
-		Running:                  true,
-		pendingOutput:            append([]byte(nil), chunk...),
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput: append([]byte(nil), chunk...),
+		},
 		actorWritesPending:       1,
 		actorWriteEpoch:          11,
 		actorQueuedCarry:         prevCarry,
@@ -392,11 +397,11 @@ func TestUpdatePTYFlush_RebuffersChunkAfterActorFallbackWithOlderPendingWrites(t
 	if !bytes.Equal(tab.actorQueuedNoiseTrailing, prevNoiseTrailing) {
 		t.Fatalf("expected queued noise trailing restored to %q, got %q", prevNoiseTrailing, tab.actorQueuedNoiseTrailing)
 	}
-	if !bytes.Equal(tab.pendingOutput, chunk) {
-		t.Fatalf("expected chunk to be rebuffered for in-order retry, got %q", tab.pendingOutput)
+	if !bytes.Equal(tab.PendingOutput, chunk) {
+		t.Fatalf("expected chunk to be rebuffered for in-order retry, got %q", tab.PendingOutput)
 	}
-	if len(tab.ptyNoiseTrailing) != 0 {
-		t.Fatalf("expected no synchronous fallback write while older actor writes remain, got trailing %q", tab.ptyNoiseTrailing)
+	if len(tab.NoiseTrailing) != 0 {
+		t.Fatalf("expected no synchronous fallback write while older actor writes remain, got trailing %q", tab.NoiseTrailing)
 	}
 	if tab.Terminal.ParserCarryState() != (vterm.ParserCarryState{}) {
 		t.Fatalf("expected terminal parser state unchanged until actor backlog drains, got %+v", tab.Terminal.ParserCarryState())
@@ -425,8 +430,8 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("echoed input"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 	_ = m.updatePTYOutput(PTYOutput{
@@ -434,8 +439,8 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 		TabID:       tab.ID,
 		Data:        []byte("still echoed input"),
 	})
-	tab.lastOutputAt = time.Now().Add(-time.Second)
-	tab.flushPendingSince = tab.lastOutputAt
+	tab.LastOutputAt = time.Now().Add(-time.Second)
+	tab.FlushPendingSince = tab.LastOutputAt
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
 	if !tab.lastVisibleOutput.IsZero() {
@@ -463,12 +468,14 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 	original := append(append([]byte(nil), head...), tail...)
 
 	tab := &Tab{
-		ID:                 TabID("tab-order"),
-		Assistant:          "codex",
-		Workspace:          ws,
-		Terminal:           vterm.New(80, 24),
-		Running:            true,
-		pendingOutput:      append([]byte(nil), original...),
+		ID:        TabID("tab-order"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput: append([]byte(nil), original...),
+		},
 		pendingOutputBytes: len(original),
 		actorWritesPending: 1,
 		actorWriteEpoch:    11,
@@ -479,11 +486,11 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
-	if !bytes.Equal(tab.pendingOutput, original) {
+	if !bytes.Equal(tab.PendingOutput, original) {
 		t.Fatalf("rebuffer must restore original stream order (prepend); len=%d endsWithTail=%v",
-			len(tab.pendingOutput), bytes.HasSuffix(tab.pendingOutput, tail))
+			len(tab.PendingOutput), bytes.HasSuffix(tab.PendingOutput, tail))
 	}
-	if !bytes.HasSuffix(tab.pendingOutput, tail) {
+	if !bytes.HasSuffix(tab.PendingOutput, tail) {
 		t.Fatalf("tail no longer at the end — chunk was appended, reordering the stream")
 	}
 }

--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -2,10 +2,10 @@ package center
 
 import (
 	"bytes"
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_lifecycle.go
+++ b/internal/ui/center/model_lifecycle.go
@@ -168,9 +168,9 @@ func (m *Model) setActiveTerminalCursorVisibility(visible bool) {
 	}
 	// Invalidate cached snapshot so focus transitions cannot reuse stale
 	// cursor-painted frames.
-	tab.cachedSnap = nil
-	tab.cachedVersion = 0
-	tab.cachedShowCursor = false
+	tab.CachedSnap = nil
+	tab.CachedVersion = 0
+	tab.CachedShowCursor = false
 	tab.cachedRecentLocalInput = false
 	tab.cachedRestrictCursor = false
 }
@@ -207,7 +207,7 @@ func (m *Model) Close() {
 			tab.resetPTYStateLocked()
 			tab.DiffViewer = nil
 			tab.Terminal = nil
-			tab.cachedSnap = nil
+			tab.CachedSnap = nil
 			tab.Workspace = nil
 			tab.Running = false
 			tab.mu.Unlock()

--- a/internal/ui/center/model_overflow_log_test.go
+++ b/internal/ui/center/model_overflow_log_test.go
@@ -30,7 +30,7 @@ func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
 		t.Fatal("third drop within the throttle window should be suppressed")
 	}
 	// Simulate the throttle window elapsing.
-	tab.lastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
+	tab.LastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
 	logNow, total = tab.noteOverflowDropLocked(10)
 	if !logNow {
 		t.Fatal("a drop after the throttle window should log")

--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -21,38 +21,38 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 		return nil
 	}
 	tab.mu.Lock()
-	if tab.readerActive {
-		if tab.ptyMsgCh == nil || tab.readerCancel == nil {
-			tab.readerActive = false
+	if tab.ReaderActive {
+		if tab.MsgCh == nil || tab.ReaderCancel == nil {
+			tab.ReaderActive = false
 		} else {
 			tab.mu.Unlock()
 			return nil
 		}
 	}
 	if tab.Agent == nil || tab.Agent.Terminal == nil || tab.Agent.Terminal.IsClosed() {
-		tab.readerActive = false
+		tab.ReaderActive = false
 		tab.mu.Unlock()
 		return nil
 	}
-	tab.readerActive = true
-	tab.ptyRestartBackoff = 0
-	atomic.StoreInt64(&tab.ptyHeartbeat, time.Now().UnixNano())
+	tab.ReaderActive = true
+	tab.RestartBackoff = 0
+	atomic.StoreInt64(&tab.Heartbeat, time.Now().UnixNano())
 
-	if tab.readerCancel != nil {
-		close(tab.readerCancel)
+	if tab.ReaderCancel != nil {
+		close(tab.ReaderCancel)
 	}
-	tab.readerCancel = make(chan struct{})
-	tab.ptyMsgCh = make(chan tea.Msg, ptyReadQueueSize)
+	tab.ReaderCancel = make(chan struct{})
+	tab.MsgCh = make(chan tea.Msg, ptyReadQueueSize)
 
 	term := tab.Agent.Terminal
 	tabID := tab.ID
-	cancel := tab.readerCancel
-	msgCh := tab.ptyMsgCh
+	cancel := tab.ReaderCancel
+	msgCh := tab.MsgCh
 	tab.mu.Unlock()
 
 	safego.Go("center.pty_reader", func() {
 		defer m.markPTYReaderStopped(tab)
-		ptyio.RunPTYReader(term, msgCh, cancel, &tab.ptyHeartbeat, ptyio.PTYReaderConfig{
+		ptyio.RunPTYReader(term, msgCh, cancel, &tab.Heartbeat, ptyio.PTYReaderConfig{
 			Label:           "center.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
@@ -89,14 +89,14 @@ func (m *Model) stopPTYReader(tab *Tab) {
 		return
 	}
 	tab.mu.Lock()
-	if tab.readerCancel != nil {
-		close(tab.readerCancel)
-		tab.readerCancel = nil
+	if tab.ReaderCancel != nil {
+		close(tab.ReaderCancel)
+		tab.ReaderCancel = nil
 	}
-	tab.readerActive = false
-	tab.ptyMsgCh = nil
+	tab.ReaderActive = false
+	tab.MsgCh = nil
 	tab.mu.Unlock()
-	atomic.StoreInt64(&tab.ptyHeartbeat, 0)
+	atomic.StoreInt64(&tab.Heartbeat, 0)
 }
 
 func (m *Model) markPTYReaderStopped(tab *Tab) {
@@ -104,8 +104,8 @@ func (m *Model) markPTYReaderStopped(tab *Tab) {
 		return
 	}
 	tab.mu.Lock()
-	tab.readerActive = false
-	tab.ptyMsgCh = nil
+	tab.ReaderActive = false
+	tab.MsgCh = nil
 	tab.mu.Unlock()
-	atomic.StoreInt64(&tab.ptyHeartbeat, 0)
+	atomic.StoreInt64(&tab.Heartbeat, 0)
 }

--- a/internal/ui/center/model_pty_reader.go
+++ b/internal/ui/center/model_pty_reader.go
@@ -20,7 +20,7 @@ func (m *Model) flushTiming(tab *Tab, active bool) (time.Duration, time.Duration
 	if tab.Terminal != nil {
 		termWidth = tab.Terminal.Width
 		termHeight = tab.Terminal.Height
-		pendingLen = len(tab.pendingOutput)
+		pendingLen = len(tab.PendingOutput)
 	}
 	tab.mu.Unlock()
 
@@ -86,7 +86,7 @@ func (m *Model) busyPTYTabCount(now time.Time) int {
 				continue
 			}
 			tab.mu.Lock()
-			busy := tab.readerActive || len(tab.pendingOutput) > 0
+			busy := tab.ReaderActive || len(tab.PendingOutput) > 0
 			tab.mu.Unlock()
 			if busy {
 				count++

--- a/internal/ui/center/model_pty_reader_test.go
+++ b/internal/ui/center/model_pty_reader_test.go
@@ -2,9 +2,9 @@ package center
 
 import (
 	"fmt"
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_pty_reader_test.go
+++ b/internal/ui/center/model_pty_reader_test.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"fmt"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/vterm"
@@ -14,10 +15,12 @@ func TestFlushTiming_InactiveBackpressureRespectsHardCap(t *testing.T) {
 	wsID := string(ws.ID())
 	width, height := 80, 24
 	tab := &Tab{
-		ID:            TabID("tab-main"),
-		Workspace:     ws,
-		Terminal:      vterm.New(width, height),
-		pendingOutput: make([]byte, ptyBackpressureMultiplier*width*height+1),
+		ID:        TabID("tab-main"),
+		Workspace: ws,
+		Terminal:  vterm.New(width, height),
+		State: ptyio.State{
+			PendingOutput: make([]byte, ptyBackpressureMultiplier*width*height+1),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 
@@ -26,9 +29,11 @@ func TestFlushTiming_InactiveBackpressureRespectsHardCap(t *testing.T) {
 	busyTabs := make([]*Tab, 0, ptyVeryHeavyLoadTabThreshold)
 	for i := 0; i < ptyVeryHeavyLoadTabThreshold; i++ {
 		busyTabs = append(busyTabs, &Tab{
-			ID:            TabID(fmt.Sprintf("tab-busy-%d", i)),
-			Workspace:     heavyWS,
-			pendingOutput: []byte{'x'},
+			ID:        TabID(fmt.Sprintf("tab-busy-%d", i)),
+			Workspace: heavyWS,
+			State: ptyio.State{
+				PendingOutput: []byte{'x'},
+			},
 		})
 	}
 	m.tabsByWorkspace[heavyWSID] = busyTabs

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -76,15 +76,15 @@ func isTabCursorOutputActiveLocked(tab *Tab, now time.Time) bool {
 	if tab == nil || tab.Detached || !tab.Running || tab.bootstrapActivity {
 		return false
 	}
-	if tab.lastOutputAt.IsZero() || now.Sub(tab.lastOutputAt) >= tabActiveWindow {
+	if tab.LastOutputAt.IsZero() || now.Sub(tab.LastOutputAt) >= tabActiveWindow {
 		return false
 	}
 	// Ignore output that is still attributable to the user's own recent edit.
 	// That prevents wrapped multiline prompts from becoming cursor-restricted
 	// after the short local-input window expires.
 	if !tab.lastUserInputAt.IsZero() &&
-		!tab.lastOutputAt.Before(tab.lastUserInputAt) &&
-		tab.lastOutputAt.Sub(tab.lastUserInputAt) <= localInputEchoSuppressWindow &&
+		!tab.LastOutputAt.Before(tab.lastUserInputAt) &&
+		tab.LastOutputAt.Sub(tab.lastUserInputAt) <= localInputEchoSuppressWindow &&
 		(tab.lastVisibleOutput.IsZero() || !tab.lastVisibleOutput.After(tab.lastUserInputAt)) {
 		return false
 	}
@@ -155,10 +155,10 @@ func (m *Model) StartPTYReaders() tea.Cmd {
 				continue
 			}
 			tab.mu.Lock()
-			readerActive := tab.readerActive
+			readerActive := tab.ReaderActive
 			tab.mu.Unlock()
 			if readerActive {
-				lastBeat := atomic.LoadInt64(&tab.ptyHeartbeat)
+				lastBeat := atomic.LoadInt64(&tab.Heartbeat)
 				if lastBeat > 0 && time.Since(time.Unix(0, lastBeat)) > ptyReaderStallTimeout {
 					logging.Warn("PTY reader stalled for tab %s; restarting", tab.ID)
 					m.stopPTYReader(tab)
@@ -223,15 +223,15 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 	// Cache key: (version, showCursor, recentLocalInput, restrictCursor) for chat
 	// tabs. Both recent local input and recent PTY activity can change cursor
 	// policy without a PTY version bump.
-	if tab.cachedSnap != nil &&
-		tab.cachedVersion == version &&
-		tab.cachedShowCursor == showCursor &&
+	if tab.CachedSnap != nil &&
+		tab.CachedVersion == version &&
+		tab.CachedShowCursor == showCursor &&
 		(!isChat ||
 			(tab.cachedRecentLocalInput == recentLocalInput &&
 				tab.cachedRestrictCursor == restrictCursor)) {
 		// Reuse cached snapshot
 		perf.Count("vterm_snapshot_cache_hit", 1)
-		return compositor.NewVTermLayer(tab.cachedSnap)
+		return compositor.NewVTermLayer(tab.CachedSnap)
 	}
 
 	// Create new snapshot while holding the lock.
@@ -292,9 +292,9 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 	perf.Count("vterm_snapshot_cache_miss", 1)
 
 	// Cache the snapshot
-	tab.cachedSnap = snap
-	tab.cachedVersion = version
-	tab.cachedShowCursor = showCursor
+	tab.CachedSnap = snap
+	tab.CachedVersion = version
+	tab.CachedShowCursor = showCursor
 	tab.cachedRecentLocalInput = recentLocalInput
 	tab.cachedRestrictCursor = restrictCursor
 

--- a/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -17,12 +18,14 @@ func TestTerminalLayerTracksFreshSubmitPromptBeforeStableCursorLearned(t *testin
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-fresh-submit-before-anchor"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastOutputAt:      time.Now(),
+		ID:        TabID("tab-chat-fresh-submit-before-anchor"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastVisibleOutput: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -31,7 +34,7 @@ func TestTerminalLayerTracksFreshSubmitPromptBeforeStableCursorLearned(t *testin
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
@@ -60,15 +63,17 @@ func TestTerminalLayerTracksIndentedSubmitRedrawBeforePostSubmitOutput(t *testin
 	term.Screen[11][0] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-indented-submit-redraw"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		stableCursorSet:   true,
-		stableCursorX:     10,
-		stableCursorY:     10,
-		lastOutputAt:      time.Now().Add(-time.Millisecond),
+		ID:              TabID("tab-chat-indented-submit-redraw"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        term,
+		Running:         true,
+		stableCursorSet: true,
+		stableCursorX:   10,
+		stableCursorY:   10,
+		State: ptyio.State{
+			LastOutputAt: time.Now().Add(-time.Millisecond),
+		},
 		lastVisibleOutput: time.Now().Add(-time.Millisecond),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -104,12 +109,14 @@ func TestTerminalLayerDoesNotLearnInitialCursorFromBlankControlOnlyJump(t *testi
 	term.CursorY = 4
 
 	tab := &Tab{
-		ID:           TabID("tab-chat-initial-blank-control-jump"),
-		Assistant:    "codex",
-		Workspace:    ws,
-		Terminal:     term,
-		Running:      true,
-		lastOutputAt: time.Now().Add(-tabActiveWindow - time.Millisecond),
+		ID:        TabID("tab-chat-initial-blank-control-jump"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now().Add(-tabActiveWindow - time.Millisecond),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -139,12 +146,14 @@ func TestTerminalLayerAllowsSecondToLastRowCursorInShortRestrictedViewport(t *te
 	term.Screen[4][1] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-short-pane-second-last-row"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastOutputAt:      time.Now(),
+		ID:        TabID("tab-chat-short-pane-second-last-row"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastVisibleOutput: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}

--- a/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
@@ -1,10 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -147,12 +148,14 @@ func TestTerminalLayerRestrictsMidScreenCursorDuringControlOnlyOutput(t *testing
 
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
-			ID:           TabID("tab-chat-control-only-output"),
-			Assistant:    "codex",
-			Workspace:    ws,
-			Terminal:     term,
-			Running:      true,
-			lastOutputAt: time.Now(),
+			ID:        TabID("tab-chat-control-only-output"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			State: ptyio.State{
+				LastOutputAt: time.Now(),
+			},
 		},
 	}
 	m.activeTabByWorkspace[wsID] = 0
@@ -178,12 +181,14 @@ func TestTerminalLayerAllowsRecentLocalInputDespiteRecentControlOnlyOutput(t *te
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-control-only-local-edit"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastOutputAt:      time.Now(),
+		ID:        TabID("tab-chat-control-only-local-edit"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastPromptInputAt: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -227,7 +232,9 @@ func TestTerminalLayerIgnoresRecentLocalEchoOutputAfterInputWindowExpires(t *tes
 		Running:           true,
 		lastUserInputAt:   now.Add(-600 * time.Millisecond),
 		lastPromptInputAt: now.Add(-600 * time.Millisecond),
-		lastOutputAt:      now.Add(-550 * time.Millisecond),
+		State: ptyio.State{
+			LastOutputAt: now.Add(-550 * time.Millisecond),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -288,12 +295,14 @@ func TestTerminalLayerTracksStoredChatCursorAcrossLiveCursorJumps(t *testing.T) 
 	term.CursorY = 11
 
 	tab := &Tab{
-		ID:           TabID("tab-chat-anchor-update"),
-		Assistant:    "codex",
-		Workspace:    ws,
-		Terminal:     term,
-		Running:      true,
-		lastOutputAt: time.Now(),
+		ID:        TabID("tab-chat-anchor-update"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -318,7 +327,7 @@ func TestTerminalLayerTracksStoredChatCursorAcrossLiveCursorJumps(t *testing.T) 
 	tab.mu.Unlock()
 
 	term.Write([]byte("a"))
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastUserInputAt = time.Now()
 	tab.lastPromptInputAt = tab.lastUserInputAt
 	second := m.TerminalLayer()
@@ -334,7 +343,7 @@ func TestTerminalLayerTracksStoredChatCursorAcrossLiveCursorJumps(t *testing.T) 
 	}
 
 	term.Write([]byte("\x1b[1;20H"))
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
 	tab.lastUserInputAt = time.Now().Add(-localInputEchoSuppressWindow - time.Millisecond)
 	tab.lastPromptInputAt = tab.lastUserInputAt
@@ -350,7 +359,7 @@ func TestTerminalLayerTracksStoredChatCursorAcrossLiveCursorJumps(t *testing.T) 
 			second.Snap.CursorX, second.Snap.CursorY, third.Snap.CursorX, third.Snap.CursorY)
 	}
 
-	tab.lastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
+	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	tab.lastVisibleOutput = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	fourth := m.TerminalLayer()
 	if fourth == nil || fourth.Snap == nil {

--- a/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
@@ -1,10 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_pty_status_chat_cursor_state_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_state_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func TestTerminalLayerUpdatesStoredCursorWhenIdlePromptMovesAfterVersionChange(t
 		t.Fatal("expected initial terminal layer snapshot")
 	}
 
-	tab.lastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
+	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	tab.lastVisibleOutput = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	term.Write([]byte("\x1b[11;5H"))
 
@@ -115,12 +116,14 @@ func TestTerminalLayerAllowsBracketedPasteAsRecentLocalInput(t *testing.T) {
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:           TabID("tab-chat-bracketed-paste"),
-		Assistant:    "codex",
-		Workspace:    ws,
-		Terminal:     term,
-		Running:      true,
-		lastOutputAt: time.Now(),
+		ID:        TabID("tab-chat-bracketed-paste"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
 	m.activeTabByWorkspace[wsID] = 0
@@ -170,7 +173,7 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 	}
 
 	term.Write([]byte("\x1b[11;5Hprompt"))
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
 
 	restricted := m.TerminalLayer()
@@ -185,7 +188,7 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 			restricted.Snap.CursorX, restricted.Snap.CursorY)
 	}
 
-	tab.lastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
+	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	tab.lastVisibleOutput = time.Now().Add(-tabActiveWindow - time.Millisecond)
 
 	idle := m.TerminalLayer()
@@ -228,7 +231,7 @@ func TestTerminalLayerPreservesStoredMultilineCursorAcrossRestrictedArtifact(t *
 	m.SetWorkspace(ws)
 	m.Focus()
 
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
 
 	layer := m.TerminalLayer()
@@ -258,15 +261,17 @@ func TestTerminalLayerTracksEnterAsRecentPromptInputForWrappedPrompt(t *testing.
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-enter-wrapped-prompt"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		stableCursorSet:   true,
-		stableCursorX:     2,
-		stableCursorY:     9,
-		lastOutputAt:      time.Now(),
+		ID:              TabID("tab-chat-enter-wrapped-prompt"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        term,
+		Running:         true,
+		stableCursorSet: true,
+		stableCursorX:   2,
+		stableCursorY:   9,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastVisibleOutput: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -303,15 +308,17 @@ func TestTerminalLayerTracksCtrlCAsRecentPromptInputForWrappedPrompt(t *testing.
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-ctrlc-wrapped-prompt"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		stableCursorSet:   true,
-		stableCursorX:     2,
-		stableCursorY:     9,
-		lastOutputAt:      time.Now(),
+		ID:              TabID("tab-chat-ctrlc-wrapped-prompt"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        term,
+		Running:         true,
+		stableCursorSet: true,
+		stableCursorX:   2,
+		stableCursorY:   9,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastVisibleOutput: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}
@@ -363,7 +370,7 @@ func TestTerminalLayerKeepsRestrictedCursorAfterSubmitWhenOutputJumpsAway(t *tes
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
 
 	layer := m.TerminalLayer()
@@ -408,7 +415,7 @@ func TestTerminalLayerKeepsRestrictedCursorWhenSubmitOutputJumpsToLeftEdge(t *te
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
 
 	layer := m.TerminalLayer()
@@ -456,7 +463,7 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 	term.CursorX = 4
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
-	tab.lastOutputAt = time.Now()
+	tab.LastOutputAt = time.Now()
 
 	restricted := m.TerminalLayer()
 	if restricted == nil || restricted.Snap == nil {
@@ -473,7 +480,7 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 		t.Fatal("expected control-only restricted render to arm idle cursor relearn")
 	}
 
-	tab.lastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
+	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 
 	idle := m.TerminalLayer()
 	if idle == nil || idle.Snap == nil {

--- a/internal/ui/center/model_pty_status_chat_cursor_state_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_state_test.go
@@ -1,10 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -51,8 +51,7 @@ func TestTerminalLayerUpdatesStoredCursorWhenIdlePromptMovesAfterVersionChange(t
 		t.Fatalf("expected moved idle prompt cursor at (4,10), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 4 || tab.stableCursorY != 10 {
-		t.Fatalf("expected stored cursor to update to moved idle prompt, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected stored cursor to update to moved idle prompt, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -184,8 +183,7 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 		t.Fatal("expected stored cursor to remain visible while output is restricted")
 	}
 	if restricted.Snap.CursorX != 1 || restricted.Snap.CursorY != 23 {
-		t.Fatalf("expected restricted render to keep stored cursor at (1,23), got (%d,%d)",
-			restricted.Snap.CursorX, restricted.Snap.CursorY)
+		t.Fatalf("expected restricted render to keep stored cursor at (1,23), got (%d,%d)", restricted.Snap.CursorX, restricted.Snap.CursorY)
 	}
 
 	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
@@ -203,8 +201,7 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 			term.CursorX, term.CursorY, idle.Snap.CursorX, idle.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != term.CursorX || tab.stableCursorY != term.CursorY {
-		t.Fatalf("expected stored cursor to update to idle multiline prompt, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected stored cursor to update to idle multiline prompt, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 

--- a/internal/ui/center/model_pty_status_chat_cursor_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_test.go
@@ -1,10 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_pty_status_chat_cursor_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -15,12 +16,14 @@ func TestTerminalLayerShowsCursorWhileNonCodexChatTabStreaming(t *testing.T) {
 
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
-			ID:           TabID("tab-chat-streaming-claude"),
-			Assistant:    "claude",
-			Workspace:    ws,
-			Terminal:     term,
-			Running:      true,
-			lastOutputAt: time.Now(),
+			ID:        TabID("tab-chat-streaming-claude"),
+			Assistant: "claude",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			State: ptyio.State{
+				LastOutputAt: time.Now(),
+			},
 		},
 	}
 	m.activeTabByWorkspace[wsID] = 0
@@ -44,12 +47,14 @@ func TestTerminalLayerShowsCursorWhileCodexChatTabStreaming(t *testing.T) {
 
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
-			ID:           TabID("tab-chat-streaming-codex-control"),
-			Assistant:    "codex",
-			Workspace:    ws,
-			Terminal:     term,
-			Running:      true,
-			lastOutputAt: time.Now(),
+			ID:        TabID("tab-chat-streaming-codex-control"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			State: ptyio.State{
+				LastOutputAt: time.Now(),
+			},
 		},
 	}
 	m.activeTabByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_stable_cursor_test.go
+++ b/internal/ui/center/model_pty_status_stable_cursor_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -22,15 +23,17 @@ func TestTerminalLayerSanitizesStoredSyntheticCursorGlyph(t *testing.T) {
 	}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-stored-synthetic-cursor"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		stableCursorSet:   true,
-		stableCursorX:     4,
-		stableCursorY:     10,
-		lastOutputAt:      time.Now(),
+		ID:              TabID("tab-chat-stored-synthetic-cursor"),
+		Assistant:       "codex",
+		Workspace:       ws,
+		Terminal:        term,
+		Running:         true,
+		stableCursorSet: true,
+		stableCursorX:   4,
+		stableCursorY:   10,
+		State: ptyio.State{
+			LastOutputAt: time.Now(),
+		},
 		lastVisibleOutput: time.Now(),
 	}
 	m.tabsByWorkspace[wsID] = []*Tab{tab}

--- a/internal/ui/center/model_pty_status_stable_cursor_test.go
+++ b/internal/ui/center/model_pty_status_stable_cursor_test.go
@@ -1,10 +1,10 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 

--- a/internal/ui/center/model_pty_status_test.go
+++ b/internal/ui/center/model_pty_status_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
@@ -303,12 +304,14 @@ func TestTerminalLayerShowsCursorForChatTabWithRecentOutput(t *testing.T) {
 
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
-			ID:           TabID("tab-chat-recent-output"),
-			Assistant:    "codex",
-			Workspace:    ws,
-			Terminal:     term,
-			Running:      true,
-			lastOutputAt: time.Now(),
+			ID:        TabID("tab-chat-recent-output"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			State: ptyio.State{
+				LastOutputAt: time.Now(),
+			},
 		},
 	}
 	m.activeTabByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_test.go
+++ b/internal/ui/center/model_pty_status_test.go
@@ -1,11 +1,11 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/ui/diff"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -376,7 +376,6 @@ func TestTerminalLayerPreservesNonBlinkingBlockElementTextAtLiveCursor(t *testin
 		Rune:  '▌',
 		Width: 1,
 	}
-
 	m.tabsByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-real-block-text"),
@@ -388,7 +387,6 @@ func TestTerminalLayerPreservesNonBlinkingBlockElementTextAtLiveCursor(t *testin
 	m.activeTabByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -9,13 +9,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
-
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/ui/common"
-	"github.com/andyrewlee/amux/internal/ui/compositor"
 	"github.com/andyrewlee/amux/internal/ui/diff"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -63,18 +61,16 @@ type Tab struct {
 	closed           uint32
 	closing          uint32
 	Running          bool // Whether the agent is actively running
-	readerActive     bool // Guard to ensure only one PTY read loop per tab
-	// Buffer PTY output to avoid rendering partial screen updates.
 
-	pendingOutput          []byte
+	// ptyio.State holds the shared PTY buffering/reader/restart/snapshot
+	// bookkeeping (locking owned by mu, as documented on the type).
+	ptyio.State
+
 	pendingOutputBytes     int
 	catchUpPendingOutput   bool
 	catchUpTargetBytes     uint64
 	ptyBytesReceived       uint64
 	ptyBytesSettled        uint64
-	ptyNoiseTrailing       []byte
-	flushScheduled         bool
-	lastOutputAt           time.Time
 	lastVisibleOutput      time.Time
 	pendingVisibleOutput   bool
 	pendingVisibleSeq      uint64
@@ -86,16 +82,11 @@ type Tab struct {
 	lastUserInputAt        time.Time
 	bootstrapActivity      bool
 	bootstrapLastOutputAt  time.Time
-	flushPendingSince      time.Time
 	postWriteVisibleState  uint32
 	lastPromptInputAt      time.Time
 	lastPromptSubmitAt     time.Time
 	pendingSubmitPasteEcho string
-	overflowTrimCarry      vterm.ParserCarryState
-	// Throttle + accumulator for the overflow-drop Warn so a sustained overflow
-	// logs at most once per overflowLogThrottle with the aggregated byte count.
-	lastOverflowLogAt        time.Time
-	overflowDroppedSinceLog  int
+
 	parserResetPending       bool
 	actorWritesPending       int
 	actorQueuedBytes         int
@@ -104,26 +95,16 @@ type Tab struct {
 	actorQueuedNoiseTrailing []byte
 	ptyRows                  int
 	ptyCols                  int
-	ptyMsgCh                 chan tea.Msg
-	readerCancel             chan struct{}
 	// Mouse selection state
 	Selection          common.SelectionState
 	selectionScroll    common.SelectionScrollState
 	selectionLastTermX int
 
-	ptyTraceFile      *os.File
-	ptyTraceBytes     int
-	ptyTraceClosed    bool
-	ptyRestartBackoff time.Duration
-	ptyHeartbeat      int64
-	ptyRestartCount   int
-	ptyRestartSince   time.Time
-	lastFocusedAt     time.Time
+	ptyTraceFile   *os.File
+	ptyTraceBytes  int
+	ptyTraceClosed bool
+	lastFocusedAt  time.Time
 
-	// Snapshot cache for VTermLayer - avoid recreating snapshot when terminal unchanged
-	cachedSnap               *compositor.VTermSnapshot
-	cachedVersion            uint64
-	cachedShowCursor         bool
 	cachedRecentLocalInput   bool
 	cachedRestrictCursor     bool
 	cursorRefreshGen         uint64
@@ -219,12 +200,12 @@ func (t *Tab) resetPTYStateLocked() {
 	if t == nil {
 		return
 	}
-	t.pendingOutput = nil
+	t.PendingOutput = nil
 	t.pendingOutputBytes = 0
 	t.clearCatchUpLocked()
 	t.ptyBytesReceived = 0
 	t.ptyBytesSettled = 0
-	t.ptyNoiseTrailing = nil
+	t.NoiseTrailing = nil
 	t.actorQueuedBytes = 0
 }
 
@@ -249,9 +230,9 @@ func (t *Tab) resetActorWriteStateLocked() {
 	t.actorWritesPending = 0
 	t.actorWriteEpoch++
 	t.clearCatchUpLocked()
-	t.pendingOutputBytes = len(t.pendingOutput)
-	t.overflowTrimCarry = vterm.ParserCarryState{}
-	t.ptyNoiseTrailing = nil
+	t.pendingOutputBytes = len(t.PendingOutput)
+	t.OverflowTrimCarry = vterm.ParserCarryState{}
+	t.NoiseTrailing = nil
 	t.actorQueuedNoiseTrailing = t.actorQueuedNoiseTrailing[:0]
 	t.actorQueuedCarry = t.Terminal.ParserCarryState()
 }
@@ -435,7 +416,7 @@ func (m *Model) CleanupWorkspace(ws *data.Workspace) {
 		tab.resetPTYStateLocked()
 		tab.DiffViewer = nil
 		tab.Terminal = nil
-		tab.cachedSnap = nil
+		tab.CachedSnap = nil
 		tab.Workspace = nil
 		tab.Running = false
 		tab.mu.Unlock()

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -230,7 +230,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 			if msg.CaptureFullPane {
 				// A full tmux pane snapshot supersedes any preserved local PTY
 				// backlog for this terminal state.
-				tab.pendingOutput = nil
+				tab.PendingOutput = nil
 				ptyio.RestorePaneCapture(
 					tab.Terminal,
 					msg.ScrollbackCapture,

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -53,7 +53,7 @@ func (m *Model) closeTabAt(index int) tea.Cmd {
 	// via CloseAgent() above; leaving the pointer intact is safe.
 	tab.DiffViewer = nil
 	tab.Terminal = nil
-	tab.cachedSnap = nil
+	tab.CachedSnap = nil
 	tab.Workspace = nil
 	tab.Running = false
 	tab.resetPTYStateLocked()

--- a/internal/ui/center/model_tabs_session_detach_test.go
+++ b/internal/ui/center/model_tabs_session_detach_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/messages"
@@ -75,11 +76,13 @@ func TestDetachTab_ClearsCatchUpPendingOutput(t *testing.T) {
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		ID:                   TabID("tab-3"),
-		Assistant:            "claude",
-		Workspace:            ws,
-		Running:              true,
-		pendingOutput:        []byte("buffered"),
+		ID:        TabID("tab-3"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 		catchUpPendingOutput: true,
 		Agent:                &appPty.Agent{Workspace: ws},
 	}
@@ -93,7 +96,7 @@ func TestDetachTab_ClearsCatchUpPendingOutput(t *testing.T) {
 	if tab.catchUpPendingOutput {
 		t.Fatal("expected catch-up latch to clear on detach")
 	}
-	if tab.pendingOutput != nil {
-		t.Fatalf("expected pending output cleared on detach, got %q", tab.pendingOutput)
+	if tab.PendingOutput != nil {
+		t.Fatalf("expected pending output cleared on detach, got %q", tab.PendingOutput)
 	}
 }

--- a/internal/ui/center/model_tabs_session_detach_test.go
+++ b/internal/ui/center/model_tabs_session_detach_test.go
@@ -1,11 +1,11 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/messages"
 	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
 func TestDetachTab_EmitsWorkspaceAwareMessage(t *testing.T) {

--- a/internal/ui/center/model_tabs_session_selection_flush_test.go
+++ b/internal/ui/center/model_tabs_session_selection_flush_test.go
@@ -1,8 +1,9 @@
 package center
 
 import (
-	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 
 	tea "charm.land/bubbletea/v2"
 

--- a/internal/ui/center/model_tabs_session_selection_flush_test.go
+++ b/internal/ui/center/model_tabs_session_selection_flush_test.go
@@ -1,6 +1,7 @@
 package center
 
 import (
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -14,11 +15,13 @@ func TestTabSelectionChangedCmd_FlushesBufferedActiveTab(t *testing.T) {
 	wsID := string(ws.ID())
 
 	tab := &Tab{
-		ID:                 TabID("tab-1"),
-		Assistant:          "claude",
-		Workspace:          ws,
-		Running:            true,
-		pendingOutput:      []byte("buffered"),
+		ID:        TabID("tab-1"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		State: ptyio.State{
+			PendingOutput: []byte("buffered"),
+		},
 		pendingOutputBytes: len("buffered"),
 		ptyBytesReceived:   uint64(len("buffered")),
 	}
@@ -33,7 +36,7 @@ func TestTabSelectionChangedCmd_FlushesBufferedActiveTab(t *testing.T) {
 	if !tab.catchUpPendingOutput {
 		t.Fatalf("expected tab selection change to latch catch-up state")
 	}
-	if got, want := tab.catchUpTargetBytes, uint64(len(tab.pendingOutput)); got != want {
+	if got, want := tab.catchUpTargetBytes, uint64(len(tab.PendingOutput)); got != want {
 		t.Fatalf("catch-up target bytes = %d, want %d", got, want)
 	}
 

--- a/internal/ui/center/tab_actor_write.go
+++ b/internal/ui/center/tab_actor_write.go
@@ -61,7 +61,7 @@ func (m *Model) handleWriteOutput(ev tabEvent) {
 // byte count, whether the filter ran, whether the redraw should be suppressed,
 // whether a follow-up flush is needed, and the activity tag to publish.
 func (m *Model) applyActorWriteLocked(tab *Tab, ev tabEvent, processedBytes int) (filteredLen int, filterApplied, suppressRedraw, requestFlush bool, tagSessionName string, tagTimestamp int64) {
-	output := ptyio.FilterKnownPTYNoiseStream(ev.output, &tab.ptyNoiseTrailing)
+	output := ptyio.FilterKnownPTYNoiseStream(ev.output, &tab.NoiseTrailing)
 	filteredLen = len(output)
 	filterApplied = true
 	if len(output) > 0 {
@@ -109,7 +109,7 @@ func enqueueActorWrite(tab *Tab, chunk []byte) (prevEpoch uint64, prevCarry vter
 	if prevPending > 0 {
 		seedCarry = prevCarry
 	}
-	previewTrailing := append([]byte(nil), tab.ptyNoiseTrailing...)
+	previewTrailing := append([]byte(nil), tab.NoiseTrailing...)
 	if prevPending > 0 {
 		previewTrailing = append(previewTrailing[:0], tab.actorQueuedNoiseTrailing...)
 	}
@@ -162,7 +162,7 @@ func recoverFailedActorSend(
 			syncFallbackChunkSize = ptyFlushChunkSizeActive
 			tab.restoreActorCarryLocked(prevCarry, prevNoiseTrailing)
 			tab.prependPendingOutputLocked(chunk[syncFallbackChunkSize:])
-			hasMore = len(tab.pendingOutput) > 0
+			hasMore = len(tab.PendingOutput) > 0
 		}
 	case tab.actorWriteEpoch != prevEpoch || tab.isClosed():
 		dropWrite = true
@@ -187,11 +187,11 @@ func (tab *Tab) restoreActorCarryLocked(prevCarry vterm.ParserCarryState, prevNo
 // rolled-back write is re-flushed before newer buffered output. Caller holds
 // tab.mu.
 func (tab *Tab) prependPendingOutputLocked(chunk []byte) {
-	restored := make([]byte, 0, len(chunk)+len(tab.pendingOutput))
+	restored := make([]byte, 0, len(chunk)+len(tab.PendingOutput))
 	restored = append(restored, chunk...)
-	restored = append(restored, tab.pendingOutput...)
-	tab.pendingOutput = restored
-	tab.pendingOutputBytes = len(tab.pendingOutput)
+	restored = append(restored, tab.PendingOutput...)
+	tab.PendingOutput = restored
+	tab.pendingOutputBytes = len(tab.PendingOutput)
 }
 
 // finalizeActorWriteLocked snapshots the parser carry/noise state after the last
@@ -199,11 +199,11 @@ func (tab *Tab) prependPendingOutputLocked(chunk []byte) {
 // Returns true when a follow-up flush should be requested. Caller holds tab.mu.
 func finalizeActorWriteLocked(tab *Tab) (requestFlush bool) {
 	tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
-	tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.ptyNoiseTrailing...)
+	tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.NoiseTrailing...)
 	if tab.parserResetPending {
 		tab.Terminal.ResetParserState()
 		tab.activityANSIState = ansiActivityText
-		tab.ptyNoiseTrailing = nil
+		tab.NoiseTrailing = nil
 		tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
 		tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
 		tab.parserResetPending = false

--- a/internal/ui/ptyio/state.go
+++ b/internal/ui/ptyio/state.go
@@ -1,0 +1,60 @@
+package ptyio
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// State holds the PTY I/O bookkeeping shared by the center tab and sidebar
+// terminal stacks: pending-output buffering, flush scheduling, overflow-trim
+// carry, reader lifecycle, restart backoff, and the rendered-snapshot cache.
+//
+// It is embedded by both consumers. Locking stays with the embedding struct:
+// unless a field is documented as atomic, it must be accessed under the
+// embedder's mutex or from the single-writer Update goroutine, exactly as the
+// fields were before they moved here.
+type State struct {
+	// PendingOutput buffers raw PTY output between flush ticks so partial
+	// screen updates are not rendered.
+	PendingOutput []byte
+	// NoiseTrailing carries an incomplete known-noise line fragment (e.g. a
+	// macOS malloc diagnostic) across chunk boundaries.
+	NoiseTrailing []byte
+	// OverflowTrimCarry is the parser carry state at the last overflow cut.
+	OverflowTrimCarry vterm.ParserCarryState
+	// FlushScheduled marks that a flush tick is already pending.
+	FlushScheduled bool
+	// LastOutputAt is when PTY data last arrived.
+	LastOutputAt time.Time
+	// FlushPendingSince is when the currently-scheduled flush was requested.
+	FlushPendingSince time.Time
+	// LastOverflowLogAt and OverflowDroppedSinceLog throttle the overflow-drop
+	// warning so a sustained overflow logs at most once per throttle window
+	// with the aggregated byte count.
+	LastOverflowLogAt       time.Time
+	OverflowDroppedSinceLog int
+
+	// MsgCh is the reader goroutine's output channel; ReaderCancel signals it
+	// to stop. ReaderActive guards against starting two readers.
+	MsgCh        chan tea.Msg
+	ReaderCancel chan struct{}
+	ReaderActive bool
+	// Heartbeat is the last reader read time in nanoseconds. Atomic.
+	Heartbeat int64
+
+	// RestartBackoff/RestartCount/RestartSince implement exponential backoff
+	// for reader restarts within a rolling window.
+	RestartBackoff time.Duration
+	RestartCount   int
+	RestartSince   time.Time
+
+	// CachedSnap/CachedVersion/CachedShowCursor cache the rendered terminal
+	// snapshot so an unchanged terminal does not rebuild it every frame.
+	CachedSnap       *compositor.VTermSnapshot
+	CachedVersion    uint64
+	CachedShowCursor bool
+}

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -12,7 +11,7 @@ import (
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
-	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -46,39 +45,18 @@ type TerminalState struct {
 	SessionName      string
 	mu               sync.Mutex
 
+	// ptyio.State holds the shared PTY buffering/reader/restart/snapshot
+	// bookkeeping (locking owned by mu, as documented on the type).
+	ptyio.State
+
 	// Track last size to avoid unnecessary resizes
 	lastWidth  int
 	lastHeight int
-
-	// PTY output buffering
-	pendingOutput     []byte
-	ptyNoiseTrailing  []byte
-	overflowTrimCarry vterm.ParserCarryState
-	flushScheduled    bool
-	lastOutputAt      time.Time
-	flushPendingSince time.Time
-	// Throttle + accumulator for the overflow-drop Warn (at most one per
-	// overflowLogThrottle with the aggregated dropped-byte count).
-	lastOverflowLogAt       time.Time
-	overflowDroppedSinceLog int
 
 	// Selection state
 	Selection          common.SelectionState
 	selectionScroll    common.SelectionScrollState
 	selectionLastTermX int
-
-	// Snapshot cache for VTermLayer - avoid recreating snapshot when terminal unchanged
-	cachedSnap       *compositor.VTermSnapshot
-	cachedVersion    uint64
-	cachedShowCursor bool
-
-	readerActive      bool
-	ptyMsgCh          chan tea.Msg
-	readerCancel      chan struct{}
-	ptyRestartBackoff time.Duration
-	ptyHeartbeat      int64
-	ptyRestartCount   int
-	ptyRestartSince   time.Time
 }
 
 // terminalTabHitKind identifies the type of tab bar click target
@@ -319,6 +297,6 @@ func (m *TerminalModel) setActiveTerminalCursorVisibility(visible bool) {
 	}
 	// Invalidate cached snapshot so focus transitions cannot reuse stale
 	// cursor-painted frames.
-	ts.cachedSnap = nil
-	ts.cachedVersion = 0
+	ts.CachedSnap = nil
+	ts.CachedVersion = 0
 }

--- a/internal/ui/sidebar/terminal_overflow_log_test.go
+++ b/internal/ui/sidebar/terminal_overflow_log_test.go
@@ -29,7 +29,7 @@ func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
 	if ln, _ := ts.noteOverflowDropLocked(25); ln {
 		t.Fatal("third drop within the throttle window should be suppressed")
 	}
-	ts.lastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
+	ts.LastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
 	logNow, total = ts.noteOverflowDropLocked(10)
 	if !logNow {
 		t.Fatal("a drop after the throttle window should log")

--- a/internal/ui/sidebar/terminal_pty_lifecycle.go
+++ b/internal/ui/sidebar/terminal_pty_lifecycle.go
@@ -117,37 +117,37 @@ func (m *TerminalModel) startPTYReader(wsID string, tabID TerminalTabID) tea.Cmd
 	}
 	ts := tab.State
 	ts.mu.Lock()
-	if ts.readerActive {
-		if ts.ptyMsgCh == nil || ts.readerCancel == nil {
-			ts.readerActive = false
+	if ts.ReaderActive {
+		if ts.MsgCh == nil || ts.ReaderCancel == nil {
+			ts.ReaderActive = false
 		} else {
 			ts.mu.Unlock()
 			return nil
 		}
 	}
 	if ts.Terminal == nil || !ts.Running {
-		ts.readerActive = false
+		ts.ReaderActive = false
 		ts.mu.Unlock()
 		return nil
 	}
 
-	if ts.readerCancel != nil {
-		close(ts.readerCancel)
+	if ts.ReaderCancel != nil {
+		close(ts.ReaderCancel)
 	}
-	ts.readerCancel = make(chan struct{})
-	ts.ptyMsgCh = make(chan tea.Msg, ptyReadQueueSize)
-	ts.readerActive = true
-	ts.ptyRestartBackoff = 0
-	atomic.StoreInt64(&ts.ptyHeartbeat, time.Now().UnixNano())
+	ts.ReaderCancel = make(chan struct{})
+	ts.MsgCh = make(chan tea.Msg, ptyReadQueueSize)
+	ts.ReaderActive = true
+	ts.RestartBackoff = 0
+	atomic.StoreInt64(&ts.Heartbeat, time.Now().UnixNano())
 
 	term := ts.Terminal
-	cancel := ts.readerCancel
-	msgCh := ts.ptyMsgCh
+	cancel := ts.ReaderCancel
+	msgCh := ts.MsgCh
 	ts.mu.Unlock()
 
 	safego.Go("sidebar.pty_reader", func() {
 		defer m.markPTYReaderStopped(ts)
-		ptyio.RunPTYReader(term, msgCh, cancel, &ts.ptyHeartbeat, ptyio.PTYReaderConfig{
+		ptyio.RunPTYReader(term, msgCh, cancel, &ts.Heartbeat, ptyio.PTYReaderConfig{
 			Label:           "sidebar.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
@@ -178,10 +178,10 @@ func (m *TerminalModel) StartPTYReaders() tea.Cmd {
 			ts := tab.State
 			if ts != nil {
 				ts.mu.Lock()
-				readerActive := ts.readerActive
+				readerActive := ts.ReaderActive
 				ts.mu.Unlock()
 				if readerActive {
-					lastBeat := atomic.LoadInt64(&ts.ptyHeartbeat)
+					lastBeat := atomic.LoadInt64(&ts.Heartbeat)
 					if lastBeat > 0 && time.Since(time.Unix(0, lastBeat)) > ptyReaderStallTimeout {
 						logging.Warn("Sidebar PTY reader stalled for workspace %s tab %s; restarting", wsID, tab.ID)
 						m.stopPTYReader(ts)
@@ -205,7 +205,7 @@ func (m *TerminalModel) CloseTerminal(wsID string) {
 				tab.State.Terminal.Close()
 			}
 			tab.State.Running = false
-			tab.State.ptyRestartBackoff = 0
+			tab.State.RestartBackoff = 0
 			tab.State.mu.Unlock()
 		}
 	}
@@ -226,14 +226,14 @@ func (m *TerminalModel) stopPTYReader(ts *TerminalState) {
 		return
 	}
 	ts.mu.Lock()
-	if ts.readerCancel != nil {
-		close(ts.readerCancel)
-		ts.readerCancel = nil
+	if ts.ReaderCancel != nil {
+		close(ts.ReaderCancel)
+		ts.ReaderCancel = nil
 	}
-	ts.readerActive = false
-	ts.ptyMsgCh = nil
+	ts.ReaderActive = false
+	ts.MsgCh = nil
 	ts.mu.Unlock()
-	atomic.StoreInt64(&ts.ptyHeartbeat, 0)
+	atomic.StoreInt64(&ts.Heartbeat, 0)
 }
 
 func (m *TerminalModel) detachState(ts *TerminalState, userInitiated bool) {
@@ -247,8 +247,8 @@ func (m *TerminalModel) detachState(ts *TerminalState, userInitiated bool) {
 	ts.Running = false
 	ts.Detached = true
 	ts.UserDetached = userInitiated
-	ts.pendingOutput = nil
-	ts.ptyNoiseTrailing = nil
+	ts.PendingOutput = nil
+	ts.NoiseTrailing = nil
 	ts.mu.Unlock()
 	if term != nil {
 		term.Close()
@@ -260,10 +260,10 @@ func (m *TerminalModel) markPTYReaderStopped(ts *TerminalState) {
 		return
 	}
 	ts.mu.Lock()
-	ts.readerActive = false
-	ts.ptyMsgCh = nil
+	ts.ReaderActive = false
+	ts.MsgCh = nil
 	ts.mu.Unlock()
-	atomic.StoreInt64(&ts.ptyHeartbeat, 0)
+	atomic.StoreInt64(&ts.Heartbeat, 0)
 }
 
 // SendToTerminal sends a string directly to the current terminal

--- a/internal/ui/sidebar/terminal_reattach_test.go
+++ b/internal/ui/sidebar/terminal_reattach_test.go
@@ -237,7 +237,7 @@ func TestHandleTerminalCreated_LoadsPaneCaptureBeforeStartingReader(t *testing.T
 	if tab.State.VTerm.CursorX != 5 || tab.State.VTerm.CursorY != 2 {
 		t.Fatalf("expected explicit pane cursor to be restored, got (%d,%d)", tab.State.VTerm.CursorX, tab.State.VTerm.CursorY)
 	}
-	if tab.State.readerActive {
+	if tab.State.ReaderActive {
 		t.Fatal("expected reader not to start without a PTY terminal")
 	}
 }

--- a/internal/ui/sidebar/terminal_render.go
+++ b/internal/ui/sidebar/terminal_render.go
@@ -164,9 +164,9 @@ func (m *TerminalModel) TerminalLayerWithCursorOwner(cursorOwner bool) *composit
 	if !cursorOwner {
 		showCursor = false
 	}
-	if ts.cachedSnap != nil && ts.cachedVersion == version && ts.cachedShowCursor == showCursor {
+	if ts.CachedSnap != nil && ts.CachedVersion == version && ts.CachedShowCursor == showCursor {
 		perf.Count("vterm_snapshot_cache_hit", 1)
-		return compositor.NewVTermLayer(ts.cachedSnap)
+		return compositor.NewVTermLayer(ts.CachedSnap)
 	}
 
 	// Do not pass the previous snapshot for reuse: NewVTermSnapshotWithCache
@@ -178,9 +178,9 @@ func (m *TerminalModel) TerminalLayerWithCursorOwner(cursorOwner bool) *composit
 	}
 	perf.Count("vterm_snapshot_cache_miss", 1)
 
-	ts.cachedSnap = snap
-	ts.cachedVersion = version
-	ts.cachedShowCursor = showCursor
+	ts.CachedSnap = snap
+	ts.CachedVersion = version
+	ts.CachedShowCursor = showCursor
 	return compositor.NewVTermLayer(snap)
 }
 
@@ -235,14 +235,16 @@ func (m *TerminalModel) helpLines(contentWidth int) []string {
 	// Tab management hints
 	items = append(items, m.helpItem("C-Spc t t", "new term"))
 	if m.HasMultipleTabs() {
-		items = append(items,
+		items = append(
+			items,
 			m.helpItem("C-Spc t n", "next"),
 			m.helpItem("C-Spc t p", "prev"),
 			m.helpItem("C-Spc t x", "close"),
 		)
 	}
 	if hasTerm {
-		items = append(items,
+		items = append(
+			items,
 			m.helpItem("C-Spc t d", "detach"),
 			m.helpItem("C-Spc t r", "reattach"),
 			m.helpItem("C-Spc t s", "restart"),
@@ -250,7 +252,8 @@ func (m *TerminalModel) helpLines(contentWidth int) []string {
 	}
 
 	if hasTerm {
-		items = append(items,
+		items = append(
+			items,
 			m.helpItem("PgUp", "half up"),
 			m.helpItem("PgDn", "half down"),
 		)

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -71,7 +71,7 @@ func (m *TerminalModel) closeTabAt(idx int) (*TerminalModel, tea.Cmd) {
 			tab.State.Terminal.Close()
 		}
 		tab.State.Running = false
-		tab.State.ptyRestartBackoff = 0
+		tab.State.RestartBackoff = 0
 		tab.State.mu.Unlock()
 	}
 

--- a/internal/ui/sidebar/terminal_tab_ops.go
+++ b/internal/ui/sidebar/terminal_tab_ops.go
@@ -90,7 +90,7 @@ func (m *TerminalModel) CloseActiveTab() tea.Cmd {
 			tab.State.Terminal.Close()
 		}
 		tab.State.Running = false
-		tab.State.ptyRestartBackoff = 0
+		tab.State.RestartBackoff = 0
 		tab.State.mu.Unlock()
 	}
 

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -20,12 +20,12 @@ const overflowLogThrottle = 2 * time.Second
 // throttled overflow Warn should be emitted now (caller logs outside the lock),
 // returning the aggregated dropped-byte total. The caller must hold ts.mu.
 func (ts *TerminalState) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
-	ts.overflowDroppedSinceLog += droppedBytes
+	ts.OverflowDroppedSinceLog += droppedBytes
 	now := time.Now()
-	if ts.lastOverflowLogAt.IsZero() || now.Sub(ts.lastOverflowLogAt) >= overflowLogThrottle {
-		total = ts.overflowDroppedSinceLog
-		ts.overflowDroppedSinceLog = 0
-		ts.lastOverflowLogAt = now
+	if ts.LastOverflowLogAt.IsZero() || now.Sub(ts.LastOverflowLogAt) >= overflowLogThrottle {
+		total = ts.OverflowDroppedSinceLog
+		ts.OverflowDroppedSinceLog = 0
+		ts.LastOverflowLogAt = now
 		return true, total
 	}
 	return false, 0
@@ -42,31 +42,31 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	ts := tab.State
 	data := msg.Data
 	ts.mu.Lock()
-	if ts.overflowTrimCarry != (vterm.ParserCarryState{}) {
-		data, ts.overflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, ts.overflowTrimCarry)
+	if ts.OverflowTrimCarry != (vterm.ParserCarryState{}) {
+		data, ts.OverflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, ts.OverflowTrimCarry)
 	}
 	ts.mu.Unlock()
-	prevPendingLen := len(ts.pendingOutput)
-	ts.pendingOutput = append(ts.pendingOutput, data...)
-	if len(ts.pendingOutput) > ptyMaxBufferedBytes {
-		overflow := len(ts.pendingOutput) - ptyMaxBufferedBytes
+	prevPendingLen := len(ts.PendingOutput)
+	ts.PendingOutput = append(ts.PendingOutput, data...)
+	if len(ts.PendingOutput) > ptyMaxBufferedBytes {
+		overflow := len(ts.PendingOutput) - ptyMaxBufferedBytes
 		perf.Count("sidebar_pty_drop_bytes", int64(overflow))
 		perf.Count("sidebar_pty_drop", 1)
 		seed := vterm.ParserCarryState{}
-		combinedLen := len(ts.pendingOutput)
+		combinedLen := len(ts.PendingOutput)
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			seed = ts.VTerm.ParserCarryState()
 			ts.VTerm.ResetParserState()
 		}
 		ts.mu.Unlock()
-		retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(ts.pendingOutput, overflow, seed)
+		retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(ts.PendingOutput, overflow, seed)
 		retainedStart := combinedLen - len(retained)
-		ts.pendingOutput = append([]byte(nil), retained...)
+		ts.PendingOutput = append([]byte(nil), retained...)
 		ts.mu.Lock()
-		ts.overflowTrimCarry = overflowCarry
+		ts.OverflowTrimCarry = overflowCarry
 		if retainedStart > prevPendingLen {
-			ts.ptyNoiseTrailing = nil
+			ts.NoiseTrailing = nil
 		}
 		overflowLogNow, overflowDroppedTotal := ts.noteOverflowDropLocked(retainedStart)
 		ts.mu.Unlock()
@@ -74,10 +74,10 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 			logging.Warn("Sidebar PTY output overflow for workspace %s tab %s: dropped %d bytes (buffer cap %d)", wsID, tabID, overflowDroppedTotal, ptyMaxBufferedBytes)
 		}
 	}
-	ts.lastOutputAt = time.Now()
-	if !ts.flushScheduled {
-		ts.flushScheduled = true
-		ts.flushPendingSince = ts.lastOutputAt
+	ts.LastOutputAt = time.Now()
+	if !ts.FlushScheduled {
+		ts.FlushScheduled = true
+		ts.FlushPendingSince = ts.LastOutputAt
 		quiet, _ := m.flushTiming()
 		return common.SafeTick(quiet, func(t time.Time) tea.Msg {
 			return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
@@ -96,10 +96,10 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 	}
 	ts := tab.State
 	now := time.Now()
-	quietFor := now.Sub(ts.lastOutputAt)
+	quietFor := now.Sub(ts.LastOutputAt)
 	pendingFor := time.Duration(0)
-	if !ts.flushPendingSince.IsZero() {
-		pendingFor = now.Sub(ts.flushPendingSince)
+	if !ts.FlushPendingSince.IsZero() {
+		pendingFor = now.Sub(ts.FlushPendingSince)
 	}
 	quiet, maxInterval := m.flushTiming()
 	if quietFor < quiet && pendingFor < maxInterval {
@@ -107,27 +107,27 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 		if delay < time.Millisecond {
 			delay = time.Millisecond
 		}
-		ts.flushScheduled = true
+		ts.FlushScheduled = true
 		return common.SafeTick(delay, func(t time.Time) tea.Msg {
 			return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
 		})
 	}
 
-	ts.flushScheduled = false
-	ts.flushPendingSince = time.Time{}
-	if len(ts.pendingOutput) > 0 {
+	ts.FlushScheduled = false
+	ts.FlushPendingSince = time.Time{}
+	if len(ts.PendingOutput) > 0 {
 		var consumed bool
 		ts.mu.Lock()
 		if ts.VTerm != nil {
-			chunkSize := len(ts.pendingOutput)
+			chunkSize := len(ts.PendingOutput)
 			if chunkSize > ptyFlushChunkSize {
 				chunkSize = ptyFlushChunkSize
 			}
-			chunk := append([]byte(nil), ts.pendingOutput[:chunkSize]...)
-			copy(ts.pendingOutput, ts.pendingOutput[chunkSize:])
-			ts.pendingOutput = ts.pendingOutput[:len(ts.pendingOutput)-chunkSize]
+			chunk := append([]byte(nil), ts.PendingOutput[:chunkSize]...)
+			copy(ts.PendingOutput, ts.PendingOutput[chunkSize:])
+			ts.PendingOutput = ts.PendingOutput[:len(ts.PendingOutput)-chunkSize]
 			processedBytes := len(chunk)
-			filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.ptyNoiseTrailing)
+			filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.NoiseTrailing)
 			filteredBytes := processedBytes - len(filtered)
 			perf.Count("pty_flush_bytes_processed", int64(processedBytes))
 			if filteredBytes > 0 {
@@ -145,11 +145,11 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 		if !consumed {
 			return nil
 		}
-		if len(ts.pendingOutput) == 0 {
-			ts.pendingOutput = ts.pendingOutput[:0]
+		if len(ts.PendingOutput) == 0 {
+			ts.PendingOutput = ts.PendingOutput[:0]
 		} else {
-			ts.flushScheduled = true
-			ts.flushPendingSince = time.Now()
+			ts.FlushScheduled = true
+			ts.FlushPendingSince = time.Now()
 			delay, _ := m.flushTiming()
 			if delay < time.Millisecond {
 				delay = time.Millisecond
@@ -173,8 +173,8 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 	ts := tab.State
 	termAlive := ts.Terminal != nil && !ts.Terminal.IsClosed()
 	ts.mu.Lock()
-	if ts.VTerm != nil && len(ts.ptyNoiseTrailing) > 0 {
-		trailing := ptyio.DrainKnownPTYNoiseTrailing(&ts.ptyNoiseTrailing)
+	if ts.VTerm != nil && len(ts.NoiseTrailing) > 0 {
+		trailing := ptyio.DrainKnownPTYNoiseTrailing(&ts.NoiseTrailing)
 		flushDone := perf.Time("pty_flush")
 		ts.VTerm.Write(trailing)
 		flushDone()
@@ -186,20 +186,20 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 		shouldRestart := true
 		var backoff time.Duration
 		ts.mu.Lock()
-		if ts.ptyRestartSince.IsZero() || time.Since(ts.ptyRestartSince) > ptyRestartWindow {
-			ts.ptyRestartSince = time.Now()
-			ts.ptyRestartCount = 0
+		if ts.RestartSince.IsZero() || time.Since(ts.RestartSince) > ptyRestartWindow {
+			ts.RestartSince = time.Now()
+			ts.RestartCount = 0
 		}
-		ts.ptyRestartCount++
-		if ts.ptyRestartCount > ptyRestartMax {
+		ts.RestartCount++
+		if ts.RestartCount > ptyRestartMax {
 			shouldRestart = false
 			ts.Running = false
 			// Mark as detached (tmux session may still be alive)
 			ts.Detached = true
 			ts.UserDetached = false
-			ts.ptyRestartBackoff = 0
+			ts.RestartBackoff = 0
 		} else {
-			backoff = ts.ptyRestartBackoff
+			backoff = ts.RestartBackoff
 			if backoff <= 0 {
 				backoff = 200 * time.Millisecond
 			} else {
@@ -208,7 +208,7 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 					backoff = 5 * time.Second
 				}
 			}
-			ts.ptyRestartBackoff = backoff
+			ts.RestartBackoff = backoff
 		}
 		ts.mu.Unlock()
 		if shouldRestart {
@@ -226,9 +226,9 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 		// Mark as detached - tmux session may still be alive
 		ts.Detached = true
 		ts.UserDetached = false
-		ts.ptyRestartBackoff = 0
-		ts.ptyRestartCount = 0
-		ts.ptyRestartSince = time.Time{}
+		ts.RestartBackoff = 0
+		ts.RestartCount = 0
+		ts.RestartSince = time.Time{}
 		ts.mu.Unlock()
 		logging.Info("Sidebar PTY stopped for workspace %s tab %s, marking detached: %v", wsID, tabID, msg.Err)
 	}
@@ -244,7 +244,7 @@ func (m *TerminalModel) handlePTYRestart(msg messages.SidebarPTYRestart) tea.Cmd
 	ts := tab.State
 	if ts.Terminal == nil || ts.Terminal.IsClosed() {
 		ts.mu.Lock()
-		ts.ptyRestartBackoff = 0
+		ts.RestartBackoff = 0
 		ts.mu.Unlock()
 		return nil
 	}

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -115,51 +115,51 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 
 	ts.FlushScheduled = false
 	ts.FlushPendingSince = time.Time{}
-	if len(ts.PendingOutput) > 0 {
-		var consumed bool
-		ts.mu.Lock()
-		if ts.VTerm != nil {
-			chunkSize := len(ts.PendingOutput)
-			if chunkSize > ptyFlushChunkSize {
-				chunkSize = ptyFlushChunkSize
-			}
-			chunk := append([]byte(nil), ts.PendingOutput[:chunkSize]...)
-			copy(ts.PendingOutput, ts.PendingOutput[chunkSize:])
-			ts.PendingOutput = ts.PendingOutput[:len(ts.PendingOutput)-chunkSize]
-			processedBytes := len(chunk)
-			filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.NoiseTrailing)
-			filteredBytes := processedBytes - len(filtered)
-			perf.Count("pty_flush_bytes_processed", int64(processedBytes))
-			if filteredBytes > 0 {
-				perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
-			}
-			if len(filtered) > 0 {
-				flushDone := perf.Time("pty_flush")
-				ts.VTerm.Write(filtered)
-				flushDone()
-				perf.Count("pty_flush_bytes", int64(len(filtered)))
-			}
-			consumed = true
-		}
-		ts.mu.Unlock()
-		if !consumed {
-			return nil
-		}
-		if len(ts.PendingOutput) == 0 {
-			ts.PendingOutput = ts.PendingOutput[:0]
-		} else {
-			ts.FlushScheduled = true
-			ts.FlushPendingSince = time.Now()
-			delay, _ := m.flushTiming()
-			if delay < time.Millisecond {
-				delay = time.Millisecond
-			}
-			return common.SafeTick(delay, func(t time.Time) tea.Msg {
-				return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
-			})
-		}
+	if len(ts.PendingOutput) == 0 || !flushSidebarPendingOutput(ts) {
+		return nil
 	}
-	return nil
+	if len(ts.PendingOutput) == 0 {
+		ts.PendingOutput = ts.PendingOutput[:0]
+		return nil
+	}
+	ts.FlushScheduled = true
+	ts.FlushPendingSince = time.Now()
+	delay, _ := m.flushTiming()
+	if delay < time.Millisecond {
+		delay = time.Millisecond
+	}
+	return common.SafeTick(delay, func(t time.Time) tea.Msg {
+		return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
+	})
+}
+
+func flushSidebarPendingOutput(ts *TerminalState) bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.VTerm == nil {
+		return false
+	}
+	chunkSize := len(ts.PendingOutput)
+	if chunkSize > ptyFlushChunkSize {
+		chunkSize = ptyFlushChunkSize
+	}
+	chunk := append([]byte(nil), ts.PendingOutput[:chunkSize]...)
+	copy(ts.PendingOutput, ts.PendingOutput[chunkSize:])
+	ts.PendingOutput = ts.PendingOutput[:len(ts.PendingOutput)-chunkSize]
+	processedBytes := len(chunk)
+	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.NoiseTrailing)
+	filteredBytes := processedBytes - len(filtered)
+	perf.Count("pty_flush_bytes_processed", int64(processedBytes))
+	if filteredBytes > 0 {
+		perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
+	}
+	if len(filtered) > 0 {
+		flushDone := perf.Time("pty_flush")
+		ts.VTerm.Write(filtered)
+		flushDone()
+		perf.Count("pty_flush_bytes", int64(len(filtered)))
+	}
+	return true
 }
 
 // handlePTYStopped handles PTY reader exit, restarting with backoff or marking detached.

--- a/internal/ui/sidebar/terminal_update_pty_test.go
+++ b/internal/ui/sidebar/terminal_update_pty_test.go
@@ -3,6 +3,8 @@ package sidebar
 import (
 	"testing"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/vterm"
@@ -14,7 +16,9 @@ func TestHandlePTYStopped_PreservesOverflowTrimCarry(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-tab-1")
 	state := &TerminalState{
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
@@ -23,8 +27,8 @@ func TestHandlePTYStopped_PreservesOverflowTrimCarry(t *testing.T) {
 		TabID:       string(tabID),
 	})
 
-	if state.overflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
-		t.Fatalf("expected overflowTrimCarry preserved on PTY stop, got %+v", state.overflowTrimCarry)
+	if state.OverflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
+		t.Fatalf("expected overflowTrimCarry preserved on PTY stop, got %+v", state.OverflowTrimCarry)
 	}
 
 	_ = m.handlePTYOutput(messages.SidebarPTYOutput{
@@ -32,8 +36,8 @@ func TestHandlePTYStopped_PreservesOverflowTrimCarry(t *testing.T) {
 		TabID:       string(tabID),
 		Data:        []byte("31mHello"),
 	})
-	if string(state.pendingOutput) != "Hello" {
-		t.Fatalf("expected post-stop continuation to trim to visible text, got %q", state.pendingOutput)
+	if string(state.PendingOutput) != "Hello" {
+		t.Fatalf("expected post-stop continuation to trim to visible text, got %q", state.PendingOutput)
 	}
 }
 
@@ -43,7 +47,9 @@ func TestHandlePTYRestart_PreservesOverflowTrimCarry(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-tab-1")
 	state := &TerminalState{
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
@@ -52,8 +58,8 @@ func TestHandlePTYRestart_PreservesOverflowTrimCarry(t *testing.T) {
 		TabID:       string(tabID),
 	})
 
-	if state.overflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
-		t.Fatalf("expected overflowTrimCarry preserved on PTY restart, got %+v", state.overflowTrimCarry)
+	if state.OverflowTrimCarry != (vterm.ParserCarryState{Mode: vterm.ParserCarryCSI}) {
+		t.Fatalf("expected overflowTrimCarry preserved on PTY restart, got %+v", state.OverflowTrimCarry)
 	}
 
 	_ = m.handlePTYOutput(messages.SidebarPTYOutput{
@@ -61,8 +67,8 @@ func TestHandlePTYRestart_PreservesOverflowTrimCarry(t *testing.T) {
 		TabID:       string(tabID),
 		Data:        []byte("31mHello"),
 	})
-	if string(state.pendingOutput) != "Hello" {
-		t.Fatalf("expected post-restart continuation to trim to visible text, got %q", state.pendingOutput)
+	if string(state.PendingOutput) != "Hello" {
+		t.Fatalf("expected post-restart continuation to trim to visible text, got %q", state.PendingOutput)
 	}
 }
 
@@ -72,7 +78,9 @@ func TestHandlePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-tab-da-stop")
 	state := &TerminalState{
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
@@ -83,8 +91,8 @@ func TestHandlePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 		Data:        []byte("[>1;10;0cvisible"),
 	})
 
-	if string(state.pendingOutput) != "visible" {
-		t.Fatalf("expected secondary DA continuation trimmed after stop, got %q", state.pendingOutput)
+	if string(state.PendingOutput) != "visible" {
+		t.Fatalf("expected secondary DA continuation trimmed after stop, got %q", state.PendingOutput)
 	}
 }
 
@@ -94,7 +102,9 @@ func TestHandlePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-tab-da-restart")
 	state := &TerminalState{
-		overflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		State: ptyio.State{
+			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
+		},
 	}
 	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
@@ -105,7 +115,7 @@ func TestHandlePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 		Data:        []byte("[>1;10;0cvisible"),
 	})
 
-	if string(state.pendingOutput) != "visible" {
-		t.Fatalf("expected secondary DA continuation trimmed after restart, got %q", state.pendingOutput)
+	if string(state.PendingOutput) != "visible" {
+		t.Fatalf("expected secondary DA continuation trimmed after restart, got %q", state.PendingOutput)
 	}
 }

--- a/internal/ui/sidebar/terminal_update_session.go
+++ b/internal/ui/sidebar/terminal_update_session.go
@@ -123,9 +123,9 @@ func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) 
 	ts.UserDetached = false
 	ts.reattachInFlight = false
 	ts.SessionName = msg.SessionName
-	ts.pendingOutput = nil
-	ts.ptyNoiseTrailing = nil
-	ts.overflowTrimCarry = vterm.ParserCarryState{}
+	ts.PendingOutput = nil
+	ts.NoiseTrailing = nil
+	ts.OverflowTrimCarry = vterm.ParserCarryState{}
 	ts.lastWidth = termWidth
 	ts.lastHeight = termHeight
 	ts.mu.Unlock()
@@ -188,7 +188,7 @@ func (m *TerminalModel) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) te
 				tab.State.Terminal.Close()
 			}
 			tab.State.Running = false
-			tab.State.ptyRestartBackoff = 0
+			tab.State.RestartBackoff = 0
 			tab.State.mu.Unlock()
 		}
 	}


### PR DESCRIPTION
Move the duplicated buffering/lifecycle fields (pending output, noise
carry, overflow-trim carry, flush scheduling, reader channel/cancel/
heartbeat, restart backoff, snapshot cache) into one ptyio.State,
embedded by both center.Tab and sidebar.TerminalState. Fields move,
logic does not.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E1**, 14/36). Stacked on `rp/g1-shared-parser-carry`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.