### PR TITLE
G2: Harden tmux output parsing with parseTabFields

### DIFF
--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -89,6 +90,21 @@ func sessionPaneID(sessionName string, opts Options) (string, error) {
 	return firstAlive, nil
 }
 
+// parseTabFields splits a tab-separated tmux -F output line into trimmed
+// fields and verifies it has at least want of them. It exists so positional
+// indexing into tmux output can never panic and malformed lines surface as
+// errors instead of silent zero values.
+func parseTabFields(line string, want int) ([]string, error) {
+	parts := strings.Split(line, "\t")
+	if len(parts) < want {
+		return nil, fmt.Errorf("malformed tmux output line: got %d fields, want at least %d: %q", len(parts), want, line)
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts, nil
+}
+
 func paneCursorPosition(paneID string, opts Options) (int, int, bool, error) {
 	if paneID == "" {
 		return 0, 0, false, nil
@@ -100,17 +116,14 @@ func paneCursorPosition(paneID string, opts Options) (int, int, bool, error) {
 		return 0, 0, false, err
 	}
 	for _, line := range parseOutputLines(output) {
-		parts := strings.Split(line, "\t")
-		if len(parts) < 3 {
+		parts, err := parseTabFields(line, 3)
+		if err != nil || parts[0] != paneID {
 			continue
 		}
-		if strings.TrimSpace(parts[0]) != paneID {
-			continue
-		}
-		cursorX, errX := strconv.Atoi(strings.TrimSpace(parts[1]))
-		cursorY, errY := strconv.Atoi(strings.TrimSpace(parts[2]))
+		cursorX, errX := strconv.Atoi(parts[1])
+		cursorY, errY := strconv.Atoi(parts[2])
 		if errX != nil || errY != nil {
-			return 0, 0, false, nil
+			return 0, 0, false, fmt.Errorf("malformed cursor position for pane %s: %q", paneID, line)
 		}
 		return cursorX, cursorY, true, nil
 	}
@@ -128,17 +141,14 @@ func paneSize(paneID string, opts Options) (int, int, bool, error) {
 		return 0, 0, false, err
 	}
 	for _, line := range parseOutputLines(output) {
-		parts := strings.Split(line, "\t")
-		if len(parts) < 3 {
+		parts, err := parseTabFields(line, 3)
+		if err != nil || parts[0] != paneID {
 			continue
 		}
-		if strings.TrimSpace(parts[0]) != paneID {
-			continue
-		}
-		cols, errCols := strconv.Atoi(strings.TrimSpace(parts[1]))
-		rows, errRows := strconv.Atoi(strings.TrimSpace(parts[2]))
+		cols, errCols := strconv.Atoi(parts[1])
+		rows, errRows := strconv.Atoi(parts[2])
 		if errCols != nil || errRows != nil || cols <= 0 || rows <= 0 {
-			return 0, 0, false, nil
+			return 0, 0, false, fmt.Errorf("malformed pane size for pane %s: %q", paneID, line)
 		}
 		return cols, rows, true, nil
 	}

--- a/internal/tmux/capture_snapshot.go
+++ b/internal/tmux/capture_snapshot.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"strconv"
-	"strings"
 )
 
 func capturePaneSnapshotData(paneID string, opts Options) ([]byte, error) {
@@ -108,20 +107,20 @@ func paneSnapshotMetadataForPane(paneID string, opts Options) (paneSnapshotMetad
 		return paneSnapshotMetadata{}, err
 	}
 	for _, line := range parseOutputLines(output) {
-		parts := strings.Split(line, "\t")
-		if len(parts) < 12 || strings.TrimSpace(parts[0]) != paneID {
+		parts, err := parseTabFields(line, 12)
+		if err != nil || parts[0] != paneID {
 			continue
 		}
 		meta := paneSnapshotMetadata{}
-		cols, errCols := strconv.Atoi(strings.TrimSpace(parts[1]))
-		rows, errRows := strconv.Atoi(strings.TrimSpace(parts[2]))
+		cols, errCols := strconv.Atoi(parts[1])
+		rows, errRows := strconv.Atoi(parts[2])
 		if errCols == nil && errRows == nil && cols > 0 && rows > 0 {
 			meta.Cols = cols
 			meta.Rows = rows
 			meta.HasSize = true
 		}
-		cursorX, errCursorX := strconv.Atoi(strings.TrimSpace(parts[3]))
-		cursorY, errCursorY := strconv.Atoi(strings.TrimSpace(parts[4]))
+		cursorX, errCursorX := strconv.Atoi(parts[3])
+		cursorY, errCursorY := strconv.Atoi(parts[4])
 		if errCursorX == nil && errCursorY == nil {
 			meta.CursorX = cursorX
 			meta.CursorY = cursorY

--- a/internal/tmux/parse_tab_fields_test.go
+++ b/internal/tmux/parse_tab_fields_test.go
@@ -1,0 +1,24 @@
+package tmux
+
+import "testing"
+
+func TestParseTabFields(t *testing.T) {
+	parts, err := parseTabFields("%1\t 12 \t34", 3)
+	if err != nil {
+		t.Fatalf("parseTabFields error = %v", err)
+	}
+	if parts[0] != "%1" || parts[1] != "12" || parts[2] != "34" {
+		t.Fatalf("expected trimmed fields, got %q", parts)
+	}
+
+	if _, err := parseTabFields("%1\t12", 3); err == nil {
+		t.Fatal("expected error for line with too few fields")
+	}
+	if _, err := parseTabFields("", 2); err == nil {
+		t.Fatal("expected error for empty line")
+	}
+	// More fields than required is fine (forward compatible).
+	if _, err := parseTabFields("a\tb\tc\td", 3); err != nil {
+		t.Fatalf("unexpected error for extra fields: %v", err)
+	}
+}


### PR DESCRIPTION
parseTabFields splits tab-separated tmux -F output into trimmed fields
and verifies the field count, so positional indexing can never panic and
malformed matching lines surface as errors instead of silent zero
values. paneCursorPosition, paneSize and the pane snapshot metadata
parser use it; unit tests cover malformed lines.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G2**, 28/36). Stacked on `rp/f5-terminal-snapshot`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.