### PR TITLE
G3: Structure git command errors with Args, ExitCode and Stderr

### DIFF
--- a/internal/git/git_test_helpers_test.go
+++ b/internal/git/git_test_helpers_test.go
@@ -29,7 +29,8 @@ func runGit(t *testing.T, dir string, args ...string) string {
 		}
 	}
 
-	cmd.Env = append(env,
+	cmd.Env = append(
+		env,
 		"GIT_AUTHOR_NAME=Test",
 		"GIT_AUTHOR_EMAIL=test@example.com",
 		"GIT_COMMITTER_NAME=Test",

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -40,25 +40,26 @@ func RunGitCtx(ctx context.Context, dir string, args ...string) (string, error) 
 		if ctxErr := gitCommandContextErrorWithKill(ctx, err, args, killedByContext); ctxErr != nil {
 			return "", ctxErr
 		}
-		// Include stderr in error for debugging
-		if stderr.Len() > 0 {
-			return "", &Error{
-				Command: strings.Join(args, " "),
-				Stderr:  stderr.String(),
-				Err:     err,
-			}
-		}
-		return "", err
+		// Every non-context failure is structured so callers can classify by
+		// exit code and stderr.
+		return "", newGitError(args, stderr.String(), err)
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-// Error wraps git command errors with additional context
+// Error wraps git command errors with structured context: the exact argv,
+// the process exit code, and captured stderr. Callers classify failures by
+// matching ExitCode/Stderr through errors.As instead of parsing the prose of
+// Error().
 type Error struct {
-	Command string
-	Stderr  string
-	Err     error
+	Command string   // joined args, for display
+	Args    []string // exact argv passed to git
+	// ExitCode is the git process exit code; -1 when the process did not run
+	// or did not exit normally.
+	ExitCode int
+	Stderr   string
+	Err      error
 }
 
 func (e *Error) Error() string {
@@ -67,6 +68,22 @@ func (e *Error) Error() string {
 
 func (e *Error) Unwrap() error {
 	return e.Err
+}
+
+// newGitError builds a structured Error for a failed git invocation.
+func newGitError(args []string, stderr string, err error) *Error {
+	exitCode := -1
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	return &Error{
+		Command:  strings.Join(args, " "),
+		Args:     append([]string(nil), args...),
+		ExitCode: exitCode,
+		Stderr:   stderr,
+		Err:      err,
+	}
 }
 
 // IsGitRepository checks if the given path is a git repository
@@ -114,11 +131,7 @@ func RunGitAllowFailureCtx(ctx context.Context, dir string, args ...string) (str
 	// Only return error if there's actual stderr output indicating a problem
 	// and no stdout (which would indicate the command worked but returned non-zero)
 	if stderr.Len() > 0 && stdout.Len() == 0 {
-		return "", &Error{
-			Command: strings.Join(args, " "),
-			Stderr:  stderr.String(),
-			Err:     err,
-		}
+		return "", newGitError(args, stderr.String(), err)
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
@@ -143,14 +156,7 @@ func RunGitRawCtx(ctx context.Context, dir string, args ...string) ([]byte, erro
 		if ctxErr := gitCommandContextErrorWithKill(ctx, err, args, killedByContext); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if stderr.Len() > 0 {
-			return nil, &Error{
-				Command: strings.Join(args, " "),
-				Stderr:  stderr.String(),
-				Err:     err,
-			}
-		}
-		return nil, err
+		return nil, newGitError(args, stderr.String(), err)
 	}
 
 	return stdout.Bytes(), nil

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -63,7 +63,13 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return "git " + e.Command + ": " + e.Stderr
+	if e.Stderr != "" {
+		return "git " + e.Command + ": " + e.Stderr
+	}
+	if e.Err != nil {
+		return "git " + e.Command + ": " + e.Err.Error()
+	}
+	return "git " + e.Command
 }
 
 func (e *Error) Unwrap() error {

--- a/internal/git/operations_start_error_test.go
+++ b/internal/git/operations_start_error_test.go
@@ -1,0 +1,29 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunGitCtxStartErrorIncludesCause(t *testing.T) {
+	skipIfNoGit(t)
+
+	missingDir := filepath.Join(t.TempDir(), "missing")
+	_, err := RunGitCtx(context.Background(), missingDir, "status")
+	if err == nil {
+		t.Fatal("expected invalid working directory error")
+	}
+	var gitErr *Error
+	if !errors.As(err, &gitErr) {
+		t.Fatalf("expected structured git error, got %T", err)
+	}
+	if gitErr.Stderr != "" {
+		t.Fatalf("expected start failure to have empty stderr, got %q", gitErr.Stderr)
+	}
+	if !strings.Contains(err.Error(), "chdir") && !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("expected error string to include start failure cause, got %v", err)
+	}
+}

--- a/internal/git/workspace.go
+++ b/internal/git/workspace.go
@@ -115,10 +115,17 @@ func isBranchAlreadyExistsError(err error, branch string) bool {
 	if branch == "" {
 		return false
 	}
+	// Classify through the structured error: a failed git invocation with the
+	// branch-exists message on stderr. Matching is restricted to stderr (never
+	// the command line) so a branch name appearing in argv cannot false-match.
+	var gitErr *Error
+	if !errors.As(err, &gitErr) || gitErr.ExitCode == 0 {
+		return false
+	}
 	// Normalize backtick quoting to a single straight quote so we match git's
 	// "a branch named '<x>'" and "branch '<x>'" phrasings without enumerating
 	// quote permutations.
-	msg := strings.ReplaceAll(strings.ToLower(err.Error()), "`", "'")
+	msg := strings.ReplaceAll(strings.ToLower(gitErr.Stderr), "`", "'")
 	if strings.Contains(msg, "a branch named '"+branch+"' already exists") {
 		return true
 	}

--- a/internal/git/workspace_test.go
+++ b/internal/git/workspace_test.go
@@ -137,21 +137,33 @@ branch refs/heads/feature-branch
 }
 
 func TestIsBranchAlreadyExistsError(t *testing.T) {
-	err := errors.New("fatal: a branch named 'feature-a' already exists")
+	gitErr := func(stderr string) error {
+		return &Error{Command: "worktree add", ExitCode: 128, Stderr: stderr, Err: errors.New("exit status 128")}
+	}
+	err := gitErr("fatal: a branch named 'feature-a' already exists")
 	if !isBranchAlreadyExistsError(err, "feature-a") {
 		t.Fatalf("expected branch already exists error to match")
 	}
-	if !isBranchAlreadyExistsError(errors.New("fatal: a branch named `feature-a` already exists"), "feature-a") {
+	if !isBranchAlreadyExistsError(gitErr("fatal: a branch named `feature-a` already exists"), "feature-a") {
 		t.Fatalf("expected backtick-quoted branch error to match after normalization")
 	}
 	if isBranchAlreadyExistsError(err, "feature-b") {
 		t.Fatalf("expected non-matching branch name to return false")
 	}
-	if isBranchAlreadyExistsError(errors.New("fatal: branch lock failed"), "feature-a") {
+	if isBranchAlreadyExistsError(gitErr("fatal: branch lock failed"), "feature-a") {
 		t.Fatalf("expected unrelated branch error to return false")
 	}
-	if isBranchAlreadyExistsError(errors.New("fatal: already exists"), "") {
+	if isBranchAlreadyExistsError(gitErr("fatal: already exists"), "") {
 		t.Fatalf("expected empty branch name to return false")
+	}
+	// Unstructured errors never classify: the branch-exists decision flows
+	// through the structured Error's stderr/exit code only.
+	if isBranchAlreadyExistsError(errors.New("fatal: a branch named 'feature-a' already exists"), "feature-a") {
+		t.Fatalf("expected plain (non-*Error) error to return false")
+	}
+	// The branch name appearing only in the command line must not match.
+	if isBranchAlreadyExistsError(&Error{Command: "worktree add -b feature-a", ExitCode: 128, Stderr: "fatal: permission denied"}, "feature-a") {
+		t.Fatalf("expected command-line-only match to return false")
 	}
 }
 
@@ -171,7 +183,7 @@ func TestCreateWorkspace_RetryUsesFreshContext(t *testing.T) {
 			if got, want := strings.Join(args, " "), "worktree add -b feature-ws /tmp/ws HEAD"; got != want {
 				t.Fatalf("first call args = %q, want %q", got, want)
 			}
-			return "", errors.New("fatal: a branch named 'feature-ws' already exists")
+			return "", &Error{Command: "worktree add", ExitCode: 128, Stderr: "fatal: a branch named 'feature-ws' already exists", Err: errors.New("exit status 128")}
 		case 2:
 			if firstCtx == nil {
 				t.Fatalf("expected first context to be captured")


### PR DESCRIPTION
Every non-context exit from RunGitCtx/RunGitAllowFailureCtx/RunGitRawCtx
now returns a structured *Error carrying the exact argv, process exit
code and captured stderr. Branch-already-exists classification flows
through it via errors.As, matching stderr only — a branch name appearing
in the command line can no longer false-match — instead of parsing the
prose of Error().

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G3**, 29/36). Stacked on `rp/g2-parse-tab-fields`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.