### PR TITLE
G4: Write workspace cleanup markers as versioned JSON

### DIFF
--- a/internal/git/workspace_cleanup_marker.go
+++ b/internal/git/workspace_cleanup_marker.go
@@ -192,11 +192,12 @@ func writeWorkspaceCleanupState(workspacePath string, state workspaceCleanupStat
 		return clearPrunedWorkspaceRetryMarker(workspacePath)
 	}
 
+	needsUnregister := state.NeedsUnregister
 	payload, err := json.Marshal(workspaceCleanupMarkerFile{
 		Version:                workspaceCleanupMarkerVersion,
 		RepoPath:               state.RepoPath,
 		CleanupPath:            state.CleanupPath,
-		NeedsUnregister:        state.NeedsUnregister,
+		NeedsUnregister:        &needsUnregister,
 		WorkspaceGitRef:        state.WorkspaceGitRef,
 		WorkspaceGitRefModTime: state.WorkspaceGitRefModTime,
 		WorkspaceFingerprint:   state.WorkspaceFingerprint,
@@ -218,7 +219,7 @@ type workspaceCleanupMarkerFile struct {
 	Version                int    `json:"version"`
 	RepoPath               string `json:"repo_path,omitempty"`
 	CleanupPath            string `json:"cleanup_path,omitempty"`
-	NeedsUnregister        bool   `json:"needs_unregister"`
+	NeedsUnregister        *bool  `json:"needs_unregister"`
 	WorkspaceGitRef        string `json:"workspace_git_ref,omitempty"`
 	WorkspaceGitRefModTime int64  `json:"workspace_git_ref_mtime_unix_nano,omitempty"`
 	WorkspaceFingerprint   string `json:"workspace_fingerprint,omitempty"`
@@ -234,8 +235,11 @@ func parseWorkspaceCleanupMarkerJSON(trimmed, markerPath string) (workspaceClean
 	if file.Version != workspaceCleanupMarkerVersion {
 		return workspaceCleanupState{}, fmt.Errorf("unsupported workspace cleanup marker version %d in %s", file.Version, markerPath)
 	}
+	if file.NeedsUnregister == nil {
+		return workspaceCleanupState{}, fmt.Errorf("incomplete workspace cleanup marker %s: missing needs_unregister", markerPath)
+	}
 	state := workspaceCleanupState{
-		NeedsUnregister:        file.NeedsUnregister,
+		NeedsUnregister:        *file.NeedsUnregister,
 		WorkspaceGitRef:        file.WorkspaceGitRef,
 		WorkspaceGitRefModTime: file.WorkspaceGitRefModTime,
 		WorkspaceFingerprint:   file.WorkspaceFingerprint,
@@ -245,6 +249,9 @@ func parseWorkspaceCleanupMarkerJSON(trimmed, markerPath string) (workspaceClean
 	}
 	if file.CleanupPath != "" {
 		state.CleanupPath = filepath.Clean(file.CleanupPath)
+	}
+	if state.CleanupPath == "" && !state.NeedsUnregister {
+		return workspaceCleanupState{}, fmt.Errorf("incomplete workspace cleanup marker %s: no cleanup action", markerPath)
 	}
 	return state, nil
 }

--- a/internal/git/workspace_cleanup_marker.go
+++ b/internal/git/workspace_cleanup_marker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 )
 
 const prunedWorkspaceCleanupRetryMetadataName = ".amux-pruned-worktree-retry"
@@ -174,10 +175,18 @@ func writeWorkspaceCleanupState(workspacePath string, state workspaceCleanupStat
 		return fmt.Errorf("refusing to persist legacy-ambiguous workspace cleanup state for %s", workspacePath)
 	}
 	if state.RepoPath != "" {
+		if !utf8.ValidString(state.RepoPath) {
+			return fmt.Errorf("refusing to persist non-UTF-8 workspace cleanup repo path")
+		}
 		state.RepoPath = filepath.Clean(state.RepoPath)
 	}
-	if state.CleanupPath != "" && !isSafeWorkspaceCleanupPath(state.CleanupPath) {
-		return fmt.Errorf("refusing to persist unsafe workspace cleanup path: %s", state.CleanupPath)
+	if state.CleanupPath != "" {
+		if !utf8.ValidString(state.CleanupPath) {
+			return fmt.Errorf("refusing to persist non-UTF-8 workspace cleanup path")
+		}
+		if !isSafeWorkspaceCleanupPath(state.CleanupPath) {
+			return fmt.Errorf("refusing to persist unsafe workspace cleanup path: %s", state.CleanupPath)
+		}
 	}
 	if !state.NeedsUnregister && state.CleanupPath == "" {
 		return clearPrunedWorkspaceRetryMarker(workspacePath)

--- a/internal/git/workspace_cleanup_marker.go
+++ b/internal/git/workspace_cleanup_marker.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -176,13 +177,13 @@ func writeWorkspaceCleanupState(workspacePath string, state workspaceCleanupStat
 	}
 	if state.RepoPath != "" {
 		if !utf8.ValidString(state.RepoPath) {
-			return fmt.Errorf("refusing to persist non-UTF-8 workspace cleanup repo path")
+			return errors.New("refusing to persist non-UTF-8 workspace cleanup repo path")
 		}
 		state.RepoPath = filepath.Clean(state.RepoPath)
 	}
 	if state.CleanupPath != "" {
 		if !utf8.ValidString(state.CleanupPath) {
-			return fmt.Errorf("refusing to persist non-UTF-8 workspace cleanup path")
+			return errors.New("refusing to persist non-UTF-8 workspace cleanup path")
 		}
 		if !isSafeWorkspaceCleanupPath(state.CleanupPath) {
 			return fmt.Errorf("refusing to persist unsafe workspace cleanup path: %s", state.CleanupPath)

--- a/internal/git/workspace_cleanup_marker.go
+++ b/internal/git/workspace_cleanup_marker.go
@@ -6,13 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-)
-
-var (
-	writeRetryMarkerRenamePath = os.Rename
-	writeRetryMarkerRemovePath = os.Remove
 )
 
 const prunedWorkspaceCleanupRetryMetadataName = ".amux-pruned-worktree-retry"
@@ -244,80 +238,6 @@ func parseWorkspaceCleanupMarkerJSON(trimmed, markerPath string) (workspaceClean
 		state.CleanupPath = filepath.Clean(file.CleanupPath)
 	}
 	return state, nil
-}
-
-func writeRetryMarkerFileAtomically(path string, payload []byte, perm os.FileMode) error {
-	return writeRetryMarkerFileAtomicallyForGOOS(runtime.GOOS, path, payload, perm)
-}
-
-func writeRetryMarkerFileAtomicallyForGOOS(goos, path string, payload []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tempFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tempPath := tempFile.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tempPath)
-		}
-	}()
-
-	if err := tempFile.Chmod(perm); err != nil {
-		_ = tempFile.Close()
-		return err
-	}
-	if _, err := tempFile.Write(payload); err != nil {
-		_ = tempFile.Close()
-		return err
-	}
-	if err := tempFile.Close(); err != nil {
-		return err
-	}
-	if goos == "windows" {
-		if err := replaceFileForWindows(path, tempPath); err != nil {
-			return err
-		}
-	} else {
-		if err := writeRetryMarkerRenamePath(tempPath, path); err != nil {
-			return err
-		}
-	}
-	cleanup = false
-	return nil
-}
-
-func replaceFileForWindows(path, tempPath string) error {
-	backupPath := retryMarkerBackupPath(path)
-	hadPrimary := false
-	hadBackupOnly := false
-	if _, err := os.Stat(path); err == nil {
-		hadPrimary = true
-		if err := writeRetryMarkerRemovePath(backupPath); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		if err := writeRetryMarkerRenamePath(path, backupPath); err != nil {
-			return err
-		}
-	} else if !os.IsNotExist(err) {
-		return err
-	} else if _, err := os.Stat(backupPath); err == nil {
-		hadBackupOnly = true
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	if err := writeRetryMarkerRenamePath(tempPath, path); err != nil {
-		if hadPrimary {
-			_ = writeRetryMarkerRenamePath(backupPath, path)
-		}
-		return err
-	}
-	if hadPrimary || hadBackupOnly {
-		_ = writeRetryMarkerRemovePath(backupPath)
-	}
-	return nil
 }
 
 func readWorkspaceCleanupMarkerFile(markerPath string) ([]byte, error) {

--- a/internal/git/workspace_cleanup_marker.go
+++ b/internal/git/workspace_cleanup_marker.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,6 +60,16 @@ func readWorkspaceCleanupState(workspacePath string) (workspaceCleanupState, boo
 	trimmed := strings.TrimSpace(string(content))
 	if trimmed == "" {
 		return workspaceCleanupState{}, false, fmt.Errorf("empty workspace cleanup marker: %s", markerPath)
+	}
+	// Current format: versioned JSON. Legacy formats (ambiguous prose,
+	// single-line prefixed paths, key=value) remain readable below but are
+	// never written anymore.
+	if strings.HasPrefix(trimmed, "{") {
+		state, err := parseWorkspaceCleanupMarkerJSON(trimmed, markerPath)
+		if err != nil {
+			return workspaceCleanupState{}, false, err
+		}
+		return state, true, nil
 	}
 	if trimmed == "pruned workspace cleanup pending" {
 		return workspaceCleanupState{LegacyAmbiguous: true}, true, nil
@@ -178,17 +189,61 @@ func writeWorkspaceCleanupState(workspacePath string, state workspaceCleanupStat
 		return clearPrunedWorkspaceRetryMarker(workspacePath)
 	}
 
-	var builder strings.Builder
-	fmt.Fprintf(&builder, "repo_path=%s\n", state.RepoPath)
-	fmt.Fprintf(&builder, "cleanup_path=%s\n", state.CleanupPath)
-	fmt.Fprintf(&builder, "needs_unregister=%t\n", state.NeedsUnregister)
-	fmt.Fprintf(&builder, "workspace_git_ref=%s\n", state.WorkspaceGitRef)
-	fmt.Fprintf(&builder, "workspace_git_ref_mtime_unix_nano=%d\n", state.WorkspaceGitRefModTime)
-	if state.WorkspaceFingerprint != "" {
-		fmt.Fprintf(&builder, "workspace_fingerprint=%s\n", state.WorkspaceFingerprint)
+	payload, err := json.Marshal(workspaceCleanupMarkerFile{
+		Version:                workspaceCleanupMarkerVersion,
+		RepoPath:               state.RepoPath,
+		CleanupPath:            state.CleanupPath,
+		NeedsUnregister:        state.NeedsUnregister,
+		WorkspaceGitRef:        state.WorkspaceGitRef,
+		WorkspaceGitRefModTime: state.WorkspaceGitRefModTime,
+		WorkspaceFingerprint:   state.WorkspaceFingerprint,
+	})
+	if err != nil {
+		return fmt.Errorf("encode workspace cleanup marker: %w", err)
 	}
-	payload := []byte(builder.String())
 	return writeRetryMarkerFile(prunedWorkspaceRetryMarkerPath(workspacePath), payload, 0o600)
+}
+
+// workspaceCleanupMarkerVersion is the current on-disk marker format version.
+const workspaceCleanupMarkerVersion = 1
+
+// workspaceCleanupMarkerFile is the versioned JSON codec for the cleanup
+// marker. Read-side support for the legacy formats (prose, prefixed
+// single-line, key=value) lives in readWorkspaceCleanupState; only this
+// format is written.
+type workspaceCleanupMarkerFile struct {
+	Version                int    `json:"version"`
+	RepoPath               string `json:"repo_path,omitempty"`
+	CleanupPath            string `json:"cleanup_path,omitempty"`
+	NeedsUnregister        bool   `json:"needs_unregister"`
+	WorkspaceGitRef        string `json:"workspace_git_ref,omitempty"`
+	WorkspaceGitRefModTime int64  `json:"workspace_git_ref_mtime_unix_nano,omitempty"`
+	WorkspaceFingerprint   string `json:"workspace_fingerprint,omitempty"`
+}
+
+func parseWorkspaceCleanupMarkerJSON(trimmed, markerPath string) (workspaceCleanupState, error) {
+	var file workspaceCleanupMarkerFile
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&file); err != nil {
+		return workspaceCleanupState{}, fmt.Errorf("invalid workspace cleanup marker %s: %w", markerPath, err)
+	}
+	if file.Version != workspaceCleanupMarkerVersion {
+		return workspaceCleanupState{}, fmt.Errorf("unsupported workspace cleanup marker version %d in %s", file.Version, markerPath)
+	}
+	state := workspaceCleanupState{
+		NeedsUnregister:        file.NeedsUnregister,
+		WorkspaceGitRef:        file.WorkspaceGitRef,
+		WorkspaceGitRefModTime: file.WorkspaceGitRefModTime,
+		WorkspaceFingerprint:   file.WorkspaceFingerprint,
+	}
+	if file.RepoPath != "" {
+		state.RepoPath = filepath.Clean(file.RepoPath)
+	}
+	if file.CleanupPath != "" {
+		state.CleanupPath = filepath.Clean(file.CleanupPath)
+	}
+	return state, nil
 }
 
 func writeRetryMarkerFileAtomically(path string, payload []byte, perm os.FileMode) error {

--- a/internal/git/workspace_cleanup_marker_atomic.go
+++ b/internal/git/workspace_cleanup_marker_atomic.go
@@ -1,0 +1,84 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	writeRetryMarkerRenamePath = os.Rename
+	writeRetryMarkerRemovePath = os.Remove
+)
+
+func writeRetryMarkerFileAtomically(path string, payload []byte, perm os.FileMode) error {
+	return writeRetryMarkerFileAtomicallyForGOOS(runtime.GOOS, path, payload, perm)
+}
+
+func writeRetryMarkerFileAtomicallyForGOOS(goos, path string, payload []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tempFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := tempFile.Chmod(perm); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if _, err := tempFile.Write(payload); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if goos == "windows" {
+		if err := replaceFileForWindows(path, tempPath); err != nil {
+			return err
+		}
+	} else if err := writeRetryMarkerRenamePath(tempPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func replaceFileForWindows(path, tempPath string) error {
+	backupPath := retryMarkerBackupPath(path)
+	hadPrimary := false
+	hadBackupOnly := false
+	if _, err := os.Stat(path); err == nil {
+		hadPrimary = true
+		if err := writeRetryMarkerRemovePath(backupPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := writeRetryMarkerRenamePath(path, backupPath); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	} else if _, err := os.Stat(backupPath); err == nil {
+		hadBackupOnly = true
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := writeRetryMarkerRenamePath(tempPath, path); err != nil {
+		if hadPrimary {
+			_ = writeRetryMarkerRenamePath(backupPath, path)
+		}
+		return err
+	}
+	if hadPrimary || hadBackupOnly {
+		_ = writeRetryMarkerRemovePath(backupPath)
+	}
+	return nil
+}

--- a/internal/git/workspace_cleanup_marker_atomic.go
+++ b/internal/git/workspace_cleanup_marker_atomic.go
@@ -53,24 +53,10 @@ func writeRetryMarkerFileAtomicallyForGOOS(goos, path string, payload []byte, pe
 
 func replaceFileForWindows(path, tempPath string) error {
 	backupPath := retryMarkerBackupPath(path)
-	hadPrimary := false
-	hadBackupOnly := false
-	if _, err := os.Stat(path); err == nil {
-		hadPrimary = true
-		if err := writeRetryMarkerRemovePath(backupPath); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		if err := writeRetryMarkerRenamePath(path, backupPath); err != nil {
-			return err
-		}
-	} else if !os.IsNotExist(err) {
-		return err
-	} else if _, err := os.Stat(backupPath); err == nil {
-		hadBackupOnly = true
-	} else if !os.IsNotExist(err) {
+	hadPrimary, hadBackupOnly, err := prepareRetryMarkerWindowsBackup(path, backupPath)
+	if err != nil {
 		return err
 	}
-
 	if err := writeRetryMarkerRenamePath(tempPath, path); err != nil {
 		if hadPrimary {
 			_ = writeRetryMarkerRenamePath(backupPath, path)
@@ -81,4 +67,24 @@ func replaceFileForWindows(path, tempPath string) error {
 		_ = writeRetryMarkerRemovePath(backupPath)
 	}
 	return nil
+}
+
+func prepareRetryMarkerWindowsBackup(path, backupPath string) (hadPrimary, hadBackupOnly bool, err error) {
+	if _, err := os.Stat(path); err == nil {
+		if err := writeRetryMarkerRemovePath(backupPath); err != nil && !os.IsNotExist(err) {
+			return false, false, err
+		}
+		if err := writeRetryMarkerRenamePath(path, backupPath); err != nil {
+			return false, false, err
+		}
+		return true, false, nil
+	} else if !os.IsNotExist(err) {
+		return false, false, err
+	}
+	if _, err := os.Stat(backupPath); err == nil {
+		return false, true, nil
+	} else if !os.IsNotExist(err) {
+		return false, false, err
+	}
+	return false, false, nil
 }

--- a/internal/git/workspace_cleanup_marker_format_test.go
+++ b/internal/git/workspace_cleanup_marker_format_test.go
@@ -1,0 +1,84 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeMarker(t *testing.T, workspacePath, content string) {
+	t.Helper()
+	if err := os.WriteFile(prunedWorkspaceRetryMarkerPath(workspacePath), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkspaceCleanupMarkerWritesVersionedJSON(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	cleanup := filepath.Join(dir, "ws.amux-cleanup")
+
+	if err := writeWorkspaceCleanupState(ws, workspaceCleanupState{
+		RepoPath:        filepath.Join(dir, "repo"),
+		CleanupPath:     cleanup,
+		NeedsUnregister: true,
+	}); err != nil {
+		t.Fatalf("writeWorkspaceCleanupState error = %v", err)
+	}
+
+	raw, err := os.ReadFile(prunedWorkspaceRetryMarkerPath(ws))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(raw)), "{") {
+		t.Fatalf("expected JSON marker, got %q", raw)
+	}
+	if !strings.Contains(string(raw), `"version":1`) {
+		t.Fatalf("expected version field, got %q", raw)
+	}
+
+	state, marked, err := readWorkspaceCleanupState(ws)
+	if err != nil || !marked {
+		t.Fatalf("readWorkspaceCleanupState = (%+v, %v, %v)", state, marked, err)
+	}
+	if state.CleanupPath != filepath.Clean(cleanup) || !state.NeedsUnregister {
+		t.Fatalf("round-trip mismatch: %+v", state)
+	}
+}
+
+func TestWorkspaceCleanupMarkerReadsLegacyFormats(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	cleanup := filepath.Join(dir, "stage")
+
+	// Legacy ambiguous prose.
+	writeMarker(t, ws, "pruned workspace cleanup pending")
+	state, marked, err := readWorkspaceCleanupState(ws)
+	if err != nil || !marked || !state.LegacyAmbiguous {
+		t.Fatalf("legacy prose: (%+v, %v, %v)", state, marked, err)
+	}
+
+	// Legacy prefixed single line.
+	writeMarker(t, ws, "su:"+cleanup)
+	state, marked, err = readWorkspaceCleanupState(ws)
+	if err != nil || !marked || !state.NeedsUnregister || state.CleanupPath != filepath.Clean(cleanup) {
+		t.Fatalf("legacy prefixed: (%+v, %v, %v)", state, marked, err)
+	}
+
+	// Legacy key=value.
+	writeMarker(t, ws, "repo_path=\ncleanup_path="+cleanup+"\nneeds_unregister=true\nworkspace_git_ref=\nworkspace_git_ref_mtime_unix_nano=0\n")
+	state, marked, err = readWorkspaceCleanupState(ws)
+	if err != nil || !marked || !state.NeedsUnregister || state.CleanupPath != filepath.Clean(cleanup) {
+		t.Fatalf("legacy key=value: (%+v, %v, %v)", state, marked, err)
+	}
+}
+
+func TestWorkspaceCleanupMarkerRejectsUnknownVersion(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	writeMarker(t, ws, `{"version":99,"cleanup_path":"/x","needs_unregister":true}`)
+	if _, _, err := readWorkspaceCleanupState(ws); err == nil {
+		t.Fatal("expected unknown marker version to be rejected")
+	}
+}

--- a/internal/git/workspace_cleanup_marker_format_test.go
+++ b/internal/git/workspace_cleanup_marker_format_test.go
@@ -82,3 +82,19 @@ func TestWorkspaceCleanupMarkerRejectsUnknownVersion(t *testing.T) {
 		t.Fatal("expected unknown marker version to be rejected")
 	}
 }
+
+func TestWorkspaceCleanupMarkerRejectsNonUTF8Paths(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	badPath := string([]byte{'/', 't', 'm', 'p', '/', 0xff})
+
+	if err := writeWorkspaceCleanupState(ws, workspaceCleanupState{CleanupPath: badPath}); err == nil {
+		t.Fatal("expected non-UTF-8 cleanup path to be rejected")
+	}
+	if err := writeWorkspaceCleanupState(ws, workspaceCleanupState{
+		RepoPath:        badPath,
+		NeedsUnregister: true,
+	}); err == nil {
+		t.Fatal("expected non-UTF-8 repo path to be rejected")
+	}
+}

--- a/internal/git/workspace_cleanup_marker_format_test.go
+++ b/internal/git/workspace_cleanup_marker_format_test.go
@@ -83,6 +83,20 @@ func TestWorkspaceCleanupMarkerRejectsUnknownVersion(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCleanupMarkerRejectsIncompleteJSON(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+
+	writeMarker(t, ws, `{"version":1,"cleanup_path":"/tmp/ws.amux-cleanup"}`)
+	if _, _, err := readWorkspaceCleanupState(ws); err == nil {
+		t.Fatal("expected missing needs_unregister to be rejected")
+	}
+	writeMarker(t, ws, `{"version":1,"needs_unregister":false}`)
+	if _, _, err := readWorkspaceCleanupState(ws); err == nil {
+		t.Fatal("expected marker with no cleanup action to be rejected")
+	}
+}
+
 func TestWorkspaceCleanupMarkerRejectsNonUTF8Paths(t *testing.T) {
 	dir := t.TempDir()
 	ws := filepath.Join(dir, "ws")


### PR DESCRIPTION
Replace the hand-rolled key=value writer with a versioned JSON codec
({"version":1,...}); read-side support for the legacy formats (ambiguous
prose, prefixed single-line paths, key=value) is retained, and unknown
versions are rejected rather than misread. Round-trip, legacy-read and
version-rejection tests included.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G4**, 31/36). Stacked on `rp/g6-fsatomic`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.