### PR TITLE
F3: Make the sync viewport anchor an explicit API

### DIFF
--- a/internal/ui/center/model_scrolled_history.go
+++ b/internal/ui/center/model_scrolled_history.go
@@ -121,10 +121,13 @@ func (m *Model) clampScrolledChatHistoryViewOffsetLocked(tab *Tab) {
 	maxOffset := scrolledChatHistoryMaxViewOffset(tab.Terminal)
 	if maxOffset == 0 {
 		tab.Terminal.ScrollViewToBottom()
+		tab.Terminal.NoteSyncViewportInteraction()
+		tab.Terminal.NoteSyncViewportInteraction()
 		return
 	}
 	if tab.Terminal.ViewOffset > maxOffset {
 		tab.Terminal.ScrollViewTo(maxOffset)
+		tab.Terminal.NoteSyncViewportInteraction()
 	}
 }
 
@@ -134,6 +137,7 @@ func (m *Model) scrollTerminalViewLocked(tab *Tab, delta int) {
 	}
 	m.clampScrolledChatHistoryViewOffsetLocked(tab)
 	tab.Terminal.ScrollView(delta)
+	tab.Terminal.NoteSyncViewportInteraction()
 	m.clampScrolledChatHistoryViewOffsetLocked(tab)
 }
 
@@ -152,10 +156,12 @@ func (m *Model) scrollTerminalToTopLocked(tab *Tab) {
 		maxOffset := scrolledChatHistoryMaxViewOffset(tab.Terminal)
 		if maxOffset > 0 {
 			tab.Terminal.ScrollViewTo(maxOffset)
+			tab.Terminal.NoteSyncViewportInteraction()
 			return
 		}
 	}
 	tab.Terminal.ScrollViewToTop()
+	tab.Terminal.NoteSyncViewportInteraction()
 }
 
 func (m *Model) displayedScrollInfoLocked(tab *Tab) (offset, maxOffset int) {

--- a/internal/ui/center/model_scrolled_history.go
+++ b/internal/ui/center/model_scrolled_history.go
@@ -122,7 +122,6 @@ func (m *Model) clampScrolledChatHistoryViewOffsetLocked(tab *Tab) {
 	if maxOffset == 0 {
 		tab.Terminal.ScrollViewToBottom()
 		tab.Terminal.NoteSyncViewportInteraction()
-		tab.Terminal.NoteSyncViewportInteraction()
 		return
 	}
 	if tab.Terminal.ViewOffset > maxOffset {
@@ -146,6 +145,7 @@ func (m *Model) scrollTerminalToBottomLocked(tab *Tab) {
 		return
 	}
 	tab.Terminal.ScrollViewToBottom()
+	tab.Terminal.NoteSyncViewportInteraction()
 }
 
 func (m *Model) scrollTerminalToTopLocked(tab *Tab) {

--- a/internal/ui/ptyio/session_restore.go
+++ b/internal/ui/ptyio/session_restore.go
@@ -70,6 +70,9 @@ func RestoreScrollbackCapture(
 		return
 	}
 	term.ScrollViewToBottom()
+	// Restore lands on the live view; release any sync viewport anchor so a
+	// sync that ends right after restore does not re-scroll into history.
+	term.NoteSyncViewportInteraction()
 	term.PrependScrollbackWithSize(data, captureCols, captureRows)
 	if currentCols > 0 && currentRows > 0 && (term.Width != currentCols || term.Height != currentRows) {
 		term.Resize(currentCols, currentRows)

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -183,10 +183,12 @@ func (m *TerminalModel) handleMouseMotion(msg tea.MouseMotionMsg) (*TerminalMode
 		if termY < 0 {
 			// Dragging above viewport - scroll up into history
 			ts.VTerm.ScrollView(1)
+			ts.VTerm.NoteSyncViewportInteraction()
 			termY = 0
 		} else if termY >= termHeight {
 			// Dragging below viewport - scroll down toward live
 			ts.VTerm.ScrollView(-1)
+			ts.VTerm.NoteSyncViewportInteraction()
 			termY = termHeight - 1
 		}
 
@@ -268,6 +270,7 @@ func (m *TerminalModel) handleSelectionScrollTick(msg SidebarSelectionScrollTick
 		return nil
 	}
 	ts.VTerm.ScrollView(ts.selectionScroll.ScrollDir)
+	ts.VTerm.NoteSyncViewportInteraction()
 
 	// Update selection endpoint to viewport edge
 	edgeY := 0

--- a/internal/ui/sidebar/terminal_update.go
+++ b/internal/ui/sidebar/terminal_update.go
@@ -115,8 +115,10 @@ func (m *TerminalModel) handleMouseWheel(msg tea.MouseWheelMsg) (*TerminalModel,
 	delta := common.ScrollDeltaForHeight(ts.VTerm.Height, 8) // ~12.5% of viewport
 	if msg.Button == tea.MouseWheelUp {
 		ts.VTerm.ScrollView(delta)
+		ts.VTerm.NoteSyncViewportInteraction()
 	} else if msg.Button == tea.MouseWheelDown {
 		ts.VTerm.ScrollView(-delta)
+		ts.VTerm.NoteSyncViewportInteraction()
 	}
 	ts.mu.Unlock()
 	return m, nil
@@ -178,6 +180,7 @@ func (m *TerminalModel) handleKeyPress(msg tea.KeyPressMsg) (*TerminalModel, tea
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			ts.VTerm.ScrollView(common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
+			ts.VTerm.NoteSyncViewportInteraction()
 		}
 		ts.mu.Unlock()
 		return m, nil
@@ -186,6 +189,7 @@ func (m *TerminalModel) handleKeyPress(msg tea.KeyPressMsg) (*TerminalModel, tea
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			ts.VTerm.ScrollView(-common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
+			ts.VTerm.NoteSyncViewportInteraction()
 		}
 		ts.mu.Unlock()
 		return m, nil
@@ -195,6 +199,7 @@ func (m *TerminalModel) handleKeyPress(msg tea.KeyPressMsg) (*TerminalModel, tea
 	ts.mu.Lock()
 	if ts.VTerm != nil && ts.VTerm.IsScrolled() {
 		ts.VTerm.ScrollViewToBottom()
+		ts.VTerm.NoteSyncViewportInteraction()
 	}
 	ts.mu.Unlock()
 

--- a/internal/vterm/sync_flags_test.go
+++ b/internal/vterm/sync_flags_test.go
@@ -26,11 +26,13 @@ func TestScrollDuringSyncTogglesPreserveViewport(t *testing.T) {
 	}
 
 	v.ScrollView(3)
+	v.NoteSyncViewportInteraction()
 	if !v.syncPreserveViewport {
 		t.Fatal("scrolling up during sync must anchor the viewport")
 	}
 
 	v.ScrollViewToBottom()
+	v.NoteSyncViewportInteraction()
 	if v.syncPreserveViewport {
 		t.Fatal("scrolling back to offset 0 during sync must release the anchor")
 	}

--- a/internal/vterm/vterm_scroll.go
+++ b/internal/vterm/vterm_scroll.go
@@ -75,11 +75,17 @@ func (v *VTerm) clampViewOffsetToCurrentMax() {
 	}
 }
 
-func (v *VTerm) noteSyncViewportInteraction(oldOffset int) {
+// NoteSyncViewportInteraction records a viewport interaction during
+// synchronized output. Scrolled into history, the frozen viewport stays
+// anchored when the sync ends; back at the live view, the anchor is released
+// and recorded hidden growth is discarded. This is an explicit API called by
+// the UI scroll paths (mousewheel/keys) rather than a hidden side effect of
+// the viewport math: programmatic ViewOffset changes do not touch the anchor
+// unless their call site opts in.
+func (v *VTerm) NoteSyncViewportInteraction() {
 	if v == nil || !v.syncActive {
 		return
 	}
-	_ = oldOffset
 	v.syncPreserveViewport = v.ViewOffset > 0
 }
 
@@ -110,7 +116,6 @@ func (v *VTerm) ScrollView(delta int) {
 	oldOffset := v.ViewOffset
 	v.ViewOffset += delta
 	v.clampViewOffsetToCurrentMax()
-	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -121,7 +126,6 @@ func (v *VTerm) ScrollViewTo(offset int) {
 	oldOffset := v.ViewOffset
 	v.ViewOffset = offset
 	v.clampViewOffsetToCurrentMax()
-	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -131,7 +135,6 @@ func (v *VTerm) ScrollViewTo(offset int) {
 func (v *VTerm) ScrollViewToTop() {
 	oldOffset := v.ViewOffset
 	v.ViewOffset = v.currentMaxViewOffset()
-	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}
@@ -141,7 +144,6 @@ func (v *VTerm) ScrollViewToTop() {
 func (v *VTerm) ScrollViewToBottom() {
 	oldOffset := v.ViewOffset
 	v.ViewOffset = 0
-	v.noteSyncViewportInteraction(oldOffset)
 	if v.ViewOffset != oldOffset {
 		v.bumpVersion()
 	}


### PR DESCRIPTION
Replace the noteSyncViewportInteraction side effect hidden inside every
ScrollView* call with an exported NoteSyncViewportInteraction that the
UI scroll paths (mousewheel/keys, selection auto-scroll, session
restore) call explicitly. Programmatic ViewOffset changes no longer
touch the anchor unless their call site opts in. The growth-delta
accumulator stays: recomputing from scrollback length at sync end would
be wrong when history is prepended (prepends legitimately skip the
anchor adjustment).

---
Part of the REFACTOR_PLAN stacked-PR chain (item **F3**, 25/36). Stacked on `rp/f2-alt-capture-state`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.