### PR TITLE
D3: Document workspace create/delete message ordering and dispatch routing

### DIFF
--- a/internal/app/MESSAGE_FLOW.md
+++ b/internal/app/MESSAGE_FLOW.md
@@ -46,3 +46,56 @@ Rules:
 
 - Use `common.ReportError(...)` (or a thin wrapper) to log + toast + emit `messages.Error`.
 - `messages.Error` is handled in one place (`App.handleErrorMessage`) to keep error UX consistent.
+
+## Workspace Create → Activate Flow
+
+Lifecycle phases live in `workspaceLifecycleState` (`app/workspace_lifecycle_state.go`):
+a workspace is `active` (untracked), `creating`, or `deleting`; transitions go
+through the FSM and invalid moves (e.g. create while delete-in-flight) are
+rejected and logged.
+
+1. `messages.CreateWorkspace` (dialog) → `handleCreateWorkspace`
+   (`app_input_messages_workspace.go`): validates input, marks the pending
+   workspace `creating` via `lifecycle.markCreating`, shows the dashboard
+   spinner, and enqueues the async `workspaceService.CreateWorkspace` cmd.
+2. The service creates the worktree, waits for `.git`, and saves metadata.
+   Any failure after the worktree exists rolls the worktree/branch back and
+   returns `messages.WorkspaceCreateFailed` — never `WorkspaceCreated` — so no
+   setup or reload runs for a workspace that no longer exists.
+3. `messages.WorkspaceCreated` → `handleWorkspaceCreated`
+   (`app_input_workspace.go`): settles the phase back to active
+   (`lifecycle.clearCreating`), clears the spinner, enqueues `runSetupAsync`
+   and `loadProjects`.
+4. `messages.ProjectsLoaded` → `handleProjectsLoaded`: applies the freshest
+   load generation only (stale `LoadToken`s are dropped) and rebinds the
+   active selection.
+5. `messages.WorkspaceActivated` → `handleWorkspaceActivated`: sets the active
+   workspace, discovers/restores tabs, starts git status + file watching.
+
+While `creating`, a projects reload that does not yet contain the workspace
+must not clear the phase — only `WorkspaceCreated`/`WorkspaceCreateFailed`
+settle it (see `TestLifecycleCreateWhileProjectsLoading`).
+
+## Workspace Delete Flow
+
+1. `messages.DeleteWorkspace` (confirm dialog) → `handleDeleteWorkspace`
+   (`app_input_workspace.go`): marks the workspace `deleting`
+   (`lifecycle.markDeleting`), shows the dashboard spinner, and enqueues the
+   async `workspaceService.DeleteWorkspace` cmd. Sessions are NOT killed here:
+   a rejected/failed delete must leave live agents intact.
+2. The service validates (primary-checkout guard, repo/path checks), writes a
+   durable delete tombstone, removes the worktree under the per-repo git lock,
+   kills the workspace's tmux sessions only after worktree removal succeeded,
+   deletes the branch (failure is a warning), then deletes metadata.
+3. `messages.WorkspaceDeleted` → `handleWorkspaceDeleted`: settles the phase,
+   drops the workspace from the active set, navigates home when it was the
+   active workspace, clears its dirty marker, and reloads projects.
+4. `messages.WorkspaceDeleteFailed` → `handleWorkspaceDeleteFailed`: settles
+   the phase first, clears the tombstone only when the worktree still exists,
+   then requeues persistence (`persistWorkspaceTabs`) — this is why the dirty
+   marker is orthogonal to the lifecycle phase and survives `deleting`.
+
+While `deleting`, persistence is suppressed (`persistWorkspaceTabs` and
+`handlePersistDebounce` consult `isWorkspaceDeleteInFlight`), orphan GC treats
+the workspace's sessions as known (`snapshotDeleting`), and store mutations are
+guarded by `runUnlessWorkspaceDeleteInFlight`.

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -11,10 +11,37 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/dashboard"
 )
 
-// The four updateXMsg sub-dispatchers below carve App.update's message switch
+// The updateXMsg sub-dispatchers below carve App.update's message switch
 // into themed groups so the central routing function stays under the complexity
 // ratchet. Each returns true (and appends to cmds) when it handled the message;
 // the message types are disjoint across dispatchers, so call order is irrelevant.
+//
+// Routing map — which dispatcher owns a message type, and where its handlers
+// live (see MESSAGE_FLOW.md for the create/activate and delete sequences):
+//
+//	handlePreSwitchInput   dialog/file-picker/settings/toast/overlay input
+//	                       → app_input_dialogs.go
+//	updateUpgradeMsg       UpdateCheckComplete, TriggerUpgrade, UpgradeComplete
+//	                       → service_update.go
+//	updateTabMsg           OpenDiff, CloseTab, LaunchAgent, TabCreated/Closed/
+//	                       Detached/Reattached/StateChanged/SelectionChanged,
+//	                       persistDebounceMsg, center.TabInputFailed
+//	                       → app_input_messages_center.go, app_persistence.go
+//	updateTmuxMsg          CleanupTmuxSessions, SpinnerTick, GitStatusTick,
+//	                       OrphanGCTick, PTYWatchdogTick, tmuxActivityTick/
+//	                       Result, tmuxAvailableResult, TmuxSyncTick,
+//	                       tmuxTabsSyncResult, tmuxTabs/SidebarDiscoverResult,
+//	                       orphanGCResult, staleDetachedAgentGCResult
+//	                       → app_tmux*.go
+//	updateWorkspaceLifecycleMsg  ProjectsLoaded, WorkspaceActivated/Created/
+//	                       CreatedWithWarning/CreateFailed/SetupComplete,
+//	                       CreateWorkspace, DeleteWorkspace, WorkspaceDeleted/
+//	                       DeleteFailed, AddProject/RemoveProject/ProjectRemoved,
+//	                       RefreshDashboard, RescanWorkspaces, GitStatusResult,
+//	                       FileWatcherEvent, StateWatcherEvent
+//	                       → app_input_messages_workspace.go, app_input_workspace.go
+//	updateDialogShowMsg    Show* dialog requests, ThemePreview, SettingsResult
+//	                       → app_input_dialogs.go
 
 // handlePreSwitchInput runs the overlay/dialog guards that may consume a message
 // before the main routing switch. It returns the resulting command and true when


### PR DESCRIPTION
MESSAGE_FLOW.md gains the create -> activate and delete sequences
(including the lifecycle-phase guarantees and why dirty survives a
deleting phase); app_input_dispatch.go gains a routing map from message
type to owning dispatcher and handler file.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **D3**, 22/36). Stacked on `rp/e6-tab-decomposition`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.