### PR TITLE
F2: Group alt-screen capture tracking and log invariant violations

### DIFF
--- a/internal/vterm/alt_screen_capture.go
+++ b/internal/vterm/alt_screen_capture.go
@@ -1,5 +1,7 @@
 package vterm
 
+import "github.com/andyrewlee/amux/internal/logging"
+
 // captureScreenToScrollback copies the visible screen frame into the
 // scrollback buffer. It trims leading/trailing blank rows and clips each row
 // to the current terminal width so only what was actually visible is stored.
@@ -40,11 +42,11 @@ func (v *VTerm) captureScreenToScrollback() bool {
 
 	// Dedup: skip if these lines match the tail of scrollback
 	if matchesScrollbackTail(v.Scrollback, lines) {
-		v.altScreenCaptureLen = len(lines)
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = len(dropped) > 0 && captureRowsMatch(lines, dropped, v.Width)
-		if v.altScreenCaptureTracked {
-			v.altScreenCaptureDropLen = len(lines)
+		v.altCapture.frameLen = len(lines)
+		v.altCapture.dropLen = 0
+		v.altCapture.tracked = len(dropped) > 0 && captureRowsMatch(lines, dropped, v.Width)
+		if v.altCapture.tracked {
+			v.altCapture.dropLen = len(lines)
 		}
 		deductOffset()
 		v.trimScrollback()
@@ -59,9 +61,9 @@ func (v *VTerm) captureScreenToScrollback() bool {
 		v.Scrollback = append(v.Scrollback, CopyLine(line))
 		added++
 	}
-	v.altScreenCaptureLen = len(lines)
-	v.altScreenCaptureDropLen = added
-	v.altScreenCaptureTracked = true
+	v.altCapture.frameLen = len(lines)
+	v.altCapture.dropLen = added
+	v.altCapture.tracked = true
 	if oldViewOffset > 0 {
 		v.adjustAnchoredViewOffset(pendingAdded - removed + added)
 	}
@@ -125,26 +127,23 @@ func isVisiblyBlankLine(line []Cell) bool {
 // if scrollUp has appended lines after them (tracked by
 // altScreenCaptureEndOffset); untracked captures must still match the tail.
 func (v *VTerm) matchesTrackedAltScreenCapture(lines [][]Cell) (bool, int) {
-	if v.altScreenCaptureLen <= 0 || v.altScreenCaptureLen != len(lines) {
+	if v.altCapture.frameLen <= 0 || v.altCapture.frameLen != len(lines) {
 		return false, 0
 	}
-	if !v.altScreenCaptureTracked {
+	if !v.altCapture.tracked {
 		if matchesScrollbackTail(v.Scrollback, lines) {
 			return true, 0
 		}
 		return false, 0
 	}
-	total := v.altScreenCaptureLen + v.altScreenCaptureEndOffset
+	total := v.altCapture.frameLen + v.altCapture.endOffset
 	sb := len(v.Scrollback)
 	if sb < total {
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = false
-		v.altScreenCaptureEndOffset = 0
+		v.altCapture.resetInvalid("scrollback shrank below tracked frame")
 		return false, 0
 	}
 	captureStart := sb - total
-	for i := 0; i < v.altScreenCaptureLen; i++ {
+	for i := 0; i < v.altCapture.frameLen; i++ {
 		if !linesEqual(v.Scrollback[captureStart+i], lines[i]) {
 			return false, 0
 		}
@@ -162,15 +161,17 @@ func (v *VTerm) matchesTrackedAltScreenCapture(lines [][]Cell) (bool, int) {
 // a tracked frame by moving them into transcript order ahead of that frame.
 // Any prefix that already matches the existing history tail is dropped.
 func (v *VTerm) foldTrackedAltScreenTrailing(captureStart int) int {
-	trailing := v.altScreenCaptureEndOffset
+	trailing := v.altCapture.endOffset
 	if trailing <= 0 {
 		return 0
 	}
 
-	captureEnd := captureStart + v.altScreenCaptureLen
+	captureEnd := captureStart + v.altCapture.frameLen
 	trailingStart := captureEnd
 	if trailingStart < 0 || trailingStart > len(v.Scrollback) || trailingStart+trailing > len(v.Scrollback) {
-		v.altScreenCaptureEndOffset = 0
+		logging.Warn("alt-screen capture: trailing range out of bounds (start=%d trailing=%d scrollback=%d)",
+			trailingStart, trailing, len(v.Scrollback))
+		v.altCapture.endOffset = 0
 		return 0
 	}
 
@@ -184,7 +185,7 @@ func (v *VTerm) foldTrackedAltScreenTrailing(captureStart int) int {
 	reordered = append(reordered, trailingLines[overlap:]...)
 	reordered = append(reordered, captureLines...)
 	v.Scrollback = reordered
-	v.altScreenCaptureEndOffset = 0
+	v.altCapture.endOffset = 0
 
 	return overlap
 }
@@ -195,55 +196,42 @@ func (v *VTerm) foldTrackedAltScreenTrailing(captureStart int) int {
 // we remove from its tracked position and preserve any overlap prefix plus
 // trailing scrollUp lines.
 func (v *VTerm) dropTrackedAltScreenCapture() (int, [][]Cell) {
-	if v.altScreenCaptureLen <= 0 || !v.altScreenCaptureTracked {
-		if v.altScreenCaptureLen <= 0 {
-			v.altScreenCaptureDropLen = 0
-			v.altScreenCaptureEndOffset = 0
-			return 0, nil
-		}
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureEndOffset = 0
+	if v.altCapture.frameLen <= 0 || !v.altCapture.tracked {
+		v.altCapture.reset()
 		return 0, nil
 	}
-	if v.altScreenCaptureDropLen <= 0 || v.altScreenCaptureDropLen > v.altScreenCaptureLen {
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = false
-		v.altScreenCaptureEndOffset = 0
+	if v.altCapture.dropLen <= 0 || v.altCapture.dropLen > v.altCapture.frameLen {
+		v.altCapture.resetInvalid("drop length out of range")
 		return 0, nil
 	}
-	total := v.altScreenCaptureLen + v.altScreenCaptureEndOffset
+	total := v.altCapture.frameLen + v.altCapture.endOffset
 	if len(v.Scrollback) < total {
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = false
-		v.altScreenCaptureEndOffset = 0
+		v.altCapture.resetInvalid("scrollback shrank below tracked frame")
 		return 0, nil
 	}
 	captureStart := len(v.Scrollback) - total
-	captureEnd := captureStart + v.altScreenCaptureLen
-	dropStart := captureEnd - v.altScreenCaptureDropLen
+	captureEnd := captureStart + v.altCapture.frameLen
+	dropStart := captureEnd - v.altCapture.dropLen
 
 	// Copy the removed rows so the returned slice doesn't alias the
 	// Scrollback backing array — a subsequent append could overwrite it.
 	src := v.Scrollback[dropStart:captureEnd]
 	removedRows := make([][]Cell, len(src))
 	copy(removedRows, src)
-	removed := v.altScreenCaptureDropLen
+	removed := v.altCapture.dropLen
 
 	// Remove the tracked suffix from the frame while preserving any overlapping
 	// prefix that was already in scrollback and any trailing scrollUp lines.
 	v.Scrollback = append(v.Scrollback[:dropStart], v.Scrollback[captureEnd:]...)
-	v.altScreenCaptureLen = 0
-	v.altScreenCaptureDropLen = 0
-	v.altScreenCaptureTracked = false
+	v.altCapture.frameLen = 0
+	v.altCapture.dropLen = 0
+	v.altCapture.tracked = false
 
 	// Dedup scrollUp trailing lines against pre-capture scrollback.
 	// After removal, trailing lines are at [dropStart, dropStart+endOffset).
 	dedupRemoved := v.dedupScrollUpTrailing(dropStart)
 	removed += dedupRemoved
-	v.altScreenCaptureEndOffset = 0
+	v.altCapture.endOffset = 0
 
 	return removed, removedRows
 }
@@ -253,7 +241,7 @@ func (v *VTerm) dropTrackedAltScreenCapture() (int, [][]Cell) {
 // suffix->prefix shift of it. This keeps transcript-style fullscreen redraws
 // (for example Claude review output) from dropping earlier text on each erase.
 func (v *VTerm) transitionTrackedAltScreenCapture(lines [][]Cell) (int, [][]Cell, bool) {
-	if len(lines) == 0 || !v.altScreenCaptureTracked || v.altScreenCaptureLen <= 0 {
+	if len(lines) == 0 || !v.altCapture.tracked || v.altCapture.frameLen <= 0 {
 		return 0, nil, false
 	}
 	captureStart, captureEnd, dropStart, oldLines, ok := v.trackedAltScreenCapture()
@@ -275,22 +263,22 @@ func (v *VTerm) transitionTrackedAltScreenCapture(lines [][]Cell) (int, [][]Cell
 		return 0, nil, false
 	}
 
-	overlapPrefixLen := len(oldLines) - v.altScreenCaptureDropLen
+	overlapPrefixLen := len(oldLines) - v.altCapture.dropLen
 	if overlapPrefixLen > scrolledOff {
 		overlapPrefixLen = scrolledOff
 	}
 	preserveRows := oldLines[overlapPrefixLen:scrolledOff]
 	coveredByTrailing := 0
-	if v.altScreenCaptureEndOffset > 0 {
+	if v.altCapture.endOffset > 0 {
 		trailingStart := captureEnd
-		trailingEnd := trailingStart + v.altScreenCaptureEndOffset
+		trailingEnd := trailingStart + v.altCapture.endOffset
 		if trailingStart >= 0 && trailingEnd <= len(v.Scrollback) {
 			coveredByTrailing = scrollbackTailOverlap(v.Scrollback[trailingStart:trailingEnd], preserveRows)
 		}
 	}
 	preserveAdded := len(preserveRows) - coveredByTrailing
-	if preserveAdded > v.altScreenCaptureDropLen {
-		preserveAdded = v.altScreenCaptureDropLen
+	if preserveAdded > v.altCapture.dropLen {
+		preserveAdded = v.altCapture.dropLen
 	}
 	removeStart := dropStart + preserveAdded
 	if removeStart > captureEnd {
@@ -303,39 +291,33 @@ func (v *VTerm) transitionTrackedAltScreenCapture(lines [][]Cell) (int, [][]Cell
 	removed := len(src)
 
 	v.Scrollback = append(v.Scrollback[:removeStart], v.Scrollback[captureEnd:]...)
-	v.altScreenCaptureLen = 0
-	v.altScreenCaptureDropLen = 0
-	v.altScreenCaptureTracked = false
+	v.altCapture.frameLen = 0
+	v.altCapture.dropLen = 0
+	v.altCapture.tracked = false
 
 	dedupRemoved := v.dedupScrollUpTrailing(removeStart)
 	removed += dedupRemoved
-	v.altScreenCaptureEndOffset = 0
+	v.altCapture.endOffset = 0
 
 	return removed, removedRows, true
 }
 
 func (v *VTerm) trackedAltScreenCapture() (int, int, int, [][]Cell, bool) {
-	if v.altScreenCaptureLen <= 0 || !v.altScreenCaptureTracked {
+	if v.altCapture.frameLen <= 0 || !v.altCapture.tracked {
 		return 0, 0, 0, nil, false
 	}
-	if v.altScreenCaptureDropLen <= 0 || v.altScreenCaptureDropLen > v.altScreenCaptureLen {
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = false
-		v.altScreenCaptureEndOffset = 0
+	if v.altCapture.dropLen <= 0 || v.altCapture.dropLen > v.altCapture.frameLen {
+		v.altCapture.resetInvalid("drop length out of range")
 		return 0, 0, 0, nil, false
 	}
-	total := v.altScreenCaptureLen + v.altScreenCaptureEndOffset
+	total := v.altCapture.frameLen + v.altCapture.endOffset
 	if len(v.Scrollback) < total {
-		v.altScreenCaptureLen = 0
-		v.altScreenCaptureDropLen = 0
-		v.altScreenCaptureTracked = false
-		v.altScreenCaptureEndOffset = 0
+		v.altCapture.resetInvalid("scrollback shrank below tracked frame")
 		return 0, 0, 0, nil, false
 	}
 	captureStart := len(v.Scrollback) - total
-	captureEnd := captureStart + v.altScreenCaptureLen
-	dropStart := captureEnd - v.altScreenCaptureDropLen
+	captureEnd := captureStart + v.altCapture.frameLen
+	dropStart := captureEnd - v.altCapture.dropLen
 	return captureStart, captureEnd, dropStart, v.Scrollback[captureStart:captureEnd], true
 }
 
@@ -345,9 +327,9 @@ func (v *VTerm) trackedAltScreenCapture() (int, int, int, [][]Cell, bool) {
 // tracked frame, where the trailing scrollUp rows already belong after the
 // remaining history and only an overlap against that history needs pruning.
 func (v *VTerm) dedupScrollUpTrailing(preCaptureLen int) int {
-	trailing := v.altScreenCaptureEndOffset
+	trailing := v.altCapture.endOffset
 	if trailing <= 0 {
-		v.altScreenCaptureEndOffset = 0
+		v.altCapture.endOffset = 0
 		return 0
 	}
 
@@ -373,7 +355,7 @@ func (v *VTerm) dedupScrollUpTrailing(preCaptureLen int) int {
 
 	// Remove the overlapping prefix from the trailing lines
 	v.Scrollback = append(v.Scrollback[:trailingStart], v.Scrollback[trailingStart+overlap:]...)
-	v.altScreenCaptureEndOffset = trailing - overlap
+	v.altCapture.endOffset = trailing - overlap
 	return overlap
 }
 
@@ -383,10 +365,7 @@ func (v *VTerm) invalidateAltScreenCapture() {
 }
 
 func (v *VTerm) invalidateTrackedAltScreenCapture() {
-	v.altScreenCaptureLen = 0
-	v.altScreenCaptureDropLen = 0
-	v.altScreenCaptureTracked = false
-	v.altScreenCaptureEndOffset = 0
+	v.altCapture.reset()
 }
 
 // captureRowsMatch compares lines with captured rows using the current terminal width.

--- a/internal/vterm/alt_screen_capture_state.go
+++ b/internal/vterm/alt_screen_capture_state.go
@@ -1,0 +1,40 @@
+package vterm
+
+import "github.com/andyrewlee/amux/internal/logging"
+
+// altScreenCaptureState tracks the alt-screen frame currently reserved in
+// scrollback. captureScreenToScrollback copies the visible alt-screen frame
+// into scrollback before each erase-display redraw; this state remembers
+// where that frame sits so the next redraw can dedup, replace, or transition
+// it instead of appending duplicates.
+//
+// Invariants (checked by users of this struct):
+//   - tracked implies 0 < dropLen <= frameLen
+//   - frameLen + endOffset <= len(Scrollback)
+//   - endOffset > 0 only while tracked
+type altScreenCaptureState struct {
+	// frameLen is the full reserved frame length in scrollback.
+	frameLen int
+	// dropLen is the removable suffix length of the reserved frame (rows the
+	// capture added itself, as opposed to rows that already overlapped).
+	dropLen int
+	// tracked marks whether the frame's position is still known after
+	// scrollUp appended rows behind it.
+	tracked bool
+	// endOffset counts scrollUp rows that accumulated after the tracked frame.
+	endOffset int
+}
+
+// reset clears the tracking state (normal completion or invalidation).
+func (c *altScreenCaptureState) reset() {
+	*c = altScreenCaptureState{}
+}
+
+// resetInvalid clears the tracking state after an invariant violation,
+// logging the observed state so violations are diagnosable instead of being
+// silently swallowed.
+func (c *altScreenCaptureState) resetInvalid(reason string) {
+	logging.Warn("alt-screen capture: invariant violation (%s): frameLen=%d dropLen=%d tracked=%v endOffset=%d",
+		reason, c.frameLen, c.dropLen, c.tracked, c.endOffset)
+	c.reset()
+}

--- a/internal/vterm/alt_screen_erase_capture_test.go
+++ b/internal/vterm/alt_screen_erase_capture_test.go
@@ -70,10 +70,10 @@ func TestAltScreenEraseDedupedHistoryIsPreserved(t *testing.T) {
 	if vt.Scrollback[0][0].Rune != 'f' {
 		t.Fatalf("expected existing history to remain, got %q", vt.Scrollback[0][0].Rune)
 	}
-	if vt.altScreenCaptureLen != 1 {
-		t.Fatalf("expected deduped frame reserved for resize, got %d", vt.altScreenCaptureLen)
+	if vt.altCapture.frameLen != 1 {
+		t.Fatalf("expected deduped frame reserved for resize, got %d", vt.altCapture.frameLen)
 	}
-	if vt.altScreenCaptureTracked {
+	if vt.altCapture.tracked {
 		t.Fatalf("expected deduped frame not tracked as removable capture")
 	}
 
@@ -274,8 +274,8 @@ func TestAltScreenEraseDedupedFrameRemainsReservedOnResizeGrow(t *testing.T) {
 	vt.Write([]byte("frame"))
 	vt.Write([]byte("\x1b[2J"))
 
-	if vt.altScreenCaptureLen != 1 {
-		t.Fatalf("expected deduped frame to stay reserved, got %d", vt.altScreenCaptureLen)
+	if vt.altCapture.frameLen != 1 {
+		t.Fatalf("expected deduped frame to stay reserved, got %d", vt.altCapture.frameLen)
 	}
 
 	vt.Resize(5, 3)

--- a/internal/vterm/alt_screen_erase_overlap_test.go
+++ b/internal/vterm/alt_screen_erase_overlap_test.go
@@ -275,13 +275,13 @@ func TestAltScreenErasePartialOverlapReservesFullFrameOnResizeGrow(t *testing.T)
 
 	vt.Write([]byte("\x1b[2J"))
 
-	if vt.altScreenCaptureLen != 2 {
-		t.Fatalf("captureLen = %d, want 2", vt.altScreenCaptureLen)
+	if vt.altCapture.frameLen != 2 {
+		t.Fatalf("captureLen = %d, want 2", vt.altCapture.frameLen)
 	}
-	if vt.altScreenCaptureDropLen != 1 {
-		t.Fatalf("dropLen = %d, want 1", vt.altScreenCaptureDropLen)
+	if vt.altCapture.dropLen != 1 {
+		t.Fatalf("dropLen = %d, want 1", vt.altCapture.dropLen)
 	}
-	if !vt.altScreenCaptureTracked {
+	if !vt.altCapture.tracked {
 		t.Fatal("expected partial-overlap capture to stay tracked")
 	}
 
@@ -349,7 +349,8 @@ func TestResizeGrowReservesTrackedCaptureEndOffset(t *testing.T) {
 		return line
 	}
 
-	vt.Scrollback = append(vt.Scrollback,
+	vt.Scrollback = append(
+		vt.Scrollback,
 		makeLine("hist1"),
 		makeLine("hist2"),
 		makeLine("cap1"),
@@ -357,10 +358,10 @@ func TestResizeGrowReservesTrackedCaptureEndOffset(t *testing.T) {
 		makeLine("cap3"),
 		makeLine("tail"),
 	)
-	vt.altScreenCaptureLen = 3
-	vt.altScreenCaptureDropLen = 3
-	vt.altScreenCaptureTracked = true
-	vt.altScreenCaptureEndOffset = 1
+	vt.altCapture.frameLen = 3
+	vt.altCapture.dropLen = 3
+	vt.altCapture.tracked = true
+	vt.altCapture.endOffset = 1
 
 	vt.Resize(5, 5)
 
@@ -405,8 +406,8 @@ func TestScrollUpCustomScrollRegionPreservesTrackedAltScreenCaptureReplacement(t
 	vt.scrollUp(1)
 	vt.Screen[3] = makeLine("four")
 
-	if vt.altScreenCaptureEndOffset != 1 {
-		t.Fatalf("endOffset = %d, want 1 after region scroll", vt.altScreenCaptureEndOffset)
+	if vt.altCapture.endOffset != 1 {
+		t.Fatalf("endOffset = %d, want 1 after region scroll", vt.altCapture.endOffset)
 	}
 
 	vt.captureScreenToScrollback()
@@ -437,8 +438,8 @@ func TestAltScreenDropRecaptureResetsEndOffset(t *testing.T) {
 	vt.Write([]byte("AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE"))
 	vt.Write([]byte("\x1b[2J"))
 
-	if vt.altScreenCaptureLen != 3 {
-		t.Fatalf("cycle 1: captureLen = %d, want 3", vt.altScreenCaptureLen)
+	if vt.altCapture.frameLen != 3 {
+		t.Fatalf("cycle 1: captureLen = %d, want 3", vt.altCapture.frameLen)
 	}
 
 	// Cycle 2: completely different content — forces drop+recapture
@@ -446,9 +447,9 @@ func TestAltScreenDropRecaptureResetsEndOffset(t *testing.T) {
 	vt.Write([]byte("PPP\r\nQQQ\r\nRRR\r\nSSS\r\nTTT"))
 	vt.Write([]byte("\x1b[2J"))
 
-	if vt.altScreenCaptureEndOffset != 0 {
+	if vt.altCapture.endOffset != 0 {
 		t.Fatalf("cycle 2: endOffset = %d after drop+recapture, want 0",
-			vt.altScreenCaptureEndOffset)
+			vt.altCapture.endOffset)
 	}
 
 	// Cycle 3: same as cycle 2 — should match cleanly

--- a/internal/vterm/characterization_test.go
+++ b/internal/vterm/characterization_test.go
@@ -64,13 +64,13 @@ func TestAltScreenCaptureRedrawsNeverDuplicateFrames(t *testing.T) {
 			v.Write(frame(current))
 
 			// Invariants on the tracking fields after every redraw.
-			if v.altScreenCaptureLen < 0 || v.altScreenCaptureDropLen < 0 || v.altScreenCaptureEndOffset < 0 {
+			if v.altCapture.frameLen < 0 || v.altCapture.dropLen < 0 || v.altCapture.endOffset < 0 {
 				t.Fatalf("trial %d step %d: negative capture tracking: len=%d drop=%d end=%d",
-					trial, step, v.altScreenCaptureLen, v.altScreenCaptureDropLen, v.altScreenCaptureEndOffset)
+					trial, step, v.altCapture.frameLen, v.altCapture.dropLen, v.altCapture.endOffset)
 			}
-			if v.altScreenCaptureLen+v.altScreenCaptureEndOffset > len(v.Scrollback) {
+			if v.altCapture.frameLen+v.altCapture.endOffset > len(v.Scrollback) {
 				t.Fatalf("trial %d step %d: capture tracking exceeds scrollback: len=%d end=%d scrollback=%d",
-					trial, step, v.altScreenCaptureLen, v.altScreenCaptureEndOffset, len(v.Scrollback))
+					trial, step, v.altCapture.frameLen, v.altCapture.endOffset, len(v.Scrollback))
 			}
 
 			lines := scrollbackLines(v)

--- a/internal/vterm/scroll.go
+++ b/internal/vterm/scroll.go
@@ -29,9 +29,9 @@ func (v *VTerm) scrollUp(n int) {
 			}
 		}
 		if added > 0 {
-			if v.altScreenCaptureTracked && v.altScreenCaptureLen > 0 &&
-				v.altScreenCaptureDropLen > 0 {
-				v.altScreenCaptureEndOffset += added
+			if v.altCapture.tracked && v.altCapture.frameLen > 0 &&
+				v.altCapture.dropLen > 0 {
+				v.altCapture.endOffset += added
 			} else {
 				v.invalidateAltScreenCapture()
 			}

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -37,12 +37,9 @@ type VTerm struct {
 	// AllowAltScreenScrollback keeps scrollback active even in alt screen.
 	// Useful for tmux-backed sessions where scrollback should remain available.
 	AllowAltScreenScrollback bool
-	// altScreenCaptureLen tracks the full reserved frame length in scrollback.
-	altScreenCaptureLen int
-	// altScreenCaptureDropLen tracks the removable suffix for the reserved frame.
-	altScreenCaptureDropLen   int
-	altScreenCaptureTracked   bool
-	altScreenCaptureEndOffset int
+	// altCapture tracks the alt-screen frame currently reserved in scrollback
+	// (see altScreenCaptureState).
+	altCapture altScreenCaptureState
 	// altScreenRestorePending tracks a freshly restored alt-screen frame until
 	// the first attached clear-screen redraw so it is not re-captured as new
 	// scrollback.
@@ -207,12 +204,12 @@ func (v *VTerm) resize(width, height int, revealHistoryOnGrow bool) {
 	if height > oldHeight && revealHistoryOnGrow && v.scrollbackEnabled() && v.ViewOffset == 0 {
 		added := height - oldHeight
 		restore := added
-		reserved := v.altScreenCaptureLen + v.altScreenCaptureEndOffset
+		reserved := v.altCapture.frameLen + v.altCapture.endOffset
 		if reserved > len(v.Scrollback) {
 			reserved = 0
-			v.altScreenCaptureLen = 0
-			v.altScreenCaptureTracked = false
-			v.altScreenCaptureEndOffset = 0
+			v.altCapture.frameLen = 0
+			v.altCapture.tracked = false
+			v.altCapture.endOffset = 0
 		}
 		available := len(v.Scrollback) - reserved
 		if restore > available {

--- a/internal/vterm/vterm_test.go
+++ b/internal/vterm/vterm_test.go
@@ -346,15 +346,16 @@ func TestTrimScrollbackPreservesTrackedAltScreenCapturePosition(t *testing.T) {
 	for i := 0; i < MaxScrollback-1; i++ {
 		vt.Scrollback = append(vt.Scrollback, makeLine("old"))
 	}
-	vt.Scrollback = append(vt.Scrollback,
+	vt.Scrollback = append(
+		vt.Scrollback,
 		makeLine("cap1"),
 		makeLine("cap2"),
 		makeLine("tail"),
 	)
-	vt.altScreenCaptureLen = 2
-	vt.altScreenCaptureDropLen = 2
-	vt.altScreenCaptureTracked = true
-	vt.altScreenCaptureEndOffset = 1
+	vt.altCapture.frameLen = 2
+	vt.altCapture.dropLen = 2
+	vt.altCapture.tracked = true
+	vt.altCapture.endOffset = 1
 
 	vt.trimScrollback()
 


### PR DESCRIPTION
Replace the four loose tracker fields with altScreenCaptureState
(frameLen/dropLen/tracked/endOffset) carrying documented invariants and
a resetInvalid method, so violations are logged with the observed state
instead of being silently reset.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **F2**, 24/36). Stacked on `rp/f1-vterm-characterization`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.