### PR TITLE
G7: Fold FilterKnownPTYNoise into the stream variant

### DIFF
--- a/internal/ui/ptyio/pty_output_filter.go
+++ b/internal/ui/ptyio/pty_output_filter.go
@@ -6,50 +6,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// FilterKnownPTYNoise removes known host-runtime diagnostic lines that should
-// not be rendered inside interactive agent prompts.
-func FilterKnownPTYNoise(data []byte) []byte {
-	if len(data) == 0 || !mightContainMallocDiagnostic(data) {
-		return data
-	}
-
-	out := make([]byte, 0, len(data))
-	removed := false
-	start := 0
-
-	for start < len(data) {
-		rel := bytes.IndexByte(data[start:], '\n')
-		end := len(data)
-		hasNewline := false
-		if rel >= 0 {
-			end = start + rel
-			hasNewline = true
-		}
-
-		line := data[start:end]
-		// PTY chunks may end mid-line; avoid filtering incomplete trailing
-		// fragments because the remainder may arrive in a future flush.
-		if !hasNewline {
-			out = append(out, line...)
-			break
-		}
-		trimmed := bytes.TrimRight(line, "\r")
-		if isMacOSMallocDiagnosticLine(trimmed) {
-			removed = true
-		} else {
-			out = append(out, line...)
-			out = append(out, '\n')
-		}
-
-		start = end + 1
-	}
-
-	if !removed {
-		return data
-	}
-	return out
-}
-
 // DrainKnownPTYNoiseTrailing flushes any carried line fragment at stream end.
 func DrainKnownPTYNoiseTrailing(trailing *[]byte) []byte {
 	if trailing == nil || len(*trailing) == 0 {
@@ -64,7 +20,19 @@ func DrainKnownPTYNoiseTrailing(trailing *[]byte) []byte {
 // trailing diagnostic fragment between chunks so split lines can be removed.
 func FilterKnownPTYNoiseStream(data []byte, trailing *[]byte) []byte {
 	if trailing == nil {
-		return FilterKnownPTYNoise(data)
+		// Stateless call: filter with a local, discarded carry. An incomplete
+		// trailing fragment is passed through unfiltered — the remainder may
+		// arrive in a chunk this caller will never see, so holding it back
+		// would lose output.
+		var local []byte
+		filtered := FilterKnownPTYNoiseStream(data, &local)
+		if len(local) > 0 {
+			out := make([]byte, 0, len(filtered)+len(local))
+			out = append(out, filtered...)
+			out = append(out, local...)
+			return out
+		}
+		return filtered
 	}
 
 	carried := 0

--- a/internal/ui/ptyio/pty_output_filter_test.go
+++ b/internal/ui/ptyio/pty_output_filter_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestFilterKnownPTYNoise_RemovesMacOSMallocDiagnosticLine(t *testing.T) {
 	in := []byte("hello\r\ncodex(32758,0x16f58f000) malloc: nano zone abandoned\r\nworld\r\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	want := "hello\r\nworld\r\n"
 	if string(got) != want {
 		t.Fatalf("filtered output = %q, want %q", string(got), want)
@@ -13,7 +13,7 @@ func TestFilterKnownPTYNoise_RemovesMacOSMallocDiagnosticLine(t *testing.T) {
 
 func TestFilterKnownPTYNoise_RemovesUppercaseMallocPrefix(t *testing.T) {
 	in := []byte("codex(32758) Malloc: debugging enabled\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if len(got) != 0 {
 		t.Fatalf("expected diagnostic line to be removed, got %q", string(got))
 	}
@@ -21,7 +21,7 @@ func TestFilterKnownPTYNoise_RemovesUppercaseMallocPrefix(t *testing.T) {
 
 func TestFilterKnownPTYNoise_KeepsNormalOutput(t *testing.T) {
 	in := []byte("> codex review malloc issue\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if string(got) != string(in) {
 		t.Fatalf("normal output was modified: got %q want %q", string(got), string(in))
 	}
@@ -29,7 +29,7 @@ func TestFilterKnownPTYNoise_KeepsNormalOutput(t *testing.T) {
 
 func TestFilterKnownPTYNoise_KeepsNonDiagnosticMallocMentions(t *testing.T) {
 	in := []byte("alloc_report(42) mallocz: custom allocator stats\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if string(got) != string(in) {
 		t.Fatalf("non-diagnostic line was removed: got %q want %q", string(got), string(in))
 	}
@@ -37,7 +37,7 @@ func TestFilterKnownPTYNoise_KeepsNonDiagnosticMallocMentions(t *testing.T) {
 
 func TestFilterKnownPTYNoise_KeepsIncompleteTrailingDiagnosticFragment(t *testing.T) {
 	in := []byte("prefix\ncodex(32758,0x16f58f000) malloc: nano zone")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if string(got) != string(in) {
 		t.Fatalf("incomplete trailing fragment was modified: got %q want %q", string(got), string(in))
 	}
@@ -45,7 +45,7 @@ func TestFilterKnownPTYNoise_KeepsIncompleteTrailingDiagnosticFragment(t *testin
 
 func TestFilterKnownPTYNoise_RemovesMixedCaseMallocPrefix(t *testing.T) {
 	in := []byte("codex(32758) mAlLoC: debugging enabled\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if len(got) != 0 {
 		t.Fatalf("expected mixed-case diagnostic line to be removed, got %q", string(got))
 	}
@@ -53,7 +53,7 @@ func TestFilterKnownPTYNoise_RemovesMixedCaseMallocPrefix(t *testing.T) {
 
 func TestFilterKnownPTYNoise_RemovesDiagnosticLineWithANSI(t *testing.T) {
 	in := []byte("\x1b[31mcodex(32758) malloc: debugging enabled\x1b[0m\n")
-	got := FilterKnownPTYNoise(in)
+	got := FilterKnownPTYNoiseStream(in, nil)
 	if len(got) != 0 {
 		t.Fatalf("expected ANSI-styled diagnostic line to be removed, got %q", string(got))
 	}


### PR DESCRIPTION
The stateless entry point becomes FilterKnownPTYNoiseStream(data, nil),
which filters with a local discarded carry and passes any incomplete
trailing fragment through unfiltered. Removes the duplicated line-walk;
perf-checked against the harness presets.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G7**, 33/36). Stacked on `rp/g5-cleanup-fsm`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.