### PR TITLE
E3: Name and share the PTY reader restart backoff

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -44,30 +44,11 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 		}
 		tab.resetActivityANSIState()
 		if termAlive {
-			shouldRestart := true
-			var backoff time.Duration
 			tab.mu.Lock()
-			if tab.RestartSince.IsZero() || time.Since(tab.RestartSince) > ptyRestartWindow {
-				tab.RestartSince = time.Now()
-				tab.RestartCount = 0
-			}
-			tab.RestartCount++
-			if tab.RestartCount > ptyRestartMax {
-				shouldRestart = false
+			backoff, shouldRestart := tab.State.NextRestartBackoffLocked(ptyRestartWindow, ptyRestartMax)
+			if !shouldRestart {
 				tab.Running = false
 				tab.Detached = true
-				tab.RestartBackoff = 0
-			} else {
-				backoff = tab.RestartBackoff
-				if backoff <= 0 {
-					backoff = 200 * time.Millisecond
-				} else {
-					backoff *= 2
-					if backoff > 5*time.Second {
-						backoff = 5 * time.Second
-					}
-				}
-				tab.RestartBackoff = backoff
 			}
 			tab.mu.Unlock()
 			if shouldRestart {
@@ -87,9 +68,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			tab.mu.Lock()
 			tab.Running = false
 			tab.Detached = true
-			tab.RestartBackoff = 0
-			tab.RestartCount = 0
-			tab.RestartSince = time.Time{}
+			tab.State.ResetRestartBackoffLocked()
 			tab.mu.Unlock()
 			logging.Info("PTY stopped for tab %s, marking detached: %v", msg.TabID, msg.Err)
 			cmds = append(cmds, func() tea.Msg {

--- a/internal/ui/ptyio/reader_lifecycle.go
+++ b/internal/ui/ptyio/reader_lifecycle.go
@@ -109,3 +109,51 @@ func (st *State) ReaderStalled(mu sync.Locker, stallTimeout time.Duration) bool 
 	lastBeat := atomic.LoadInt64(&st.Heartbeat)
 	return lastBeat > 0 && time.Since(time.Unix(0, lastBeat)) > stallTimeout
 }
+
+// Reader-restart backoff policy: restarts are counted within a rolling
+// window; each retry doubles the delay from RestartBackoffInitial up to
+// RestartBackoffCap, and once the per-window restart budget is exhausted the
+// caller should stop restarting and mark the terminal detached.
+const (
+	// RestartBackoffInitial is the first reader-restart delay.
+	RestartBackoffInitial = 200 * time.Millisecond
+	// RestartBackoffCap bounds the exponential reader-restart delay.
+	RestartBackoffCap = 5 * time.Second
+)
+
+// NextRestartBackoffLocked advances the restart-backoff state and returns the
+// delay before the next restart attempt. ok is false once more than
+// maxRestarts attempts happened inside the rolling window — the caller should
+// give up instead of restarting. The caller must hold the state lock.
+func (st *State) NextRestartBackoffLocked(window time.Duration, maxRestarts int) (backoff time.Duration, ok bool) {
+	now := time.Now()
+	if st.RestartSince.IsZero() || now.Sub(st.RestartSince) > window {
+		st.RestartSince = now
+		st.RestartCount = 0
+	}
+	st.RestartCount++
+	if st.RestartCount > maxRestarts {
+		st.RestartBackoff = 0
+		return 0, false
+	}
+	backoff = st.RestartBackoff
+	if backoff <= 0 {
+		backoff = RestartBackoffInitial
+	} else {
+		backoff *= 2
+		if backoff > RestartBackoffCap {
+			backoff = RestartBackoffCap
+		}
+	}
+	st.RestartBackoff = backoff
+	return backoff, true
+}
+
+// ResetRestartBackoffLocked clears restart-backoff state, e.g. when the
+// terminal is detached and restarts no longer apply. The caller must hold the
+// state lock.
+func (st *State) ResetRestartBackoffLocked() {
+	st.RestartBackoff = 0
+	st.RestartCount = 0
+	st.RestartSince = time.Time{}
+}

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -183,32 +183,13 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 	ts.mu.Unlock()
 	m.stopPTYReader(ts)
 	if termAlive {
-		shouldRestart := true
-		var backoff time.Duration
 		ts.mu.Lock()
-		if ts.RestartSince.IsZero() || time.Since(ts.RestartSince) > ptyRestartWindow {
-			ts.RestartSince = time.Now()
-			ts.RestartCount = 0
-		}
-		ts.RestartCount++
-		if ts.RestartCount > ptyRestartMax {
-			shouldRestart = false
+		backoff, shouldRestart := ts.State.NextRestartBackoffLocked(ptyRestartWindow, ptyRestartMax)
+		if !shouldRestart {
 			ts.Running = false
 			// Mark as detached (tmux session may still be alive)
 			ts.Detached = true
 			ts.UserDetached = false
-			ts.RestartBackoff = 0
-		} else {
-			backoff = ts.RestartBackoff
-			if backoff <= 0 {
-				backoff = 200 * time.Millisecond
-			} else {
-				backoff *= 2
-				if backoff > 5*time.Second {
-					backoff = 5 * time.Second
-				}
-			}
-			ts.RestartBackoff = backoff
 		}
 		ts.mu.Unlock()
 		if shouldRestart {
@@ -226,9 +207,7 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 		// Mark as detached - tmux session may still be alive
 		ts.Detached = true
 		ts.UserDetached = false
-		ts.RestartBackoff = 0
-		ts.RestartCount = 0
-		ts.RestartSince = time.Time{}
+		ts.State.ResetRestartBackoffLocked()
 		ts.mu.Unlock()
 		logging.Info("Sidebar PTY stopped for workspace %s tab %s, marking detached: %v", wsID, tabID, msg.Err)
 	}


### PR DESCRIPTION
NextRestartBackoffLocked/ResetRestartBackoffLocked on ptyio.State own
the rolling-window exponential backoff (200ms doubling to a 5s cap, give
up after the per-window budget). Both the center restart handler and the
sidebar stop handler now use it instead of inline copies of the math.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E3**, 16/36). Stacked on `rp/e2-unified-reader`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.