### PR TITLE
F5: Unify the capture-load entry points behind vterm.TerminalSnapshot

### DIFF
--- a/internal/ui/ptyio/session_restore.go
+++ b/internal/ui/ptyio/session_restore.go
@@ -45,7 +45,15 @@ func RestorePaneCapture(
 	if term.Width != restoreCols || term.Height != restoreRows {
 		term.Resize(restoreCols, restoreRows)
 	}
-	term.LoadPaneCaptureWithCursorAndModes(data, cursorX, cursorY, hasCursor, SessionRestorePaneModeState(mode))
+	term.LoadSnapshot(vterm.TerminalSnapshot{
+		Data:      data,
+		Cols:      restoreCols,
+		Rows:      restoreRows,
+		CursorX:   cursorX,
+		CursorY:   cursorY,
+		HasCursor: hasCursor,
+		ModeState: SessionRestorePaneModeState(mode),
+	})
 	if restoreCols != currentCols || restoreRows != currentRows {
 		prevScrollbackLen := len(term.Scrollback)
 		if mode.AltScreen && currentRows > restoreRows {
@@ -57,7 +65,11 @@ func RestorePaneCapture(
 			}
 		}
 	}
-	term.AppendScrollbackDeltaWithSize(postAttachScrollback, restoreCols, restoreRows, visibleHistoryRows)
+	term.AppendDelta(vterm.TerminalSnapshot{
+		Data: postAttachScrollback,
+		Cols: restoreCols,
+		Rows: restoreRows,
+	}, visibleHistoryRows)
 }
 
 func RestoreScrollbackCapture(
@@ -73,7 +85,7 @@ func RestoreScrollbackCapture(
 	// Restore lands on the live view; release any sync viewport anchor so a
 	// sync that ends right after restore does not re-scroll into history.
 	term.NoteSyncViewportInteraction()
-	term.PrependScrollbackWithSize(data, captureCols, captureRows)
+	term.PrependHistory(vterm.TerminalSnapshot{Data: data, Cols: captureCols, Rows: captureRows})
 	if currentCols > 0 && currentRows > 0 && (term.Width != currentCols || term.Height != currentRows) {
 		term.Resize(currentCols, currentRows)
 	}
@@ -89,4 +101,21 @@ func ResizeTerminalForSessionRestore(term *vterm.VTerm, cols, rows int) {
 		return
 	}
 	term.Resize(cols, rows)
+}
+
+// TerminalSnapshotFromPane converts a tmux pane snapshot into the vterm
+// snapshot type. tmux deliberately does not depend on vterm, so this boundary
+// conversion lives here; the missing-mode-state policy is made explicit the
+// same way SessionRestorePaneModeState does it (no tmux state → preserve the
+// terminal's existing modes).
+func TerminalSnapshotFromPane(snap tmux.PaneSnapshot) vterm.TerminalSnapshot {
+	return vterm.TerminalSnapshot{
+		Data:      snap.Data,
+		Cols:      snap.Cols,
+		Rows:      snap.Rows,
+		CursorX:   snap.CursorX,
+		CursorY:   snap.CursorY,
+		HasCursor: snap.HasCursor,
+		ModeState: SessionRestorePaneModeState(snap.ModeState),
+	}
 }

--- a/internal/vterm/prepend_scrollback_load_test.go
+++ b/internal/vterm/prepend_scrollback_load_test.go
@@ -21,6 +21,25 @@ func TestLoadPaneCapture_RestoresVisibleScreenAndScrollback(t *testing.T) {
 	}
 }
 
+func TestLoadSnapshot_UsesSnapshotGeometry(t *testing.T) {
+	t.Parallel()
+	vt := New(4, 2)
+
+	vt.LoadSnapshot(TerminalSnapshot{
+		Data:      []byte("abcde\nfghi"),
+		Cols:      5,
+		Rows:      2,
+		ModeState: PaneModeState{PreserveExistingState: true},
+	})
+
+	if vt.Width != 5 || vt.Height != 2 {
+		t.Fatalf("expected snapshot geometry 5x2, got %dx%d", vt.Width, vt.Height)
+	}
+	if got := plainLine(vt.Screen[0]); got != "abcde" {
+		t.Fatalf("expected first screen row parsed at snapshot width, got %q", got)
+	}
+}
+
 func TestLoadPaneCapture_RestoresCurrentStyle(t *testing.T) {
 	t.Parallel()
 	vt := New(20, 2)

--- a/internal/vterm/snapshot.go
+++ b/internal/vterm/snapshot.go
@@ -1,0 +1,51 @@
+package vterm
+
+// TerminalSnapshot is a captured pane image plus the metadata needed to
+// replay it into a VTerm: the raw capture bytes, the geometry the capture was
+// taken at, the cursor, and the pane mode state.
+//
+// It is the unified entry point for the capture-load paths. The historical
+// per-shape variants (PrependScrollbackWithSize, LoadPaneCaptureWithCursorAndModes,
+// AppendScrollbackDeltaWithSize) remain as the implementation, but new callers
+// should construct a TerminalSnapshot and use LoadSnapshot / AppendDelta /
+// PrependHistory.
+//
+// Missing mode state is an explicit decision, never a silent default: when
+// ModeState.HasState is false, ModeState.PreserveExistingState selects
+// between keeping the terminal's current modes (partial captures) and
+// resetting them to defaults (authoritative captures). Builders of a
+// TerminalSnapshot must set it deliberately.
+type TerminalSnapshot struct {
+	// Data is the raw ANSI capture (e.g. tmux capture-pane output).
+	Data []byte
+	// Cols/Rows are the dimensions the capture was taken at; zero values fall
+	// back to the terminal's current size.
+	Cols, Rows int
+	// CursorX/CursorY position the cursor after a full load when HasCursor is
+	// set.
+	CursorX, CursorY int
+	HasCursor        bool
+	// ModeState carries alt-screen/origin/cursor-visibility/scroll-region
+	// state, with the explicit missing-state policy described above.
+	ModeState PaneModeState
+}
+
+// LoadSnapshot replaces the terminal's screen and scrollback with the
+// snapshot content, applying cursor and mode state.
+func (v *VTerm) LoadSnapshot(snap TerminalSnapshot) {
+	v.LoadPaneCaptureWithCursorAndModes(snap.Data, snap.CursorX, snap.CursorY, snap.HasCursor, snap.ModeState)
+}
+
+// AppendDelta appends the snapshot rows that are missing from the current
+// buffers (post-attach growth). visibleHistoryRows is the number of history
+// rows that a preceding resize folded back into the visible screen, so they
+// are not appended twice.
+func (v *VTerm) AppendDelta(snap TerminalSnapshot, visibleHistoryRows int) {
+	v.AppendScrollbackDeltaWithSize(snap.Data, snap.Cols, snap.Rows, visibleHistoryRows)
+}
+
+// PrependHistory inserts the snapshot rows above the existing scrollback
+// (older captured history fetched after the live view was already populated).
+func (v *VTerm) PrependHistory(snap TerminalSnapshot) {
+	v.PrependScrollbackWithSize(snap.Data, snap.Cols, snap.Rows)
+}

--- a/internal/vterm/snapshot.go
+++ b/internal/vterm/snapshot.go
@@ -33,6 +33,16 @@ type TerminalSnapshot struct {
 // LoadSnapshot replaces the terminal's screen and scrollback with the
 // snapshot content, applying cursor and mode state.
 func (v *VTerm) LoadSnapshot(snap TerminalSnapshot) {
+	cols, rows := v.Width, v.Height
+	if snap.Cols > 0 {
+		cols = snap.Cols
+	}
+	if snap.Rows > 0 {
+		rows = snap.Rows
+	}
+	if cols != v.Width || rows != v.Height {
+		v.ResizeWithoutHistoryReveal(cols, rows)
+	}
 	v.LoadPaneCaptureWithCursorAndModes(snap.Data, snap.CursorX, snap.CursorY, snap.HasCursor, snap.ModeState)
 }
 


### PR DESCRIPTION
TerminalSnapshot carries the capture bytes, geometry, cursor and mode
state; LoadSnapshot/AppendDelta/PrependHistory are the unified entry
points over the historical per-shape variants. ptyio's session restore
uses them, and TerminalSnapshotFromPane bridges tmux.PaneSnapshot at the
ptyio boundary (tmux deliberately does not depend on vterm). Missing
mode state is an explicit PreserveExistingState decision, never a silent
default.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **F5**, 27/36). Stacked on `rp/f4-render-epochs`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.