### PR TITLE
E2: Unify the center/sidebar PTY reader lifecycle in ptyio

### DIFF
--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -65,10 +65,3 @@ func (m *Model) stopPTYReader(tab *Tab) {
 	}
 	tab.State.StopReader(&tab.mu)
 }
-
-func (m *Model) markPTYReaderStopped(tab *Tab) {
-	if tab == nil {
-		return
-	}
-	tab.State.MarkReaderStopped(&tab.mu)
-}

--- a/internal/ui/center/model_pty_lifecycle.go
+++ b/internal/ui/center/model_pty_lifecycle.go
@@ -1,12 +1,10 @@
 package center
 
 import (
-	"sync/atomic"
-	"time"
+	"io"
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/andyrewlee/amux/internal/safego"
 	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
@@ -20,51 +18,28 @@ func (m *Model) startPTYReader(wtID string, tab *Tab) tea.Cmd {
 	if !tab.Running {
 		return nil
 	}
-	tab.mu.Lock()
-	if tab.ReaderActive {
-		if tab.MsgCh == nil || tab.ReaderCancel == nil {
-			tab.ReaderActive = false
-		} else {
-			tab.mu.Unlock()
-			return nil
-		}
-	}
-	if tab.Agent == nil || tab.Agent.Terminal == nil || tab.Agent.Terminal.IsClosed() {
-		tab.ReaderActive = false
-		tab.mu.Unlock()
-		return nil
-	}
-	tab.ReaderActive = true
-	tab.RestartBackoff = 0
-	atomic.StoreInt64(&tab.Heartbeat, time.Now().UnixNano())
-
-	if tab.ReaderCancel != nil {
-		close(tab.ReaderCancel)
-	}
-	tab.ReaderCancel = make(chan struct{})
-	tab.MsgCh = make(chan tea.Msg, ptyReadQueueSize)
-
-	term := tab.Agent.Terminal
 	tabID := tab.ID
-	cancel := tab.ReaderCancel
-	msgCh := tab.MsgCh
-	tab.mu.Unlock()
-
-	safego.Go("center.pty_reader", func() {
-		defer m.markPTYReaderStopped(tab)
-		ptyio.RunPTYReader(term, msgCh, cancel, &tab.Heartbeat, ptyio.PTYReaderConfig{
+	tab.State.StartReader(&tab.mu, ptyio.StartReaderOptions{
+		AcquireTerm: func() io.Reader {
+			if tab.Agent == nil || tab.Agent.Terminal == nil || tab.Agent.Terminal.IsClosed() {
+				return nil
+			}
+			return tab.Agent.Terminal
+		},
+		Config: ptyio.PTYReaderConfig{
 			Label:           "center.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
 			FrameInterval:   ptyFrameInterval,
 			MaxPendingBytes: ptyMaxPendingBytes,
-		}, ptyio.PTYMsgFactory{
+		},
+		Factory: ptyio.PTYMsgFactory{
 			Output:  func(data []byte) tea.Msg { return PTYOutput{WorkspaceID: wtID, TabID: tabID, Data: data} },
 			Stopped: func(err error) tea.Msg { return PTYStopped{WorkspaceID: wtID, TabID: tabID, Err: err} },
-		})
-	})
-	safego.Go("center.pty_forward", func() {
-		m.forwardPTYMsgs(msgCh)
+		},
+		ReaderLabel:  "center.pty_reader",
+		ForwardLabel: "center.pty_forward",
+		Forward:      m.forwardPTYMsgs,
 	})
 	return nil
 }
@@ -88,24 +63,12 @@ func (m *Model) stopPTYReader(tab *Tab) {
 	if tab == nil {
 		return
 	}
-	tab.mu.Lock()
-	if tab.ReaderCancel != nil {
-		close(tab.ReaderCancel)
-		tab.ReaderCancel = nil
-	}
-	tab.ReaderActive = false
-	tab.MsgCh = nil
-	tab.mu.Unlock()
-	atomic.StoreInt64(&tab.Heartbeat, 0)
+	tab.State.StopReader(&tab.mu)
 }
 
 func (m *Model) markPTYReaderStopped(tab *Tab) {
 	if tab == nil {
 		return
 	}
-	tab.mu.Lock()
-	tab.ReaderActive = false
-	tab.MsgCh = nil
-	tab.mu.Unlock()
-	atomic.StoreInt64(&tab.Heartbeat, 0)
+	tab.State.MarkReaderStopped(&tab.mu)
 }

--- a/internal/ui/ptyio/reader_lifecycle.go
+++ b/internal/ui/ptyio/reader_lifecycle.go
@@ -1,0 +1,111 @@
+package ptyio
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/safego"
+)
+
+// StartReaderOptions bundles the per-consumer pieces of starting a PTY read
+// loop on a shared State: how to get the terminal, how messages are built,
+// and how they are forwarded into the UI.
+type StartReaderOptions struct {
+	// AcquireTerm is evaluated under the state lock. It returns the terminal
+	// to read from, or nil when the tab/terminal is not in a readable state.
+	// It must return an untyped nil for "not readable" (not a nil pointer
+	// wrapped in the interface).
+	AcquireTerm func() io.Reader
+	Config      PTYReaderConfig
+	Factory     PTYMsgFactory
+	// ReaderLabel and ForwardLabel name the spawned goroutines.
+	ReaderLabel  string
+	ForwardLabel string
+	// Forward drains the reader's message channel into the UI sink.
+	Forward func(<-chan tea.Msg)
+}
+
+// StartReader starts the PTY read loop for st unless one is already running.
+// mu is the embedding struct's mutex (the one documented to guard st). The
+// reader marks st stopped (under mu) when it exits.
+func (st *State) StartReader(mu sync.Locker, opts StartReaderOptions) {
+	mu.Lock()
+	if st.ReaderActive {
+		if st.MsgCh == nil || st.ReaderCancel == nil {
+			// Inconsistent leftover state: treat as not running and rearm.
+			st.ReaderActive = false
+		} else {
+			mu.Unlock()
+			return
+		}
+	}
+	term := opts.AcquireTerm()
+	if term == nil {
+		st.ReaderActive = false
+		mu.Unlock()
+		return
+	}
+	st.ReaderActive = true
+	st.RestartBackoff = 0
+	atomic.StoreInt64(&st.Heartbeat, time.Now().UnixNano())
+
+	if st.ReaderCancel != nil {
+		close(st.ReaderCancel)
+	}
+	st.ReaderCancel = make(chan struct{})
+	st.MsgCh = make(chan tea.Msg, opts.Config.ReadQueueSize)
+
+	cancel := st.ReaderCancel
+	msgCh := st.MsgCh
+	mu.Unlock()
+
+	safego.Go(opts.ReaderLabel, func() {
+		defer st.MarkReaderStopped(mu)
+		RunPTYReader(term, msgCh, cancel, &st.Heartbeat, opts.Config, opts.Factory)
+	})
+	safego.Go(opts.ForwardLabel, func() {
+		opts.Forward(msgCh)
+	})
+}
+
+// StopReader signals the read loop to stop and clears reader bookkeeping.
+// mu must not be held by the caller.
+func (st *State) StopReader(mu sync.Locker) {
+	mu.Lock()
+	if st.ReaderCancel != nil {
+		close(st.ReaderCancel)
+		st.ReaderCancel = nil
+	}
+	st.ReaderActive = false
+	st.MsgCh = nil
+	mu.Unlock()
+	atomic.StoreInt64(&st.Heartbeat, 0)
+}
+
+// MarkReaderStopped clears reader bookkeeping after the read loop has exited
+// on its own (RunPTYReader returned). The cancel channel is intentionally
+// left in place for the next StartReader to close.
+func (st *State) MarkReaderStopped(mu sync.Locker) {
+	mu.Lock()
+	st.ReaderActive = false
+	st.MsgCh = nil
+	mu.Unlock()
+	atomic.StoreInt64(&st.Heartbeat, 0)
+}
+
+// ReaderStalled reports whether an active reader's heartbeat is older than
+// stallTimeout. mu must not be held by the caller.
+func (st *State) ReaderStalled(mu sync.Locker, stallTimeout time.Duration) bool {
+	mu.Lock()
+	active := st.ReaderActive
+	mu.Unlock()
+	if !active {
+		return false
+	}
+	lastBeat := atomic.LoadInt64(&st.Heartbeat)
+	return lastBeat > 0 && time.Since(time.Unix(0, lastBeat)) > stallTimeout
+}

--- a/internal/ui/sidebar/terminal_pty_lifecycle.go
+++ b/internal/ui/sidebar/terminal_pty_lifecycle.go
@@ -1,15 +1,13 @@
 package sidebar
 
 import (
-	"sync/atomic"
-	"time"
+	"io"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/pty"
-	"github.com/andyrewlee/amux/internal/safego"
 	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
@@ -116,54 +114,31 @@ func (m *TerminalModel) startPTYReader(wsID string, tabID TerminalTabID) tea.Cmd
 		return nil
 	}
 	ts := tab.State
-	ts.mu.Lock()
-	if ts.ReaderActive {
-		if ts.MsgCh == nil || ts.ReaderCancel == nil {
-			ts.ReaderActive = false
-		} else {
-			ts.mu.Unlock()
-			return nil
-		}
-	}
-	if ts.Terminal == nil || !ts.Running {
-		ts.ReaderActive = false
-		ts.mu.Unlock()
-		return nil
-	}
-
-	if ts.ReaderCancel != nil {
-		close(ts.ReaderCancel)
-	}
-	ts.ReaderCancel = make(chan struct{})
-	ts.MsgCh = make(chan tea.Msg, ptyReadQueueSize)
-	ts.ReaderActive = true
-	ts.RestartBackoff = 0
-	atomic.StoreInt64(&ts.Heartbeat, time.Now().UnixNano())
-
-	term := ts.Terminal
-	cancel := ts.ReaderCancel
-	msgCh := ts.MsgCh
-	ts.mu.Unlock()
-
-	safego.Go("sidebar.pty_reader", func() {
-		defer m.markPTYReaderStopped(ts)
-		ptyio.RunPTYReader(term, msgCh, cancel, &ts.Heartbeat, ptyio.PTYReaderConfig{
+	ts.State.StartReader(&ts.mu, ptyio.StartReaderOptions{
+		AcquireTerm: func() io.Reader {
+			if ts.Terminal == nil || !ts.Running {
+				return nil
+			}
+			return ts.Terminal
+		},
+		Config: ptyio.PTYReaderConfig{
 			Label:           "sidebar.pty_read_loop",
 			ReadBufferSize:  ptyReadBufferSize,
 			ReadQueueSize:   ptyReadQueueSize,
 			FrameInterval:   ptyFrameInterval,
 			MaxPendingBytes: ptyMaxPendingBytes,
-		}, ptyio.PTYMsgFactory{
+		},
+		Factory: ptyio.PTYMsgFactory{
 			Output: func(data []byte) tea.Msg {
 				return messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: data}
 			},
 			Stopped: func(err error) tea.Msg {
 				return messages.SidebarPTYStopped{WorkspaceID: wsID, TabID: string(tabID), Err: err}
 			},
-		})
-	})
-	safego.Go("sidebar.pty_forward", func() {
-		m.forwardPTYMsgs(msgCh)
+		},
+		ReaderLabel:  "sidebar.pty_reader",
+		ForwardLabel: "sidebar.pty_forward",
+		Forward:      m.forwardPTYMsgs,
 	})
 	return nil
 }
@@ -175,18 +150,9 @@ func (m *TerminalModel) StartPTYReaders() tea.Cmd {
 			if tab == nil {
 				continue
 			}
-			ts := tab.State
-			if ts != nil {
-				ts.mu.Lock()
-				readerActive := ts.ReaderActive
-				ts.mu.Unlock()
-				if readerActive {
-					lastBeat := atomic.LoadInt64(&ts.Heartbeat)
-					if lastBeat > 0 && time.Since(time.Unix(0, lastBeat)) > ptyReaderStallTimeout {
-						logging.Warn("Sidebar PTY reader stalled for workspace %s tab %s; restarting", wsID, tab.ID)
-						m.stopPTYReader(ts)
-					}
-				}
+			if ts := tab.State; ts != nil && ts.State.ReaderStalled(&ts.mu, ptyReaderStallTimeout) {
+				logging.Warn("Sidebar PTY reader stalled for workspace %s tab %s; restarting", wsID, tab.ID)
+				m.stopPTYReader(ts)
 			}
 			_ = m.startPTYReader(wsID, tab.ID)
 		}
@@ -225,15 +191,7 @@ func (m *TerminalModel) stopPTYReader(ts *TerminalState) {
 	if ts == nil {
 		return
 	}
-	ts.mu.Lock()
-	if ts.ReaderCancel != nil {
-		close(ts.ReaderCancel)
-		ts.ReaderCancel = nil
-	}
-	ts.ReaderActive = false
-	ts.MsgCh = nil
-	ts.mu.Unlock()
-	atomic.StoreInt64(&ts.Heartbeat, 0)
+	ts.State.StopReader(&ts.mu)
 }
 
 func (m *TerminalModel) detachState(ts *TerminalState, userInitiated bool) {
@@ -253,17 +211,6 @@ func (m *TerminalModel) detachState(ts *TerminalState, userInitiated bool) {
 	if term != nil {
 		term.Close()
 	}
-}
-
-func (m *TerminalModel) markPTYReaderStopped(ts *TerminalState) {
-	if ts == nil {
-		return
-	}
-	ts.mu.Lock()
-	ts.ReaderActive = false
-	ts.MsgCh = nil
-	ts.mu.Unlock()
-	atomic.StoreInt64(&ts.Heartbeat, 0)
 }
 
 // SendToTerminal sends a string directly to the current terminal


### PR DESCRIPTION
One StartReader/StopReader/MarkReaderStopped/ReaderStalled on
ptyio.State, parameterized by an AcquireTerm closure (evaluated under
the state lock) and per-consumer message factory/forwarder. Replaces
the two hand-rolled start/stop/mark-stopped triplets.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E2**, 15/36). Stacked on `rp/e1-ptyio-state`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.