### PR TITLE
F4: Move the vterm render cache to epoch counters

### DIFF
--- a/internal/vterm/cache.go
+++ b/internal/vterm/cache.go
@@ -1,10 +1,23 @@
 package vterm
 
+// Render-cache dirty tracking is epoch-based: every dirty mark advances a
+// monotonic epoch counter and stamps the affected line; invalidation stamps a
+// global epoch instead of touching every line. A line is dirty when its stamp
+// (or the global stamp) is newer than the epoch recorded by the last clear.
+// Compared to per-line bools plus an all-dirty flag, there is no state to
+// forget to reset per line — clearing is a single counter assignment.
+
+// bumpRenderEpoch advances the epoch counter and returns the new epoch.
+func (v *VTerm) bumpRenderEpoch() uint64 {
+	v.renderEpoch++
+	return v.renderEpoch
+}
+
 func (v *VTerm) ensureRenderCache(height int) {
 	if len(v.renderCache) != height {
 		v.renderCache = make([]string, height)
-		v.renderDirty = make([]bool, height)
-		v.renderDirtyAll = true
+		v.renderLineEpoch = make([]uint64, height)
+		v.renderGlobalEpoch = v.bumpRenderEpoch()
 	}
 }
 
@@ -13,10 +26,10 @@ func (v *VTerm) markDirtyLine(y int) {
 		return
 	}
 	v.bumpVersion()
-	if len(v.renderDirty) == v.Height {
-		v.renderDirty[y] = true
+	if len(v.renderLineEpoch) == v.Height {
+		v.renderLineEpoch[y] = v.bumpRenderEpoch()
 	} else {
-		v.renderDirtyAll = true
+		v.renderGlobalEpoch = v.bumpRenderEpoch()
 	}
 }
 
@@ -31,19 +44,20 @@ func (v *VTerm) markDirtyRange(start, end int) {
 		return
 	}
 	v.bumpVersion()
-	if len(v.renderDirty) == v.Height {
+	if len(v.renderLineEpoch) == v.Height {
+		epoch := v.bumpRenderEpoch()
 		for y := start; y <= end; y++ {
-			v.renderDirty[y] = true
+			v.renderLineEpoch[y] = epoch
 		}
 		return
 	}
-	v.renderDirtyAll = true
+	v.renderGlobalEpoch = v.bumpRenderEpoch()
 }
 
 func (v *VTerm) invalidateRenderCache() {
 	v.renderCache = nil
-	v.renderDirty = nil
-	v.renderDirtyAll = true
+	v.renderLineEpoch = nil
+	v.renderGlobalEpoch = v.bumpRenderEpoch()
 	v.bumpVersion()
 }
 
@@ -51,8 +65,25 @@ func (v *VTerm) liveRenderCacheActive() bool {
 	return v.ViewOffset == 0 && !v.syncActive
 }
 
+// lineDirty reports whether line y is dirty relative to the last clear.
+func (v *VTerm) lineDirty(y int) bool {
+	if v.allDirty() {
+		return true
+	}
+	if y < 0 || y >= len(v.renderLineEpoch) {
+		return true
+	}
+	return v.renderLineEpoch[y] > v.renderCleanEpoch
+}
+
+// allDirty reports whether a global invalidation is newer than the last clear.
+func (v *VTerm) allDirty() bool {
+	return v.renderGlobalEpoch > v.renderCleanEpoch
+}
+
 // DirtyLines returns the dirty line flags and whether all lines are dirty.
-// This is used by VTermLayer for optimized rendering.
+// This is used by VTermLayer for optimized rendering. The returned slice is
+// reused between calls; callers must not retain it across mutations.
 func (v *VTerm) DirtyLines() ([]bool, bool) {
 	// When scrolled, we can't use dirty tracking effectively
 	if v.ViewOffset > 0 {
@@ -62,7 +93,16 @@ func (v *VTerm) DirtyLines() ([]bool, bool) {
 	if v.syncActive {
 		return nil, true
 	}
-	return v.renderDirty, v.renderDirtyAll
+	if v.allDirty() {
+		return nil, true
+	}
+	if len(v.renderDirtyScratch) != len(v.renderLineEpoch) {
+		v.renderDirtyScratch = make([]bool, len(v.renderLineEpoch))
+	}
+	for y := range v.renderLineEpoch {
+		v.renderDirtyScratch[y] = v.renderLineEpoch[y] > v.renderCleanEpoch
+	}
+	return v.renderDirtyScratch, false
 }
 
 // ClearDirty resets dirty tracking state after a render.
@@ -70,10 +110,7 @@ func (v *VTerm) ClearDirty() {
 	if !v.liveRenderCacheActive() {
 		return
 	}
-	v.renderDirtyAll = false
-	for i := range v.renderDirty {
-		v.renderDirty[i] = false
-	}
+	v.renderCleanEpoch = v.renderEpoch
 }
 
 // ClearDirtyWithCursor resets dirty tracking state and updates cursor tracking.
@@ -82,13 +119,18 @@ func (v *VTerm) ClearDirtyWithCursor(showCursor bool) {
 	if !v.liveRenderCacheActive() {
 		return
 	}
-	v.renderDirtyAll = false
-	for i := range v.renderDirty {
-		v.renderDirty[i] = false
-	}
+	v.ClearDirty()
 	// Track cursor state for next frame's dirty detection
 	v.lastShowCursor = showCursor
 	v.lastCursorHidden = v.CursorHiddenForRender()
 	v.lastCursorX = v.CursorX
 	v.lastCursorY = v.CursorY
+}
+
+// RenderAndClear renders the terminal and marks the rendered state clean in
+// one step, so callers cannot forget the clear that keeps the cache coherent.
+func (v *VTerm) RenderAndClear() string {
+	out := v.Render()
+	v.ClearDirty()
+	return out
 }

--- a/internal/vterm/render.go
+++ b/internal/vterm/render.go
@@ -193,13 +193,14 @@ func (v *VTerm) renderScreenCached(screen [][]Cell) string {
 
 	// Invalidate cursor lines if cursor state changed
 	if v.ShowCursor != v.lastShowCursor || v.CursorHiddenForRender() != v.lastCursorHidden || v.CursorX != v.lastCursorX || v.CursorY != v.lastCursorY {
+		epoch := v.bumpRenderEpoch()
 		// Mark old cursor line dirty
-		if v.lastCursorY >= 0 && v.lastCursorY < len(v.renderDirty) {
-			v.renderDirty[v.lastCursorY] = true
+		if v.lastCursorY >= 0 && v.lastCursorY < len(v.renderLineEpoch) {
+			v.renderLineEpoch[v.lastCursorY] = epoch
 		}
 		// Mark new cursor line dirty
-		if v.CursorY >= 0 && v.CursorY < len(v.renderDirty) {
-			v.renderDirty[v.CursorY] = true
+		if v.CursorY >= 0 && v.CursorY < len(v.renderLineEpoch) {
+			v.renderLineEpoch[v.CursorY] = epoch
 		}
 		v.lastShowCursor = v.ShowCursor
 		v.lastCursorHidden = v.CursorHiddenForRender()
@@ -209,15 +210,15 @@ func (v *VTerm) renderScreenCached(screen [][]Cell) string {
 
 	lines := make([]string, len(screen))
 	for y, row := range screen {
-		if v.renderDirtyAll || v.renderDirty[y] || v.renderCache[y] == "" {
+		if v.lineDirty(y) || v.renderCache[y] == "" {
 			lines[y] = v.renderRow(row, y)
 			v.renderCache[y] = lines[y]
-			v.renderDirty[y] = false
 		} else {
 			lines[y] = v.renderCache[y]
 		}
 	}
-	v.renderDirtyAll = false
+	// The cached render pass consumed all outstanding dirtiness.
+	v.ClearDirty()
 
 	out := strings.Join(lines, "\n")
 	return out + "\x1b[0m"

--- a/internal/vterm/selection.go
+++ b/internal/vterm/selection.go
@@ -72,7 +72,7 @@ func (v *VTerm) SetSelection(startX, startLine, endX, endLine int, active, rect 
 	v.selEndLine = endLine
 	v.selActive = active
 	v.selRect = rect
-	v.renderDirtyAll = true
+	v.renderGlobalEpoch = v.bumpRenderEpoch()
 	v.bumpVersion()
 }
 
@@ -83,7 +83,7 @@ func (v *VTerm) ClearSelection() {
 	}
 	v.selActive = false
 	v.selRect = false
-	v.renderDirtyAll = true
+	v.renderGlobalEpoch = v.bumpRenderEpoch()
 	v.bumpVersion()
 }
 
@@ -121,7 +121,7 @@ func (v *VTerm) shiftSelectionAfterTrim(trim int) {
 		prevStartLine != v.selStartLine ||
 		prevEndX != v.selEndX ||
 		prevEndLine != v.selEndLine {
-		v.renderDirtyAll = true
+		v.renderGlobalEpoch = v.bumpRenderEpoch()
 		v.bumpVersion()
 	}
 }

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -114,9 +114,14 @@ type VTerm struct {
 	syncPreserveViewport bool
 
 	// Render cache for live screen (ViewOffset == 0)
-	renderCache    []string
-	renderDirty    []bool
-	renderDirtyAll bool
+	renderCache []string
+	// Epoch-based dirty tracking (see cache.go): a line is dirty when its
+	// epoch (or the global epoch) is newer than the last clear.
+	renderEpoch        uint64
+	renderLineEpoch    []uint64
+	renderGlobalEpoch  uint64
+	renderCleanEpoch   uint64
+	renderDirtyScratch []bool
 
 	// Version counter for snapshot caching - increments on visible content/cursor changes.
 	// UI-driven cursor visibility (ShowCursor) is handled by the snapshot cache key.


### PR DESCRIPTION
Per-line epochs plus a global epoch replace the per-line dirty bools and
renderDirtyAll flag: marking stamps the line, invalidation stamps the
global epoch, and clearing is a single counter assignment, so there is
no per-line state to forget to reset. Adds RenderAndClear so callers
cannot forget the clear that keeps the cache coherent.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **F4**, 26/36). Stacked on `rp/f3-sync-anchor-api`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.