### PR TITLE
D1: Make the workspace lifecycle an explicit state machine

### DIFF
--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -116,7 +116,7 @@ func TestHandleWorkspaceDeleted_NoTrailingSessionKill(t *testing.T) {
 		tmuxService:     ops,
 		tmuxOptions:     tmux.Options{},
 		lifecycle: workspaceLifecycleState{
-			deleting: map[string]bool{string(ws.ID()): true},
+			phases: map[string]lifecyclePhase{string(ws.ID()): lifecycleDeleting},
 		},
 	}
 

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -370,7 +370,15 @@ func (a *App) handleCreateWorkspace(msg messages.CreateWorkspace) []tea.Cmd {
 		pending := a.workspaceService.pendingWorkspace(msg.Project, name, base)
 		if pending != nil {
 			pending.Assistant = assistant
-			a.lifecycle.markCreating(string(pending.ID()))
+			if !a.lifecycle.markCreating(string(pending.ID())) {
+				cmds = append(cmds, func() tea.Msg {
+					return messages.WorkspaceCreateFailed{
+						Workspace: pending,
+						Err:       fmt.Errorf("workspace %s is already being deleted", pending.Name),
+					}
+				})
+				return cmds
+			}
 			if cmd := a.dashboard.SetWorkspaceCreating(pending, true); cmd != nil {
 				cmds = append(cmds, cmd)
 			}

--- a/internal/app/app_input_messages_workspace_create_test.go
+++ b/internal/app/app_input_messages_workspace_create_test.go
@@ -15,7 +15,7 @@ func TestHandleCreateWorkspaceSkipsPendingTrackingWithoutService(t *testing.T) {
 	app := &App{
 		dashboard: dashboard.New(),
 		lifecycle: workspaceLifecycleState{
-			creating: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 		// workspaceService intentionally nil
 	}
@@ -30,8 +30,8 @@ func TestHandleCreateWorkspaceSkipsPendingTrackingWithoutService(t *testing.T) {
 
 	cmds := app.handleCreateWorkspace(msg)
 	// Should not panic and should not track any pending IDs
-	if len(app.lifecycle.creating) != 0 {
-		t.Fatalf("expected no pending IDs without workspace service, got %d", len(app.lifecycle.creating))
+	if len(app.lifecycle.snapshotCreating()) != 0 {
+		t.Fatalf("expected no pending IDs without workspace service, got %d", len(app.lifecycle.snapshotCreating()))
 	}
 	// Should still return the createWorkspace cmd (which will be nil since service is nil)
 	_ = cmds
@@ -53,7 +53,7 @@ func TestHandleCreateWorkspaceTracksAndClearsPendingIDOnFailure(t *testing.T) {
 	app := &App{
 		dashboard: dashboard.New(),
 		lifecycle: workspaceLifecycleState{
-			creating: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 		workspaceService: svc,
 	}
@@ -68,13 +68,13 @@ func TestHandleCreateWorkspaceTracksAndClearsPendingIDOnFailure(t *testing.T) {
 
 	// Step 1: handleCreateWorkspace should track the pending ID
 	cmds := app.handleCreateWorkspace(msg)
-	if len(app.lifecycle.creating) != 1 {
-		t.Fatalf("expected 1 pending ID after handleCreateWorkspace, got %d", len(app.lifecycle.creating))
+	if len(app.lifecycle.snapshotCreating()) != 1 {
+		t.Fatalf("expected 1 pending ID after handleCreateWorkspace, got %d", len(app.lifecycle.snapshotCreating()))
 	}
 
 	// Capture the tracked ID
 	var trackedID string
-	for id := range app.lifecycle.creating {
+	for id := range app.lifecycle.snapshotCreating() {
 		trackedID = id
 	}
 
@@ -103,8 +103,8 @@ func TestHandleCreateWorkspaceTracksAndClearsPendingIDOnFailure(t *testing.T) {
 		if failed, ok := result.(messages.WorkspaceCreateFailed); ok {
 			// Step 3: handleWorkspaceCreateFailed should clear the pending ID
 			app.handleWorkspaceCreateFailed(failed)
-			if len(app.lifecycle.creating) != 0 {
-				t.Fatalf("expected 0 pending IDs after failure, got %d", len(app.lifecycle.creating))
+			if len(app.lifecycle.snapshotCreating()) != 0 {
+				t.Fatalf("expected 0 pending IDs after failure, got %d", len(app.lifecycle.snapshotCreating()))
 			}
 			// Verify the failure workspace ID matches what was tracked
 			if failed.Workspace != nil && string(failed.Workspace.ID()) != trackedID {
@@ -125,7 +125,7 @@ func TestHandleCreateWorkspaceClearsPendingIDOnValidationFailure(t *testing.T) {
 	app := &App{
 		dashboard: dashboard.New(),
 		lifecycle: workspaceLifecycleState{
-			creating: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 		workspaceService: svc,
 	}
@@ -139,8 +139,8 @@ func TestHandleCreateWorkspaceClearsPendingIDOnValidationFailure(t *testing.T) {
 	}
 
 	cmds := app.handleCreateWorkspace(msg)
-	if len(app.lifecycle.creating) != 1 {
-		t.Fatalf("expected 1 pending ID after handleCreateWorkspace, got %d", len(app.lifecycle.creating))
+	if len(app.lifecycle.snapshotCreating()) != 1 {
+		t.Fatalf("expected 1 pending ID after handleCreateWorkspace, got %d", len(app.lifecycle.snapshotCreating()))
 	}
 
 	for _, cmd := range cmds {
@@ -156,8 +156,8 @@ func TestHandleCreateWorkspaceClearsPendingIDOnValidationFailure(t *testing.T) {
 			t.Fatal("expected workspace in validation failure")
 		}
 		app.handleWorkspaceCreateFailed(failed)
-		if len(app.lifecycle.creating) != 0 {
-			t.Fatalf("expected 0 pending IDs after validation failure, got %d", len(app.lifecycle.creating))
+		if len(app.lifecycle.snapshotCreating()) != 0 {
+			t.Fatalf("expected 0 pending IDs after validation failure, got %d", len(app.lifecycle.snapshotCreating()))
 		}
 		return
 	}

--- a/internal/app/app_input_pty_file_watcher_test.go
+++ b/internal/app/app_input_pty_file_watcher_test.go
@@ -58,8 +58,8 @@ func TestHandleFileWatcherEvent_ActiveWorkspaceRequestsFullStatus(t *testing.T) 
 		dashboard:       dashboard.New(),
 		activeWorkspace: active,
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			creating: make(map[string]bool),
+			dirty:  make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 
@@ -101,8 +101,8 @@ func TestHandleFileWatcherEvent_InactiveWorkspaceRequestsFastStatus(t *testing.T
 		dashboard:       dashboard.New(),
 		activeWorkspace: active,
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			creating: make(map[string]bool),
+			dirty:  make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 
@@ -143,8 +143,8 @@ func TestHandleGitStatusTick_ActiveWorkspaceCacheMissRequestsFullStatus(t *testi
 		dashboard:       dashboard.New(),
 		activeWorkspace: active,
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			creating: make(map[string]bool),
+			dirty:  make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 
@@ -189,8 +189,8 @@ func TestHandleGitStatusTick_ActiveWorkspaceCachedStatusSkipsRefresh(t *testing.
 		dashboard:       dashboard.New(),
 		activeWorkspace: active,
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			creating: make(map[string]bool),
+			dirty:  make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -18,7 +18,10 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		logging.Warn("DeleteWorkspace received with nil project or workspace")
 		return nil
 	}
-	a.markWorkspaceDeleteInFlight(msg.Workspace, true)
+	if !a.markWorkspaceDeleteInFlight(msg.Workspace, true) {
+		logging.Warn("DeleteWorkspace rejected while workspace %s is in another lifecycle phase", msg.Workspace.ID())
+		return nil
+	}
 	// Do NOT kill the workspace's tmux sessions here. All real delete validation
 	// (primary-checkout guard, repo/path checks, worktree removal) runs later in
 	// the async DeleteWorkspace cmd; killing up-front means a rejected or failed

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -21,8 +21,8 @@ func TestHandleWorkspaceDeletedClearsDirtyWorkspaceMarker(t *testing.T) {
 		sidebar:         sidebar.NewTabbedSidebar(),
 		sidebarTerminal: sidebar.NewTerminalModel(),
 		lifecycle: workspaceLifecycleState{
-			dirty:    map[string]bool{wsID: true},
-			deleting: map[string]bool{wsID: true},
+			dirty:  map[string]bool{wsID: true},
+			phases: map[string]lifecyclePhase{wsID: lifecycleDeleting},
 		},
 	}
 
@@ -101,7 +101,7 @@ func TestHandleWorkspaceDeleted_ClearsActiveWorkspace(t *testing.T) {
 			activeWorkspaceIDs: map[string]bool{idDel: true, idKeep: true},
 		},
 		lifecycle: workspaceLifecycleState{
-			deleting: map[string]bool{idDel: true},
+			phases: map[string]lifecyclePhase{idDel: lifecycleDeleting},
 		},
 	}
 
@@ -130,8 +130,8 @@ func TestHandleWorkspaceDeleted_WithMetadataErrorRemovesLoadedWorkspace(t *testi
 		sidebarTerminal: sidebar.NewTerminalModel(),
 		activeWorkspace: wsDel,
 		lifecycle: workspaceLifecycleState{
-			dirty:    map[string]bool{wsID: true},
-			deleting: map[string]bool{wsID: true},
+			dirty:  map[string]bool{wsID: true},
+			phases: map[string]lifecyclePhase{wsID: lifecycleDeleting},
 		},
 	}
 	app.dashboard.SetProjects(app.projects)

--- a/internal/app/app_persistence_test.go
+++ b/internal/app/app_persistence_test.go
@@ -96,8 +96,8 @@ func TestPersistAllWorkspacesNowSkipsDeleteInFlightWorkspace(t *testing.T) {
 		workspaceService: svc,
 		projects:         []data.Project{{Name: "p", Path: "/repo", Workspaces: []data.Workspace{*ws}}},
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			deleting: map[string]bool{wsID: true},
+			dirty:  make(map[string]bool),
+			phases: map[string]lifecyclePhase{wsID: lifecycleDeleting},
 		},
 	}
 
@@ -130,8 +130,8 @@ func TestPersistWorkspaceTabsInitializesDirtyMap(t *testing.T) {
 func TestPersistWorkspaceTabsSkipsDeleteInFlightWorkspace(t *testing.T) {
 	app := &App{
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			deleting: map[string]bool{"ws-123": true},
+			dirty:  make(map[string]bool),
+			phases: map[string]lifecyclePhase{"ws-123": lifecycleDeleting},
 		},
 	}
 
@@ -189,7 +189,7 @@ func TestHandlePersistDebounceSkipsDeleteInFlightWorkspace(t *testing.T) {
 		lifecycle: workspaceLifecycleState{
 			persistToken: 1,
 			dirty:        map[string]bool{wsID: true},
-			deleting:     map[string]bool{wsID: true},
+			phases:       map[string]lifecyclePhase{wsID: lifecycleDeleting},
 			localSavesAt: make(map[string]localWorkspaceSaveMarker),
 		},
 	}
@@ -230,7 +230,7 @@ func TestDeleteFailureRequeuesAndDebouncedPersistSavesWorkspace(t *testing.T) {
 		lifecycle: workspaceLifecycleState{
 			persistToken: 1,
 			dirty:        map[string]bool{wsID: true},
-			deleting:     map[string]bool{wsID: true},
+			phases:       map[string]lifecyclePhase{wsID: lifecycleDeleting},
 			localSavesAt: make(map[string]localWorkspaceSaveMarker),
 		},
 	}

--- a/internal/app/app_tmux_gc.go
+++ b/internal/app/app_tmux_gc.go
@@ -40,7 +40,7 @@ func (a *App) collectKnownWorkspaceIDs() map[string]bool {
 			ids[string(a.projects[i].Workspaces[j].ID())] = true
 		}
 	}
-	for id := range a.lifecycle.creating {
+	for id := range a.lifecycle.snapshotCreating() {
 		ids[id] = true
 	}
 	// A workspace mid-delete may already be absent from a.projects (loadProjects

--- a/internal/app/app_tmux_gc_safety_test.go
+++ b/internal/app/app_tmux_gc_safety_test.go
@@ -236,7 +236,7 @@ func TestGcOrphanedTmuxSessions_SkipsDeleteInFlightOrphan(t *testing.T) {
 	app := newGCTestApp(ops)
 	// dead-ws is mid-delete and already absent from a.projects; orphan GC must
 	// treat it as known and leave its session for the orderly delete cleanup.
-	app.lifecycle.deleting = map[string]bool{"dead-ws": true}
+	app.lifecycle.phases = map[string]lifecyclePhase{"dead-ws": lifecycleDeleting}
 
 	msg := app.gcOrphanedTmuxSessions()()
 	result, ok := msg.(orphanGCResult)

--- a/internal/app/app_tmux_gc_test.go
+++ b/internal/app/app_tmux_gc_test.go
@@ -63,7 +63,7 @@ func TestCollectKnownWorkspaceIDs_IncludesCreating(t *testing.T) {
 	creatingID := string(ws.ID())
 	app := &App{
 		lifecycle: workspaceLifecycleState{
-			creating: map[string]bool{creatingID: true},
+			phases: map[string]lifecyclePhase{creatingID: lifecycleCreating},
 		},
 	}
 
@@ -357,7 +357,7 @@ func TestCollectKnownWorkspaceIDs_IncludesDeleting(t *testing.T) {
 	deletingID := string(ws.ID())
 	app := &App{
 		lifecycle: workspaceLifecycleState{
-			deleting: map[string]bool{deletingID: true},
+			phases: map[string]lifecyclePhase{deletingID: lifecycleDeleting},
 		},
 	}
 

--- a/internal/app/app_tmux_sync_test.go
+++ b/internal/app/app_tmux_sync_test.go
@@ -77,7 +77,7 @@ func TestHandleTmuxTabsSyncResult_SaveAndDeleteMarkAreAtomic(t *testing.T) {
 		workspaceService: svc,
 		projects:         []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{*ws}}},
 		lifecycle: workspaceLifecycleState{
-			deleting: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 

--- a/internal/app/workspace_delete_guard.go
+++ b/internal/app/workspace_delete_guard.go
@@ -5,11 +5,11 @@ import "github.com/andyrewlee/amux/internal/data"
 // Thin App wrappers over workspaceLifecycleState's delete-in-flight guard;
 // these exist so the workspace service can be wired to App methods in app_init.
 
-func (a *App) markWorkspaceDeleteInFlight(ws *data.Workspace, deleting bool) {
+func (a *App) markWorkspaceDeleteInFlight(ws *data.Workspace, deleting bool) bool {
 	if ws == nil {
-		return
+		return false
 	}
-	a.lifecycle.markDeleting(string(ws.ID()), deleting)
+	return a.lifecycle.markDeleting(string(ws.ID()), deleting)
 }
 
 func (a *App) isWorkspaceDeleteInFlight(wsID string) bool {

--- a/internal/app/workspace_delete_guard_test.go
+++ b/internal/app/workspace_delete_guard_test.go
@@ -17,8 +17,8 @@ func TestMarkWorkspaceDeleteInFlightPreservesDirtyState(t *testing.T) {
 
 	app := &App{
 		lifecycle: workspaceLifecycleState{
-			dirty:    map[string]bool{wsID: true},
-			deleting: make(map[string]bool),
+			dirty:  map[string]bool{wsID: true},
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 
@@ -39,8 +39,8 @@ func TestHandleWorkspaceDeleteFailedRequeuesWorkspacePersistence(t *testing.T) {
 	app := &App{
 		dashboard: dashboard.New(),
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			deleting: map[string]bool{wsID: true},
+			dirty:  make(map[string]bool),
+			phases: map[string]lifecyclePhase{wsID: lifecycleDeleting},
 		},
 	}
 
@@ -65,7 +65,7 @@ func TestWorkspaceDeleteInFlightConcurrentAccess(t *testing.T) {
 
 	app := &App{
 		lifecycle: workspaceLifecycleState{
-			deleting: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 
@@ -104,7 +104,7 @@ func TestWorkspaceDeleteInFlightConcurrentAccess(t *testing.T) {
 func TestRunUnlessWorkspaceDeleteInFlightSkipsWhenDeleting(t *testing.T) {
 	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
 	wsID := string(ws.ID())
-	app := &App{lifecycle: workspaceLifecycleState{deleting: map[string]bool{wsID: true}}}
+	app := &App{lifecycle: workspaceLifecycleState{phases: map[string]lifecyclePhase{wsID: lifecycleDeleting}}}
 
 	ran := false
 	ok := app.runUnlessWorkspaceDeleteInFlight(wsID, func() {
@@ -121,7 +121,7 @@ func TestRunUnlessWorkspaceDeleteInFlightSkipsWhenDeleting(t *testing.T) {
 func TestRunUnlessWorkspaceDeleteInFlightBlocksDeleteMarkUntilCallbackReturns(t *testing.T) {
 	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
 	wsID := string(ws.ID())
-	app := &App{lifecycle: workspaceLifecycleState{deleting: make(map[string]bool)}}
+	app := &App{lifecycle: workspaceLifecycleState{phases: make(map[string]lifecyclePhase)}}
 
 	entered := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/app/workspace_delete_isolation_test.go
+++ b/internal/app/workspace_delete_isolation_test.go
@@ -19,6 +19,7 @@ func (s *recordingWorkspaceStore) ListByRepo(string) ([]*data.Workspace, error) 
 func (s *recordingWorkspaceStore) ListByRepoIncludingArchived(string) ([]*data.Workspace, error) {
 	return nil, nil
 }
+
 func (s *recordingWorkspaceStore) LoadMetadataFor(*data.Workspace) (bool, error) { return false, nil }
 func (s *recordingWorkspaceStore) UpsertFromDiscovery(*data.Workspace) error     { return nil }
 
@@ -79,7 +80,7 @@ func TestHandleTmuxTabsSyncResult_DeleteInFlightIsolatesSibling(t *testing.T) {
 			Workspaces: []data.Workspace{*wsA, *wsB},
 		}},
 		lifecycle: workspaceLifecycleState{
-			deleting: make(map[string]bool),
+			phases: make(map[string]lifecyclePhase),
 		},
 	}
 	app.markWorkspaceDeleteInFlight(wsA, true)
@@ -149,7 +150,7 @@ func TestKillWorkspaceSessionsSync_TagArgsAreWorkspaceScoped(t *testing.T) {
 func TestWorkspaceDeleteInFlight_PerWorkspaceIsolation(t *testing.T) {
 	wsA := data.NewWorkspace("a", "a", "main", "/repo", "/repo/a")
 	wsB := data.NewWorkspace("b", "b", "main", "/repo", "/repo/b")
-	app := &App{lifecycle: workspaceLifecycleState{deleting: make(map[string]bool)}}
+	app := &App{lifecycle: workspaceLifecycleState{phases: make(map[string]lifecyclePhase)}}
 
 	app.markWorkspaceDeleteInFlight(wsA, true)
 	if !app.isWorkspaceDeleteInFlight(string(wsA.ID())) {

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -28,6 +28,7 @@ func (s *failingTombstoneWorkspaceStore) LoadMetadataFor(*data.Workspace) (bool,
 func (s *failingTombstoneWorkspaceStore) UpsertFromDiscovery(*data.Workspace) error { return nil }
 func (s *failingTombstoneWorkspaceStore) Save(*data.Workspace) error                { return nil }
 func (s *failingTombstoneWorkspaceStore) Delete(data.WorkspaceID) error             { return s.deleteErr }
+
 func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant
 }
@@ -136,8 +137,8 @@ func TestPersistAllWorkspacesNow_SkipsDeleteInFlight(t *testing.T) {
 			Workspaces: []data.Workspace{*gone, *live, *kept},
 		}},
 		lifecycle: workspaceLifecycleState{
-			dirty:    make(map[string]bool),
-			deleting: map[string]bool{string(gone.ID()): true, string(live.ID()): true},
+			dirty:  make(map[string]bool),
+			phases: map[string]lifecyclePhase{string(gone.ID()): lifecycleDeleting, string(live.ID()): lifecycleDeleting},
 		},
 	}
 

--- a/internal/app/workspace_lifecycle_fsm_test.go
+++ b/internal/app/workspace_lifecycle_fsm_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+)
+
+func TestLifecyclePhaseTransitionTable(t *testing.T) {
+	cases := []struct {
+		name string
+		from lifecyclePhase
+		to   lifecyclePhase
+		want bool
+	}{
+		{"active->creating", lifecycleActive, lifecycleCreating, true},
+		{"active->deleting", lifecycleActive, lifecycleDeleting, true},
+		{"creating->active", lifecycleCreating, lifecycleActive, true},
+		{"deleting->active", lifecycleDeleting, lifecycleActive, true},
+		{"creating->creating", lifecycleCreating, lifecycleCreating, true},
+		{"deleting->deleting", lifecycleDeleting, lifecycleDeleting, true},
+		{"creating->deleting rejected", lifecycleCreating, lifecycleDeleting, false},
+		{"deleting->creating rejected", lifecycleDeleting, lifecycleCreating, false},
+	}
+	for _, tc := range cases {
+		if got := lifecycleTransitionAllowed(tc.from, tc.to); got != tc.want {
+			t.Errorf("%s: lifecycleTransitionAllowed(%s, %s) = %v, want %v", tc.name, tc.from, tc.to, got, tc.want)
+		}
+	}
+}
+
+func TestLifecycleRejectsCreateWhileDeleting(t *testing.T) {
+	st := newWorkspaceLifecycleState()
+	st.markDeleting("ws-1", true)
+
+	if st.markCreating("ws-1") {
+		t.Fatal("expected markCreating to be rejected while delete is in flight")
+	}
+	if !st.isDeleting("ws-1") {
+		t.Fatal("expected deleting phase preserved after rejected create")
+	}
+	// clearCreating must not stomp the deleting phase either.
+	st.clearCreating("ws-1")
+	if !st.isDeleting("ws-1") {
+		t.Fatal("expected deleting phase preserved after clearCreating")
+	}
+
+	st.markDeleting("ws-1", false)
+	if st.phase("ws-1") != lifecycleActive {
+		t.Fatalf("expected workspace settled back to active, got %s", st.phase("ws-1"))
+	}
+	if !st.markCreating("ws-1") {
+		t.Fatal("expected markCreating accepted once the delete settled")
+	}
+}
+
+// TestLifecycleCreateWhileProjectsLoading proves the message interleaving that
+// motivated the creating phase: a workspace marked create-in-flight stays in
+// that phase across a ProjectsLoaded that does not yet contain it, and only
+// settles when WorkspaceCreated lands.
+func TestLifecycleCreateWhileProjectsLoading(t *testing.T) {
+	app := &App{
+		lifecycle:        newWorkspaceLifecycleState(),
+		tmuxActivity:     newTmuxActivityState(),
+		dashboard:        dashboard.New(),
+		center:           center.New(nil),
+		workspaceService: newWorkspaceService(nil, nil, nil, t.TempDir()),
+	}
+
+	project := data.NewProject("/repo")
+	app.handleCreateWorkspace(messages.CreateWorkspace{
+		Project:   project,
+		Name:      "feature",
+		Base:      "main",
+		Assistant: "claude",
+	})
+	creating := app.lifecycle.snapshotCreating()
+	if len(creating) != 1 {
+		t.Fatalf("expected one create-in-flight workspace, got %v", creating)
+	}
+	var wsID string
+	for id := range creating {
+		wsID = id
+	}
+
+	// A projects reload that does not include the half-created workspace must
+	// not clear the creating phase (the workspace is not loaded yet).
+	app.handleProjectsLoaded(messages.ProjectsLoaded{Projects: []data.Project{*project}})
+	if !app.lifecycle.isCreating(wsID) {
+		t.Fatal("expected creating phase to survive a projects reload")
+	}
+
+	pending := app.workspaceService.pendingWorkspace(project, "feature", "main")
+	app.handleWorkspaceCreated(messages.WorkspaceCreated{Workspace: pending})
+	if app.lifecycle.phase(wsID) != lifecycleActive {
+		t.Fatalf("expected workspace settled after WorkspaceCreated, got %s", app.lifecycle.phase(wsID))
+	}
+}
+
+// TestLifecycleDeleteWhilePersisting exercises the deleting phase against the
+// persistence paths concurrently (the guard methods are read from Cmd/worker
+// goroutines while Update-handler transitions run); run with -race.
+func TestLifecycleDeleteWhilePersisting(t *testing.T) {
+	st := newWorkspaceLifecycleState()
+	const wsID = "ws-race"
+	st.markDirty(wsID)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 200; j++ {
+				st.markDeleting(wsID, j%2 == 0)
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 200; j++ {
+				_ = st.isDeleting(wsID)
+				_ = st.snapshotDeleting()
+				st.runUnlessDeleting(wsID, func() {})
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// The dirty marker is orthogonal to the lifecycle phase and must survive
+	// the delete churn so a failed delete can requeue persistence.
+	if !st.dirty[wsID] {
+		t.Fatal("expected dirty marker to survive delete-phase churn")
+	}
+}

--- a/internal/app/workspace_lifecycle_fsm_test.go
+++ b/internal/app/workspace_lifecycle_fsm_test.go
@@ -101,6 +101,73 @@ func TestLifecycleCreateWhileProjectsLoading(t *testing.T) {
 	}
 }
 
+func TestHandleCreateWorkspaceStopsWhenLifecycleRejectsCreate(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	project := data.NewProject("/repo")
+	service := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	pending := service.pendingWorkspace(project, "feature", "main")
+	if pending == nil {
+		t.Fatal("expected pending workspace")
+	}
+
+	app := &App{
+		lifecycle:        newWorkspaceLifecycleState(),
+		dashboard:        dashboard.New(),
+		workspaceService: service,
+	}
+	app.lifecycle.markDeleting(string(pending.ID()), true)
+
+	cmds := app.handleCreateWorkspace(messages.CreateWorkspace{
+		Project:   project,
+		Name:      "feature",
+		Base:      "main",
+		Assistant: "claude",
+	})
+	if len(cmds) != 1 {
+		t.Fatalf("expected only the create-failed command, got %d commands", len(cmds))
+	}
+	msg := cmds[0]()
+	failed, ok := msg.(messages.WorkspaceCreateFailed)
+	if !ok {
+		t.Fatalf("expected WorkspaceCreateFailed, got %T", msg)
+	}
+	if failed.Workspace == nil || failed.Workspace.ID() != pending.ID() {
+		t.Fatalf("expected failed pending workspace %s, got %#v", pending.ID(), failed.Workspace)
+	}
+	if failed.Err == nil {
+		t.Fatal("expected lifecycle rejection error")
+	}
+	if !app.lifecycle.isDeleting(string(pending.ID())) {
+		t.Fatal("expected deleting phase to remain active after rejected create")
+	}
+	if app.lifecycle.isCreating(string(pending.ID())) {
+		t.Fatal("expected rejected create not to mark workspace creating")
+	}
+}
+
+func TestHandleDeleteWorkspaceStopsWhenLifecycleRejectsDelete(t *testing.T) {
+	project := data.NewProject("/repo")
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	app := &App{
+		lifecycle: newWorkspaceLifecycleState(),
+		dashboard: dashboard.New(),
+	}
+	if !app.lifecycle.markCreating(string(ws.ID())) {
+		t.Fatal("expected setup create phase accepted")
+	}
+
+	cmds := app.handleDeleteWorkspace(messages.DeleteWorkspace{Project: project, Workspace: ws})
+	if len(cmds) != 0 {
+		t.Fatalf("expected rejected delete to queue no commands, got %d", len(cmds))
+	}
+	if !app.lifecycle.isCreating(string(ws.ID())) {
+		t.Fatal("expected creating phase to remain active after rejected delete")
+	}
+	if app.lifecycle.isDeleting(string(ws.ID())) {
+		t.Fatal("expected rejected delete not to mark workspace deleting")
+	}
+}
+
 // TestLifecycleDeleteWhilePersisting exercises the deleting phase against the
 // persistence paths concurrently (the guard methods are read from Cmd/worker
 // goroutines while Update-handler transitions run); run with -race.

--- a/internal/app/workspace_lifecycle_state.go
+++ b/internal/app/workspace_lifecycle_state.go
@@ -1,20 +1,65 @@
 package app
 
-import "sync"
+import (
+	"sync"
 
-// workspaceLifecycleState groups the workspace create/delete/persist
-// bookkeeping that previously lived as loose fields on App. The creating and
-// dirty maps are touched only from App.Update handlers (single writer); the
-// deleting map and local-save markers are also read from Cmd/worker
-// goroutines, so they carry their own locks.
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+// lifecyclePhase is a workspace's position in the create/delete lifecycle.
+// Workspaces not present in the phase map are active: loaded, with no
+// lifecycle operation in flight.
+type lifecyclePhase uint8
+
+const (
+	lifecycleActive lifecyclePhase = iota
+	// lifecycleCreating: create accepted, worktree/metadata still being built;
+	// the workspace is not in the projects list yet.
+	lifecycleCreating
+	// lifecycleDeleting: delete accepted, teardown in flight.
+	lifecycleDeleting
+)
+
+func (p lifecyclePhase) String() string {
+	switch p {
+	case lifecycleCreating:
+		return "creating"
+	case lifecycleDeleting:
+		return "deleting"
+	default:
+		return "active"
+	}
+}
+
+// lifecycleTransitionAllowed is the transition table: creating and deleting
+// are mutually exclusive, entered only from active, and always allowed to
+// settle back to active. Same-phase moves are idempotent no-ops.
+func lifecycleTransitionAllowed(from, to lifecyclePhase) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case lifecycleActive:
+		return true
+	case lifecycleCreating, lifecycleDeleting:
+		return to == lifecycleActive
+	default:
+		return false
+	}
+}
+
+// workspaceLifecycleState holds the workspace create/delete/persist
+// bookkeeping. The phase map is the explicit lifecycle state machine; the
+// dirty set is deliberately NOT a phase, because a dirty marker must survive
+// a delete that later fails (the failed-delete handler requeues persistence),
+// so dirty coexists with deleting.
 type workspaceLifecycleState struct {
-	// creating tracks workspaces in the creation flow that have not been
-	// loaded into the projects list yet.
-	creating map[string]bool
-	// deletingMu guards deleting; see markDeleting/isDeleting.
-	deletingMu sync.RWMutex
-	deleting   map[string]bool
+	// phaseMu guards phases; the deleting phase is read from Cmd/worker
+	// goroutines via the App guard helpers.
+	phaseMu sync.RWMutex
+	phases  map[string]lifecyclePhase
 	// dirty tracks workspaces with unsaved tab state (persist debounce).
+	// Touched only from App.Update handlers (single writer).
 	dirty map[string]bool
 	// persistToken is the current persist-debounce generation.
 	persistToken persistToken
@@ -29,27 +74,130 @@ type workspaceLifecycleState struct {
 
 func newWorkspaceLifecycleState() workspaceLifecycleState {
 	return workspaceLifecycleState{
-		creating:     make(map[string]bool),
-		deleting:     make(map[string]bool),
+		phases:       make(map[string]lifecyclePhase),
 		dirty:        make(map[string]bool),
 		localSavesAt: make(map[string]localWorkspaceSaveMarker),
 	}
 }
 
-// markCreating records a workspace as create-in-flight.
-func (w *workspaceLifecycleState) markCreating(wsID string) {
+// transition moves wsID to a new phase, rejecting (and logging) moves the
+// transition table does not allow — e.g. deleting → creating.
+func (w *workspaceLifecycleState) transition(wsID string, to lifecyclePhase) bool {
 	if wsID == "" {
-		return
+		return false
 	}
-	if w.creating == nil {
-		w.creating = make(map[string]bool)
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	if w.phases == nil {
+		w.phases = make(map[string]lifecyclePhase)
 	}
-	w.creating[wsID] = true
+	from := w.phases[wsID]
+	if !lifecycleTransitionAllowed(from, to) {
+		logging.Warn("workspace lifecycle: rejected transition %s -> %s for workspace %s", from, to, wsID)
+		return false
+	}
+	if to == lifecycleActive {
+		delete(w.phases, wsID)
+	} else {
+		w.phases[wsID] = to
+	}
+	return true
 }
 
-// clearCreating removes a workspace from the create-in-flight set.
+// phase returns the workspace's current lifecycle phase.
+func (w *workspaceLifecycleState) phase(wsID string) lifecyclePhase {
+	w.phaseMu.RLock()
+	defer w.phaseMu.RUnlock()
+	return w.phases[wsID]
+}
+
+// markCreating records a workspace as create-in-flight. It reports whether
+// the transition was accepted (rejected when the workspace is mid-delete).
+func (w *workspaceLifecycleState) markCreating(wsID string) bool {
+	return w.transition(wsID, lifecycleCreating)
+}
+
+// clearCreating settles a creating workspace back to active. A workspace in
+// any other phase is left untouched.
 func (w *workspaceLifecycleState) clearCreating(wsID string) {
-	delete(w.creating, wsID)
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	if w.phases[wsID] == lifecycleCreating {
+		delete(w.phases, wsID)
+	}
+}
+
+// isCreating reports whether a workspace is currently create-in-flight.
+func (w *workspaceLifecycleState) isCreating(wsID string) bool {
+	return w.phase(wsID) == lifecycleCreating
+}
+
+// markDeleting sets or clears the delete-in-flight phase for a workspace.
+// Setting is rejected while the workspace is mid-create; clearing only
+// settles a deleting workspace (it never stomps another phase).
+func (w *workspaceLifecycleState) markDeleting(wsID string, deleting bool) {
+	if deleting {
+		w.transition(wsID, lifecycleDeleting)
+		return
+	}
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	if w.phases[wsID] == lifecycleDeleting {
+		delete(w.phases, wsID)
+	}
+}
+
+// isDeleting reports whether a workspace is currently delete-in-flight.
+func (w *workspaceLifecycleState) isDeleting(wsID string) bool {
+	if wsID == "" {
+		return false
+	}
+	return w.phase(wsID) == lifecycleDeleting
+}
+
+// snapshotPhase returns a copy of the IDs currently in the given phase. The
+// RLock is required because callers like collectKnownWorkspaceIDs run on the
+// Update goroutine while the map is also mutated from worker goroutines.
+func (w *workspaceLifecycleState) snapshotPhase(phase lifecyclePhase) map[string]bool {
+	w.phaseMu.RLock()
+	defer w.phaseMu.RUnlock()
+	var out map[string]bool
+	for id, p := range w.phases {
+		if p != phase {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]bool)
+		}
+		out[id] = true
+	}
+	return out
+}
+
+// snapshotDeleting returns a copy of the IDs currently delete-in-flight.
+func (w *workspaceLifecycleState) snapshotDeleting() map[string]bool {
+	return w.snapshotPhase(lifecycleDeleting)
+}
+
+// snapshotCreating returns a copy of the IDs currently create-in-flight.
+func (w *workspaceLifecycleState) snapshotCreating() map[string]bool {
+	return w.snapshotPhase(lifecycleCreating)
+}
+
+// runUnlessDeleting runs fn while holding the shared phase lock only when
+// wsID is not currently delete-in-flight. Holding the lock across fn keeps
+// the check and side effect atomic with respect to markDeleting.
+func (w *workspaceLifecycleState) runUnlessDeleting(wsID string, fn func()) bool {
+	w.phaseMu.RLock()
+	defer w.phaseMu.RUnlock()
+
+	if wsID == "" || w.phases[wsID] == lifecycleDeleting {
+		return false
+	}
+	if fn != nil {
+		fn()
+	}
+	return true
 }
 
 // markDirty records a workspace as having unsaved tab state.
@@ -61,67 +209,4 @@ func (w *workspaceLifecycleState) markDirty(wsID string) {
 		w.dirty = make(map[string]bool)
 	}
 	w.dirty[wsID] = true
-}
-
-// markDeleting sets or clears the delete-in-flight flag for a workspace.
-func (w *workspaceLifecycleState) markDeleting(wsID string, deleting bool) {
-	w.deletingMu.Lock()
-	defer w.deletingMu.Unlock()
-
-	if wsID == "" {
-		return
-	}
-	if w.deleting == nil {
-		w.deleting = make(map[string]bool)
-	}
-	if deleting {
-		w.deleting[wsID] = true
-		return
-	}
-	delete(w.deleting, wsID)
-}
-
-// isDeleting reports whether a workspace is currently delete-in-flight.
-func (w *workspaceLifecycleState) isDeleting(wsID string) bool {
-	w.deletingMu.RLock()
-	defer w.deletingMu.RUnlock()
-
-	if wsID == "" || w.deleting == nil {
-		return false
-	}
-	return w.deleting[wsID]
-}
-
-// snapshotDeleting returns a copy of the IDs currently marked
-// delete-in-flight. The RLock is required because callers like
-// collectKnownWorkspaceIDs run on the Update goroutine while the map is also
-// mutated from worker goroutines.
-func (w *workspaceLifecycleState) snapshotDeleting() map[string]bool {
-	w.deletingMu.RLock()
-	defer w.deletingMu.RUnlock()
-
-	if len(w.deleting) == 0 {
-		return nil
-	}
-	out := make(map[string]bool, len(w.deleting))
-	for id := range w.deleting {
-		out[id] = true
-	}
-	return out
-}
-
-// runUnlessDeleting runs fn while holding the shared delete-state lock only
-// when wsID is not currently marked delete-in-flight. Holding the lock across
-// fn keeps the check and side effect atomic with respect to markDeleting.
-func (w *workspaceLifecycleState) runUnlessDeleting(wsID string, fn func()) bool {
-	w.deletingMu.RLock()
-	defer w.deletingMu.RUnlock()
-
-	if wsID == "" || w.deleting[wsID] {
-		return false
-	}
-	if fn != nil {
-		fn()
-	}
-	return true
 }

--- a/internal/app/workspace_lifecycle_state.go
+++ b/internal/app/workspace_lifecycle_state.go
@@ -135,16 +135,16 @@ func (w *workspaceLifecycleState) isCreating(wsID string) bool {
 // markDeleting sets or clears the delete-in-flight phase for a workspace.
 // Setting is rejected while the workspace is mid-create; clearing only
 // settles a deleting workspace (it never stomps another phase).
-func (w *workspaceLifecycleState) markDeleting(wsID string, deleting bool) {
+func (w *workspaceLifecycleState) markDeleting(wsID string, deleting bool) bool {
 	if deleting {
-		w.transition(wsID, lifecycleDeleting)
-		return
+		return w.transition(wsID, lifecycleDeleting)
 	}
 	w.phaseMu.Lock()
 	defer w.phaseMu.Unlock()
 	if w.phases[wsID] == lifecycleDeleting {
 		delete(w.phases, wsID)
 	}
+	return true
 }
 
 // isDeleting reports whether a workspace is currently delete-in-flight.


### PR DESCRIPTION
Replace the creating/deleting maps inside workspaceLifecycleState with a
single phase map (active/creating/deleting) behind a transition table
that rejects and logs invalid moves (e.g. markCreating while a delete is
in flight). The dirty set deliberately stays orthogonal to the phase: a
dirty marker must survive a delete that later fails so the failed-delete
handler can requeue persistence. Adds transition-table, message-
interleaving (create-while-projects-loading) and -race concurrency
(delete-while-persisting) tests.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **D1**, 19/36). Stacked on `rp/e5-tabset`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.