### PR TITLE
E5: Extract generic common.TabSet for per-workspace tab management

### DIFF
--- a/internal/ui/center/harness.go
+++ b/internal/ui/center/harness.go
@@ -5,20 +5,20 @@ func (m *Model) AddTab(tab *Tab) {
 	if m == nil || tab == nil || tab.Workspace == nil {
 		return
 	}
-	if m.tabsByWorkspace == nil {
-		m.tabsByWorkspace = make(map[string][]*Tab)
+	if m.tabs.ByWorkspace == nil {
+		m.tabs.ByWorkspace = make(map[string][]*Tab)
 	}
-	if m.activeTabByWorkspace == nil {
-		m.activeTabByWorkspace = make(map[string]int)
+	if m.tabs.ActiveByWorkspace == nil {
+		m.tabs.ActiveByWorkspace = make(map[string]int)
 	}
 	wtID := string(tab.Workspace.ID())
 	if tab.Terminal != nil {
 		tab.Terminal.IgnoreCursorVisibilityControls = false
 	}
-	m.tabsByWorkspace[wtID] = append(m.tabsByWorkspace[wtID], tab)
+	m.tabs.ByWorkspace[wtID] = append(m.tabs.ByWorkspace[wtID], tab)
 	m.noteTabsChanged()
-	if _, ok := m.activeTabByWorkspace[wtID]; !ok {
-		m.activeTabByWorkspace[wtID] = 0
+	if _, ok := m.tabs.ActiveByWorkspace[wtID]; !ok {
+		m.tabs.ActiveByWorkspace[wtID] = 0
 	}
 }
 

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -26,8 +26,7 @@ type Model struct {
 	workspaceIDCached     string
 	workspaceIDRepo       string
 	workspaceIDRoot       string
-	tabsByWorkspace       map[string][]*Tab // tabs per workspace ID
-	activeTabByWorkspace  map[string]int    // active tab index per workspace
+	tabs                  common.TabSet[*Tab] // tabs + active index per workspace ID
 	focused               bool
 	canFocusRight         bool
 	tabsRevision          uint64

--- a/internal/ui/center/model_activity_test.go
+++ b/internal/ui/center/model_activity_test.go
@@ -38,7 +38,7 @@ func TestIsTabActiveChatOnly(t *testing.T) {
 		Running:           true,
 		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
-	m.tabsByWorkspace[string(ws.ID())] = []*Tab{activeChat}
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{activeChat}
 
 	if !m.IsTabActive(activeChat) {
 		t.Fatalf("expected chat tab to be active with recent output")
@@ -92,8 +92,8 @@ func TestGetActiveWorkspaceIDsChatOnly(t *testing.T) {
 		lastVisibleOutput: now.Add(-1 * time.Second),
 	}
 
-	m.tabsByWorkspace[string(ws1.ID())] = []*Tab{activeChat}
-	m.tabsByWorkspace[string(ws2.ID())] = []*Tab{viewer}
+	m.tabs.ByWorkspace[string(ws1.ID())] = []*Tab{activeChat}
+	m.tabs.ByWorkspace[string(ws2.ID())] = []*Tab{viewer}
 
 	ids := m.GetActiveWorkspaceIDs()
 	if len(ids) != 1 || ids[0] != string(ws1.ID()) {

--- a/internal/ui/center/model_actor_ready_test.go
+++ b/internal/ui/center/model_actor_ready_test.go
@@ -48,8 +48,8 @@ func TestUpdatePTYFlush_StaleActorHeartbeatForcesParserResetFallback(t *testing.
 		parserResetPending: true,
 		actorWritesPending: 1,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})

--- a/internal/ui/center/model_cursor_refresh_test.go
+++ b/internal/ui/center/model_cursor_refresh_test.go
@@ -25,7 +25,7 @@ func TestUpdatePTYCursorRefresh_SchedulesWhileCursorTimersPending(t *testing.T) 
 			CachedSnap: &compositor.VTermSnapshot{},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	cmd := m.updatePTYCursorRefresh(PTYCursorRefresh{WorkspaceID: wsID, TabID: tab.ID})
 	if cmd == nil {
@@ -92,7 +92,7 @@ func TestUpdatePTYCursorRefresh_RequestPreservesPendingTimer(t *testing.T) {
 			CachedSnap: &compositor.VTermSnapshot{},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	first := m.scheduleChatCursorRefresh(tab, wsID, now)
 	if first == nil {
@@ -132,7 +132,7 @@ func TestUpdatePTYCursorRefresh_InvalidatesCachedSnapshotForNonChatTabs(t *testi
 			CachedSnap: &compositor.VTermSnapshot{},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	cmd := m.updatePTYCursorRefresh(PTYCursorRefresh{WorkspaceID: wsID, TabID: tab.ID})
 	if cmd != nil {

--- a/internal/ui/center/model_input_lifecycle_bootstrap_test.go
+++ b/internal/ui/center/model_input_lifecycle_bootstrap_test.go
@@ -22,8 +22,8 @@ func TestUpdatePTYOutput_DoesNotExtendBootstrapOnEachChunk(t *testing.T) {
 		bootstrapActivity:     true,
 		bootstrapLastOutputAt: bootstrapAt,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYOutput(PTYOutput{

--- a/internal/ui/center/model_input_lifecycle_capture_size_test.go
+++ b/internal/ui/center/model_input_lifecycle_capture_size_test.go
@@ -31,7 +31,7 @@ func TestUpdatePtyTabReattachResult_UsesSnapshotSizeBeforeResizingToCurrentSize(
 		Workspace: ws,
 		Terminal:  vterm.New(snapshotWidth, snapshotHeight),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -87,7 +87,7 @@ func TestHandlePtyTabCreated_UsesSnapshotSizeBeforeResizingToCurrentSize(t *test
 		SnapshotRows:      snapshotHeight,
 	})
 
-	tab := m.tabsByWorkspace[wsID][0]
+	tab := m.tabs.ByWorkspace[wsID][0]
 	if got := tab.Terminal.Width; got != current.Width {
 		t.Fatalf("expected terminal width %d after live resize, got %d", current.Width, got)
 	}
@@ -116,7 +116,7 @@ func TestUpdatePtyTabReattachResult_UsesCaptureSizeBeforeResizingForHistoryOnly(
 		Workspace: ws,
 		Terminal:  vterm.New(current.Width, current.Height),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -166,7 +166,7 @@ func TestHandlePtyTabCreated_UsesCaptureSizeBeforeResizingForHistoryOnly(t *test
 		CaptureFullPane:   false,
 	})
 
-	tab := m.tabsByWorkspace[wsID][0]
+	tab := m.tabs.ByWorkspace[wsID][0]
 	if got := tab.Terminal.Width; got != current.Width {
 		t.Fatalf("expected terminal width %d after live resize, got %d", current.Width, got)
 	}
@@ -195,7 +195,7 @@ func TestUpdatePtyTabReattachResult_UsesLiveDefaultPTYSizeBeforeFirstLayout(t *t
 		Assistant: "codex",
 		Workspace: ws,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -237,7 +237,7 @@ func TestHandlePtyTabCreated_UsesLiveDefaultPTYSizeBeforeFirstLayout(t *testing.
 		CaptureFullPane:   false,
 	})
 
-	tab := m.tabsByWorkspace[wsID][0]
+	tab := m.tabs.ByWorkspace[wsID][0]
 	if tab.ptyRows != current.Height || tab.ptyCols != current.Width {
 		t.Fatalf("expected live PTY size %dx%d before first layout, got %dx%d", current.Width, current.Height, tab.ptyCols, tab.ptyRows)
 	}

--- a/internal/ui/center/model_input_lifecycle_flush_test.go
+++ b/internal/ui/center/model_input_lifecycle_flush_test.go
@@ -24,8 +24,8 @@ func TestUpdatePTYFlush_UsesLargerChunkForActiveTab(t *testing.T) {
 			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSizeActive+17),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
@@ -53,8 +53,8 @@ func TestUpdatePTYFlush_CatchUpWithoutActorKeepsActiveChunkCap(t *testing.T) {
 		catchUpTargetBytes:   ptyFlushChunkSizeActive + 17,
 		ptyBytesReceived:     ptyFlushChunkSizeActive + 17,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
@@ -86,8 +86,8 @@ func TestUpdatePTYFlush_FastForwardsCatchUpActiveTabViaActor(t *testing.T) {
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
@@ -134,8 +134,8 @@ func TestUpdatePTYFlush_CatchUpUsesBoundedActorChunk(t *testing.T) {
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
@@ -182,8 +182,8 @@ func TestUpdatePTYFlush_PendingCatchUpOverridesStaleFlushMessage(t *testing.T) {
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
@@ -222,8 +222,8 @@ func TestUpdatePTYFlush_StaleCatchUpMessageDoesNotRelatchAfterBacklogDrains(t *t
 			FlushPendingSince: time.Now().Add(-time.Second),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
@@ -268,8 +268,8 @@ func TestUpdatePTYFlush_UsesBaseChunkForInactiveTab(t *testing.T) {
 			PendingOutput:     bytes.Repeat([]byte("x"), ptyFlushChunkSize+17),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{active, inactive}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{active, inactive}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: inactive.ID})
@@ -303,8 +303,8 @@ func TestUpdatePTYFlush_CatchUpHintIgnoredWhenTabIsNoLongerActive(t *testing.T) 
 		catchUpTargetBytes:   ptyFlushChunkSize + 17,
 		ptyBytesReceived:     ptyFlushChunkSize + 17,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{active, inactive}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{active, inactive}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: inactive.ID})
@@ -340,8 +340,8 @@ func TestUpdatePTYFlush_CatchUpFallsBackToActiveChunkWhenActorQueueIsFull(t *tes
 		catchUpTargetBytes:   uint64(len(payload)),
 		ptyBytesReceived:     uint64(len(payload)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})
@@ -386,8 +386,8 @@ func TestUpdatePTYFlush_CatchUpClearsAfterInitialBacklogPass(t *testing.T) {
 		catchUpTargetBytes:   uint64(len(initialBacklog)),
 		ptyBytesReceived:     uint64(len(initialBacklog) + len(steadyState)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID, CatchUp: true})

--- a/internal/ui/center/model_input_lifecycle_pane_capture_test.go
+++ b/internal/ui/center/model_input_lifecycle_pane_capture_test.go
@@ -42,7 +42,7 @@ func TestUpdatePtyTabReattachResult_NormalizesCapturedPaneLFForChatTabs(t *testi
 		Assistant: "codex",
 		Workspace: ws,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -78,7 +78,7 @@ func TestUpdatePtyTabReattachResult_LoadsPaneCaptureIntoVisibleScreen(t *testing
 		},
 	}
 	tab.pendingOutputBytes = len(tab.PendingOutput)
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -120,7 +120,7 @@ func TestUpdatePtyTabReattachResult_ReconcilesPostAttachHistoryAfterFullPaneRest
 		Workspace: ws,
 		Terminal:  vterm.New(20, 2),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:                 wsID,
@@ -158,7 +158,7 @@ func TestUpdatePtyTabReattachResult_ResizesExistingTerminalBeforeFullPaneRestore
 		Workspace: ws,
 		Terminal:  term,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -200,7 +200,7 @@ func TestUpdatePtyTabReattachResult_NonAuthoritativeEmptyCapturePreservesExistin
 		},
 	}
 	tab.pendingOutputBytes = len(tab.PendingOutput)
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID: wsID,
@@ -242,7 +242,7 @@ func TestUpdatePtyTabReattachResult_PreservesExistingAltScreenStateWithoutSnapsh
 		Workspace: ws,
 		Terminal:  term,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID:       wsID,
@@ -288,7 +288,7 @@ func TestHandlePtyTabCreated_NewTabNormalizesCapturedPaneLFForChatTabs(t *testin
 		CaptureFullPane:   true,
 	})
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 1 {
 		t.Fatalf("expected 1 tab, got %d", len(tabs))
 	}
@@ -318,7 +318,7 @@ func TestHandlePtyTabCreated_LoadsPaneCaptureIntoVisibleScreen(t *testing.T) {
 		CaptureFullPane:   true,
 	})
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 1 {
 		t.Fatalf("expected 1 tab, got %d", len(tabs))
 	}
@@ -344,7 +344,7 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 	term := vterm.New(20, 2)
 	term.LoadPaneCapture([]byte("old history\nstale one\nstale two\n"))
 	tabID := TabID("tab-existing-pane-capture")
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        tabID,
 			Name:      "codex",
@@ -356,7 +356,7 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 			},
 		},
 	}
-	m.tabsByWorkspace[wsID][0].pendingOutputBytes = len(m.tabsByWorkspace[wsID][0].PendingOutput)
+	m.tabs.ByWorkspace[wsID][0].pendingOutputBytes = len(m.tabs.ByWorkspace[wsID][0].PendingOutput)
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace:         ws,
@@ -370,7 +370,7 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 		CaptureFullPane:   true,
 	})
 
-	tab := m.tabsByWorkspace[wsID][0]
+	tab := m.tabs.ByWorkspace[wsID][0]
 	if tab.Terminal == nil {
 		t.Fatal("expected terminal to be preserved")
 	}
@@ -397,7 +397,7 @@ func TestHandlePtyTabCreated_ResizesExistingTerminalBeforeFullPaneRestore(t *tes
 	wsID := string(ws.ID())
 	term := vterm.New(4, 2)
 	tabID := TabID("tab-existing-pane-resize")
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        tabID,
 			Name:      "codex",
@@ -419,7 +419,7 @@ func TestHandlePtyTabCreated_ResizesExistingTerminalBeforeFullPaneRestore(t *tes
 		CaptureFullPane:   true,
 	})
 
-	tab := m.tabsByWorkspace[wsID][0]
+	tab := m.tabs.ByWorkspace[wsID][0]
 	if tab.Terminal == nil {
 		t.Fatal("expected terminal to be preserved")
 	}

--- a/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_catchup_reset_test.go
@@ -28,8 +28,8 @@ func TestUpdatePTYFlush_StaleCatchUpMessageIgnoredAfterReattachReset(t *testing.
 			PendingOutput: []byte("old buffered output"),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{

--- a/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
@@ -20,7 +20,7 @@ func TestUpdatePtyTabReattachResult_ResetsActivityANSIState(t *testing.T) {
 		Workspace:         ws,
 		activityANSIState: ansiActivityString,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID: wsID,
@@ -64,7 +64,7 @@ func TestUpdatePtyTabReattachResult_ResetsStableCursor(t *testing.T) {
 		lastPromptInputAt: time.Now(),
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID: wsID,
@@ -109,7 +109,7 @@ func TestUpdatePtyTabReattachResult_PreservesParserCarryOnExistingTerminal(t *te
 			PendingOutput: []byte("[31mHello"),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	if got := tab.Terminal.ParserCarryState(); got != (vterm.ParserCarryState{Mode: vterm.ParserCarryEscape}) {
 		t.Fatalf("expected precondition escape carry, got %+v", got)
@@ -148,7 +148,7 @@ func TestUpdatePtyTabReattachResult_ClearsCatchUpPendingOutput(t *testing.T) {
 			PendingOutput: []byte("buffered"),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
 		WorkspaceID: wsID,
@@ -173,7 +173,7 @@ func TestHandlePtyTabCreated_ExistingResetsActivityANSIState(t *testing.T) {
 		Workspace:         ws,
 		activityANSIState: ansiActivityOSC,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace: ws,
@@ -204,7 +204,7 @@ func TestHandlePtyTabCreated_ExistingClearsCatchUpPendingOutput(t *testing.T) {
 			PendingOutput: []byte("buffered"),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace: ws,
@@ -236,7 +236,7 @@ func TestHandlePtyTabCreated_ExistingPreservesParserCarry(t *testing.T) {
 			PendingOutput: []byte("[31mHello"),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	if got := tab.Terminal.ParserCarryState(); got != (vterm.ParserCarryState{Mode: vterm.ParserCarryEscape}) {
 		t.Fatalf("expected precondition escape carry, got %+v", got)
@@ -288,8 +288,8 @@ func TestHandlePtyTabCreated_RejectsMissingTabID(t *testing.T) {
 	if errMsg.Err == nil || errMsg.Err.Error() != "missing tab id" {
 		t.Fatalf("expected missing tab id error, got %v", errMsg.Err)
 	}
-	if len(m.tabsByWorkspace[wsID]) != 0 {
-		t.Fatalf("expected no tabs to be created on missing tab id, got %d", len(m.tabsByWorkspace[wsID]))
+	if len(m.tabs.ByWorkspace[wsID]) != 0 {
+		t.Fatalf("expected no tabs to be created on missing tab id, got %d", len(m.tabs.ByWorkspace[wsID]))
 	}
 }
 
@@ -312,7 +312,7 @@ func TestHandlePtyTabCreated_ExistingResetsStableCursor(t *testing.T) {
 		lastPromptInputAt: time.Now(),
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace: ws,
@@ -357,7 +357,7 @@ func TestUpdatePTYStopped_ResetsActivityANSIState(t *testing.T) {
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.updatePTYStopped(PTYStopped{
 		WorkspaceID: wsID,
@@ -394,7 +394,7 @@ func TestUpdatePTYRestart_ResetsActivityANSIState(t *testing.T) {
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.updatePTYRestart(PTYRestart{
 		WorkspaceID: wsID,
@@ -430,7 +430,7 @@ func TestUpdatePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.updatePTYStopped(PTYStopped{WorkspaceID: wsID, TabID: tab.ID})
 	_ = m.updatePTYOutput(PTYOutput{
@@ -456,7 +456,7 @@ func TestUpdatePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_ = m.updatePTYRestart(PTYRestart{WorkspaceID: wsID, TabID: tab.ID})
 	_ = m.updatePTYOutput(PTYOutput{

--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -122,8 +122,8 @@ func TestUpdatePTYOutput_DoesNotTagControlOnlyOutput(t *testing.T) {
 		SessionName: "amux-test-session",
 		Running:     true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
@@ -155,8 +155,8 @@ func TestUpdatePTYOutput_TagsVisibleOutput(t *testing.T) {
 		Running:           true,
 		lastActivityTagAt: before,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
@@ -189,8 +189,8 @@ func TestUpdatePTYOutput_ResetsActivityStateAfterOverflowCarryTrim(t *testing.T)
 		},
 		activityANSIState: ansiActivityCSI,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
@@ -226,8 +226,8 @@ func TestUpdatePTYOutput_EndsBootstrapAfterQuietGap(t *testing.T) {
 		bootstrapActivity:     true,
 		bootstrapLastOutputAt: time.Now().Add(-(bootstrapQuietGap + 200*time.Millisecond)),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -266,8 +266,8 @@ func TestUpdatePTYFlush_TagsVisibleScreenDelta(t *testing.T) {
 		Running:           true,
 		lastActivityTagAt: before,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -317,8 +317,8 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 		Terminal:    vterm.New(80, 24),
 		Running:     true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -382,8 +382,8 @@ func TestUpdatePTYFlush_RebuffersChunkAfterActorFallbackWithOlderPendingWrites(t
 		actorQueuedNoiseTrailing: []byte("queued-noise"),
 	}
 	prevNoiseTrailing := append([]byte(nil), tab.actorQueuedNoiseTrailing...)
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
@@ -421,8 +421,8 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 		Running:         true,
 		lastUserInputAt: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYOutput(PTYOutput{
@@ -480,8 +480,8 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 		actorWritesPending: 1,
 		actorWriteEpoch:    11,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})

--- a/internal/ui/center/model_input_test.go
+++ b/internal/ui/center/model_input_test.go
@@ -19,8 +19,8 @@ func TestUpdatePasteWithoutAttachedTerminalDoesNotTagActivity(t *testing.T) {
 		Workspace:   ws,
 		SessionName: "session-1",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -40,8 +40,8 @@ func TestUpdatePasteActorFallbackWithoutTerminalDoesNotTagActivity(t *testing.T)
 		Workspace:   ws,
 		SessionName: "session-1",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -64,8 +64,8 @@ func TestUpdatePasteQueuedDoesNotStampLocalInputWindow(t *testing.T) {
 		Workspace:   ws,
 		SessionName: "session-paste-queued",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -92,8 +92,8 @@ func TestUpdateQueuedKeyInputDoesNotStampLocalInputWindow(t *testing.T) {
 		SessionName: "session-key-queued",
 		Agent:       &appPty.Agent{Terminal: &appPty.Terminal{}},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -124,8 +124,8 @@ func TestUpdateKeyPgUpScrollsOneLineOnShortTerminal(t *testing.T) {
 		Terminal:  term,
 		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -154,8 +154,8 @@ func TestUpdateCtrlUDoesNotScrollCenterTerminalHistory(t *testing.T) {
 		Terminal:  term,
 		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -185,8 +185,8 @@ func TestUpdateCtrlDReturnsCenterTerminalToLiveOutput(t *testing.T) {
 		Terminal:  term,
 		Agent:     &appPty.Agent{Terminal: &appPty.Terminal{}},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 
@@ -214,8 +214,8 @@ func TestTabActorScrollPageScrollsOneLineOnShortTerminal(t *testing.T) {
 		Workspace: ws,
 		Terminal:  term,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 	m.focused = true
 

--- a/internal/ui/center/model_lifecycle.go
+++ b/internal/ui/center/model_lifecycle.go
@@ -13,13 +13,12 @@ import (
 // New creates a new center pane model.
 func New(cfg *config.Config) *Model {
 	return &Model{
-		tabsByWorkspace:      make(map[string][]*Tab),
-		activeTabByWorkspace: make(map[string]int),
-		config:               cfg,
-		agentManager:         appPty.NewAgentManager(cfg),
-		styles:               common.DefaultStyles(),
-		tabEvents:            make(chan tabEvent, 4096),
-		tmuxOpts:             tmux.DefaultOptions(),
+		tabs:         common.NewTabSet[*Tab](),
+		config:       cfg,
+		agentManager: appPty.NewAgentManager(cfg),
+		styles:       common.DefaultStyles(),
+		tabEvents:    make(chan tabEvent, 4096),
+		tmuxOpts:     tmux.DefaultOptions(),
 	}
 }
 
@@ -82,7 +81,7 @@ func (m *Model) SetShowKeymapHints(show bool) {
 func (m *Model) SetStyles(styles common.Styles) {
 	m.styles = styles
 	// Propagate to all viewers in tabs
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab == nil {
 				continue
@@ -129,7 +128,7 @@ func (m *Model) SetSize(width, height int) {
 	viewerHeight := termHeight
 
 	// Update all terminals across all workspaces
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			tab.mu.Lock()
 			if tab.Terminal != nil {
@@ -194,7 +193,7 @@ func (m *Model) syncActiveDiffViewerFocus(focused bool) {
 
 // Close cleans up all resources.
 func (m *Model) Close() {
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			tab.markClosing()
 			m.stopPTYReader(tab)

--- a/internal/ui/center/model_lifecycle_focus_test.go
+++ b/internal/ui/center/model_lifecycle_focus_test.go
@@ -22,8 +22,8 @@ func TestFocusSyncsActiveDiffViewerFocus(t *testing.T) {
 		DiffViewer: dv,
 	}
 	wsID := string(ws.ID())
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	m.Focus()
 	if !dv.Focused() {

--- a/internal/ui/center/model_overflow_log_test.go
+++ b/internal/ui/center/model_overflow_log_test.go
@@ -60,8 +60,8 @@ func TestUpdatePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
 	m.SetWorkspace(ws)
 	wsID := string(ws.ID())
 	tab := &Tab{ID: TabID("overflow-tab"), Workspace: ws, Terminal: vterm.New(80, 24), Running: true}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	overflowChunk := bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+4096)
 	_ = m.updatePTYOutput(PTYOutput{WorkspaceID: wsID, TabID: tab.ID, Data: overflowChunk})
@@ -90,8 +90,8 @@ func TestUpdatePTYOutput_OverflowWarnReportsActualTrimmedBytes(t *testing.T) {
 	m.SetWorkspace(ws)
 	wsID := string(ws.ID())
 	tab := &Tab{ID: TabID("overflow-tab"), Workspace: ws, Terminal: vterm.New(80, 24), Running: true}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	controlSeq := []byte("\x1b[>1;10;0c")
 	chunk := append([]byte{}, controlSeq...)

--- a/internal/ui/center/model_pty_reader.go
+++ b/internal/ui/center/model_pty_reader.go
@@ -80,7 +80,7 @@ func (m *Model) busyPTYTabCount(now time.Time) int {
 		return m.cachedBusyTabCount
 	}
 	count := 0
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab == nil || tab.isClosed() {
 				continue

--- a/internal/ui/center/model_pty_reader_test.go
+++ b/internal/ui/center/model_pty_reader_test.go
@@ -22,7 +22,7 @@ func TestFlushTiming_InactiveBackpressureRespectsHardCap(t *testing.T) {
 			PendingOutput: make([]byte, ptyBackpressureMultiplier*width*height+1),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	heavyWS := newTestWorkspace("ws-heavy", "/repo/ws-heavy")
 	heavyWSID := string(heavyWS.ID())
@@ -36,7 +36,7 @@ func TestFlushTiming_InactiveBackpressureRespectsHardCap(t *testing.T) {
 			},
 		})
 	}
-	m.tabsByWorkspace[heavyWSID] = busyTabs
+	m.tabs.ByWorkspace[heavyWSID] = busyTabs
 
 	quiet, maxInterval := m.flushTiming(tab, false)
 	if quiet != ptyFlushInactiveMaxIntervalCap {

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -15,7 +15,7 @@ const tabActiveWindow = 2 * time.Second
 
 // HasRunningAgents returns whether any tab has an active agent across workspaces.
 func (m *Model) HasRunningAgents() bool {
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab.isClosed() {
 				continue
@@ -34,7 +34,7 @@ func (m *Model) HasRunningAgents() bool {
 // HasActiveAgents returns whether any tab has emitted output recently.
 // This is used to drive UI activity indicators without relying on process liveness alone.
 func (m *Model) HasActiveAgents() bool {
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if m.IsTabActive(tab) {
 				return true
@@ -93,7 +93,7 @@ func isTabCursorOutputActiveLocked(tab *Tab, now time.Time) bool {
 
 // HasActiveAgentsInWorkspace returns whether any tab in a workspace is actively outputting.
 func (m *Model) HasActiveAgentsInWorkspace(wsID string) bool {
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if m.IsTabActive(tab) {
 			return true
 		}
@@ -104,7 +104,7 @@ func (m *Model) HasActiveAgentsInWorkspace(wsID string) bool {
 // GetActiveWorkspaceRoots returns all workspace root paths with active agents.
 func (m *Model) GetActiveWorkspaceRoots() []string {
 	var active []string
-	for wsID, tabs := range m.tabsByWorkspace {
+	for wsID, tabs := range m.tabs.ByWorkspace {
 		if m.HasActiveAgentsInWorkspace(wsID) {
 			// Get the root path from one of the tabs
 			for _, tab := range tabs {
@@ -121,7 +121,7 @@ func (m *Model) GetActiveWorkspaceRoots() []string {
 // GetActiveWorkspaceIDs returns all workspace IDs with active agents.
 func (m *Model) GetActiveWorkspaceIDs() []string {
 	var active []string
-	for wsID := range m.tabsByWorkspace {
+	for wsID := range m.tabs.ByWorkspace {
 		if m.HasActiveAgentsInWorkspace(wsID) {
 			active = append(active, wsID)
 		}
@@ -133,7 +133,7 @@ func (m *Model) GetActiveWorkspaceIDs() []string {
 // This includes agents that are running but idle (waiting at prompt).
 func (m *Model) GetRunningWorkspaceRoots() []string {
 	var running []string
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if !m.isChatTab(tab) {
 				continue
@@ -149,7 +149,7 @@ func (m *Model) GetRunningWorkspaceRoots() []string {
 
 // StartPTYReaders starts reading from all PTYs across all workspaces
 func (m *Model) StartPTYReaders() tea.Cmd {
-	for wtID, tabs := range m.tabsByWorkspace {
+	for wtID, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab == nil || tab.isClosed() {
 				continue

--- a/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
@@ -28,8 +28,8 @@ func TestTerminalLayerTracksFreshSubmitPromptBeforeStableCursorLearned(t *testin
 		},
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -76,8 +76,8 @@ func TestTerminalLayerTracksIndentedSubmitRedrawBeforePostSubmitOutput(t *testin
 		},
 		lastVisibleOutput: time.Now().Add(-time.Millisecond),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -118,8 +118,8 @@ func TestTerminalLayerDoesNotLearnInitialCursorFromBlankControlOnlyJump(t *testi
 			LastOutputAt: time.Now().Add(-tabActiveWindow - time.Millisecond),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -156,8 +156,8 @@ func TestTerminalLayerAllowsSecondToLastRowCursorInShortRestrictedViewport(t *te
 		},
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
@@ -23,8 +23,8 @@ func TestTerminalLayerRecomputesCachedBlankCornerPromptAfterRecentLocalInput(t *
 		Workspace: ws,
 		Terminal:  term,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -76,8 +76,8 @@ func TestTerminalLayerRecomputesCachedPromptWhenVisibleActivityEnds(t *testing.T
 		Running:           true,
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -114,7 +114,7 @@ func TestTerminalLayerHidesBlankCornerArtifactWhileVisiblyActiveWithoutStoredCur
 	term.CursorY = 11
 	term.Screen[11][0] = vterm.Cell{Rune: ' ', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:                TabID("tab-chat-active-corner-artifact"),
 			Assistant:         "codex",
@@ -124,7 +124,7 @@ func TestTerminalLayerHidesBlankCornerArtifactWhileVisiblyActiveWithoutStoredCur
 			lastVisibleOutput: time.Now(),
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -146,7 +146,7 @@ func TestTerminalLayerRestrictsMidScreenCursorDuringControlOnlyOutput(t *testing
 	term.CursorY = 4
 	term.Screen[4][4] = vterm.Cell{Rune: 'x', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-control-only-output"),
 			Assistant: "codex",
@@ -158,7 +158,7 @@ func TestTerminalLayerRestrictsMidScreenCursorDuringControlOnlyOutput(t *testing
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -191,8 +191,8 @@ func TestTerminalLayerAllowsRecentLocalInputDespiteRecentControlOnlyOutput(t *te
 		},
 		lastPromptInputAt: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -236,8 +236,8 @@ func TestTerminalLayerIgnoresRecentLocalEchoOutputAfterInputWindowExpires(t *tes
 			LastOutputAt: now.Add(-550 * time.Millisecond),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -262,7 +262,7 @@ func TestTerminalLayerPreservesRealBlockGlyphAtStoredCursorPosition(t *testing.T
 	term.CursorY = 0
 	term.Screen[11][3] = vterm.Cell{Rune: '█', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:              TabID("tab-chat-stored-block-glyph"),
 			Assistant:       "codex",
@@ -273,7 +273,7 @@ func TestTerminalLayerPreservesRealBlockGlyphAtStoredCursorPosition(t *testing.T
 			stableCursorY:   11,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -304,8 +304,8 @@ func TestTerminalLayerTracksStoredChatCursorAcrossLiveCursorJumps(t *testing.T) 
 			LastOutputAt: time.Now(),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -391,8 +391,8 @@ func TestTerminalLayerTreatsWrappedMultilinePromptAsInputSection(t *testing.T) {
 		Running:           true,
 		lastVisibleOutput: time.Now().Add(-tabActiveWindow - time.Millisecond),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -423,7 +423,7 @@ func TestTerminalLayerKeepsVisiblyActiveChatCursorRestrictedToBottomInputBand(t 
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:                TabID("tab-chat-running-midscreen-cursor"),
 			Assistant:         "codex",
@@ -433,7 +433,7 @@ func TestTerminalLayerKeepsVisiblyActiveChatCursorRestrictedToBottomInputBand(t 
 			lastVisibleOutput: time.Now(),
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_chat_cursor_state_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_state_test.go
@@ -26,8 +26,8 @@ func TestTerminalLayerUpdatesStoredCursorWhenIdlePromptMovesAfterVersionChange(t
 		stableCursorX:   1,
 		stableCursorY:   11,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -78,8 +78,8 @@ func TestTerminalLayerPreservesStoredCursorAcrossTemporaryScrollback(t *testing.
 		stableCursorVersion: term.Version(),
 		lastVisibleOutput:   time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -124,8 +124,8 @@ func TestTerminalLayerAllowsBracketedPasteAsRecentLocalInput(t *testing.T) {
 			LastOutputAt: time.Now(),
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -161,8 +161,8 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 		stableCursorX:   1,
 		stableCursorY:   23,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -223,8 +223,8 @@ func TestTerminalLayerPreservesStoredMultilineCursorAcrossRestrictedArtifact(t *
 		stableCursorX:   4,
 		stableCursorY:   10,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -271,8 +271,8 @@ func TestTerminalLayerTracksEnterAsRecentPromptInputForWrappedPrompt(t *testing.
 		},
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -318,8 +318,8 @@ func TestTerminalLayerTracksCtrlCAsRecentPromptInputForWrappedPrompt(t *testing.
 		},
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -361,8 +361,8 @@ func TestTerminalLayerKeepsRestrictedCursorAfterSubmitWhenOutputJumpsAway(t *tes
 		stableCursorX:   2,
 		stableCursorY:   9,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -406,8 +406,8 @@ func TestTerminalLayerKeepsRestrictedCursorWhenSubmitOutputJumpsToLeftEdge(t *te
 		stableCursorX:   10,
 		stableCursorY:   9,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -452,8 +452,8 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 		stableCursorY:       20,
 		stableCursorVersion: term.Version(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_chat_cursor_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_test.go
@@ -14,7 +14,7 @@ func TestTerminalLayerShowsCursorWhileNonCodexChatTabStreaming(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-streaming-claude"),
 			Assistant: "claude",
@@ -26,7 +26,7 @@ func TestTerminalLayerShowsCursorWhileNonCodexChatTabStreaming(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -45,7 +45,7 @@ func TestTerminalLayerShowsCursorWhileCodexChatTabStreaming(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-streaming-codex-control"),
 			Assistant: "codex",
@@ -57,7 +57,7 @@ func TestTerminalLayerShowsCursorWhileCodexChatTabStreaming(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -78,7 +78,7 @@ func TestTerminalLayerHidesChatCursorOutsideInputSectionWithoutStoredCursor(t *t
 	term.CursorX = 19
 	term.CursorY = 0
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:                TabID("tab-chat-unanchored-top-right"),
 			Assistant:         "codex",
@@ -88,7 +88,7 @@ func TestTerminalLayerHidesChatCursorOutsideInputSectionWithoutStoredCursor(t *t
 			lastVisibleOutput: time.Now(),
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -110,7 +110,7 @@ func TestTerminalLayerUsesLiveCursorInAltScreenChatTab(t *testing.T) {
 	term.CursorX = 10
 	term.CursorY = 4
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:              TabID("tab-chat-alt-screen"),
 			Assistant:       "codex",
@@ -121,7 +121,7 @@ func TestTerminalLayerUsesLiveCursorInAltScreenChatTab(t *testing.T) {
 			stableCursorY:   11,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -145,7 +145,7 @@ func TestTerminalLayerUsesStoredChatCursorWhenLiveCursorLeavesInputSection(t *te
 	term.CursorX = 19
 	term.CursorY = 0
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:                TabID("tab-chat-anchored-input"),
 			Assistant:         "codex",
@@ -158,7 +158,7 @@ func TestTerminalLayerUsesStoredChatCursorWhenLiveCursorLeavesInputSection(t *te
 			stableCursorY:     11,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -183,7 +183,7 @@ func TestTerminalLayerKeepsStoredChatCursorWhenLiveCursorFallsOnBlankCorner(t *t
 	term.CursorY = 11
 	term.Screen[11][19] = vterm.Cell{Rune: ' ', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:              TabID("tab-chat-corner-artifact"),
 			Assistant:       "codex",
@@ -194,7 +194,7 @@ func TestTerminalLayerKeepsStoredChatCursorWhenLiveCursorFallsOnBlankCorner(t *t
 			stableCursorY:   11,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -226,8 +226,8 @@ func TestTerminalLayerAllowsBlankCornerCursorAfterRecentLocalInput(t *testing.T)
 		Terminal:          term,
 		lastPromptInputAt: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -263,8 +263,8 @@ func TestTerminalLayerShowsBlankCornerPromptWithoutRecentLocalInput(t *testing.T
 		Workspace: ws,
 		Terminal:  term,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_cursor_owner_test.go
+++ b/internal/ui/center/model_pty_status_cursor_owner_test.go
@@ -12,7 +12,7 @@ func TestTerminalLayerWithCursorOwner_HidesCursorWhenNotOwner(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owner"),
 			Assistant: "codex",
@@ -20,7 +20,7 @@ func TestTerminalLayerWithCursorOwner_HidesCursorWhenNotOwner(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -39,7 +39,7 @@ func TestTerminalLayerWithCursorOwner_ShowsCursorWhenOwner(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owner"),
 			Assistant: "codex",
@@ -47,7 +47,7 @@ func TestTerminalLayerWithCursorOwner_ShowsCursorWhenOwner(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -77,8 +77,8 @@ func TestTerminalLayerWithCursorOwner_DoesNotLearnStableCursorWhenNotOwner(t *te
 		stableCursorX:   1,
 		stableCursorY:   11,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_stable_cursor_test.go
+++ b/internal/ui/center/model_pty_status_stable_cursor_test.go
@@ -36,8 +36,8 @@ func TestTerminalLayerSanitizesStoredSyntheticCursorGlyph(t *testing.T) {
 		},
 		lastVisibleOutput: time.Now(),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_pty_status_test.go
+++ b/internal/ui/center/model_pty_status_test.go
@@ -16,7 +16,7 @@ func TestTerminalLayerForcesVisibleCursorForChatTabs(t *testing.T) {
 	term := vterm.New(10, 3)
 	term.Write([]byte("\x1b[?25l"))
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat"),
 			Assistant: "codex",
@@ -24,7 +24,7 @@ func TestTerminalLayerForcesVisibleCursorForChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -53,7 +53,7 @@ func TestTerminalLayerLetsChatAppOwnSyntheticCursorWhenHidden(t *testing.T) {
 	term.CursorY = 2
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owned-cursor"),
 			Assistant: "claude",
@@ -61,7 +61,7 @@ func TestTerminalLayerLetsChatAppOwnSyntheticCursorWhenHidden(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -91,7 +91,7 @@ func TestTerminalLayerLetsChatAppOwnSteadyBarCursorWhenHidden(t *testing.T) {
 		Style: vterm.Style{Reverse: true},
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owned-steady-bar-cursor"),
 			Assistant: "claude",
@@ -99,7 +99,7 @@ func TestTerminalLayerLetsChatAppOwnSteadyBarCursorWhenHidden(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -125,7 +125,7 @@ func TestTerminalLayerPreservesCursorForLiteralBlockTextWhenHidden(t *testing.T)
 	term.CursorY = 2
 	term.Screen[2][2] = vterm.Cell{Rune: '▌', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-literal-block-text"),
 			Assistant: "claude",
@@ -133,7 +133,7 @@ func TestTerminalLayerPreservesCursorForLiteralBlockTextWhenHidden(t *testing.T)
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -156,7 +156,7 @@ func TestTerminalLayerPreservesCursorForStoredLiteralFullBlockWhenHidden(t *test
 	term.CursorY = 3
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:              TabID("tab-chat-stored-literal-full-block"),
 			Assistant:       "claude",
@@ -167,7 +167,7 @@ func TestTerminalLayerPreservesCursorForStoredLiteralFullBlockWhenHidden(t *test
 			stableCursorY:   2,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -190,7 +190,7 @@ func TestTerminalLayerIgnoresUnrelatedSyntheticGlyphWhenCursorHidden(t *testing.
 	term.CursorY = 3
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-unrelated-cursor-glyph"),
 			Assistant: "claude",
@@ -198,7 +198,7 @@ func TestTerminalLayerIgnoresUnrelatedSyntheticGlyphWhenCursorHidden(t *testing.
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -218,7 +218,7 @@ func TestTerminalLayerPreservesCursorHiddenForNonChatTabs(t *testing.T) {
 	term := vterm.New(10, 3)
 	term.Write([]byte("\x1b[?25l"))
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat"),
 			Assistant: "bash",
@@ -226,7 +226,7 @@ func TestTerminalLayerPreservesCursorHiddenForNonChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -272,7 +272,7 @@ func TestTerminalLayerShowsCursorForIdleBootstrapChatTab(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:                    TabID("tab-chat-bootstrap"),
 			Assistant:             "codex",
@@ -283,7 +283,7 @@ func TestTerminalLayerShowsCursorForIdleBootstrapChatTab(t *testing.T) {
 			bootstrapLastOutputAt: time.Now(),
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -302,7 +302,7 @@ func TestTerminalLayerShowsCursorForChatTabWithRecentOutput(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-recent-output"),
 			Assistant: "codex",
@@ -314,7 +314,7 @@ func TestTerminalLayerShowsCursorForChatTabWithRecentOutput(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -340,7 +340,7 @@ func TestTerminalLayerNormalizesSyntheticCursorCellForChatTabs(t *testing.T) {
 		Style: vterm.Style{Blink: true},
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-artifact"),
 			Assistant: "codex",
@@ -348,7 +348,7 @@ func TestTerminalLayerNormalizesSyntheticCursorCellForChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -376,7 +376,7 @@ func TestTerminalLayerPreservesNonBlinkingBlockElementTextAtLiveCursor(t *testin
 		Rune:  '▌',
 		Width: 1,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-real-block-text"),
 			Assistant: "codex",
@@ -384,7 +384,7 @@ func TestTerminalLayerPreservesNonBlinkingBlockElementTextAtLiveCursor(t *testin
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 	layer := m.TerminalLayer()
@@ -410,7 +410,7 @@ func TestTerminalLayerKeepsSyntheticCursorCellForNonChatTabs(t *testing.T) {
 		Style: vterm.Style{Blink: true},
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat-artifact"),
 			Assistant: "bash",
@@ -418,7 +418,7 @@ func TestTerminalLayerKeepsSyntheticCursorCellForNonChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -446,7 +446,7 @@ func TestTerminalLayerClearsBlinkAttributesForChatTabs(t *testing.T) {
 		Style: vterm.Style{Blink: true},
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-blink"),
 			Assistant: "codex",
@@ -454,7 +454,7 @@ func TestTerminalLayerClearsBlinkAttributesForChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 
@@ -478,7 +478,7 @@ func TestTerminalLayerPreservesBlinkAttributesForNonChatTabs(t *testing.T) {
 		Style: vterm.Style{Blink: true},
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat-blink"),
 			Assistant: "bash",
@@ -486,7 +486,7 @@ func TestTerminalLayerPreservesBlinkAttributesForNonChatTabs(t *testing.T) {
 			Terminal:  term,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 

--- a/internal/ui/center/model_reattach_detach_race_test.go
+++ b/internal/ui/center/model_reattach_detach_race_test.go
@@ -23,8 +23,8 @@ func TestUpdatePtyTabReattachResult_RejectsResultForDetachedTab(t *testing.T) {
 		// ...which cleared the in-flight flag (detachTab does this).
 		reattachInFlight: false,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	staleAgent := &appPty.Agent{Workspace: ws, Session: "amux-ws-sess"}
 	m.updatePtyTabReattachResult(ptyTabReattachResult{
@@ -61,8 +61,8 @@ func TestUpdatePtyTabReattachResult_AppliesForLiveReattach(t *testing.T) {
 		Running:          false,
 		reattachInFlight: true, // a reattach IS in flight
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	agent := &appPty.Agent{Workspace: ws, Session: "amux-ws-sess"}
 	m.updatePtyTabReattachResult(ptyTabReattachResult{
@@ -94,8 +94,8 @@ func TestUpdatePtyTabReattachResult_AppliesForDetachedRestart(t *testing.T) {
 		Running:          false,
 		reattachInFlight: true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	agent := &appPty.Agent{Workspace: ws, Session: "amux-ws-sess"}
 	m.updatePtyTabReattachResult(ptyTabReattachResult{
@@ -128,8 +128,8 @@ func TestRestartActiveTabMarksRestartInFlight(t *testing.T) {
 		Detached:    true,
 		Running:     false,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.RestartActiveTab()

--- a/internal/ui/center/model_scrolled_history_test.go
+++ b/internal/ui/center/model_scrolled_history_test.go
@@ -300,8 +300,8 @@ func setupScrolledChatHistoryModelWithBuffers(scrollbackLines, screenLines []str
 		Terminal:  term,
 		Running:   true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
 	return m, tab

--- a/internal/ui/center/model_stopped_reattach_test.go
+++ b/internal/ui/center/model_stopped_reattach_test.go
@@ -24,8 +24,8 @@ func TestUpdateTabSessionStatus_StoppedClearsReattachInFlight(t *testing.T) {
 		reattachInFlight: true,
 		Agent:            &appPty.Agent{Workspace: ws, Session: "amux-ws-sess"},
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	m.updateTabSessionStatus(messages.TabSessionStatus{
 		Status:      "stopped",

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -288,12 +288,12 @@ func (t *Tab) settlePTYBytesLocked(n int) (before, after bool) {
 
 // getTabs returns the tabs for the current workspace
 func (m *Model) getTabs() []*Tab {
-	return m.tabsByWorkspace[m.workspaceID()]
+	return m.tabs.ByWorkspace[m.workspaceID()]
 }
 
 // getTabByID returns the tab with the given ID, or nil if not found
 func (m *Model) getTabByID(wsID string, tabID TabID) *Tab {
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab.ID == tabID && !tab.isClosed() {
 			return tab
 		}
@@ -306,7 +306,7 @@ func (m *Model) getTabBySession(wsID, sessionName string) *Tab {
 	if sessionName == "" {
 		return nil
 	}
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab == nil || tab.isClosed() {
 			continue
 		}
@@ -322,7 +322,7 @@ func (m *Model) getTabBySession(wsID, sessionName string) *Tab {
 
 // getActiveTabIdx returns the active tab index for the current workspace
 func (m *Model) getActiveTabIdx() int {
-	return m.activeTabByWorkspace[m.workspaceID()]
+	return m.tabs.ActiveByWorkspace[m.workspaceID()]
 }
 
 // setActiveTabIdx sets the active tab index for the current workspace
@@ -334,13 +334,13 @@ func (m *Model) setActiveTabIdxForWorkspace(wsID string, idx int) {
 	if wsID == "" {
 		return
 	}
-	m.activeTabByWorkspace[wsID] = idx
+	m.tabs.ActiveByWorkspace[wsID] = idx
 	m.syncPostWriteVisibility()
 	m.markTabFocused(wsID, idx)
 }
 
 func (m *Model) markTabFocused(wsID string, idx int) {
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if idx < 0 || idx >= len(tabs) {
 		return
 	}
@@ -374,9 +374,9 @@ func (m *Model) syncPostWriteVisibility() {
 	activeWSID := m.workspaceID()
 	activeIdx := -1
 	if activeWSID != "" {
-		activeIdx = m.activeTabByWorkspace[activeWSID]
+		activeIdx = m.tabs.ActiveByWorkspace[activeWSID]
 	}
-	for wsID, tabs := range m.tabsByWorkspace {
+	for wsID, tabs := range m.tabs.ByWorkspace {
 		for idx, tab := range tabs {
 			if tab == nil || tab.isClosed() {
 				continue
@@ -389,9 +389,9 @@ func (m *Model) syncPostWriteVisibility() {
 // removeTab removes a tab at index from the current workspace
 func (m *Model) removeTab(idx int) {
 	wsID := m.workspaceID()
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if idx >= 0 && idx < len(tabs) {
-		m.tabsByWorkspace[wsID] = append(tabs[:idx], tabs[idx+1:]...)
+		m.tabs.ByWorkspace[wsID] = append(tabs[:idx], tabs[idx+1:]...)
 		m.noteTabsChanged()
 	}
 }
@@ -404,7 +404,7 @@ func (m *Model) CleanupWorkspace(ws *data.Workspace) {
 	wsID := string(ws.ID())
 
 	// Close resources for each tab before removing
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		tab.markClosing()
 		m.stopPTYReader(tab)
 		tab.mu.Lock()
@@ -423,8 +423,7 @@ func (m *Model) CleanupWorkspace(ws *data.Workspace) {
 		tab.markClosed()
 	}
 
-	delete(m.tabsByWorkspace, wsID)
-	delete(m.activeTabByWorkspace, wsID)
+	m.tabs.DeleteWorkspace(wsID)
 	m.noteTabsChanged()
 
 	// Also cleanup agents for this workspace

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -184,7 +184,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	initialCols, initialRows := ptyio.SessionSnapshotSize(msg.CaptureFullPane, msg.SnapshotCols, msg.SnapshotRows, cols, rows)
 
 	wsID := string(msg.Workspace.ID())
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	var existing *Tab
 	existingIdx := -1
 	if msg.TabID != "" {
@@ -377,8 +377,8 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	}
 
 	// Add tab to the workspace's tab list
-	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
-	createdIdx := len(m.tabsByWorkspace[wsID]) - 1
+	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+	createdIdx := len(m.tabs.ByWorkspace[wsID]) - 1
 	if msg.Activate {
 		m.setActiveTabIdxForWorkspace(wsID, createdIdx)
 	}

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -98,20 +98,16 @@ func (m *Model) hasActiveAgent() bool {
 
 // nextTab switches to the next tab
 func (m *Model) nextTab() {
-	tabs := m.getTabs()
-	if len(tabs) > 0 {
-		m.setActiveTabIdx((m.getActiveTabIdx() + 1) % len(tabs))
+	// TabSet owns the circular index math; setActiveTabIdx re-applies the
+	// index to run the center-specific side effects (focus + visibility sync).
+	if idx, ok := m.tabs.NextIdx(m.workspaceID()); ok {
+		m.setActiveTabIdx(idx)
 	}
 }
 
 // prevTab switches to the previous tab
 func (m *Model) prevTab() {
-	tabs := m.getTabs()
-	if len(tabs) > 0 {
-		idx := m.getActiveTabIdx() - 1
-		if idx < 0 {
-			idx = len(tabs) - 1
-		}
+	if idx, ok := m.tabs.PrevIdx(m.workspaceID()); ok {
 		m.setActiveTabIdx(idx)
 	}
 }
@@ -258,7 +254,7 @@ func (m *Model) GetTabsInfo() ([]data.TabInfo, int) {
 // GetTabsInfoForWorkspace returns tab information for a specific workspace ID.
 func (m *Model) GetTabsInfoForWorkspace(wsID string) ([]data.TabInfo, int) {
 	var result []data.TabInfo
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	for _, tab := range tabs {
 		if tab == nil {
 			continue
@@ -285,13 +281,13 @@ func (m *Model) GetTabsInfoForWorkspace(wsID string) ([]data.TabInfo, int) {
 			CreatedAt:   tab.createdAt,
 		})
 	}
-	return result, m.activeTabByWorkspace[wsID]
+	return result, m.tabs.ActiveByWorkspace[wsID]
 }
 
 // HasWorkspaceState reports whether the model has tab state for a workspace.
 // True means tabs were explicitly managed (even if currently empty).
 func (m *Model) HasWorkspaceState(wsID string) bool {
-	_, ok := m.tabsByWorkspace[wsID]
+	_, ok := m.tabs.ByWorkspace[wsID]
 	return ok
 }
 

--- a/internal/ui/center/model_tabs_diff_reuse_test.go
+++ b/internal/ui/center/model_tabs_diff_reuse_test.go
@@ -21,7 +21,7 @@ func TestCreateDiffTab_ReusesExistingTabForSamePathAndMode(t *testing.T) {
 	wsID := string(ws.ID())
 	m.SetWorkspace(ws)
 
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat"),
 			Name:      "claude",
@@ -37,16 +37,16 @@ func TestCreateDiffTab_ReusesExistingTabForSamePathAndMode(t *testing.T) {
 			DiffViewer: diff.New(ws, &git.Change{Path: "main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, 80, 24),
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	cmd := m.createDiffTab(&git.Change{Path: "./main.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, ws)
 	if cmd == nil {
 		t.Fatal("expected reuse command for existing diff tab")
 	}
-	if got := len(m.tabsByWorkspace[wsID]); got != 2 {
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 2 {
 		t.Fatalf("expected existing diff tab reuse, got %d tabs", got)
 	}
-	if got := m.activeTabByWorkspace[wsID]; got != 1 {
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 1 {
 		t.Fatalf("expected existing diff tab to become active, got index %d", got)
 	}
 
@@ -101,7 +101,7 @@ func TestReuseDiffTab_RefreshesChangeKindBeforeReload(t *testing.T) {
 	m.SetWorkspace(ws)
 
 	dv := diff.New(ws, &git.Change{Path: "main.go", Kind: git.ChangeUntracked}, git.DiffModeUnstaged, 80, 24)
-	m.tabsByWorkspace[wsID] = []*Tab{
+	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:         TabID("tab-diff"),
 			Name:       "Diff: main.go",
@@ -110,7 +110,7 @@ func TestReuseDiffTab_RefreshesChangeKindBeforeReload(t *testing.T) {
 			DiffViewer: dv,
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	mustRunGit(t, repo, "add", "main.go")
 	mustRunGit(t, repo, "commit", "-m", "track main.go")

--- a/internal/ui/center/model_tabs_identity_test.go
+++ b/internal/ui/center/model_tabs_identity_test.go
@@ -29,7 +29,7 @@ func TestHandlePtyTabCreated_DoesNotRetargetExistingTabOnSessionReuse(t *testing
 		SessionName: reusedSession,
 		Running:     true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{existing}
+	m.tabs.ByWorkspace[wsID] = []*Tab{existing}
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
 		Workspace: ws,
@@ -41,7 +41,7 @@ func TestHandlePtyTabCreated_DoesNotRetargetExistingTabOnSessionReuse(t *testing
 		Activate:  true,
 	})
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 2 {
 		t.Fatalf("expected new tab to be added without mutating existing tab, got %d tabs", len(tabs))
 	}

--- a/internal/ui/center/model_tabs_limit.go
+++ b/internal/ui/center/model_tabs_limit.go
@@ -35,7 +35,7 @@ func (m *Model) EnforceAttachedAgentTabLimit(maxAttached int) ([]DetachedTabInfo
 
 	attachedCount := 0
 	candidates := make([]attachedTabCandidate, 0)
-	for wsID, tabs := range m.tabsByWorkspace {
+	for wsID, tabs := range m.tabs.ByWorkspace {
 		for idx, tab := range tabs {
 			if tab == nil || tab.isClosed() || !m.isChatTab(tab) {
 				continue

--- a/internal/ui/center/model_tabs_limit_test.go
+++ b/internal/ui/center/model_tabs_limit_test.go
@@ -39,9 +39,9 @@ func TestEnforceAttachedAgentTabLimit_DetachesLeastRecentlyFocused(t *testing.T)
 		createdAt:     now.Add(-45 * time.Minute).Unix(),
 	}
 
-	m.tabsByWorkspace[ws1ID] = []*Tab{oldest, active}
-	m.tabsByWorkspace[ws2ID] = []*Tab{mid}
-	m.activeTabByWorkspace[ws1ID] = 1
+	m.tabs.ByWorkspace[ws1ID] = []*Tab{oldest, active}
+	m.tabs.ByWorkspace[ws2ID] = []*Tab{mid}
+	m.tabs.ActiveByWorkspace[ws1ID] = 1
 	m.workspace = ws1
 
 	detached, _ := m.EnforceAttachedAgentTabLimit(2)
@@ -91,8 +91,8 @@ func TestEnforceAttachedAgentTabLimit_UsesCreatedAtWhenFocusIsUnknown(t *testing
 		createdAt:     now.Unix(),
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{older, newer, active}
-	m.activeTabByWorkspace[wsID] = 2
+	m.tabs.ByWorkspace[wsID] = []*Tab{older, newer, active}
+	m.tabs.ActiveByWorkspace[wsID] = 2
 	m.workspace = ws
 
 	detached, _ := m.EnforceAttachedAgentTabLimit(2)
@@ -133,8 +133,8 @@ func TestEnforceAttachedAgentTabLimit_ZeroDisablesEnforcement(t *testing.T) {
 		createdAt:     now.Add(-30 * time.Minute).Unix(),
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{tabA, tabB}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tabA, tabB}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	detached, cmds := m.EnforceAttachedAgentTabLimit(0)
@@ -172,8 +172,8 @@ func TestEnforceAttachedAgentTabLimit_DetachesWhenConfigIsNilFallback(t *testing
 		createdAt:     now.Add(-30 * time.Minute).Unix(),
 	}
 
-	m.tabsByWorkspace[wsID] = []*Tab{first, second}
-	m.activeTabByWorkspace[wsID] = 1
+	m.tabs.ByWorkspace[wsID] = []*Tab{first, second}
+	m.tabs.ActiveByWorkspace[wsID] = 1
 	m.workspace = ws
 
 	detached, _ := m.EnforceAttachedAgentTabLimit(1)

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -53,7 +53,7 @@ func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
 	term.TreatLFAsCRLF = isChat
 	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
-	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
+	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
 }
 
 // addPlaceholderTab synchronously creates a placeholder tab in the correct slice
@@ -106,7 +106,7 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 	term.TreatLFAsCRLF = isChat
 	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
-	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
+	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
 	return tabID, sessionName
 }
 

--- a/internal/ui/center/model_tabs_restore_test.go
+++ b/internal/ui/center/model_tabs_restore_test.go
@@ -20,7 +20,7 @@ func TestAddDetachedTab_SetsLastFocusedFromCreatedAt(t *testing.T) {
 		CreatedAt:   createdAt,
 	})
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 1 {
 		t.Fatalf("expected 1 tab, got %d", len(tabs))
 	}
@@ -47,7 +47,7 @@ func TestAddPlaceholderTab_SetsLastFocusedFromCreatedAt(t *testing.T) {
 		CreatedAt: createdAt,
 	})
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 1 {
 		t.Fatalf("expected 1 tab, got %d", len(tabs))
 	}
@@ -79,7 +79,7 @@ func TestRestoreTabsFromWorkspace_MarksReattachInFlightForRunningTabs(t *testing
 		t.Fatalf("expected restore command for running tab")
 	}
 
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	if len(tabs) != 1 {
 		t.Fatalf("expected 1 restored tab, got %d", len(tabs))
 	}
@@ -111,7 +111,7 @@ func TestAutoReattachActiveTabOnSelection_SkipsRestoreInFlightPlaceholder(t *tes
 
 	_ = m.RestoreTabsFromWorkspace(ws)
 	m.workspace = ws
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	if cmd := m.autoReattachActiveTabOnSelection(); cmd != nil {
 		t.Fatalf("expected auto reattach to skip while restore reattach is in flight")

--- a/internal/ui/center/model_tabs_session.go
+++ b/internal/ui/center/model_tabs_session.go
@@ -75,7 +75,7 @@ func (m *Model) DetachTabByID(wsID string, tabID TabID) tea.Cmd {
 	if wsID == "" {
 		return nil
 	}
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	for idx, tab := range tabs {
 		if tab == nil || tab.isClosed() || tab.ID != tabID {
 			continue
@@ -171,7 +171,7 @@ func (m *Model) RestoreTabsFromWorkspace(ws *data.Workspace) tea.Cmd {
 		return nil
 	}
 	wsID := string(ws.ID())
-	if len(m.tabsByWorkspace[wsID]) > 0 {
+	if len(m.tabs.ByWorkspace[wsID]) > 0 {
 		return nil
 	}
 
@@ -227,8 +227,8 @@ func (m *Model) AddTabsFromWorkspace(ws *data.Workspace, tabs []data.TabInfo) te
 		return nil
 	}
 	wsID := string(ws.ID())
-	existing := make(map[string]struct{}, len(m.tabsByWorkspace[wsID]))
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	existing := make(map[string]struct{}, len(m.tabs.ByWorkspace[wsID]))
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab == nil || tab.isClosed() {
 			continue
 		}

--- a/internal/ui/center/model_tabs_session_auto_reattach_test.go
+++ b/internal/ui/center/model_tabs_session_auto_reattach_test.go
@@ -18,8 +18,8 @@ func TestAutoReattachActiveTabOnSelection_SkipsAttachedTab(t *testing.T) {
 		Running:   true,
 		Detached:  false,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.autoReattachActiveTabOnSelection()
@@ -41,8 +41,8 @@ func TestAutoReattachActiveTabOnSelection_ReattachesDetachedTab(t *testing.T) {
 		Detached:    true,
 		SessionName: "sess-detached",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.autoReattachActiveTabOnSelection()
@@ -71,8 +71,8 @@ func TestReattachActiveTab_SkipsAttachedNonAssistantTab(t *testing.T) {
 		Running:   true,
 		Detached:  false,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.ReattachActiveTab()
@@ -95,8 +95,8 @@ func TestReattachActiveTab_DeduplicatesInFlight(t *testing.T) {
 		reattachInFlight: true,
 		SessionName:      "sess-inflight",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.ReattachActiveTab()
@@ -118,8 +118,8 @@ func TestReattachActiveTab_AllowsStoppedTab(t *testing.T) {
 		Detached:    false,
 		SessionName: "sess-stopped",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.ReattachActiveTab()
@@ -149,8 +149,8 @@ func TestReattachActiveTab_ClearsInFlightOnFailureAndSuccess(t *testing.T) {
 		Detached:    true,
 		SessionName: "sess-unknown",
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.ReattachActiveTab()
@@ -184,8 +184,8 @@ func TestTabSelectionChangedCmd_SkipsNoOpSelection(t *testing.T) {
 		Workspace: ws,
 		Running:   true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.tabSelectionChangedCmd(false)
@@ -211,8 +211,8 @@ func TestTabSelectionChangedCmd_RunsOnSelectionChange(t *testing.T) {
 		Workspace: ws,
 		Running:   true,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab1, tab2}
-	m.activeTabByWorkspace[wsID] = 1
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab1, tab2}
+	m.tabs.ActiveByWorkspace[wsID] = 1
 	m.workspace = ws
 
 	cmd := m.tabSelectionChangedCmd(true)

--- a/internal/ui/center/model_tabs_session_reattach_history_size_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_history_size_test.go
@@ -82,8 +82,8 @@ func TestReattachActiveTab_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
@@ -183,8 +183,8 @@ func TestReattachActiveTab_SharedClientCapturesHistoryAfterAttach(t *testing.T) 
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)

--- a/internal/ui/center/model_tabs_session_reattach_order_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_order_test.go
@@ -108,8 +108,8 @@ func TestReattachActiveTab_CapturesSnapshotBeforeAttach(t *testing.T) {
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	cmd := m.ReattachActiveTab()
 	if cmd == nil {

--- a/internal/ui/center/model_tabs_session_reattach_safety_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_safety_test.go
@@ -99,8 +99,8 @@ func TestReattachActiveTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
@@ -201,8 +201,8 @@ func TestReattachActiveTab_AttachFailureRollsBackBootstrapResize(t *testing.T) {
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	failed, ok := msg.(ptyTabReattachFailed)

--- a/internal/ui/center/model_tabs_session_reattach_snapshot_error_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_snapshot_error_test.go
@@ -99,8 +99,8 @@ func TestReattachActiveTab_SnapshotCommandErrorFallsBackToHistoryOnly(t *testing
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)

--- a/internal/ui/center/model_tabs_session_selection_flush_test.go
+++ b/internal/ui/center/model_tabs_session_selection_flush_test.go
@@ -26,8 +26,8 @@ func TestTabSelectionChangedCmd_FlushesBufferedActiveTab(t *testing.T) {
 		pendingOutputBytes: len("buffered"),
 		ptyBytesReceived:   uint64(len("buffered")),
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.tabSelectionChangedCmd(true)
@@ -89,8 +89,8 @@ func TestTabSelectionChangedCmd_FlushesActorQueuedActiveTab(t *testing.T) {
 		actorQueuedBytes:   12,
 		ptyBytesReceived:   12,
 	}
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	cmd := m.tabSelectionChangedCmd(true)

--- a/internal/ui/center/model_tabs_session_snapshot_race_test.go
+++ b/internal/ui/center/model_tabs_session_snapshot_race_test.go
@@ -110,8 +110,8 @@ func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
@@ -348,8 +348,8 @@ func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionBecomesActive(t *
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
@@ -462,8 +462,8 @@ func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionBecomesShared(t *
 		Detached:    true,
 	}
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*Tab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)

--- a/internal/ui/center/model_tabs_viewer.go
+++ b/internal/ui/center/model_tabs_viewer.go
@@ -78,7 +78,7 @@ func (m *Model) findOpenDiffTab(ws *data.Workspace, changePath string, mode git.
 		return -1, nil
 	}
 	wsID := string(ws.ID())
-	for idx, tab := range m.tabsByWorkspace[wsID] {
+	for idx, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab == nil || tab.isClosed() {
 			continue
 		}
@@ -97,7 +97,7 @@ func (m *Model) reuseDiffTab(ws *data.Workspace, idx int, tab *Tab, change *git.
 		return nil
 	}
 	wsID := string(ws.ID())
-	activeChanged := m.activeTabByWorkspace[wsID] != idx
+	activeChanged := m.tabs.ActiveByWorkspace[wsID] != idx
 	m.setActiveTabIdxForWorkspace(wsID, idx)
 
 	var cmds []tea.Cmd
@@ -151,12 +151,12 @@ func (m *Model) createDiffTab(change *git.Change, mode git.DiffMode, ws *data.Wo
 		lastFocusedAt: time.Now(),
 	}
 
-	m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
-	m.setActiveTabIdxForWorkspace(wsID, len(m.tabsByWorkspace[wsID])-1)
+	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+	m.setActiveTabIdxForWorkspace(wsID, len(m.tabs.ByWorkspace[wsID])-1)
 	m.noteTabsChanged()
 
 	return common.SafeBatch(
 		dv.Init(),
-		func() tea.Msg { return messages.TabCreated{Index: m.activeTabByWorkspace[wsID], Name: displayName} },
+		func() tea.Msg { return messages.TabCreated{Index: m.tabs.ActiveByWorkspace[wsID], Name: displayName} },
 	)
 }

--- a/internal/ui/center/model_workspace_rebind.go
+++ b/internal/ui/center/model_workspace_rebind.go
@@ -20,7 +20,7 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 		return nil
 	}
 
-	oldTabs, ok := m.tabsByWorkspace[oldID]
+	oldTabs, ok := m.tabs.ByWorkspace[oldID]
 	if !ok {
 		if m.workspace != nil && m.workspaceID() == oldID {
 			m.setWorkspace(current)
@@ -31,16 +31,16 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 	// tabs, which is distinct from the !ok case above (workspace never seen).
 	// Migrate this "seen but empty" state to preserve the semantic difference.
 	if len(oldTabs) == 0 {
-		if _, exists := m.tabsByWorkspace[newID]; !exists {
-			m.tabsByWorkspace[newID] = []*Tab{}
+		if _, exists := m.tabs.ByWorkspace[newID]; !exists {
+			m.tabs.ByWorkspace[newID] = []*Tab{}
 		}
-		if activeIdx, hasOldActive := m.activeTabByWorkspace[oldID]; hasOldActive {
-			if _, hasNewActive := m.activeTabByWorkspace[newID]; !hasNewActive {
-				m.activeTabByWorkspace[newID] = activeIdx
+		if activeIdx, hasOldActive := m.tabs.ActiveByWorkspace[oldID]; hasOldActive {
+			if _, hasNewActive := m.tabs.ActiveByWorkspace[newID]; !hasNewActive {
+				m.tabs.ActiveByWorkspace[newID] = activeIdx
 			}
-			delete(m.activeTabByWorkspace, oldID)
+			delete(m.tabs.ActiveByWorkspace, oldID)
 		}
-		delete(m.tabsByWorkspace, oldID)
+		delete(m.tabs.ByWorkspace, oldID)
 		if m.workspace != nil && m.workspaceID() == oldID {
 			m.setWorkspace(current)
 		}
@@ -48,7 +48,7 @@ func (m *Model) RebindWorkspaceID(previous, current *data.Workspace) tea.Cmd {
 		return nil
 	}
 
-	merged := common.RebindTabMaps(m.tabsByWorkspace, m.activeTabByWorkspace, oldID, newID,
+	merged := common.RebindTabMaps(m.tabs.ByWorkspace, m.tabs.ActiveByWorkspace, oldID, newID,
 		func(t *Tab) TabID { return t.ID },
 		func(t *Tab) bool { return t == nil })
 

--- a/internal/ui/center/model_workspace_rebind_test.go
+++ b/internal/ui/center/model_workspace_rebind_test.go
@@ -39,8 +39,8 @@ func TestRebindWorkspaceIDMigratesTabState(t *testing.T) {
 	oldID := string(oldWS.ID())
 	newID := string(newWS.ID())
 	tab := &Tab{ID: TabID("tab-1"), Workspace: oldWS}
-	m.tabsByWorkspace[oldID] = []*Tab{tab}
-	m.activeTabByWorkspace[oldID] = 0
+	m.tabs.ByWorkspace[oldID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[oldID] = 0
 
 	cmd := m.RebindWorkspaceID(oldWS, newWS)
 	if cmd != nil {
@@ -49,20 +49,20 @@ func TestRebindWorkspaceIDMigratesTabState(t *testing.T) {
 	if m.workspace != newWS {
 		t.Fatal("expected active workspace pointer to be rebound")
 	}
-	if _, ok := m.tabsByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ByWorkspace[oldID]; ok {
 		t.Fatalf("expected old workspace key %q to be removed", oldID)
 	}
-	gotTabs := m.tabsByWorkspace[newID]
+	gotTabs := m.tabs.ByWorkspace[newID]
 	if len(gotTabs) != 1 || gotTabs[0] != tab {
 		t.Fatalf("expected migrated tab under new workspace key, got %d", len(gotTabs))
 	}
 	if gotTabs[0].Workspace != newWS {
 		t.Fatal("expected migrated tab workspace pointer to be rebound")
 	}
-	if got := m.activeTabByWorkspace[newID]; got != 0 {
+	if got := m.tabs.ActiveByWorkspace[newID]; got != 0 {
 		t.Fatalf("expected active tab index 0, got %d", got)
 	}
-	if _, ok := m.activeTabByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ActiveByWorkspace[oldID]; ok {
 		t.Fatalf("expected old active-tab key %q to be removed", oldID)
 	}
 }
@@ -97,8 +97,8 @@ func TestRebindWorkspaceIDMigratesExplicitEmptyState(t *testing.T) {
 	m.workspace = oldWS
 	oldID := string(oldWS.ID())
 	newID := string(newWS.ID())
-	m.tabsByWorkspace[oldID] = []*Tab{}
-	m.activeTabByWorkspace[oldID] = 0
+	m.tabs.ByWorkspace[oldID] = []*Tab{}
+	m.tabs.ActiveByWorkspace[oldID] = 0
 
 	cmd := m.RebindWorkspaceID(oldWS, newWS)
 	if cmd != nil {
@@ -107,18 +107,18 @@ func TestRebindWorkspaceIDMigratesExplicitEmptyState(t *testing.T) {
 	if m.workspace != newWS {
 		t.Fatal("expected active workspace pointer to be rebound")
 	}
-	if _, ok := m.tabsByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ByWorkspace[oldID]; ok {
 		t.Fatalf("expected old workspace key %q to be removed", oldID)
 	}
-	if tabs, ok := m.tabsByWorkspace[newID]; !ok {
+	if tabs, ok := m.tabs.ByWorkspace[newID]; !ok {
 		t.Fatalf("expected migrated empty state under new workspace key %q", newID)
 	} else if len(tabs) != 0 {
 		t.Fatalf("expected migrated state to remain empty, got %d tabs", len(tabs))
 	}
-	if got := m.activeTabByWorkspace[newID]; got != 0 {
+	if got := m.tabs.ActiveByWorkspace[newID]; got != 0 {
 		t.Fatalf("expected active tab index 0, got %d", got)
 	}
-	if _, ok := m.activeTabByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ActiveByWorkspace[oldID]; ok {
 		t.Fatalf("expected old active-tab key %q to be removed", oldID)
 	}
 }

--- a/internal/ui/center/perf_test.go
+++ b/internal/ui/center/perf_test.go
@@ -50,8 +50,8 @@ func TestPerfScenario(t *testing.T) {
 		Terminal:  vterm.New(120, 40),
 		Running:   true,
 	}
-	m.tabsByWorkspace[wtID] = []*Tab{tab}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ByWorkspace[wtID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wtID] = 0
 	m.SetSize(120, 40)
 	m.SetOffset(0)
 	m.Focus()

--- a/internal/ui/center/selection_scroll_test.go
+++ b/internal/ui/center/selection_scroll_test.go
@@ -39,8 +39,8 @@ func setupScrollModel(t *testing.T) (*Model, *Tab, string) {
 		Workspace: wt,
 		Terminal:  vt,
 	}
-	m.tabsByWorkspace[wtID] = []*Tab{tab}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ByWorkspace[wtID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wtID] = 0
 	m.SetSize(100, 40)
 	m.SetOffset(0)
 	m.Focus()

--- a/internal/ui/center/selection_test.go
+++ b/internal/ui/center/selection_test.go
@@ -29,8 +29,8 @@ func setupSelectionModel(t *testing.T) (*Model, *Tab) {
 		Workspace: wt,
 		Terminal:  vterm.New(80, 24),
 	}
-	m.tabsByWorkspace[wtID] = []*Tab{tab}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ByWorkspace[wtID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wtID] = 0
 	m.SetSize(100, 40)
 	m.SetOffset(0)
 	m.Focus()
@@ -140,8 +140,8 @@ func TestTabBarClickPlusButton(t *testing.T) {
 		Terminal:  vterm.New(80, 24),
 		Name:      "claude",
 	}
-	m.tabsByWorkspace[wtID] = []*Tab{tab}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ByWorkspace[wtID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wtID] = 0
 	m.SetSize(100, 40)
 	m.SetOffset(20) // Simulate dashboard width of 20
 	m.Focus()

--- a/internal/ui/common/tabset.go
+++ b/internal/ui/common/tabset.go
@@ -1,0 +1,76 @@
+package common
+
+// TabSet tracks per-workspace tab lists and the active tab index. It is the
+// shared storage + navigation core behind the center tab strip and the
+// sidebar terminal tabs: both keep a map of workspaceID → tabs plus a map of
+// workspaceID → active index, with circular next/prev selection.
+//
+// The maps are exported because both consumers iterate and mutate them
+// directly in workspace-rebind and session-discovery paths; TabSet owns the
+// navigation math so it is written once.
+type TabSet[T any] struct {
+	ByWorkspace       map[string][]T
+	ActiveByWorkspace map[string]int
+}
+
+// NewTabSet returns an empty TabSet with initialized maps.
+func NewTabSet[T any]() TabSet[T] {
+	return TabSet[T]{
+		ByWorkspace:       make(map[string][]T),
+		ActiveByWorkspace: make(map[string]int),
+	}
+}
+
+// Tabs returns the workspace's tabs (nil when none).
+func (s *TabSet[T]) Tabs(wsID string) []T {
+	return s.ByWorkspace[wsID]
+}
+
+// ActiveIdx returns the workspace's active tab index (0 when unset).
+func (s *TabSet[T]) ActiveIdx(wsID string) int {
+	return s.ActiveByWorkspace[wsID]
+}
+
+// SetActiveIdx records the workspace's active tab index.
+func (s *TabSet[T]) SetActiveIdx(wsID string, idx int) {
+	s.ActiveByWorkspace[wsID] = idx
+}
+
+// NextIdx advances the active index circularly. It reports the new index and
+// whether a move happened (false when the workspace has no tabs).
+func (s *TabSet[T]) NextIdx(wsID string) (int, bool) {
+	tabs := s.ByWorkspace[wsID]
+	if len(tabs) == 0 {
+		return 0, false
+	}
+	idx := (s.ActiveByWorkspace[wsID] + 1) % len(tabs)
+	s.ActiveByWorkspace[wsID] = idx
+	return idx, true
+}
+
+// PrevIdx moves the active index back circularly. It reports the new index
+// and whether a move happened (false when the workspace has no tabs).
+func (s *TabSet[T]) PrevIdx(wsID string) (int, bool) {
+	tabs := s.ByWorkspace[wsID]
+	if len(tabs) == 0 {
+		return 0, false
+	}
+	idx := (s.ActiveByWorkspace[wsID] - 1 + len(tabs)) % len(tabs)
+	s.ActiveByWorkspace[wsID] = idx
+	return idx, true
+}
+
+// SelectIdx sets the active index when it is in range, reporting success.
+func (s *TabSet[T]) SelectIdx(wsID string, idx int) bool {
+	if idx < 0 || idx >= len(s.ByWorkspace[wsID]) {
+		return false
+	}
+	s.ActiveByWorkspace[wsID] = idx
+	return true
+}
+
+// DeleteWorkspace drops all tab tracking for a workspace.
+func (s *TabSet[T]) DeleteWorkspace(wsID string) {
+	delete(s.ByWorkspace, wsID)
+	delete(s.ActiveByWorkspace, wsID)
+}

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -86,10 +86,9 @@ type SidebarSelectionScrollTick struct {
 // TerminalModel is the Bubbletea model for the sidebar terminal section
 type TerminalModel struct {
 	// State per workspace - multiple tabs per workspace
-	tabsByWorkspace      map[string][]*TerminalTab
-	activeTabByWorkspace map[string]int
-	tabHits              []terminalTabHit // for mouse click handling
-	pendingCreation      map[string]bool  // tracks workspaces with tab creation in progress
+	tabs            common.TabSet[*TerminalTab]
+	tabHits         []terminalTabHit // for mouse click handling
+	pendingCreation map[string]bool  // tracks workspaces with tab creation in progress
 
 	// Current workspace
 	workspace *data.Workspace
@@ -116,11 +115,10 @@ type TerminalModel struct {
 // NewTerminalModel creates a new sidebar terminal model
 func NewTerminalModel() *TerminalModel {
 	return &TerminalModel{
-		tabsByWorkspace:      make(map[string][]*TerminalTab),
-		activeTabByWorkspace: make(map[string]int),
-		pendingCreation:      make(map[string]bool),
-		styles:               common.DefaultStyles(),
-		tmuxOpts:             tmux.DefaultOptions(),
+		tabs:            common.NewTabSet[*TerminalTab](),
+		pendingCreation: make(map[string]bool),
+		styles:          common.DefaultStyles(),
+		tmuxOpts:        tmux.DefaultOptions(),
 	}
 }
 
@@ -168,17 +166,17 @@ func (m *TerminalModel) setWorkspace(ws *data.Workspace) {
 
 // getTabs returns the tabs for the current workspace
 func (m *TerminalModel) getTabs() []*TerminalTab {
-	return m.tabsByWorkspace[m.workspaceID()]
+	return m.tabs.Tabs(m.workspaceID())
 }
 
 // getActiveTabIdx returns the active tab index for the current workspace
 func (m *TerminalModel) getActiveTabIdx() int {
-	return m.activeTabByWorkspace[m.workspaceID()]
+	return m.tabs.ActiveIdx(m.workspaceID())
 }
 
 // setActiveTabIdx sets the active tab index for the current workspace
 func (m *TerminalModel) setActiveTabIdx(idx int) {
-	m.activeTabByWorkspace[m.workspaceID()] = idx
+	m.tabs.SetActiveIdx(m.workspaceID(), idx)
 }
 
 // getActiveTab returns the active tab for the current workspace
@@ -202,7 +200,7 @@ func (m *TerminalModel) getTerminal() *TerminalState {
 
 // getTabByID returns the tab with the given ID, or nil if not found
 func (m *TerminalModel) getTabByID(wsID string, tabID TerminalTabID) *TerminalTab {
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab.ID == tabID {
 			return tab
 		}
@@ -226,33 +224,27 @@ func nextTerminalName(tabs []*TerminalTab) string {
 
 // NextTab switches to the next terminal tab (circular)
 func (m *TerminalModel) NextTab() {
-	tabs := m.getTabs()
-	if len(tabs) <= 1 {
+	if len(m.getTabs()) <= 1 {
 		return
 	}
-	idx := m.getActiveTabIdx()
-	idx = (idx + 1) % len(tabs)
-	m.setActiveTabIdx(idx)
-	m.refreshTerminalSize()
+	if _, ok := m.tabs.NextIdx(m.workspaceID()); ok {
+		m.refreshTerminalSize()
+	}
 }
 
 // PrevTab switches to the previous terminal tab (circular)
 func (m *TerminalModel) PrevTab() {
-	tabs := m.getTabs()
-	if len(tabs) <= 1 {
+	if len(m.getTabs()) <= 1 {
 		return
 	}
-	idx := m.getActiveTabIdx()
-	idx = (idx - 1 + len(tabs)) % len(tabs)
-	m.setActiveTabIdx(idx)
-	m.refreshTerminalSize()
+	if _, ok := m.tabs.PrevIdx(m.workspaceID()); ok {
+		m.refreshTerminalSize()
+	}
 }
 
 // SelectTab selects a tab by index
 func (m *TerminalModel) SelectTab(idx int) {
-	tabs := m.getTabs()
-	if idx >= 0 && idx < len(tabs) {
-		m.setActiveTabIdx(idx)
+	if m.tabs.SelectIdx(m.workspaceID(), idx) {
 		m.refreshTerminalSize()
 	}
 }

--- a/internal/ui/sidebar/terminal_capture_size_test.go
+++ b/internal/ui/sidebar/terminal_capture_size_test.go
@@ -23,7 +23,7 @@ func TestReattach_UsesCaptureSizeBeforeResizingForHistoryOnly(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := generateTerminalTabID()
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -34,7 +34,7 @@ func TestReattach_UsesCaptureSizeBeforeResizingForHistoryOnly(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	_, _ = m.Update(SidebarTerminalReattachResult{
@@ -245,8 +245,8 @@ func TestHandleReattachResult_UsesSnapshotSizeBeforeSidebarLayout(t *testing.T) 
 	wsID := string(ws.ID())
 	tabID := generateTerminalTabID()
 	m.workspace = ws
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: &TerminalState{SessionName: "session-1"}}}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: &TerminalState{SessionName: "session-1"}}}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 
 	var gotRows, gotCols uint16
 	setTerminalSizeFn = func(term *pty.Terminal, rows, cols uint16) error {

--- a/internal/ui/sidebar/terminal_cursor_owner_test.go
+++ b/internal/ui/sidebar/terminal_cursor_owner_test.go
@@ -26,8 +26,8 @@ func setupTerminalOwnerModel(t *testing.T) *TerminalModel {
 		Name:  "Terminal 1",
 		State: ts,
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	return m
 }
 

--- a/internal/ui/sidebar/terminal_overflow_log_test.go
+++ b/internal/ui/sidebar/terminal_overflow_log_test.go
@@ -55,7 +55,7 @@ func TestHandlePTYOutput_OverflowEmitsThrottledWarn(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-overflow")
 	state := &TerminalState{VTerm: vterm.New(80, 24)}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	overflowChunk := bytes.Repeat([]byte("x"), ptyMaxBufferedBytes+4096)
 	_ = m.handlePTYOutput(messages.SidebarPTYOutput{WorkspaceID: wsID, TabID: string(tabID), Data: overflowChunk})
@@ -79,7 +79,7 @@ func TestHandlePTYOutput_OverflowWarnReportsActualTrimmedBytes(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := TerminalTabID("term-overflow")
 	state := &TerminalState{VTerm: vterm.New(80, 24)}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	controlSeq := []byte("\x1b[>1;10;0c")
 	chunk := append([]byte{}, controlSeq...)

--- a/internal/ui/sidebar/terminal_pty_lifecycle.go
+++ b/internal/ui/sidebar/terminal_pty_lifecycle.go
@@ -79,19 +79,19 @@ func (m *TerminalModel) createTerminalStateForTabWithSizeAndRefresh(
 	}
 
 	// ts already initialized above, just need tabs lookup
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	tab := &TerminalTab{
 		ID:    tabID,
 		Name:  nextTerminalName(tabs),
 		State: ts,
 	}
-	m.tabsByWorkspace[wsID] = append(tabs, tab)
+	m.tabs.ByWorkspace[wsID] = append(tabs, tab)
 
 	// Clear pending creation flag now that tab exists
 	delete(m.pendingCreation, wsID)
 
 	// Set as active tab (switch to new tab)
-	m.activeTabByWorkspace[wsID] = len(m.tabsByWorkspace[wsID]) - 1
+	m.tabs.ActiveByWorkspace[wsID] = len(m.tabs.ByWorkspace[wsID]) - 1
 
 	if refresh {
 		m.refreshTerminalSize()
@@ -145,7 +145,7 @@ func (m *TerminalModel) startPTYReader(wsID string, tabID TerminalTabID) tea.Cmd
 
 // StartPTYReaders ensures PTY readers are running for all tabs.
 func (m *TerminalModel) StartPTYReaders() tea.Cmd {
-	for wsID, tabs := range m.tabsByWorkspace {
+	for wsID, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab == nil {
 				continue
@@ -162,7 +162,7 @@ func (m *TerminalModel) StartPTYReaders() tea.Cmd {
 
 // CloseTerminal closes all terminal tabs for the given workspace
 func (m *TerminalModel) CloseTerminal(wsID string) {
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	for _, tab := range tabs {
 		if tab.State != nil {
 			m.stopPTYReader(tab.State)
@@ -175,14 +175,13 @@ func (m *TerminalModel) CloseTerminal(wsID string) {
 			tab.State.mu.Unlock()
 		}
 	}
-	delete(m.tabsByWorkspace, wsID)
-	delete(m.activeTabByWorkspace, wsID)
+	m.tabs.DeleteWorkspace(wsID)
 	delete(m.pendingCreation, wsID)
 }
 
 // CloseAll closes all terminals
 func (m *TerminalModel) CloseAll() {
-	for wsID := range m.tabsByWorkspace {
+	for wsID := range m.tabs.ByWorkspace {
 		m.CloseTerminal(wsID)
 	}
 }

--- a/internal/ui/sidebar/terminal_reattach_test.go
+++ b/internal/ui/sidebar/terminal_reattach_test.go
@@ -14,7 +14,7 @@ func TestReattachPrependsScrollbackWhenCaptureExcludesScreen(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := generateTerminalTabID()
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -24,7 +24,7 @@ func TestReattachPrependsScrollbackWhenCaptureExcludesScreen(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
@@ -55,7 +55,7 @@ func TestReattachHistoryOnlyResizesExistingVTermBeforeRecordingSize(t *testing.T
 	tabID := generateTerminalTabID()
 	oldWidth, oldHeight := 6, 2
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -68,7 +68,7 @@ func TestReattachHistoryOnlyResizesExistingVTermBeforeRecordingSize(t *testing.T
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
@@ -103,7 +103,7 @@ func TestReattachLoadsPaneCapture(t *testing.T) {
 	term := vterm.New(20, 2)
 	term.LoadPaneCapture([]byte("old history\nstale one\nstale two\n"))
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -114,7 +114,7 @@ func TestReattachLoadsPaneCapture(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
@@ -156,7 +156,7 @@ func TestReattachReconcilesPostAttachHistoryAfterFullPaneRestore(t *testing.T) {
 	wsID := string(ws.ID())
 	tabID := generateTerminalTabID()
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -167,7 +167,7 @@ func TestReattachReconcilesPostAttachHistoryAfterFullPaneRestore(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
@@ -284,7 +284,7 @@ func TestReattachBlankPaneCaptureClearsStaleFrame(t *testing.T) {
 	term := vterm.New(20, 2)
 	term.LoadPaneCapture([]byte("old history\nstale one\nstale two\n"))
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -295,7 +295,7 @@ func TestReattachBlankPaneCaptureClearsStaleFrame(t *testing.T) {
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
@@ -338,7 +338,7 @@ func TestReattachPreservesExistingAltScreenStateWithoutSnapshotModes(t *testing.
 	term.SavedCursorY = 1
 	term.SavedStyle = vterm.Style{Bold: true}
 
-	m.tabsByWorkspace[wsID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{
 		{
 			ID: tabID,
 			State: &TerminalState{
@@ -349,7 +349,7 @@ func TestReattachPreservesExistingAltScreenStateWithoutSnapshotModes(t *testing.
 			},
 		},
 	}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{

--- a/internal/ui/sidebar/terminal_render.go
+++ b/internal/ui/sidebar/terminal_render.go
@@ -401,7 +401,7 @@ func (m *TerminalModel) SetSize(width, height int) {
 	termWidth, termHeight := m.terminalContentSize()
 
 	// Resize all terminal vtems across all workspaces only if size changed
-	for _, tabs := range m.tabsByWorkspace {
+	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
 			if tab.State == nil {
 				continue

--- a/internal/ui/sidebar/terminal_resize_test.go
+++ b/internal/ui/sidebar/terminal_resize_test.go
@@ -12,14 +12,14 @@ func TestTerminalResizesOnKeymapHintToggle(t *testing.T) {
 	m := NewTerminalModel()
 	m.workspace = wt
 	wtID := string(wt.ID())
-	m.tabsByWorkspace[wtID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wtID] = []*TerminalTab{
 		{
 			ID:    "tab-1",
 			Name:  "Terminal 1",
 			State: &TerminalState{VTerm: vterm.New(10, 5)},
 		},
 	}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ActiveByWorkspace[wtID] = 0
 
 	m.SetSize(80, 20)
 	ts := m.getTerminal()

--- a/internal/ui/sidebar/terminal_scroll_test.go
+++ b/internal/ui/sidebar/terminal_scroll_test.go
@@ -39,8 +39,8 @@ func setupScrollModel(t *testing.T) (*TerminalModel, *TerminalState) {
 		Name:  "Terminal 1",
 		State: ts,
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 	// width=80, height=26 → terminal viewport = 80x24 (minus tabBar=1, statusReserve=1)
 	m.width = 80
 	m.height = 26

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -76,17 +76,17 @@ func (m *TerminalModel) closeTabAt(idx int) (*TerminalModel, tea.Cmd) {
 	}
 
 	// Remove tab from slice
-	m.tabsByWorkspace[wtID] = append(tabs[:idx], tabs[idx+1:]...)
+	m.tabs.ByWorkspace[wtID] = append(tabs[:idx], tabs[idx+1:]...)
 
 	// Adjust active index
 	activeIdx := m.getActiveTabIdx()
-	newLen := len(m.tabsByWorkspace[wtID])
+	newLen := len(m.tabs.ByWorkspace[wtID])
 	if newLen == 0 {
-		m.activeTabByWorkspace[wtID] = 0
+		m.tabs.ActiveByWorkspace[wtID] = 0
 	} else if activeIdx >= newLen {
-		m.activeTabByWorkspace[wtID] = newLen - 1
+		m.tabs.ActiveByWorkspace[wtID] = newLen - 1
 	} else if idx < activeIdx {
-		m.activeTabByWorkspace[wtID] = activeIdx - 1
+		m.tabs.ActiveByWorkspace[wtID] = activeIdx - 1
 	}
 
 	m.refreshTerminalSize()

--- a/internal/ui/sidebar/terminal_selection_test.go
+++ b/internal/ui/sidebar/terminal_selection_test.go
@@ -31,14 +31,14 @@ func TestScreenToTerminalWithVTerm(t *testing.T) {
 	m := NewTerminalModel()
 	m.workspace = wt
 	wtID := string(wt.ID())
-	m.tabsByWorkspace[wtID] = []*TerminalTab{
+	m.tabs.ByWorkspace[wtID] = []*TerminalTab{
 		{
 			ID:    "test-tab",
 			Name:  "Terminal 1",
 			State: &TerminalState{VTerm: vterm.New(4, 3)},
 		},
 	}
-	m.activeTabByWorkspace[wtID] = 0
+	m.tabs.ActiveByWorkspace[wtID] = 0
 	m.offsetX = 1
 	m.offsetY = 1
 

--- a/internal/ui/sidebar/terminal_sessions.go
+++ b/internal/ui/sidebar/terminal_sessions.go
@@ -16,7 +16,7 @@ func (m *TerminalModel) tabBySession(wsID, sessionName string) *TerminalTab {
 	if sessionName == "" {
 		return nil
 	}
-	for _, tab := range m.tabsByWorkspace[wsID] {
+	for _, tab := range m.tabs.ByWorkspace[wsID] {
 		if tab.State != nil && tab.State.SessionName == sessionName {
 			return tab
 		}
@@ -62,7 +62,7 @@ func (m *TerminalModel) AddTabsFromSessions(ws *data.Workspace, sessions []strin
 		tabID := generateTerminalTabID()
 		tab := &TerminalTab{
 			ID:   tabID,
-			Name: nextTerminalName(m.tabsByWorkspace[wsID]),
+			Name: nextTerminalName(m.tabs.ByWorkspace[wsID]),
 			State: &TerminalState{
 				SessionName:      sessionName,
 				Running:          false,
@@ -70,9 +70,9 @@ func (m *TerminalModel) AddTabsFromSessions(ws *data.Workspace, sessions []strin
 				reattachInFlight: true,
 			},
 		}
-		m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
-		if len(m.tabsByWorkspace[wsID]) == 1 {
-			m.activeTabByWorkspace[wsID] = 0
+		m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+		if len(m.tabs.ByWorkspace[wsID]) == 1 {
+			m.tabs.ActiveByWorkspace[wsID] = 0
 		}
 		cmds = append(cmds, m.attachToSession(ws, tabID, sessionName, true, "reattach"))
 	}
@@ -101,16 +101,16 @@ func (m *TerminalModel) AddTabsFromSessionInfos(ws *data.Workspace, sessions []S
 		tabID := generateTerminalTabID()
 		tab := &TerminalTab{
 			ID:   tabID,
-			Name: nextTerminalName(m.tabsByWorkspace[wsID]),
+			Name: nextTerminalName(m.tabs.ByWorkspace[wsID]),
 			State: &TerminalState{
 				SessionName: session.Name,
 				Running:     false,
 				Detached:    true,
 			},
 		}
-		m.tabsByWorkspace[wsID] = append(m.tabsByWorkspace[wsID], tab)
-		if len(m.tabsByWorkspace[wsID]) == 1 {
-			m.activeTabByWorkspace[wsID] = 0
+		m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+		if len(m.tabs.ByWorkspace[wsID]) == 1 {
+			m.tabs.ActiveByWorkspace[wsID] = 0
 		}
 		if session.Attach {
 			if tab.State != nil {

--- a/internal/ui/sidebar/terminal_tab_ops.go
+++ b/internal/ui/sidebar/terminal_tab_ops.go
@@ -19,7 +19,7 @@ func (m *TerminalModel) SetWorkspace(ws *data.Workspace) tea.Cmd {
 	}
 
 	wsID := m.workspaceID()
-	if len(m.tabsByWorkspace[wsID]) > 0 {
+	if len(m.tabs.ByWorkspace[wsID]) > 0 {
 		// Tabs already exist for this workspace
 		m.refreshTerminalSize()
 		return nil
@@ -95,14 +95,14 @@ func (m *TerminalModel) CloseActiveTab() tea.Cmd {
 	}
 
 	// Remove tab from slice
-	m.tabsByWorkspace[wsID] = append(tabs[:idx], tabs[idx+1:]...)
+	m.tabs.ByWorkspace[wsID] = append(tabs[:idx], tabs[idx+1:]...)
 
 	// Adjust active index
-	newLen := len(m.tabsByWorkspace[wsID])
+	newLen := len(m.tabs.ByWorkspace[wsID])
 	if newLen == 0 {
-		m.activeTabByWorkspace[wsID] = 0
+		m.tabs.ActiveByWorkspace[wsID] = 0
 	} else if idx >= newLen {
-		m.activeTabByWorkspace[wsID] = newLen - 1
+		m.tabs.ActiveByWorkspace[wsID] = newLen - 1
 	}
 
 	m.refreshTerminalSize()
@@ -143,7 +143,7 @@ func (m *TerminalModel) AddTerminalForHarness(ws *data.Workspace) {
 	}
 	m.setWorkspace(ws)
 	wsID := m.workspaceID()
-	if len(m.tabsByWorkspace[wsID]) > 0 {
+	if len(m.tabs.ByWorkspace[wsID]) > 0 {
 		return
 	}
 	termWidth, termHeight := m.TerminalSize()
@@ -159,8 +159,8 @@ func (m *TerminalModel) AddTerminalForHarness(ws *data.Workspace) {
 			lastHeight: termHeight,
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{tab}
-	m.activeTabByWorkspace[wsID] = 0
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
 }
 
 // WriteToTerminal writes bytes to the active terminal while holding the lock.

--- a/internal/ui/sidebar/terminal_tabs_test.go
+++ b/internal/ui/sidebar/terminal_tabs_test.go
@@ -15,7 +15,7 @@ func TestAddTabsFromSessionsDedupes(t *testing.T) {
 	if len(cmds) != 2 {
 		t.Fatalf("expected 2 cmds, got %d", len(cmds))
 	}
-	if got := len(m.tabsByWorkspace[wsID]); got != 2 {
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 2 {
 		t.Fatalf("expected 2 tabs, got %d", got)
 	}
 
@@ -23,7 +23,7 @@ func TestAddTabsFromSessionsDedupes(t *testing.T) {
 	if len(cmds) != 0 {
 		t.Fatalf("expected 0 cmds on duplicate add, got %d", len(cmds))
 	}
-	if got := len(m.tabsByWorkspace[wsID]); got != 2 {
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 2 {
 		t.Fatalf("expected 2 tabs after dedupe, got %d", got)
 	}
 }
@@ -40,7 +40,7 @@ func TestAddTabsFromSessionInfosAttachRespectsFlag(t *testing.T) {
 	if len(cmds) != 2 {
 		t.Fatalf("expected 2 cmds for attachable sessions, got %d", len(cmds))
 	}
-	if got := len(m.tabsByWorkspace[wsID]); got != 2 {
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 2 {
 		t.Fatalf("expected 2 tabs, got %d", got)
 	}
 }

--- a/internal/ui/sidebar/terminal_update_pty_test.go
+++ b/internal/ui/sidebar/terminal_update_pty_test.go
@@ -20,7 +20,7 @@ func TestHandlePTYStopped_PreservesOverflowTrimCarry(t *testing.T) {
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	_ = m.handlePTYStopped(messages.SidebarPTYStopped{
 		WorkspaceID: wsID,
@@ -51,7 +51,7 @@ func TestHandlePTYRestart_PreservesOverflowTrimCarry(t *testing.T) {
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	_ = m.handlePTYRestart(messages.SidebarPTYRestart{
 		WorkspaceID: wsID,
@@ -82,7 +82,7 @@ func TestHandlePTYStopped_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	_ = m.handlePTYStopped(messages.SidebarPTYStopped{WorkspaceID: wsID, TabID: string(tabID)})
 	_ = m.handlePTYOutput(messages.SidebarPTYOutput{
@@ -106,7 +106,7 @@ func TestHandlePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryEscape},
 		},
 	}
-	m.tabsByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
 
 	_ = m.handlePTYRestart(messages.SidebarPTYRestart{WorkspaceID: wsID, TabID: string(tabID)})
 	_ = m.handlePTYOutput(messages.SidebarPTYOutput{

--- a/internal/ui/sidebar/terminal_update_session.go
+++ b/internal/ui/sidebar/terminal_update_session.go
@@ -179,7 +179,7 @@ func (m *TerminalModel) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) te
 		return nil
 	}
 	wsID := string(msg.Workspace.ID())
-	tabs := m.tabsByWorkspace[wsID]
+	tabs := m.tabs.ByWorkspace[wsID]
 	for _, tab := range tabs {
 		if tab.State != nil {
 			m.stopPTYReader(tab.State)
@@ -192,8 +192,7 @@ func (m *TerminalModel) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) te
 			tab.State.mu.Unlock()
 		}
 	}
-	delete(m.tabsByWorkspace, wsID)
-	delete(m.activeTabByWorkspace, wsID)
+	m.tabs.DeleteWorkspace(wsID)
 	delete(m.pendingCreation, wsID)
 	return nil
 }

--- a/internal/ui/sidebar/terminal_update_test.go
+++ b/internal/ui/sidebar/terminal_update_test.go
@@ -30,8 +30,8 @@ func TestUpdateKeyPgUpScrollsOneLineOnShortTerminal(t *testing.T) {
 	m := NewTerminalModel()
 	m.workspace = ws
 	m.focused = true
-	m.tabsByWorkspace[string(ws.ID())] = []*TerminalTab{tab}
-	m.activeTabByWorkspace[string(ws.ID())] = 0
+	m.tabs.ByWorkspace[string(ws.ID())] = []*TerminalTab{tab}
+	m.tabs.ActiveByWorkspace[string(ws.ID())] = 0
 
 	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
 

--- a/internal/ui/sidebar/terminal_workspace_rebind.go
+++ b/internal/ui/sidebar/terminal_workspace_rebind.go
@@ -20,7 +20,7 @@ func (m *TerminalModel) RebindWorkspaceID(previous, current *data.Workspace) tea
 		return nil
 	}
 
-	oldTabs, ok := m.tabsByWorkspace[oldID]
+	oldTabs, ok := m.tabs.ByWorkspace[oldID]
 	if !ok || len(oldTabs) == 0 {
 		if m.workspace != nil && string(m.workspace.ID()) == oldID {
 			m.workspace = current
@@ -32,7 +32,7 @@ func (m *TerminalModel) RebindWorkspaceID(previous, current *data.Workspace) tea
 		return nil
 	}
 
-	merged := common.RebindTabMaps(m.tabsByWorkspace, m.activeTabByWorkspace, oldID, newID,
+	merged := common.RebindTabMaps(m.tabs.ByWorkspace, m.tabs.ActiveByWorkspace, oldID, newID,
 		func(t *TerminalTab) TerminalTabID { return t.ID },
 		func(t *TerminalTab) bool { return t == nil })
 

--- a/internal/ui/sidebar/terminal_workspace_rebind_test.go
+++ b/internal/ui/sidebar/terminal_workspace_rebind_test.go
@@ -45,8 +45,8 @@ func TestRebindWorkspaceIDMigratesTerminalState(t *testing.T) {
 			Running: false,
 		},
 	}
-	m.tabsByWorkspace[oldID] = []*TerminalTab{tab}
-	m.activeTabByWorkspace[oldID] = 0
+	m.tabs.ByWorkspace[oldID] = []*TerminalTab{tab}
+	m.tabs.ActiveByWorkspace[oldID] = 0
 	m.pendingCreation[oldID] = true
 
 	cmd := m.RebindWorkspaceID(oldWS, newWS)
@@ -56,17 +56,17 @@ func TestRebindWorkspaceIDMigratesTerminalState(t *testing.T) {
 	if m.workspace != newWS {
 		t.Fatal("expected active workspace pointer to be rebound")
 	}
-	if _, ok := m.tabsByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ByWorkspace[oldID]; ok {
 		t.Fatalf("expected old workspace key %q to be removed", oldID)
 	}
-	gotTabs := m.tabsByWorkspace[newID]
+	gotTabs := m.tabs.ByWorkspace[newID]
 	if len(gotTabs) != 1 || gotTabs[0] != tab {
 		t.Fatalf("expected migrated terminal tab under new workspace key, got %d", len(gotTabs))
 	}
-	if got := m.activeTabByWorkspace[newID]; got != 0 {
+	if got := m.tabs.ActiveByWorkspace[newID]; got != 0 {
 		t.Fatalf("expected active tab index 0, got %d", got)
 	}
-	if _, ok := m.activeTabByWorkspace[oldID]; ok {
+	if _, ok := m.tabs.ActiveByWorkspace[oldID]; ok {
 		t.Fatalf("expected old active-tab key %q to be removed", oldID)
 	}
 	if !m.pendingCreation[newID] {


### PR DESCRIPTION
TabSet[T] owns the duplicated tabsByWorkspace/activeTabByWorkspace map
pair and the circular Next/Prev/Select index math, embedded by both
center.Model and sidebar.TerminalModel. The center keeps its
side-effectful setActiveTabIdx wrapper (focus + visibility sync) on top
of the shared math.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E5**, 18/36). Stacked on `rp/e4-flush-overflow`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.