### PR TITLE
E4: Unify the center/sidebar output-buffer flush and overflow trim

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty.go
+++ b/internal/ui/center/model_input_lifecycle_pty.go
@@ -14,25 +14,6 @@ import (
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
-// overflowLogThrottle bounds how often a sustained PTY overflow logs.
-const overflowLogThrottle = 2 * time.Second
-
-// noteOverflowDropLocked accumulates dropped overflow bytes and reports whether a
-// throttled overflow Warn should be emitted now (the caller logs outside the
-// lock). It returns the aggregated dropped-byte total to report when logNow is
-// true. The caller must hold tab.mu.
-func (t *Tab) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
-	t.OverflowDroppedSinceLog += droppedBytes
-	now := time.Now()
-	if t.LastOverflowLogAt.IsZero() || now.Sub(t.LastOverflowLogAt) >= overflowLogThrottle {
-		total = t.OverflowDroppedSinceLog
-		t.OverflowDroppedSinceLog = 0
-		t.LastOverflowLogAt = now
-		return true, total
-	}
-	return false, 0
-}
-
 // updatePTYOutput handles PTYOutput.
 func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 	var cmds []tea.Cmd
@@ -41,8 +22,9 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 		m.tracePTYOutput(tab, msg.Data)
 		data := msg.Data
 		tab.mu.Lock()
-		if tab.OverflowTrimCarry != (vterm.ParserCarryState{}) {
-			data, tab.OverflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, tab.OverflowTrimCarry)
+		var carryConsumed bool
+		data, carryConsumed = tab.State.ConsumeOverflowCarryLocked(data)
+		if carryConsumed {
 			tab.activityANSIState = ansiActivityText
 		}
 		tab.mu.Unlock()
@@ -60,7 +42,6 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 			perf.Count("pty_output_drop_bytes", int64(overflow))
 			perf.Count("pty_output_drop", 1)
 			seed := vterm.ParserCarryState{}
-			combinedLen := len(tab.PendingOutput)
 			resetNow := false
 			if m.isTabActorReady() {
 				tab.mu.Lock()
@@ -100,8 +81,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				}
 				tab.mu.Unlock()
 			}
-			retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(tab.PendingOutput, overflow, seed)
-			retainedStart := combinedLen - len(retained)
+			retained, overflowCarry, retainedStart := ptyio.TrimOverflow(tab.PendingOutput, ptyMaxBufferedBytes, seed)
 			chunkStart := prevPendingLen
 			if retainedStart > chunkStart {
 				dropFromMsg := retainedStart - chunkStart
@@ -111,7 +91,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 					activityData = data[dropFromMsg:]
 				}
 			}
-			tab.PendingOutput = append([]byte(nil), retained...)
+			tab.PendingOutput = retained
 			activityPrefixLen := len(retained) - len(activityData)
 			if activityPrefixLen < 0 {
 				activityPrefixLen = 0
@@ -126,7 +106,7 @@ func (m *Model) updatePTYOutput(msg PTYOutput) tea.Cmd {
 				tab.NoiseTrailing = nil
 				tab.actorQueuedNoiseTrailing = tab.actorQueuedNoiseTrailing[:0]
 			}
-			overflowLogNow, overflowDroppedTotal := tab.noteOverflowDropLocked(retainedStart)
+			overflowLogNow, overflowDroppedTotal := tab.NoteOverflowDropLocked(retainedStart)
 			tab.mu.Unlock()
 			if overflowLogNow {
 				logging.Warn("PTY output overflow for tab %s: dropped %d bytes (buffer cap %d)", tab.ID, overflowDroppedTotal, ptyMaxBufferedBytes)
@@ -182,18 +162,8 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 		}
 		catchUp := isActive && tab.catchUpActiveLocked()
 		tab.mu.Unlock()
-		now := time.Now()
-		quietFor := now.Sub(tab.LastOutputAt)
-		pendingFor := time.Duration(0)
-		if !tab.FlushPendingSince.IsZero() {
-			pendingFor = now.Sub(tab.FlushPendingSince)
-		}
 		quiet, maxInterval := m.flushTiming(tab, isActive)
-		if quietFor < quiet && pendingFor < maxInterval {
-			delay := quiet - quietFor
-			if delay < time.Millisecond {
-				delay = time.Millisecond
-			}
+		if delay, deferred := tab.State.FlushDelay(time.Now(), quiet, maxInterval); deferred {
 			tabID := msg.TabID
 			tab.FlushScheduled = true
 			cmds = append(cmds, common.SafeTick(delay, func(t time.Time) tea.Msg {
@@ -215,7 +185,6 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 			if tab.Terminal != nil {
 				parserResetPending = tab.parserResetPending
 				actorWritesPending = tab.actorWritesPending
-				chunkSize := len(tab.PendingOutput)
 				maxChunk := ptyFlushChunkSize
 				if isActive {
 					maxChunk = ptyFlushChunkSizeActive
@@ -225,17 +194,14 @@ func (m *Model) updatePTYFlush(msg PTYFlush) tea.Cmd {
 						maxChunk = ptyFlushChunkSizeCatchUp
 					}
 				}
-				if !parserResetPending && chunkSize > maxChunk {
-					chunkSize = maxChunk
-				}
-				if !parserResetPending && chunkSize > 0 {
-					chunk = append(chunk, tab.PendingOutput[:chunkSize]...)
-					copy(tab.PendingOutput, tab.PendingOutput[chunkSize:])
-					tab.PendingOutput = tab.PendingOutput[:len(tab.PendingOutput)-chunkSize]
-					tab.pendingOutputBytes = len(tab.PendingOutput)
-					hasMoreBuffered = len(tab.PendingOutput) > 0
-					visibleSeq = tab.pendingVisibleSeq
-					writeOutput = true
+				if !parserResetPending {
+					chunk = tab.State.TakeFlushChunkLocked(maxChunk)
+					if len(chunk) > 0 {
+						tab.pendingOutputBytes = len(tab.PendingOutput)
+						hasMoreBuffered = len(tab.PendingOutput) > 0
+						visibleSeq = tab.pendingVisibleSeq
+						writeOutput = true
+					}
 				}
 			}
 			tab.mu.Unlock()
@@ -369,14 +335,11 @@ func (m *Model) dispatchFlushChunkViaActor(tab *Tab, msg PTYFlush, chunk []byte,
 // queued carry/noise so a later actor write resumes from the applied state. It
 // returns an optional cursor-refresh command and the activity tag to publish.
 func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, hasMoreBuffered bool, visibleSeq uint64, updateActorCarry bool) (cmd tea.Cmd, tagSessionName string, tagTimestamp int64) {
-	processedBytes := len(chunk)
-	filteredLen := 0
-	filterApplied := false
 	suppressRedraw := false
 	tab.mu.Lock()
 	if tab.Terminal != nil {
-		filteredLen, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
-		filterApplied = true
+		// applyPTYChunkLocked emits the per-flush processed/filtered counters.
+		_, suppressRedraw, tagSessionName, tagTimestamp = m.applyPTYChunkLocked(tab, chunk, hasMoreBuffered, visibleSeq)
 		if updateActorCarry {
 			tab.actorQueuedCarry = tab.Terminal.ParserCarryState()
 			tab.actorQueuedNoiseTrailing = append(tab.actorQueuedNoiseTrailing[:0], tab.NoiseTrailing...)
@@ -385,13 +348,6 @@ func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, 
 	tab.mu.Unlock()
 	if !suppressRedraw {
 		cmd = m.scheduleChatCursorRefresh(tab, workspaceID, time.Now())
-	}
-	perf.Count("pty_flush_bytes_processed", int64(processedBytes))
-	if filterApplied {
-		filteredBytes := processedBytes - filteredLen
-		if filteredBytes > 0 {
-			perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
-		}
 	}
 	return cmd, tagSessionName, tagTimestamp
 }
@@ -402,14 +358,8 @@ func (m *Model) applyFlushChunkSync(tab *Tab, workspaceID string, chunk []byte, 
 // tab.Terminal != nil. It returns the filtered byte count, whether the
 // post-write redraw should be suppressed, and the activity tag to publish.
 func (m *Model) applyPTYChunkLocked(tab *Tab, chunk []byte, hasMoreBuffered bool, visibleSeq uint64) (filteredLen int, suppressRedraw bool, tagSessionName string, tagTimestamp int64) {
-	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &tab.NoiseTrailing)
+	filtered := tab.State.WriteFilteredChunkLocked(tab.Terminal.Write, chunk)
 	filteredLen = len(filtered)
-	if len(filtered) > 0 {
-		flushDone := perf.Time("pty_flush")
-		tab.Terminal.Write(filtered)
-		flushDone()
-		perf.Count("pty_flush_bytes", int64(len(filtered)))
-	}
 	// Activity state intentionally tracks visible terminal mutations only.
 	// Noise-only chunks are filtered above and must not update activity tags.
 	// We still run this to clear pending visible state when no mutation occurred.

--- a/internal/ui/center/model_overflow_log_test.go
+++ b/internal/ui/center/model_overflow_log_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -19,19 +20,19 @@ import (
 func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
 	tab := &Tab{}
 
-	logNow, total := tab.noteOverflowDropLocked(100)
+	logNow, total := tab.NoteOverflowDropLocked(100)
 	if !logNow || total != 100 {
 		t.Fatalf("first drop should log immediately with its total, got logNow=%v total=%d", logNow, total)
 	}
-	if ln, _ := tab.noteOverflowDropLocked(50); ln {
+	if ln, _ := tab.NoteOverflowDropLocked(50); ln {
 		t.Fatal("second drop within the throttle window should be suppressed")
 	}
-	if ln, _ := tab.noteOverflowDropLocked(25); ln {
+	if ln, _ := tab.NoteOverflowDropLocked(25); ln {
 		t.Fatal("third drop within the throttle window should be suppressed")
 	}
 	// Simulate the throttle window elapsing.
-	tab.LastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
-	logNow, total = tab.noteOverflowDropLocked(10)
+	tab.LastOverflowLogAt = time.Now().Add(-2 * ptyio.OverflowLogThrottle)
+	logNow, total = tab.NoteOverflowDropLocked(10)
 	if !logNow {
 		t.Fatal("a drop after the throttle window should log")
 	}

--- a/internal/ui/ptyio/flush.go
+++ b/internal/ui/ptyio/flush.go
@@ -1,0 +1,109 @@
+package ptyio
+
+import (
+	"time"
+
+	"github.com/andyrewlee/amux/internal/perf"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// OverflowLogThrottle bounds how often a sustained PTY overflow logs.
+const OverflowLogThrottle = 2 * time.Second
+
+// NoteOverflowDropLocked accumulates dropped overflow bytes and reports
+// whether a throttled overflow warning should be emitted now (the caller logs
+// outside the lock). It returns the aggregated dropped-byte total to report
+// when logNow is true. The caller must hold the state lock.
+func (st *State) NoteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
+	st.OverflowDroppedSinceLog += droppedBytes
+	now := time.Now()
+	if st.LastOverflowLogAt.IsZero() || now.Sub(st.LastOverflowLogAt) >= OverflowLogThrottle {
+		total = st.OverflowDroppedSinceLog
+		st.OverflowDroppedSinceLog = 0
+		st.LastOverflowLogAt = now
+		return true, total
+	}
+	return false, 0
+}
+
+// ConsumeOverflowCarryLocked resumes a previous overflow cut: when carry
+// state is pending from the last trim, it advances data past the unsafe
+// prefix and updates the carry. It returns the (possibly trimmed) data and
+// whether a carry was consumed. The caller must hold the state lock.
+func (st *State) ConsumeOverflowCarryLocked(data []byte) ([]byte, bool) {
+	if st.OverflowTrimCarry == (vterm.ParserCarryState{}) {
+		return data, false
+	}
+	data, st.OverflowTrimCarry = TrimPTYOverflowPrefix(data, 0, st.OverflowTrimCarry)
+	return data, true
+}
+
+// TrimOverflow applies the overflow policy to a pending buffer that exceeded
+// maxBuffered: it drops the overflow prefix at a parser-safe boundary
+// (seeded with the terminal's current parser carry state) and returns a fresh
+// copy of the retained bytes, the carry for the next chunk, and how many
+// bytes were dropped from the front.
+func TrimOverflow(pending []byte, maxBuffered int, seed vterm.ParserCarryState) (retained []byte, carry vterm.ParserCarryState, droppedFromFront int) {
+	overflow := len(pending) - maxBuffered
+	retainedSlice, carry := TrimPTYOverflowPrefix(pending, overflow, seed)
+	droppedFromFront = len(pending) - len(retainedSlice)
+	return append([]byte(nil), retainedSlice...), carry, droppedFromFront
+}
+
+// FlushDelay implements the flush quiet-period policy: a flush is deferred
+// while output is still arriving (quietFor < quiet) unless it has already
+// been pending longer than maxInterval. It returns the delay before the next
+// flush attempt and whether the flush should be deferred.
+func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (time.Duration, bool) {
+	quietFor := now.Sub(st.LastOutputAt)
+	pendingFor := time.Duration(0)
+	if !st.FlushPendingSince.IsZero() {
+		pendingFor = now.Sub(st.FlushPendingSince)
+	}
+	if quietFor < quiet && pendingFor < maxInterval {
+		delay := quiet - quietFor
+		if delay < time.Millisecond {
+			delay = time.Millisecond
+		}
+		return delay, true
+	}
+	return 0, false
+}
+
+// TakeFlushChunkLocked removes up to maxChunk bytes from the front of
+// PendingOutput and returns a copy (nil when nothing is buffered). A
+// non-positive maxChunk takes the whole buffer. The caller must hold the
+// state lock.
+func (st *State) TakeFlushChunkLocked(maxChunk int) []byte {
+	chunkSize := len(st.PendingOutput)
+	if maxChunk > 0 && chunkSize > maxChunk {
+		chunkSize = maxChunk
+	}
+	if chunkSize == 0 {
+		return nil
+	}
+	chunk := append([]byte(nil), st.PendingOutput[:chunkSize]...)
+	copy(st.PendingOutput, st.PendingOutput[chunkSize:])
+	st.PendingOutput = st.PendingOutput[:len(st.PendingOutput)-chunkSize]
+	return chunk
+}
+
+// WriteFilteredChunkLocked filters chunk for known PTY noise (carrying
+// incomplete fragments in NoiseTrailing), writes the visible remainder via
+// write, and emits the per-flush perf counters. It returns the filtered
+// bytes. The caller must hold the state lock; write goes to the terminal
+// guarded by that same lock.
+func (st *State) WriteFilteredChunkLocked(write func([]byte), chunk []byte) []byte {
+	filtered := FilterKnownPTYNoiseStream(chunk, &st.NoiseTrailing)
+	perf.Count("pty_flush_bytes_processed", int64(len(chunk)))
+	if d := len(chunk) - len(filtered); d > 0 {
+		perf.Count("pty_flush_bytes_filtered", int64(d))
+	}
+	if len(filtered) > 0 {
+		flushDone := perf.Time("pty_flush")
+		write(filtered)
+		flushDone()
+		perf.Count("pty_flush_bytes", int64(len(filtered)))
+	}
+	return filtered
+}

--- a/internal/ui/sidebar/terminal_overflow_log_test.go
+++ b/internal/ui/sidebar/terminal_overflow_log_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
@@ -19,18 +21,18 @@ import (
 func TestNoteOverflowDropLocked_ThrottlesAndAggregates(t *testing.T) {
 	ts := &TerminalState{}
 
-	logNow, total := ts.noteOverflowDropLocked(100)
+	logNow, total := ts.NoteOverflowDropLocked(100)
 	if !logNow || total != 100 {
 		t.Fatalf("first drop should log immediately with its total, got logNow=%v total=%d", logNow, total)
 	}
-	if ln, _ := ts.noteOverflowDropLocked(50); ln {
+	if ln, _ := ts.NoteOverflowDropLocked(50); ln {
 		t.Fatal("second drop within the throttle window should be suppressed")
 	}
-	if ln, _ := ts.noteOverflowDropLocked(25); ln {
+	if ln, _ := ts.NoteOverflowDropLocked(25); ln {
 		t.Fatal("third drop within the throttle window should be suppressed")
 	}
-	ts.LastOverflowLogAt = time.Now().Add(-2 * overflowLogThrottle)
-	logNow, total = ts.noteOverflowDropLocked(10)
+	ts.LastOverflowLogAt = time.Now().Add(-2 * ptyio.OverflowLogThrottle)
+	logNow, total = ts.NoteOverflowDropLocked(10)
 	if !logNow {
 		t.Fatal("a drop after the throttle window should log")
 	}

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -13,24 +13,6 @@ import (
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
-// overflowLogThrottle bounds how often a sustained PTY overflow logs.
-const overflowLogThrottle = 2 * time.Second
-
-// noteOverflowDropLocked accumulates dropped overflow bytes and reports whether a
-// throttled overflow Warn should be emitted now (caller logs outside the lock),
-// returning the aggregated dropped-byte total. The caller must hold ts.mu.
-func (ts *TerminalState) noteOverflowDropLocked(droppedBytes int) (logNow bool, total int) {
-	ts.OverflowDroppedSinceLog += droppedBytes
-	now := time.Now()
-	if ts.LastOverflowLogAt.IsZero() || now.Sub(ts.LastOverflowLogAt) >= overflowLogThrottle {
-		total = ts.OverflowDroppedSinceLog
-		ts.OverflowDroppedSinceLog = 0
-		ts.LastOverflowLogAt = now
-		return true, total
-	}
-	return false, 0
-}
-
 // handlePTYOutput buffers incoming PTY data and schedules a flush.
 func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	wsID := msg.WorkspaceID
@@ -42,9 +24,7 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	ts := tab.State
 	data := msg.Data
 	ts.mu.Lock()
-	if ts.OverflowTrimCarry != (vterm.ParserCarryState{}) {
-		data, ts.OverflowTrimCarry = ptyio.TrimPTYOverflowPrefix(data, 0, ts.OverflowTrimCarry)
-	}
+	data, _ = ts.State.ConsumeOverflowCarryLocked(data)
 	ts.mu.Unlock()
 	prevPendingLen := len(ts.PendingOutput)
 	ts.PendingOutput = append(ts.PendingOutput, data...)
@@ -53,22 +33,20 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 		perf.Count("sidebar_pty_drop_bytes", int64(overflow))
 		perf.Count("sidebar_pty_drop", 1)
 		seed := vterm.ParserCarryState{}
-		combinedLen := len(ts.PendingOutput)
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			seed = ts.VTerm.ParserCarryState()
 			ts.VTerm.ResetParserState()
 		}
 		ts.mu.Unlock()
-		retained, overflowCarry := ptyio.TrimPTYOverflowPrefix(ts.PendingOutput, overflow, seed)
-		retainedStart := combinedLen - len(retained)
-		ts.PendingOutput = append([]byte(nil), retained...)
+		retained, overflowCarry, retainedStart := ptyio.TrimOverflow(ts.PendingOutput, ptyMaxBufferedBytes, seed)
+		ts.PendingOutput = retained
 		ts.mu.Lock()
 		ts.OverflowTrimCarry = overflowCarry
 		if retainedStart > prevPendingLen {
 			ts.NoiseTrailing = nil
 		}
-		overflowLogNow, overflowDroppedTotal := ts.noteOverflowDropLocked(retainedStart)
+		overflowLogNow, overflowDroppedTotal := ts.NoteOverflowDropLocked(retainedStart)
 		ts.mu.Unlock()
 		if overflowLogNow {
 			logging.Warn("Sidebar PTY output overflow for workspace %s tab %s: dropped %d bytes (buffer cap %d)", wsID, tabID, overflowDroppedTotal, ptyMaxBufferedBytes)
@@ -95,18 +73,8 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 		return nil
 	}
 	ts := tab.State
-	now := time.Now()
-	quietFor := now.Sub(ts.LastOutputAt)
-	pendingFor := time.Duration(0)
-	if !ts.FlushPendingSince.IsZero() {
-		pendingFor = now.Sub(ts.FlushPendingSince)
-	}
 	quiet, maxInterval := m.flushTiming()
-	if quietFor < quiet && pendingFor < maxInterval {
-		delay := quiet - quietFor
-		if delay < time.Millisecond {
-			delay = time.Millisecond
-		}
+	if delay, deferred := ts.State.FlushDelay(time.Now(), quiet, maxInterval); deferred {
 		ts.FlushScheduled = true
 		return common.SafeTick(delay, func(t time.Time) tea.Msg {
 			return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
@@ -115,7 +83,18 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 
 	ts.FlushScheduled = false
 	ts.FlushPendingSince = time.Time{}
-	if len(ts.PendingOutput) == 0 || !flushSidebarPendingOutput(ts) {
+	if len(ts.PendingOutput) == 0 {
+		return nil
+	}
+	var consumed bool
+	ts.mu.Lock()
+	if ts.VTerm != nil {
+		chunk := ts.State.TakeFlushChunkLocked(ptyFlushChunkSize)
+		_ = ts.State.WriteFilteredChunkLocked(ts.VTerm.Write, chunk)
+		consumed = true
+	}
+	ts.mu.Unlock()
+	if !consumed {
 		return nil
 	}
 	if len(ts.PendingOutput) == 0 {
@@ -131,35 +110,6 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 	return common.SafeTick(delay, func(t time.Time) tea.Msg {
 		return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
 	})
-}
-
-func flushSidebarPendingOutput(ts *TerminalState) bool {
-	ts.mu.Lock()
-	defer ts.mu.Unlock()
-	if ts.VTerm == nil {
-		return false
-	}
-	chunkSize := len(ts.PendingOutput)
-	if chunkSize > ptyFlushChunkSize {
-		chunkSize = ptyFlushChunkSize
-	}
-	chunk := append([]byte(nil), ts.PendingOutput[:chunkSize]...)
-	copy(ts.PendingOutput, ts.PendingOutput[chunkSize:])
-	ts.PendingOutput = ts.PendingOutput[:len(ts.PendingOutput)-chunkSize]
-	processedBytes := len(chunk)
-	filtered := ptyio.FilterKnownPTYNoiseStream(chunk, &ts.NoiseTrailing)
-	filteredBytes := processedBytes - len(filtered)
-	perf.Count("pty_flush_bytes_processed", int64(processedBytes))
-	if filteredBytes > 0 {
-		perf.Count("pty_flush_bytes_filtered", int64(filteredBytes))
-	}
-	if len(filtered) > 0 {
-		flushDone := perf.Time("pty_flush")
-		ts.VTerm.Write(filtered)
-		flushDone()
-		perf.Count("pty_flush_bytes", int64(len(filtered)))
-	}
-	return true
 }
 
 // handlePTYStopped handles PTY reader exit, restarting with backoff or marking detached.


### PR DESCRIPTION
Shared ptyio.State helpers own the common slices: overflow-carry resume
(ConsumeOverflowCarryLocked), the overflow trim policy (TrimOverflow),
the flush quiet-period decision (FlushDelay), chunk extraction
(TakeFlushChunkLocked), and filtered terminal writes with per-flush perf
counters (WriteFilteredChunkLocked, also de-duplicating the counters the
sync path previously double-counted). The center keeps its actor-aware
seed selection; the sidebar keeps its simple VTerm seed.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E4**, 17/36). Stacked on `rp/e3-restart-backoff`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.