### PR TITLE
E6: Decompose the Tab struct into themed sub-structs

### DIFF
--- a/internal/ui/center/model_activity_contract_test.go
+++ b/internal/ui/center/model_activity_contract_test.go
@@ -11,13 +11,15 @@ func TestActivityContract_ReattachBootstrapSuppressedThenRealOutputMarksActive(t
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 5),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
-		bootstrapActivity:    true,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 5),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+			bootstrapActivity:    true,
+		},
 	}
 
 	tab.Terminal.Write([]byte("bootstrap prompt\n"))
@@ -53,12 +55,14 @@ func TestActivityContract_TypingEchoSuppressedButRealOutputAfterWindowCounts(t *
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 5),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 5),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	now := time.Now()
@@ -93,12 +97,14 @@ func TestActivityContract_BracketedPasteDoesNotSuppressImmediateRealOutput(t *te
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 5),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 5),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	now := time.Now()
@@ -126,12 +132,14 @@ func TestActivityContract_SubmittedBracketedPasteEchoSuppressesPromptEchoActivit
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 5),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 5),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	now := time.Now()
@@ -181,12 +189,14 @@ func TestActivityContract_PromptOnlyBracketedPasteSuppressesPromptEchoActivity(t
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 5),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 5),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	now := time.Now()

--- a/internal/ui/center/model_activity_test.go
+++ b/internal/ui/center/model_activity_test.go
@@ -33,10 +33,12 @@ func TestIsTabActiveChatOnly(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	activeChat := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws,
-		Running:           true,
-		lastVisibleOutput: now.Add(-1 * time.Second),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-1 * time.Second),
+		},
 	}
 	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{activeChat}
 
@@ -51,21 +53,25 @@ func TestIsTabActiveIgnoresDetachedAndNonChat(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	nonChat := &Tab{
-		Assistant:         "vim",
-		Workspace:         ws,
-		Running:           true,
-		lastVisibleOutput: now.Add(-1 * time.Second),
+		Assistant: "vim",
+		Workspace: ws,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-1 * time.Second),
+		},
 	}
 	if m.IsTabActive(nonChat) {
 		t.Fatalf("expected non-chat tab to be inactive even with output")
 	}
 
 	detached := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws,
-		Running:           true,
-		Detached:          true,
-		lastVisibleOutput: now.Add(-1 * time.Second),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		Detached:  true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-1 * time.Second),
+		},
 	}
 	if m.IsTabActive(detached) {
 		t.Fatalf("expected detached chat tab to be inactive")
@@ -80,16 +86,20 @@ func TestGetActiveWorkspaceIDsChatOnly(t *testing.T) {
 	ws2 := newTestWorkspace("ws2", "/repo/ws2")
 
 	activeChat := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws1,
-		Running:           true,
-		lastVisibleOutput: now.Add(-1 * time.Second),
+		Assistant: "claude",
+		Workspace: ws1,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-1 * time.Second),
+		},
 	}
 	viewer := &Tab{
-		Assistant:         "viewer",
-		Workspace:         ws2,
-		Running:           true,
-		lastVisibleOutput: now.Add(-1 * time.Second),
+		Assistant: "viewer",
+		Workspace: ws2,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-1 * time.Second),
+		},
 	}
 
 	m.tabs.ByWorkspace[string(ws1.ID())] = []*Tab{activeChat}
@@ -107,10 +117,12 @@ func TestIsTabActiveIdle(t *testing.T) {
 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	idle := &Tab{
-		Assistant:         "claude",
-		Workspace:         ws,
-		Running:           true,
-		lastVisibleOutput: now.Add(-3 * time.Second),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now.Add(-3 * time.Second),
+		},
 	}
 	if m.IsTabActive(idle) {
 		t.Fatalf("expected idle chat tab to be inactive")
@@ -129,7 +141,9 @@ func TestIsTabActiveUsesVisibleOutputOnly(t *testing.T) {
 		State: ptyio.State{
 			LastOutputAt: now.Add(-1 * time.Second),
 		},
-		lastVisibleOutput: time.Time{},
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Time{},
+		},
 	}
 	if m.IsTabActive(tab) {
 		t.Fatal("expected tab with no visible output timestamp to be inactive")
@@ -146,7 +160,9 @@ func TestIsTabActiveIgnoresBufferedOutputWithoutVisibleDelta(t *testing.T) {
 		State: ptyio.State{
 			PendingOutput: []byte("buffered"),
 		},
-		lastVisibleOutput: time.Time{},
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Time{},
+		},
 	}
 	if m.IsTabActive(tab) {
 		t.Fatal("expected buffered output without visible delta timestamp to be inactive")

--- a/internal/ui/center/model_activity_visibility_test.go
+++ b/internal/ui/center/model_activity_visibility_test.go
@@ -11,12 +11,14 @@ func TestNoteVisibleActivityLocked_StaleVisibleSeqKeepsPendingFlag(t *testing.T)
 	m := newTestModel()
 	ws := newTestWorkspace("ws", "/repo/ws")
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             vterm.New(40, 4),
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    2,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(40, 4),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    2,
+		},
 	}
 
 	tab.mu.Lock()
@@ -39,13 +41,15 @@ func TestNoteVisibleActivityLocked_ScrolledViewportStillDetectsLiveOutput(t *tes
 	term.ScrollView(1) // User is viewing older content.
 
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             term,
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
-		activityDigestInit:   true,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+			activityDigestInit:   true,
+		},
 	}
 
 	tab.mu.Lock()
@@ -77,13 +81,15 @@ func TestNoteVisibleActivityLocked_SuppressesBootstrapOutputAfterReattach(t *tes
 	ws := newTestWorkspace("ws", "/repo/ws")
 	term := vterm.New(20, 3)
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             term,
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
-		bootstrapActivity:    true,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+			bootstrapActivity:    true,
+		},
 	}
 
 	term.Write([]byte("bootstrap\n"))
@@ -114,12 +120,14 @@ func TestNoteVisibleActivityLocked_RecordsWhenBootstrapInactive(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	term := vterm.New(20, 3)
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             term,
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	term.Write([]byte("real-output\n"))
@@ -138,12 +146,14 @@ func TestNoteVisibleActivityLocked_SubmittedPasteSuppressionDoesNotLeakOnInvisib
 	ws := newTestWorkspace("ws", "/repo/ws")
 	term := vterm.New(20, 4)
 	tab := &Tab{
-		Assistant:            "codex",
-		Workspace:            ws,
-		Terminal:             term,
-		Running:              true,
-		pendingVisibleOutput: true,
-		pendingVisibleSeq:    1,
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			pendingVisibleOutput: true,
+			pendingVisibleSeq:    1,
+		},
 	}
 
 	recordLocalInputEchoWindow(tab, "\x1b[200~first\r\nsecond\r\x1b[201~", time.Now())
@@ -189,7 +199,7 @@ func TestNoteVisibleActivityLocked_SubmittedPasteSuppressionDoesNotLeakOnInvisib
 }
 
 func TestConsumeSubmittedPasteEchoLocked_ClearsPendingOnVisibleMismatch(t *testing.T) {
-	tab := &Tab{pendingSubmitPasteEcho: "first\nsecond"}
+	tab := &Tab{tabActivityState: tabActivityState{pendingSubmitPasteEcho: "first\nsecond"}}
 
 	if consumeSubmittedPasteEchoLocked(tab, []byte("agent: ready\n")) {
 		t.Fatal("expected visible mismatch not to be treated as consumed paste echo")

--- a/internal/ui/center/model_actor_ready_test.go
+++ b/internal/ui/center/model_actor_ready_test.go
@@ -45,8 +45,10 @@ func TestUpdatePTYFlush_StaleActorHeartbeatForcesParserResetFallback(t *testing.
 			LastOutputAt:      time.Now().Add(-time.Second),
 			FlushPendingSince: time.Now().Add(-time.Second),
 		},
-		parserResetPending: true,
-		actorWritesPending: 1,
+		tabActorWriteState: tabActorWriteState{
+			parserResetPending: true,
+			actorWritesPending: 1,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_cursor_refresh_test.go
+++ b/internal/ui/center/model_cursor_refresh_test.go
@@ -14,13 +14,15 @@ func TestUpdatePTYCursorRefresh_SchedulesWhileCursorTimersPending(t *testing.T) 
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-cursor-refresh"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastVisibleOutput: time.Now(),
-		lastPromptInputAt: time.Now(),
+		ID:        TabID("tab-cursor-refresh"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+			lastPromptInputAt: time.Now(),
+		},
 		State: ptyio.State{
 			CachedSnap: &compositor.VTermSnapshot{},
 		},
@@ -45,12 +47,14 @@ func TestScheduleChatCursorRefresh_DeduplicatesLaterRefreshDeadline(t *testing.T
 	wsID := string(ws.ID())
 	now := time.Now()
 	tab := &Tab{
-		ID:                TabID("tab-cursor-refresh-dedupe"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastVisibleOutput: now,
+		ID:        TabID("tab-cursor-refresh-dedupe"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now,
+		},
 	}
 
 	first := m.scheduleChatCursorRefresh(tab, wsID, now)
@@ -82,12 +86,14 @@ func TestUpdatePTYCursorRefresh_RequestPreservesPendingTimer(t *testing.T) {
 	wsID := string(ws.ID())
 	now := time.Now()
 	tab := &Tab{
-		ID:                TabID("tab-cursor-refresh-request"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastVisibleOutput: now,
+		ID:        TabID("tab-cursor-refresh-request"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: now,
+		},
 		State: ptyio.State{
 			CachedSnap: &compositor.VTermSnapshot{},
 		},

--- a/internal/ui/center/model_input_echo_test.go
+++ b/internal/ui/center/model_input_echo_test.go
@@ -79,8 +79,10 @@ func TestRecordLocalInputEchoWindow_TypingSetsButEnterKeepsPromptWindowOnly(t *t
 
 func TestRecordLocalInputEchoWindow_ClearsBootstrapPhaseOnUserInput(t *testing.T) {
 	tab := &Tab{
-		bootstrapActivity:     true,
-		bootstrapLastOutputAt: time.Now(),
+		tabActivityState: tabActivityState{
+			bootstrapActivity:     true,
+			bootstrapLastOutputAt: time.Now(),
+		},
 	}
 
 	recordLocalInputEchoWindow(tab, "x", time.Now())

--- a/internal/ui/center/model_input_lifecycle_bootstrap_test.go
+++ b/internal/ui/center/model_input_lifecycle_bootstrap_test.go
@@ -13,14 +13,16 @@ func TestUpdatePTYOutput_DoesNotExtendBootstrapOnEachChunk(t *testing.T) {
 	wsID := string(ws.ID())
 	bootstrapAt := time.Now().Add(-500 * time.Millisecond)
 	tab := &Tab{
-		ID:                    TabID("tab-1"),
-		Assistant:             "codex",
-		Workspace:             ws,
-		SessionName:           "amux-test-session",
-		Terminal:              vterm.New(80, 24),
-		Running:               true,
-		bootstrapActivity:     true,
-		bootstrapLastOutputAt: bootstrapAt,
+		ID:          TabID("tab-1"),
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "amux-test-session",
+		Terminal:    vterm.New(80, 24),
+		Running:     true,
+		tabActivityState: tabActivityState{
+			bootstrapActivity:     true,
+			bootstrapLastOutputAt: bootstrapAt,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_lifecycle_test.go
@@ -15,10 +15,12 @@ func TestUpdatePtyTabReattachResult_ResetsActivityANSIState(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		activityANSIState: ansiActivityString,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		tabActivityState: tabActivityState{
+			activityANSIState: ansiActivityString,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
@@ -50,19 +52,23 @@ func TestUpdatePtyTabReattachResult_ResetsStableCursor(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:              TabID("tab-1"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        vterm.New(80, 24),
-		stableCursorSet: true,
-		stableCursorX:   7,
-		stableCursorY:   20,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   7,
+			stableCursorY:   20,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastUserInputAt:   time.Now(),
-		lastPromptInputAt: time.Now(),
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastUserInputAt:   time.Now(),
+			lastPromptInputAt: time.Now(),
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
@@ -168,10 +174,12 @@ func TestHandlePtyTabCreated_ExistingResetsActivityANSIState(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		activityANSIState: ansiActivityOSC,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		tabActivityState: tabActivityState{
+			activityANSIState: ansiActivityOSC,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
@@ -298,19 +306,23 @@ func TestHandlePtyTabCreated_ExistingResetsStableCursor(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:              TabID("tab-1"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        vterm.New(80, 24),
-		stableCursorSet: true,
-		stableCursorX:   7,
-		stableCursorY:   20,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   7,
+			stableCursorY:   20,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastUserInputAt:   time.Now(),
-		lastPromptInputAt: time.Now(),
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastUserInputAt:   time.Now(),
+			lastPromptInputAt: time.Now(),
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
@@ -349,10 +361,12 @@ func TestUpdatePTYStopped_ResetsActivityANSIState(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		activityANSIState: ansiActivityOSC,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		tabActivityState: tabActivityState{
+			activityANSIState: ansiActivityOSC,
+		},
 		State: ptyio.State{
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
@@ -386,10 +400,12 @@ func TestUpdatePTYRestart_ResetsActivityANSIState(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		activityANSIState: ansiActivityCSI,
+		ID:        TabID("tab-1"),
+		Assistant: "codex",
+		Workspace: ws,
+		tabActivityState: tabActivityState{
+			activityANSIState: ansiActivityCSI,
+		},
 		State: ptyio.State{
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},

--- a/internal/ui/center/model_input_lifecycle_pty_test.go
+++ b/internal/ui/center/model_input_lifecycle_pty_test.go
@@ -35,13 +35,11 @@ func TestHasVisiblePTYOutput(t *testing.T) {
 
 func TestHasVisiblePTYOutput_SplitControlSequenceAcrossChunks(t *testing.T) {
 	state := ansiActivityText
-
 	got, next := hasVisiblePTYOutput([]byte("\x1b[?2004"), state)
 	if got {
 		t.Fatal("expected split control prefix to be non-visible")
 	}
 	state = next
-
 	got, next = hasVisiblePTYOutput([]byte("h"), state)
 	if got {
 		t.Fatal("expected split control suffix to be non-visible")
@@ -124,13 +122,11 @@ func TestUpdatePTYOutput_DoesNotTagControlOnlyOutput(t *testing.T) {
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
 		Data:        []byte("\x1b[?2004h\x1b[?2004l"),
 	})
-
 	if !tab.lastActivityTagAt.IsZero() {
 		t.Fatalf("expected lastActivityTagAt to remain zero for control-only output, got %v", tab.lastActivityTagAt)
 	}
@@ -148,22 +144,22 @@ func TestUpdatePTYOutput_TagsVisibleOutput(t *testing.T) {
 	wsID := string(ws.ID())
 	before := time.Now().Add(-2 * activityTagThrottle)
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		SessionName:       "amux-test-session",
-		Running:           true,
-		lastActivityTagAt: before,
+		ID:          TabID("tab-1"),
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "amux-test-session",
+		Running:     true,
+		tabActivityState: tabActivityState{
+			lastActivityTagAt: before,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
 		Data:        []byte("visible output"),
 	})
-
 	if !tab.lastVisibleOutput.IsZero() {
 		t.Fatalf("expected lastVisibleOutput to remain zero until flush, got %v", tab.lastVisibleOutput)
 	}
@@ -187,17 +183,17 @@ func TestUpdatePTYOutput_ResetsActivityStateAfterOverflowCarryTrim(t *testing.T)
 		State: ptyio.State{
 			OverflowTrimCarry: vterm.ParserCarryState{Mode: vterm.ParserCarryCSI},
 		},
-		activityANSIState: ansiActivityCSI,
+		tabActivityState: tabActivityState{
+			activityANSIState: ansiActivityCSI,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
 		Data:        []byte("31mX"),
 	})
-
 	if string(tab.PendingOutput) != "X" {
 		t.Fatalf("expected overflow carry trim to retain visible suffix, got %q", tab.PendingOutput)
 	}
@@ -217,19 +213,20 @@ func TestUpdatePTYOutput_EndsBootstrapAfterQuietGap(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:                    TabID("tab-1"),
-		Assistant:             "codex",
-		Workspace:             ws,
-		SessionName:           "amux-test-session",
-		Terminal:              vterm.New(80, 24),
-		Running:               true,
-		bootstrapActivity:     true,
-		bootstrapLastOutputAt: time.Now().Add(-(bootstrapQuietGap + 200*time.Millisecond)),
+		ID:          TabID("tab-1"),
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "amux-test-session",
+		Terminal:    vterm.New(80, 24),
+		Running:     true,
+		tabActivityState: tabActivityState{
+			bootstrapActivity:     true,
+			bootstrapLastOutputAt: time.Now().Add(-(bootstrapQuietGap + 200*time.Millisecond)),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
@@ -258,18 +255,19 @@ func TestUpdatePTYFlush_TagsVisibleScreenDelta(t *testing.T) {
 	wsID := string(ws.ID())
 	before := time.Now().Add(-2 * activityTagThrottle)
 	tab := &Tab{
-		ID:                TabID("tab-1"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		SessionName:       "amux-test-session",
-		Terminal:          vterm.New(80, 24),
-		Running:           true,
-		lastActivityTagAt: before,
+		ID:          TabID("tab-1"),
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "amux-test-session",
+		Terminal:    vterm.New(80, 24),
+		Running:     true,
+		tabActivityState: tabActivityState{
+			lastActivityTagAt: before,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
@@ -279,7 +277,6 @@ func TestUpdatePTYFlush_TagsVisibleScreenDelta(t *testing.T) {
 	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
-
 	if tab.lastVisibleOutput.IsZero() {
 		t.Fatalf("expected first visible delta flush to set lastVisibleOutput")
 	}
@@ -320,7 +317,6 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
@@ -338,7 +334,6 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 	if firstTag.IsZero() {
 		t.Fatalf("expected initial visible output to set activity tag timestamp")
 	}
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
@@ -348,7 +343,6 @@ func TestUpdatePTYFlush_DoesNotTagUnchangedVisibleScreen(t *testing.T) {
 	tab.FlushPendingSince = tab.LastOutputAt
 	m.tabEvents = nil
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
-
 	if !tab.lastVisibleOutput.Equal(firstVisible) {
 		t.Fatalf("expected unchanged rendered content not to refresh lastVisibleOutput: before=%v after=%v", firstVisible, tab.lastVisibleOutput)
 	}
@@ -362,7 +356,6 @@ func TestUpdatePTYFlush_RebuffersChunkAfterActorFallbackWithOlderPendingWrites(t
 	m.setTabActorReady()
 	m.tabEvents = make(chan tabEvent, 1)
 	m.tabEvents <- tabEvent{kind: tabEventWriteOutput}
-
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	prevCarry := vterm.ParserCarryState{Mode: vterm.ParserCarryCSIParam}
@@ -376,18 +369,18 @@ func TestUpdatePTYFlush_RebuffersChunkAfterActorFallbackWithOlderPendingWrites(t
 		State: ptyio.State{
 			PendingOutput: append([]byte(nil), chunk...),
 		},
-		actorWritesPending:       1,
-		actorWriteEpoch:          11,
-		actorQueuedCarry:         prevCarry,
-		actorQueuedNoiseTrailing: []byte("queued-noise"),
+		tabActorWriteState: tabActorWriteState{
+			actorWritesPending:       1,
+			actorWriteEpoch:          11,
+			actorQueuedCarry:         prevCarry,
+			actorQueuedNoiseTrailing: []byte("queued-noise"),
+		},
 	}
 	prevNoiseTrailing := append([]byte(nil), tab.actorQueuedNoiseTrailing...)
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
-
 	if tab.actorWritesPending != 1 {
 		t.Fatalf("expected older queued write to remain pending, got %d", tab.actorWritesPending)
 	}
@@ -413,18 +406,19 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	tab := &Tab{
-		ID:              TabID("tab-1"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		SessionName:     "amux-test-session",
-		Terminal:        vterm.New(80, 24),
-		Running:         true,
-		lastUserInputAt: time.Now(),
+		ID:          TabID("tab-1"),
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "amux-test-session",
+		Terminal:    vterm.New(80, 24),
+		Running:     true,
+		tabActivityState: tabActivityState{
+			lastUserInputAt: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYOutput(PTYOutput{
 		WorkspaceID: wsID,
 		TabID:       tab.ID,
@@ -442,7 +436,6 @@ func TestUpdatePTYFlush_SuppressesImmediateUserInputEcho(t *testing.T) {
 	tab.LastOutputAt = time.Now().Add(-time.Second)
 	tab.FlushPendingSince = tab.LastOutputAt
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
-
 	if !tab.lastVisibleOutput.IsZero() {
 		t.Fatalf("expected user-input echo not to set lastVisibleOutput, got %v", tab.lastVisibleOutput)
 	}
@@ -456,7 +449,6 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 	m.setTabActorReady()
 	m.tabEvents = make(chan tabEvent, 1)
 	m.tabEvents <- tabEvent{kind: tabEventWriteOutput} // fill queue so sendTabEvent fails
-
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 
@@ -466,7 +458,6 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 	head := bytes.Repeat([]byte("H"), ptyFlushChunkSizeActive+8)
 	tail := []byte("TAILxyz")
 	original := append(append([]byte(nil), head...), tail...)
-
 	tab := &Tab{
 		ID:        TabID("tab-order"),
 		Assistant: "codex",
@@ -477,18 +468,17 @@ func TestUpdatePTYFlush_RebufferPreservesOrderWithTrailingPending(t *testing.T) 
 			PendingOutput: append([]byte(nil), original...),
 		},
 		pendingOutputBytes: len(original),
-		actorWritesPending: 1,
-		actorWriteEpoch:    11,
+		tabActorWriteState: tabActorWriteState{
+			actorWritesPending: 1,
+			actorWriteEpoch:    11,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.workspace = ws
-
 	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
-
 	if !bytes.Equal(tab.PendingOutput, original) {
-		t.Fatalf("rebuffer must restore original stream order (prepend); len=%d endsWithTail=%v",
-			len(tab.PendingOutput), bytes.HasSuffix(tab.PendingOutput, tail))
+		t.Fatalf("rebuffer must restore original stream order (prepend); len=%d endsWithTail=%v", len(tab.PendingOutput), bytes.HasSuffix(tab.PendingOutput, tail))
 	}
 	if !bytes.HasSuffix(tab.PendingOutput, tail) {
 		t.Fatalf("tail no longer at the end — chunk was appended, reordering the stream")

--- a/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_initial_test.go
@@ -26,7 +26,9 @@ func TestTerminalLayerTracksFreshSubmitPromptBeforeStableCursorLearned(t *testin
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -63,18 +65,22 @@ func TestTerminalLayerTracksIndentedSubmitRedrawBeforePostSubmitOutput(t *testin
 	term.Screen[11][0] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:              TabID("tab-chat-indented-submit-redraw"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   10,
-		stableCursorY:   10,
+		ID:        TabID("tab-chat-indented-submit-redraw"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   10,
+			stableCursorY:   10,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now().Add(-time.Millisecond),
 		},
-		lastVisibleOutput: time.Now().Add(-time.Millisecond),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now().Add(-time.Millisecond),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -154,7 +160,9 @@ func TestTerminalLayerAllowsSecondToLastRowCursorInShortRestrictedViewport(t *te
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_regression_test.go
@@ -69,12 +69,14 @@ func TestTerminalLayerRecomputesCachedPromptWhenVisibleActivityEnds(t *testing.T
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-cached-activity-idle"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastVisibleOutput: time.Now(),
+		ID:        TabID("tab-chat-cached-activity-idle"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -116,12 +118,14 @@ func TestTerminalLayerHidesBlankCornerArtifactWhileVisiblyActiveWithoutStoredCur
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:                TabID("tab-chat-active-corner-artifact"),
-			Assistant:         "codex",
-			Workspace:         ws,
-			Terminal:          term,
-			Running:           true,
-			lastVisibleOutput: time.Now(),
+			ID:        TabID("tab-chat-active-corner-artifact"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			tabActivityState: tabActivityState{
+				lastVisibleOutput: time.Now(),
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -189,7 +193,9 @@ func TestTerminalLayerAllowsRecentLocalInputDespiteRecentControlOnlyOutput(t *te
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastPromptInputAt: time.Now(),
+		tabActivityState: tabActivityState{
+			lastPromptInputAt: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -225,13 +231,15 @@ func TestTerminalLayerIgnoresRecentLocalEchoOutputAfterInputWindowExpires(t *tes
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-local-echo-expired"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastUserInputAt:   now.Add(-600 * time.Millisecond),
-		lastPromptInputAt: now.Add(-600 * time.Millisecond),
+		ID:        TabID("tab-chat-local-echo-expired"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastUserInputAt:   now.Add(-600 * time.Millisecond),
+			lastPromptInputAt: now.Add(-600 * time.Millisecond),
+		},
 		State: ptyio.State{
 			LastOutputAt: now.Add(-550 * time.Millisecond),
 		},
@@ -264,13 +272,15 @@ func TestTerminalLayerPreservesRealBlockGlyphAtStoredCursorPosition(t *testing.T
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:              TabID("tab-chat-stored-block-glyph"),
-			Assistant:       "codex",
-			Workspace:       ws,
-			Terminal:        term,
-			stableCursorSet: true,
-			stableCursorX:   3,
-			stableCursorY:   11,
+			ID:        TabID("tab-chat-stored-block-glyph"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			tabCursorState: tabCursorState{
+				stableCursorSet: true,
+				stableCursorX:   3,
+				stableCursorY:   11,
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -384,12 +394,14 @@ func TestTerminalLayerTreatsWrappedMultilinePromptAsInputSection(t *testing.T) {
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-multiline-prompt"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		Running:           true,
-		lastVisibleOutput: time.Now().Add(-tabActiveWindow - time.Millisecond),
+		ID:        TabID("tab-chat-multiline-prompt"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now().Add(-tabActiveWindow - time.Millisecond),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -425,12 +437,14 @@ func TestTerminalLayerKeepsVisiblyActiveChatCursorRestrictedToBottomInputBand(t 
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:                TabID("tab-chat-running-midscreen-cursor"),
-			Assistant:         "codex",
-			Workspace:         ws,
-			Terminal:          term,
-			Running:           true,
-			lastVisibleOutput: time.Now(),
+			ID:        TabID("tab-chat-running-midscreen-cursor"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			tabActivityState: tabActivityState{
+				lastVisibleOutput: time.Now(),
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_chat_cursor_state_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_state_test.go
@@ -15,22 +15,22 @@ func TestTerminalLayerUpdatesStoredCursorWhenIdlePromptMovesAfterVersionChange(t
 	term := vterm.New(20, 12)
 	term.CursorX = 1
 	term.CursorY = 11
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-idle-prompt-move"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   1,
-		stableCursorY:   11,
+		ID:        TabID("tab-chat-idle-prompt-move"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   1,
+			stableCursorY:   11,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	seed := m.TerminalLayer()
 	if seed == nil || seed.Snap == nil {
 		t.Fatal("expected initial terminal layer snapshot")
@@ -39,7 +39,6 @@ func TestTerminalLayerUpdatesStoredCursorWhenIdlePromptMovesAfterVersionChange(t
 	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	tab.lastVisibleOutput = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	term.Write([]byte("\x1b[11;5H"))
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected updated terminal layer snapshot")
@@ -65,18 +64,21 @@ func TestTerminalLayerPreservesStoredCursorAcrossTemporaryScrollback(t *testing.
 	}
 	term.CursorX = 2
 	term.CursorY = 11
-
 	tab := &Tab{
-		ID:                  TabID("tab-chat-scrollback-stable"),
-		Assistant:           "codex",
-		Workspace:           ws,
-		Terminal:            term,
-		Running:             true,
-		stableCursorSet:     true,
-		stableCursorX:       2,
-		stableCursorY:       11,
-		stableCursorVersion: term.Version(),
-		lastVisibleOutput:   time.Now(),
+		ID:        TabID("tab-chat-scrollback-stable"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet:     true,
+			stableCursorX:       2,
+			stableCursorY:       11,
+			stableCursorVersion: term.Version(),
+		},
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -113,7 +115,6 @@ func TestTerminalLayerAllowsBracketedPasteAsRecentLocalInput(t *testing.T) {
 	term.CursorX = 4
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
 		ID:        TabID("tab-chat-bracketed-paste"),
 		Assistant: "codex",
@@ -130,7 +131,6 @@ func TestTerminalLayerAllowsBracketedPasteAsRecentLocalInput(t *testing.T) {
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\x1b[200~hello\x1b[201~", time.Now())
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -150,22 +150,22 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 	term := vterm.New(20, 24)
 	term.CursorX = 1
 	term.CursorY = 23
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-idle-multiline-relearn"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   1,
-		stableCursorY:   23,
+		ID:        TabID("tab-chat-idle-multiline-relearn"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   1,
+			stableCursorY:   23,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	seed := m.TerminalLayer()
 	if seed == nil || seed.Snap == nil {
 		t.Fatal("expected seeded terminal layer snapshot")
@@ -174,7 +174,6 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 	term.Write([]byte("\x1b[11;5Hprompt"))
 	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
-
 	restricted := m.TerminalLayer()
 	if restricted == nil || restricted.Snap == nil {
 		t.Fatal("expected restricted terminal layer snapshot")
@@ -188,7 +187,6 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 
 	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
 	tab.lastVisibleOutput = time.Now().Add(-tabActiveWindow - time.Millisecond)
-
 	idle := m.TerminalLayer()
 	if idle == nil || idle.Snap == nil {
 		t.Fatal("expected idle terminal layer snapshot")
@@ -197,8 +195,7 @@ func TestTerminalLayerRelearnsStoredCursorFromIdleMultilinePromptAfterRestricted
 		t.Fatal("expected idle multiline prompt cursor to become visible")
 	}
 	if idle.Snap.CursorX != term.CursorX || idle.Snap.CursorY != term.CursorY {
-		t.Fatalf("expected idle render to re-learn live multiline prompt cursor at (%d,%d), got (%d,%d)",
-			term.CursorX, term.CursorY, idle.Snap.CursorX, idle.Snap.CursorY)
+		t.Fatalf("expected idle render to re-learn live multiline prompt cursor at (%d,%d), got (%d,%d)", term.CursorX, term.CursorY, idle.Snap.CursorX, idle.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != term.CursorX || tab.stableCursorY != term.CursorY {
 		t.Fatalf("expected stored cursor to update to idle multiline prompt, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
@@ -212,16 +209,17 @@ func TestTerminalLayerPreservesStoredMultilineCursorAcrossRestrictedArtifact(t *
 	term := vterm.New(20, 24)
 	term.CursorX = 19
 	term.CursorY = 23
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-restricted-stored-multiline"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   4,
-		stableCursorY:   10,
+		ID:        TabID("tab-chat-restricted-stored-multiline"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   4,
+			stableCursorY:   10,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -230,7 +228,6 @@ func TestTerminalLayerPreservesStoredMultilineCursorAcrossRestrictedArtifact(t *
 
 	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -239,12 +236,10 @@ func TestTerminalLayerPreservesStoredMultilineCursorAcrossRestrictedArtifact(t *
 		t.Fatal("expected stored multiline cursor to remain visible during restricted output")
 	}
 	if layer.Snap.CursorX != 4 || layer.Snap.CursorY != 10 {
-		t.Fatalf("expected restricted render to keep stored cursor at (4,10), got (%d,%d)",
-			layer.Snap.CursorX, layer.Snap.CursorY)
+		t.Fatalf("expected restricted render to keep stored cursor at (4,10), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 4 || tab.stableCursorY != 10 {
-		t.Fatalf("expected stored multiline cursor anchor to survive restricted render, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected stored multiline cursor anchor to survive restricted render, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -256,20 +251,23 @@ func TestTerminalLayerTracksEnterAsRecentPromptInputForWrappedPrompt(t *testing.
 	term.CursorX = 4
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-enter-wrapped-prompt"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   2,
-		stableCursorY:   9,
+		ID:        TabID("tab-chat-enter-wrapped-prompt"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   2,
+			stableCursorY:   9,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -277,7 +275,6 @@ func TestTerminalLayerTracksEnterAsRecentPromptInputForWrappedPrompt(t *testing.
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -286,12 +283,10 @@ func TestTerminalLayerTracksEnterAsRecentPromptInputForWrappedPrompt(t *testing.
 		t.Fatal("expected wrapped prompt cursor to remain visible after Enter")
 	}
 	if layer.Snap.CursorX != 4 || layer.Snap.CursorY != 10 {
-		t.Fatalf("expected Enter redraw to use live wrapped prompt cursor at (4,10), got (%d,%d)",
-			layer.Snap.CursorX, layer.Snap.CursorY)
+		t.Fatalf("expected Enter redraw to use live wrapped prompt cursor at (4,10), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 4 || tab.stableCursorY != 10 {
-		t.Fatalf("expected Enter redraw to update stored cursor to (4,10), got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected Enter redraw to update stored cursor to (4,10), got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -303,20 +298,23 @@ func TestTerminalLayerTracksCtrlCAsRecentPromptInputForWrappedPrompt(t *testing.
 	term.CursorX = 4
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-ctrlc-wrapped-prompt"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   2,
-		stableCursorY:   9,
+		ID:        TabID("tab-chat-ctrlc-wrapped-prompt"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   2,
+			stableCursorY:   9,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -324,7 +322,6 @@ func TestTerminalLayerTracksCtrlCAsRecentPromptInputForWrappedPrompt(t *testing.
 	m.Focus()
 
 	recordLocalInputEchoWindow(tab, "\x03", time.Now())
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -333,12 +330,10 @@ func TestTerminalLayerTracksCtrlCAsRecentPromptInputForWrappedPrompt(t *testing.
 		t.Fatal("expected wrapped prompt cursor to remain visible after Ctrl-C")
 	}
 	if layer.Snap.CursorX != 4 || layer.Snap.CursorY != 10 {
-		t.Fatalf("expected Ctrl-C redraw to use live wrapped prompt cursor at (4,10), got (%d,%d)",
-			layer.Snap.CursorX, layer.Snap.CursorY)
+		t.Fatalf("expected Ctrl-C redraw to use live wrapped prompt cursor at (4,10), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 4 || tab.stableCursorY != 10 {
-		t.Fatalf("expected Ctrl-C redraw to update stored cursor to (4,10), got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected Ctrl-C redraw to update stored cursor to (4,10), got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -350,16 +345,17 @@ func TestTerminalLayerKeepsRestrictedCursorAfterSubmitWhenOutputJumpsAway(t *tes
 	term.CursorX = 18
 	term.CursorY = 4
 	term.Screen[4][18] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-submit-output-restrict"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   2,
-		stableCursorY:   9,
+		ID:        TabID("tab-chat-submit-output-restrict"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   2,
+			stableCursorY:   9,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -369,7 +365,6 @@ func TestTerminalLayerKeepsRestrictedCursorAfterSubmitWhenOutputJumpsAway(t *tes
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
 	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -378,12 +373,10 @@ func TestTerminalLayerKeepsRestrictedCursorAfterSubmitWhenOutputJumpsAway(t *tes
 		t.Fatal("expected stored cursor to remain visible during submit-triggered output")
 	}
 	if layer.Snap.CursorX != 2 || layer.Snap.CursorY != 9 {
-		t.Fatalf("expected submit-time output to keep stored cursor at (2,9), got (%d,%d)",
-			layer.Snap.CursorX, layer.Snap.CursorY)
+		t.Fatalf("expected submit-time output to keep stored cursor at (2,9), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 2 || tab.stableCursorY != 9 {
-		t.Fatalf("expected submit-time output not to overwrite stored cursor, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected submit-time output not to overwrite stored cursor, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -395,16 +388,17 @@ func TestTerminalLayerKeepsRestrictedCursorWhenSubmitOutputJumpsToLeftEdge(t *te
 	term.CursorX = 0
 	term.CursorY = 10
 	term.Screen[10][0] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
-		ID:              TabID("tab-chat-submit-output-left-edge"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   10,
-		stableCursorY:   9,
+		ID:        TabID("tab-chat-submit-output-left-edge"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   10,
+			stableCursorY:   9,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -414,7 +408,6 @@ func TestTerminalLayerKeepsRestrictedCursorWhenSubmitOutputJumpsToLeftEdge(t *te
 	recordLocalInputEchoWindow(tab, "\r", time.Now())
 	tab.LastOutputAt = time.Now()
 	tab.lastVisibleOutput = time.Now()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -423,12 +416,10 @@ func TestTerminalLayerKeepsRestrictedCursorWhenSubmitOutputJumpsToLeftEdge(t *te
 		t.Fatal("expected stored cursor to remain visible during left-edge submit output")
 	}
 	if layer.Snap.CursorX != 10 || layer.Snap.CursorY != 9 {
-		t.Fatalf("expected left-edge submit output to keep stored cursor at (10,9), got (%d,%d)",
-			layer.Snap.CursorX, layer.Snap.CursorY)
+		t.Fatalf("expected left-edge submit output to keep stored cursor at (10,9), got (%d,%d)", layer.Snap.CursorX, layer.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 10 || tab.stableCursorY != 9 {
-		t.Fatalf("expected left-edge submit output not to overwrite stored cursor, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected left-edge submit output not to overwrite stored cursor, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 }
 
@@ -440,17 +431,18 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 	term.CursorX = 2
 	term.CursorY = 20
 	term.Screen[20][2] = vterm.Cell{Rune: 'x', Width: 1}
-
 	tab := &Tab{
-		ID:                  TabID("tab-chat-control-only-idle-relearn"),
-		Assistant:           "codex",
-		Workspace:           ws,
-		Terminal:            term,
-		Running:             true,
-		stableCursorSet:     true,
-		stableCursorX:       2,
-		stableCursorY:       20,
-		stableCursorVersion: term.Version(),
+		ID:        TabID("tab-chat-control-only-idle-relearn"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet:     true,
+			stableCursorX:       2,
+			stableCursorY:       20,
+			stableCursorVersion: term.Version(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -461,7 +453,6 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 	term.CursorY = 10
 	term.Screen[10][4] = vterm.Cell{Rune: 'x', Width: 1}
 	tab.LastOutputAt = time.Now()
-
 	restricted := m.TerminalLayer()
 	if restricted == nil || restricted.Snap == nil {
 		t.Fatal("expected restricted terminal layer snapshot")
@@ -470,15 +461,13 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 		t.Fatal("expected restricted render to keep a visible stored cursor")
 	}
 	if restricted.Snap.CursorX != 2 || restricted.Snap.CursorY != 20 {
-		t.Fatalf("expected restricted render to keep stored cursor at (2,20), got (%d,%d)",
-			restricted.Snap.CursorX, restricted.Snap.CursorY)
+		t.Fatalf("expected restricted render to keep stored cursor at (2,20), got (%d,%d)", restricted.Snap.CursorX, restricted.Snap.CursorY)
 	}
 	if !tab.pendingIdleCursorRelearn {
 		t.Fatal("expected control-only restricted render to arm idle cursor relearn")
 	}
 
 	tab.LastOutputAt = time.Now().Add(-tabActiveWindow - time.Millisecond)
-
 	idle := m.TerminalLayer()
 	if idle == nil || idle.Snap == nil {
 		t.Fatal("expected idle terminal layer snapshot")
@@ -487,12 +476,10 @@ func TestTerminalLayerRelearnsCursorAfterControlOnlyMoveGoesIdle(t *testing.T) {
 		t.Fatal("expected idle cursor to become visible after control-only move")
 	}
 	if idle.Snap.CursorX != 4 || idle.Snap.CursorY != 10 {
-		t.Fatalf("expected idle render to re-learn live cursor at (4,10), got (%d,%d)",
-			idle.Snap.CursorX, idle.Snap.CursorY)
+		t.Fatalf("expected idle render to re-learn live cursor at (4,10), got (%d,%d)", idle.Snap.CursorX, idle.Snap.CursorY)
 	}
 	if !tab.stableCursorSet || tab.stableCursorX != 4 || tab.stableCursorY != 10 {
-		t.Fatalf("expected stored cursor to update to re-learned live cursor, got set=%v pos=(%d,%d)",
-			tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
+		t.Fatalf("expected stored cursor to update to re-learned live cursor, got set=%v pos=(%d,%d)", tab.stableCursorSet, tab.stableCursorX, tab.stableCursorY)
 	}
 	if tab.pendingIdleCursorRelearn {
 		t.Fatal("expected idle cursor relearn to clear the pending flag")

--- a/internal/ui/center/model_pty_status_chat_cursor_test.go
+++ b/internal/ui/center/model_pty_status_chat_cursor_test.go
@@ -80,12 +80,14 @@ func TestTerminalLayerHidesChatCursorOutsideInputSectionWithoutStoredCursor(t *t
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:                TabID("tab-chat-unanchored-top-right"),
-			Assistant:         "codex",
-			Workspace:         ws,
-			Terminal:          term,
-			Running:           true,
-			lastVisibleOutput: time.Now(),
+			ID:        TabID("tab-chat-unanchored-top-right"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			tabActivityState: tabActivityState{
+				lastVisibleOutput: time.Now(),
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -112,13 +114,15 @@ func TestTerminalLayerUsesLiveCursorInAltScreenChatTab(t *testing.T) {
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:              TabID("tab-chat-alt-screen"),
-			Assistant:       "codex",
-			Workspace:       ws,
-			Terminal:        term,
-			stableCursorSet: true,
-			stableCursorX:   2,
-			stableCursorY:   11,
+			ID:        TabID("tab-chat-alt-screen"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			tabCursorState: tabCursorState{
+				stableCursorSet: true,
+				stableCursorX:   2,
+				stableCursorY:   11,
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -147,15 +151,19 @@ func TestTerminalLayerUsesStoredChatCursorWhenLiveCursorLeavesInputSection(t *te
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:                TabID("tab-chat-anchored-input"),
-			Assistant:         "codex",
-			Workspace:         ws,
-			Terminal:          term,
-			Running:           true,
-			lastVisibleOutput: time.Now(),
-			stableCursorSet:   true,
-			stableCursorX:     2,
-			stableCursorY:     11,
+			ID:        TabID("tab-chat-anchored-input"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			tabActivityState: tabActivityState{
+				lastVisibleOutput: time.Now(),
+			},
+			tabCursorState: tabCursorState{
+				stableCursorSet: true,
+				stableCursorX:   2,
+				stableCursorY:   11,
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -185,13 +193,15 @@ func TestTerminalLayerKeepsStoredChatCursorWhenLiveCursorFallsOnBlankCorner(t *t
 
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:              TabID("tab-chat-corner-artifact"),
-			Assistant:       "codex",
-			Workspace:       ws,
-			Terminal:        term,
-			stableCursorSet: true,
-			stableCursorX:   3,
-			stableCursorY:   11,
+			ID:        TabID("tab-chat-corner-artifact"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			tabCursorState: tabCursorState{
+				stableCursorSet: true,
+				stableCursorX:   3,
+				stableCursorY:   11,
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
@@ -220,11 +230,13 @@ func TestTerminalLayerAllowsBlankCornerCursorAfterRecentLocalInput(t *testing.T)
 	term.Screen[11][0] = vterm.Cell{Rune: ' ', Width: 1}
 
 	tab := &Tab{
-		ID:                TabID("tab-chat-local-corner"),
-		Assistant:         "codex",
-		Workspace:         ws,
-		Terminal:          term,
-		lastPromptInputAt: time.Now(),
+		ID:        TabID("tab-chat-local-corner"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		tabActivityState: tabActivityState{
+			lastPromptInputAt: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_cursor_owner_test.go
+++ b/internal/ui/center/model_pty_status_cursor_owner_test.go
@@ -69,13 +69,15 @@ func TestTerminalLayerWithCursorOwner_DoesNotLearnStableCursorWhenNotOwner(t *te
 	term.CursorY = 11
 
 	tab := &Tab{
-		ID:              TabID("tab-chat-owner-stable"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		stableCursorSet: true,
-		stableCursorX:   1,
-		stableCursorY:   11,
+		ID:        TabID("tab-chat-owner-stable"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   1,
+			stableCursorY:   11,
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_stable_cursor_test.go
+++ b/internal/ui/center/model_pty_status_stable_cursor_test.go
@@ -23,18 +23,22 @@ func TestTerminalLayerSanitizesStoredSyntheticCursorGlyph(t *testing.T) {
 	}
 
 	tab := &Tab{
-		ID:              TabID("tab-chat-stored-synthetic-cursor"),
-		Assistant:       "codex",
-		Workspace:       ws,
-		Terminal:        term,
-		Running:         true,
-		stableCursorSet: true,
-		stableCursorX:   4,
-		stableCursorY:   10,
+		ID:        TabID("tab-chat-stored-synthetic-cursor"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  term,
+		Running:   true,
+		tabCursorState: tabCursorState{
+			stableCursorSet: true,
+			stableCursorX:   4,
+			stableCursorY:   10,
+		},
 		State: ptyio.State{
 			LastOutputAt: time.Now(),
 		},
-		lastVisibleOutput: time.Now(),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/model_pty_status_test.go
+++ b/internal/ui/center/model_pty_status_test.go
@@ -15,7 +15,6 @@ func TestTerminalLayerForcesVisibleCursorForChatTabs(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 	term.Write([]byte("\x1b[?25l"))
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat"),
@@ -27,7 +26,6 @@ func TestTerminalLayerForcesVisibleCursorForChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -52,7 +50,6 @@ func TestTerminalLayerLetsChatAppOwnSyntheticCursorWhenHidden(t *testing.T) {
 	term.CursorX = 2
 	term.CursorY = 2
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owned-cursor"),
@@ -64,7 +61,6 @@ func TestTerminalLayerLetsChatAppOwnSyntheticCursorWhenHidden(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -90,7 +86,6 @@ func TestTerminalLayerLetsChatAppOwnSteadyBarCursorWhenHidden(t *testing.T) {
 		Width: 1,
 		Style: vterm.Style{Reverse: true},
 	}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-owned-steady-bar-cursor"),
@@ -102,7 +97,6 @@ func TestTerminalLayerLetsChatAppOwnSteadyBarCursorWhenHidden(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -124,7 +118,6 @@ func TestTerminalLayerPreservesCursorForLiteralBlockTextWhenHidden(t *testing.T)
 	term.CursorX = 2
 	term.CursorY = 2
 	term.Screen[2][2] = vterm.Cell{Rune: '▌', Width: 1}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-literal-block-text"),
@@ -136,7 +129,6 @@ func TestTerminalLayerPreservesCursorForLiteralBlockTextWhenHidden(t *testing.T)
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -155,22 +147,22 @@ func TestTerminalLayerPreservesCursorForStoredLiteralFullBlockWhenHidden(t *test
 	term.CursorX = 0
 	term.CursorY = 3
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:              TabID("tab-chat-stored-literal-full-block"),
-			Assistant:       "claude",
-			Workspace:       ws,
-			Terminal:        term,
-			stableCursorSet: true,
-			stableCursorX:   2,
-			stableCursorY:   2,
+			ID:        TabID("tab-chat-stored-literal-full-block"),
+			Assistant: "claude",
+			Workspace: ws,
+			Terminal:  term,
+			tabCursorState: tabCursorState{
+				stableCursorSet: true,
+				stableCursorX:   2,
+				stableCursorY:   2,
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -189,7 +181,6 @@ func TestTerminalLayerIgnoresUnrelatedSyntheticGlyphWhenCursorHidden(t *testing.
 	term.CursorX = 0
 	term.CursorY = 3
 	term.Screen[2][2] = vterm.Cell{Rune: '█', Width: 1}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-unrelated-cursor-glyph"),
@@ -201,7 +192,6 @@ func TestTerminalLayerIgnoresUnrelatedSyntheticGlyphWhenCursorHidden(t *testing.
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -217,7 +207,6 @@ func TestTerminalLayerPreservesCursorHiddenForNonChatTabs(t *testing.T) {
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
 	term.Write([]byte("\x1b[?25l"))
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat"),
@@ -229,7 +218,6 @@ func TestTerminalLayerPreservesCursorHiddenForNonChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -271,22 +259,22 @@ func TestTerminalLayerShowsCursorForIdleBootstrapChatTab(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
-			ID:                    TabID("tab-chat-bootstrap"),
-			Assistant:             "codex",
-			Workspace:             ws,
-			Terminal:              term,
-			Running:               true,
-			bootstrapActivity:     true,
-			bootstrapLastOutputAt: time.Now(),
+			ID:        TabID("tab-chat-bootstrap"),
+			Assistant: "codex",
+			Workspace: ws,
+			Terminal:  term,
+			Running:   true,
+			tabActivityState: tabActivityState{
+				bootstrapActivity:     true,
+				bootstrapLastOutputAt: time.Now(),
+			},
 		},
 	}
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -301,7 +289,6 @@ func TestTerminalLayerShowsCursorForChatTabWithRecentOutput(t *testing.T) {
 	ws := newTestWorkspace("ws", "/repo/ws")
 	wsID := string(ws.ID())
 	term := vterm.New(10, 3)
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-recent-output"),
@@ -317,7 +304,6 @@ func TestTerminalLayerShowsCursorForChatTabWithRecentOutput(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -339,7 +325,6 @@ func TestTerminalLayerNormalizesSyntheticCursorCellForChatTabs(t *testing.T) {
 		Width: 1,
 		Style: vterm.Style{Blink: true},
 	}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-artifact"),
@@ -351,7 +336,6 @@ func TestTerminalLayerNormalizesSyntheticCursorCellForChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -409,7 +393,6 @@ func TestTerminalLayerKeepsSyntheticCursorCellForNonChatTabs(t *testing.T) {
 		Width: 1,
 		Style: vterm.Style{Blink: true},
 	}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat-artifact"),
@@ -421,7 +404,6 @@ func TestTerminalLayerKeepsSyntheticCursorCellForNonChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -445,7 +427,6 @@ func TestTerminalLayerClearsBlinkAttributesForChatTabs(t *testing.T) {
 		Width: 1,
 		Style: vterm.Style{Blink: true},
 	}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-chat-blink"),
@@ -457,7 +438,6 @@ func TestTerminalLayerClearsBlinkAttributesForChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")
@@ -477,7 +457,6 @@ func TestTerminalLayerPreservesBlinkAttributesForNonChatTabs(t *testing.T) {
 		Width: 1,
 		Style: vterm.Style{Blink: true},
 	}
-
 	m.tabs.ByWorkspace[wsID] = []*Tab{
 		{
 			ID:        TabID("tab-non-chat-blink"),
@@ -489,7 +468,6 @@ func TestTerminalLayerPreservesBlinkAttributesForNonChatTabs(t *testing.T) {
 	m.tabs.ActiveByWorkspace[wsID] = 0
 	m.SetWorkspace(ws)
 	m.Focus()
-
 	layer := m.TerminalLayer()
 	if layer == nil || layer.Snap == nil {
 		t.Fatal("expected terminal layer snapshot")

--- a/internal/ui/center/model_render.go
+++ b/internal/ui/center/model_render.go
@@ -145,12 +145,14 @@ func (m *Model) helpLines(contentWidth int) []string {
 
 	hasTabs := len(m.getTabs()) > 0
 	if m.workspace != nil {
-		items = append(items,
+		items = append(
+			items,
 			m.helpItem("C-Spc t a", "new agent tab"),
 		)
 	}
 	if hasTabs {
-		items = append(items,
+		items = append(
+			items,
 			m.helpItem("C-Spc t x", "close"),
 			m.helpItem("C-Spc t d", "detach"),
 			m.helpItem("C-Spc t r", "reattach"),

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -66,11 +66,37 @@ type Tab struct {
 	// bookkeeping (locking owned by mu, as documented on the type).
 	ptyio.State
 
-	pendingOutputBytes     int
-	catchUpPendingOutput   bool
-	catchUpTargetBytes     uint64
-	ptyBytesReceived       uint64
-	ptyBytesSettled        uint64
+	pendingOutputBytes   int
+	catchUpPendingOutput bool
+	catchUpTargetBytes   uint64
+	ptyBytesReceived     uint64
+	ptyBytesSettled      uint64
+
+	// Embedded state groups; fields are promoted so accesses read the same as
+	// before the decomposition. Locking follows the same rule as the flat
+	// fields did: guarded by mu unless documented atomic.
+	tabActivityState
+	tabActorWriteState
+	tabCursorState
+
+	ptyRows int
+	ptyCols int
+	// Mouse selection state
+	Selection          common.SelectionState
+	selectionScroll    common.SelectionScrollState
+	selectionLastTermX int
+
+	ptyTraceFile   *os.File
+	ptyTraceBytes  int
+	ptyTraceClosed bool
+	lastFocusedAt  time.Time
+
+	createdAt int64 // Unix timestamp for ordering; persisted in workspace.json
+}
+
+// tabActivityState groups chat-activity detection state: visible-output
+// tracking, the activity digest, bootstrap windows and prompt timing.
+type tabActivityState struct {
 	lastVisibleOutput      time.Time
 	pendingVisibleOutput   bool
 	pendingVisibleSeq      uint64
@@ -82,29 +108,27 @@ type Tab struct {
 	lastUserInputAt        time.Time
 	bootstrapActivity      bool
 	bootstrapLastOutputAt  time.Time
-	postWriteVisibleState  uint32
+	postWriteVisibleState  uint32 // atomic
 	lastPromptInputAt      time.Time
 	lastPromptSubmitAt     time.Time
 	pendingSubmitPasteEcho string
+}
 
+// tabActorWriteState groups the tab-actor write pipeline state: queued write
+// accounting and the parser carry/reset flow (see model_tab_phase.go for how
+// parserResetPending gates flushing).
+type tabActorWriteState struct {
 	parserResetPending       bool
 	actorWritesPending       int
 	actorQueuedBytes         int
 	actorWriteEpoch          uint64
 	actorQueuedCarry         vterm.ParserCarryState
 	actorQueuedNoiseTrailing []byte
-	ptyRows                  int
-	ptyCols                  int
-	// Mouse selection state
-	Selection          common.SelectionState
-	selectionScroll    common.SelectionScrollState
-	selectionLastTermX int
+}
 
-	ptyTraceFile   *os.File
-	ptyTraceBytes  int
-	ptyTraceClosed bool
-	lastFocusedAt  time.Time
-
+// tabCursorState groups cursor stabilization/refresh state used by the chat
+// cursor overlay.
+type tabCursorState struct {
 	cachedRecentLocalInput   bool
 	cachedRestrictCursor     bool
 	cursorRefreshGen         uint64
@@ -116,7 +140,6 @@ type Tab struct {
 	stableCursorVersion      uint64
 	lastRestrictedVersion    uint64
 	pendingIdleCursorRelearn bool
-	createdAt                int64 // Unix timestamp for ordering; persisted in workspace.json
 }
 
 func (t *Tab) isClosed() bool {

--- a/internal/ui/center/model_tabs_session_selection_flush_test.go
+++ b/internal/ui/center/model_tabs_session_selection_flush_test.go
@@ -81,13 +81,15 @@ func TestTabSelectionChangedCmd_FlushesActorQueuedActiveTab(t *testing.T) {
 	wsID := string(ws.ID())
 
 	tab := &Tab{
-		ID:                 TabID("tab-actor-queued"),
-		Assistant:          "claude",
-		Workspace:          ws,
-		Running:            true,
-		actorWritesPending: 1,
-		actorQueuedBytes:   12,
-		ptyBytesReceived:   12,
+		ID:        TabID("tab-actor-queued"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		tabActorWriteState: tabActorWriteState{
+			actorWritesPending: 1,
+			actorQueuedBytes:   12,
+		},
+		ptyBytesReceived: 12,
 	}
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 	m.tabs.ActiveByWorkspace[wsID] = 0

--- a/internal/ui/center/tab_actor_input_test.go
+++ b/internal/ui/center/tab_actor_input_test.go
@@ -104,12 +104,14 @@ func TestHandleTabEvent_WriteOutputEmitsPostWriteRedrawForChatAndActiveTabs(t *t
 func TestHandleTabEvent_WriteOutputPreservesCatchUpForParserResetRetry(t *testing.T) {
 	m := newTestModel()
 	tab := &Tab{
-		ID:                 TabID("tab-write-output-catch-up-retry"),
-		Assistant:          "codex",
-		Terminal:           vterm.New(80, 24),
-		actorWriteEpoch:    7,
-		actorWritesPending: 1,
-		parserResetPending: true,
+		ID:        TabID("tab-write-output-catch-up-retry"),
+		Assistant: "codex",
+		Terminal:  vterm.New(80, 24),
+		tabActorWriteState: tabActorWriteState{
+			actorWriteEpoch:    7,
+			actorWritesPending: 1,
+			parserResetPending: true,
+		},
 	}
 
 	var gotFlush PTYFlush
@@ -145,11 +147,13 @@ func TestHandleTabEvent_WriteOutputPreservesCatchUpForParserResetRetry(t *testin
 func TestHandleTabEvent_WriteOutputSuppressesRedrawUntilCatchUpTarget(t *testing.T) {
 	m := newTestModel()
 	tab := &Tab{
-		ID:                   TabID("tab-write-output-catch-up-redraw"),
-		Assistant:            "codex",
-		Terminal:             vterm.New(80, 24),
-		actorWritesPending:   2,
-		actorQueuedBytes:     2,
+		ID:        TabID("tab-write-output-catch-up-redraw"),
+		Assistant: "codex",
+		Terminal:  vterm.New(80, 24),
+		tabActorWriteState: tabActorWriteState{
+			actorWritesPending: 2,
+			actorQueuedBytes:   2,
+		},
 		catchUpPendingOutput: true,
 		catchUpTargetBytes:   2,
 		ptyBytesReceived:     2,
@@ -302,11 +306,13 @@ func TestHandleTabEvent_SelectionClearEmitsRedrawOnlyWhenSelectionChanged(t *tes
 func TestHandleTabEvent_WriteOutputDropsStaleEpoch(t *testing.T) {
 	m := newTestModel()
 	tab := &Tab{
-		ID:                 TabID("tab-stale-epoch"),
-		Assistant:          "codex",
-		Terminal:           vterm.New(80, 24),
-		actorWriteEpoch:    8,
-		actorWritesPending: 1,
+		ID:        TabID("tab-stale-epoch"),
+		Assistant: "codex",
+		Terminal:  vterm.New(80, 24),
+		tabActorWriteState: tabActorWriteState{
+			actorWriteEpoch:    8,
+			actorWritesPending: 1,
+		},
 	}
 	tab.Terminal.Write([]byte("BASE"))
 	baseline := tab.Terminal.Render()


### PR DESCRIPTION
With the PTY plumbing already extracted to ptyio.State, group the
remaining ~40 flat fields into embedded tabActivityState (chat-activity
detection), tabActorWriteState (actor write pipeline + parser carry) and
tabCursorState (cursor stabilization/refresh). Field promotion keeps
every access site unchanged; struct literals in tests now name the
groups.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **E6**, 21/36). Stacked on `rp/d2-pty-phase`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.