### PR TITLE
D2: Model the center tab PTY lifecycle as an explicit ptyPhase

### DIFF
--- a/internal/ui/center/model_input.go
+++ b/internal/ui/center/model_input.go
@@ -20,8 +20,7 @@ func (m *Model) directSendToTerminal(tab *Tab, data, label string) (*Model, bool
 	if err := tab.Agent.Terminal.SendString(data); err != nil {
 		logging.Warn("%s failed for tab %s: %v", label, tab.ID, err)
 		tab.mu.Lock()
-		tab.Running = false
-		tab.Detached = true
+		tab.markDetachedLocked()
 		tab.mu.Unlock()
 		wsID := m.workspaceID()
 		return m, false, func() tea.Msg {

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -134,9 +134,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 	}
 	tab.Agent = msg.Agent
 	tab.SessionName = msg.Agent.Session
-	tab.Detached = false
-	tab.reattachInFlight = false
-	tab.Running = true
+	tab.markAttachedLocked()
 	resetChatCursorActivityStateLocked(tab)
 	tab.resetActorWriteStateLocked()
 	tab.bootstrapActivity = true
@@ -176,12 +174,8 @@ func (m *Model) updatePtyTabReattachFailed(msg ptyTabReattachFailed) (*Model, te
 		return m, nil
 	}
 	tab.mu.Lock()
-	tab.Running = false
-	tab.reattachInFlight = false
-	// Any stopped reattach clears Detached so the tab shows as stopped.
-	if msg.Stopped {
-		tab.Detached = false
-	}
+	// A stopped reattach also clears Detached so the tab shows as stopped.
+	tab.markReattachFailedLocked(msg.Stopped)
 	tab.mu.Unlock()
 	logging.Warn("Reattach failed for tab %s: %v", msg.TabID, msg.Err)
 	action := msg.Action
@@ -223,13 +217,7 @@ func (m *Model) updateTabSessionStatus(msg messages.TabSessionStatus) (*Model, t
 		_ = m.agentManager.CloseAgent(agent)
 	}
 	tab.mu.Lock()
-	tab.Running = false
-	tab.Detached = false
-	// Clear the in-flight reattach guard too: this is the only stop/detach
-	// transition that did not, leaving a tab wedged if a stopped message lands
-	// while a reattach is in flight (all reattach gates bail on this flag, so the
-	// user could no longer reattach a tab that now shows stopped).
-	tab.reattachInFlight = false
+	tab.markStoppedLocked()
 	tab.mu.Unlock()
 	tab.resetActivityANSIState()
 	return m, common.SafeBatch(func() tea.Msg {

--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -47,8 +47,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			tab.mu.Lock()
 			backoff, shouldRestart := tab.State.NextRestartBackoffLocked(ptyRestartWindow, ptyRestartMax)
 			if !shouldRestart {
-				tab.Running = false
-				tab.Detached = true
+				tab.markDetachedLocked()
 			}
 			tab.mu.Unlock()
 			if shouldRestart {
@@ -66,8 +65,7 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			}
 		} else {
 			tab.mu.Lock()
-			tab.Running = false
-			tab.Detached = true
+			tab.markDetachedLocked()
 			tab.State.ResetRestartBackoffLocked()
 			tab.mu.Unlock()
 			logging.Info("PTY stopped for tab %s, marking detached: %v", msg.TabID, msg.Err)

--- a/internal/ui/center/model_tab_phase.go
+++ b/internal/ui/center/model_tab_phase.go
@@ -1,0 +1,134 @@
+package center
+
+// ptyPhase is a Tab's PTY lifecycle phase. The phase is derived from the
+// underlying flags (Running/Detached/reattachInFlight) rather than stored:
+// Running and Detached are exported package API (the app, harness and
+// persistence read them), so the flags remain the storage while every
+// multi-field transition goes through the methods below. That keeps the
+// implicit invariants — e.g. "a detached tab is never Running", "a stopped
+// reattach must clear the in-flight guard" — in one place.
+//
+// Legal transitions:
+//
+//	stopped     → running        (markAttachedLocked: tab created/agent launched)
+//	running     → detached       (markDetachedLocked: PTY lost, session may live)
+//	running     → stopped        (markStoppedLocked: agent closed for good)
+//	detached    → reattaching    (beginReattachLocked)
+//	reattaching → running        (markAttachedLocked: reattach succeeded)
+//	reattaching → detached       (markDetachedEndingReattachLocked / reattach failed)
+//	reattaching → stopped        (markReattachFailedLocked(stopped=true))
+//
+// Related but deliberately separate: the actor-write parser flow. When PTY
+// overflow trims the buffer while actor writes are still queued, the cut
+// invalidates the parser state the queued writes were encoded against, so
+// parserResetPending is latched. Flushes then stall until the queued writes
+// drain (actorWritesPending reaches 0 and their bytes are settled into
+// ptyBytesSettled), the terminal parser is reset, and only then does normal
+// chunked flushing resume. That flow is parser/buffer state, not lifecycle
+// state, which is why parserResetPending is not part of ptyPhase.
+type ptyPhase uint8
+
+const (
+	// ptyPhaseStopped: no live PTY and no tmux session expected.
+	ptyPhaseStopped ptyPhase = iota
+	// ptyPhaseRunning: agent attached with a live PTY.
+	ptyPhaseRunning
+	// ptyPhaseDetached: PTY gone but the tmux session may still be alive.
+	ptyPhaseDetached
+	// ptyPhaseReattaching: a reattach is in flight (transition lock; all
+	// reattach gates bail while set).
+	ptyPhaseReattaching
+)
+
+func (p ptyPhase) String() string {
+	switch p {
+	case ptyPhaseRunning:
+		return "running"
+	case ptyPhaseDetached:
+		return "detached"
+	case ptyPhaseReattaching:
+		return "reattaching"
+	default:
+		return "stopped"
+	}
+}
+
+// ptyPhaseLocked derives the tab's current phase. The caller must hold t.mu
+// (or be on the single-writer Update goroutine).
+func (t *Tab) ptyPhaseLocked() ptyPhase {
+	switch {
+	case t.reattachInFlight:
+		return ptyPhaseReattaching
+	case t.Running:
+		return ptyPhaseRunning
+	case t.Detached:
+		return ptyPhaseDetached
+	default:
+		return ptyPhaseStopped
+	}
+}
+
+// markAttachedLocked transitions to running: the tab has a live PTY (fresh
+// launch or successful reattach). Clears any reattach lock.
+func (t *Tab) markAttachedLocked() {
+	t.Detached = false
+	t.reattachInFlight = false
+	t.Running = true
+}
+
+// markDetachedLocked transitions to detached: the PTY is gone but the tmux
+// session may still be alive, so the tab is offered for reattach. It does not
+// touch the reattach lock — restart/input-failure paths may run while a
+// reattach is in flight, and the reattach outcome owns that flag.
+func (t *Tab) markDetachedLocked() {
+	t.Running = false
+	t.Detached = true
+}
+
+// markDetachedEndingReattachLocked transitions to detached and releases the
+// reattach lock; used by the session-detach path, which is itself the
+// terminal outcome of any in-flight reattach.
+func (t *Tab) markDetachedEndingReattachLocked() {
+	t.Running = false
+	t.Detached = true
+	t.reattachInFlight = false
+}
+
+// markStoppedLocked transitions to stopped: no PTY and no session worth
+// reattaching. Clears the in-flight reattach guard too: this is the only
+// stop/detach transition that previously did not, leaving a tab wedged if a
+// stopped message landed while a reattach was in flight (all reattach gates
+// bail on this flag, so the user could no longer reattach a tab that now
+// shows stopped).
+func (t *Tab) markStoppedLocked() {
+	t.Running = false
+	t.Detached = false
+	t.reattachInFlight = false
+}
+
+// markReattachFailedLocked records a failed reattach: the tab is no longer
+// running and the lock is released. A stopped outcome also clears Detached so
+// the tab shows as stopped rather than detached.
+func (t *Tab) markReattachFailedLocked(stopped bool) {
+	t.Running = false
+	t.reattachInFlight = false
+	if stopped {
+		t.Detached = false
+	}
+}
+
+// beginReattachLocked acquires the reattach transition lock, reporting false
+// when a reattach is already in flight.
+func (t *Tab) beginReattachLocked() bool {
+	if t.reattachInFlight {
+		return false
+	}
+	t.reattachInFlight = true
+	return true
+}
+
+// endReattachLocked releases the reattach transition lock without changing
+// the running/detached outcome (used on early-bail paths).
+func (t *Tab) endReattachLocked() {
+	t.reattachInFlight = false
+}

--- a/internal/ui/center/model_tab_phase_test.go
+++ b/internal/ui/center/model_tab_phase_test.go
@@ -1,0 +1,55 @@
+package center
+
+import "testing"
+
+func TestTabPTYPhaseTransitions(t *testing.T) {
+	tab := &Tab{}
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseStopped {
+		t.Fatalf("new tab phase = %s, want stopped", got)
+	}
+
+	tab.markAttachedLocked()
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseRunning {
+		t.Fatalf("after attach phase = %s, want running", got)
+	}
+
+	tab.markDetachedLocked()
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseDetached {
+		t.Fatalf("after detach phase = %s, want detached", got)
+	}
+
+	if !tab.beginReattachLocked() {
+		t.Fatal("expected reattach lock acquired")
+	}
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseReattaching {
+		t.Fatalf("during reattach phase = %s, want reattaching", got)
+	}
+	if tab.beginReattachLocked() {
+		t.Fatal("expected second reattach to be rejected while one is in flight")
+	}
+
+	// Failed reattach with a stopped outcome settles to stopped, not detached.
+	tab.markReattachFailedLocked(true)
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseStopped {
+		t.Fatalf("after stopped reattach failure phase = %s, want stopped", got)
+	}
+
+	// Failed reattach without a stopped outcome returns to detached.
+	tab.markDetachedLocked()
+	_ = tab.beginReattachLocked()
+	tab.markReattachFailedLocked(false)
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseDetached {
+		t.Fatalf("after reattach failure phase = %s, want detached", got)
+	}
+
+	// A stop while a reattach is in flight must release the lock so the tab
+	// cannot wedge in a state where no reattach gate will ever pass.
+	_ = tab.beginReattachLocked()
+	tab.markStoppedLocked()
+	if got := tab.ptyPhaseLocked(); got != ptyPhaseStopped {
+		t.Fatalf("after stop phase = %s, want stopped", got)
+	}
+	if !tab.beginReattachLocked() {
+		t.Fatal("expected reattach available again after stop")
+	}
+}

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -256,8 +256,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 		tab.Workspace = msg.Workspace
 		tab.Agent = msg.Agent
 		tab.SessionName = msg.Agent.Session
-		tab.Detached = false
-		tab.Running = true
+		tab.markAttachedLocked()
 		tab.resetActorWriteStateLocked()
 		m.applyTerminalCursorPolicyLocked(tab)
 		if tab.createdAt == 0 {

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -195,8 +195,7 @@ func (m *Model) SendToTerminal(s string) {
 		if err := agent.Terminal.SendString(s); err != nil {
 			logging.Warn("SendToTerminal failed for tab %s: %v", tab.ID, err)
 			tab.mu.Lock()
-			tab.Running = false
-			tab.Detached = true
+			tab.markDetachedLocked()
 			tab.mu.Unlock()
 		}
 	}

--- a/internal/ui/center/model_tabs_session.go
+++ b/internal/ui/center/model_tabs_session.go
@@ -40,9 +40,7 @@ func (m *Model) detachTab(tab *Tab, index int) tea.Cmd {
 	}
 	m.stopPTYReader(tab)
 	tab.mu.Lock()
-	tab.Running = false
-	tab.Detached = true
-	tab.reattachInFlight = false
+	tab.markDetachedEndingReattachLocked()
 	tab.resetPTYStateLocked()
 	if tab.Agent != nil && tab.SessionName == "" {
 		tab.SessionName = tab.Agent.Session

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -103,7 +103,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 	sessionName := tab.SessionName
 	canReattach := detached || !running
 	if canReattach && !reattachInFlight {
-		tab.reattachInFlight = true
+		_ = tab.beginReattachLocked()
 	}
 	tab.mu.Unlock()
 	if !canReattach {
@@ -114,7 +114,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 	}
 	if m.config == nil || m.config.Assistants == nil {
 		tab.mu.Lock()
-		tab.reattachInFlight = false
+		tab.endReattachLocked()
 		tab.mu.Unlock()
 		return func() tea.Msg {
 			return messages.Toast{
@@ -125,7 +125,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 	}
 	if _, ok := m.config.Assistants[tab.Assistant]; !ok {
 		tab.mu.Lock()
-		tab.reattachInFlight = false
+		tab.endReattachLocked()
 		tab.mu.Unlock()
 		return func() tea.Msg {
 			return messages.Toast{
@@ -289,7 +289,7 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 		sessionName = tab.Agent.Session
 	}
 	if !running && !reattachInFlight {
-		tab.reattachInFlight = true
+		_ = tab.beginReattachLocked()
 	}
 	tab.mu.Unlock()
 	if running {

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -301,8 +301,7 @@ func (m *Model) sendToTerminal(tab *Tab, data string, tabID TabID, workspaceID, 
 	if err := tab.Agent.Terminal.SendString(data); err != nil {
 		logging.Warn("%s failed for tab %s: %v", label, tab.ID, err)
 		tab.mu.Lock()
-		tab.Running = false
-		tab.Detached = true
+		tab.markDetachedLocked()
 		tab.mu.Unlock()
 		if m.msgSink != nil {
 			m.msgSink(TabInputFailed{TabID: tabID, WorkspaceID: workspaceID, Err: err})


### PR DESCRIPTION
Derived ptyPhase (stopped/running/detached/reattaching) plus transition
methods (markAttachedLocked, markDetachedLocked,
markDetachedEndingReattachLocked, markStoppedLocked,
markReattachFailedLocked, beginReattachLocked/endReattachLocked) replace
every scattered multi-field mutation of Running/Detached/
reattachInFlight. The legal transitions and the related
parserResetPending -> actorWritesPending -> ptyBytesSettled flush flow
are documented on the type. Flags remain the storage: Running/Detached
are exported package API.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **D2**, 20/36). Stacked on `rp/d1-workspace-lifecycle-fsm`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.