### PR TITLE
G8: Parse the config file once

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/andyrewlee/amux/internal/logging"
+
 	"github.com/andyrewlee/amux/internal/validation"
 )
 
@@ -52,20 +54,48 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
-	// loadAssistantOverrides and loadUISettings each read the config file
-	// independently. This is intentional: each loader fails independently and
-	// returns safe defaults, keeping the two subsystems decoupled.
+	// The config file is parsed exactly once; each section loader receives
+	// its slice of the parsed structure. A corrupted file therefore surfaces
+	// one warning here instead of two independent silent default fallbacks.
+	file, err := readConfigFile(paths.ConfigPath)
+	if err != nil {
+		logging.Warn("config: failed to parse %s; using defaults: %v", paths.ConfigPath, err)
+	}
+
 	assistants := defaultAssistants()
-	loadAssistantOverrides(paths.ConfigPath, assistants)
+	applyAssistantOverrides(assistants, file.Assistants)
 
 	cfg := &Config{
 		Paths:         paths,
 		PortStart:     6200,
 		PortRangeSize: 10,
-		UI:            loadUISettings(paths.ConfigPath),
+		UI:            applyUISettings(defaultUISettings(), file.UI),
 		Assistants:    assistants,
 	}
 	return cfg, nil
+}
+
+// configFile is the single on-disk config schema.
+type configFile struct {
+	Assistants map[string]assistantConfigRaw `json:"assistants"`
+	UI         uiSettingsRaw                 `json:"ui"`
+}
+
+// readConfigFile parses the config file once. A missing file is not an
+// error; a corrupted file returns the parse error along with zero contents.
+func readConfigFile(path string) (configFile, error) {
+	var file configFile
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return file, nil
+		}
+		return file, err
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return configFile{}, err
+	}
+	return file, nil
 }
 
 // AssistantNames returns assistant IDs in deterministic display order.
@@ -143,20 +173,10 @@ func defaultAssistants() map[string]AssistantConfig {
 	}
 }
 
-func loadAssistantOverrides(path string, assistants map[string]AssistantConfig) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return
-	}
-
-	var raw struct {
-		Assistants map[string]assistantConfigRaw `json:"assistants"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return
-	}
-
-	for name, override := range raw.Assistants {
+// applyAssistantOverrides overlays parsed config-file assistant entries onto
+// the built-in defaults.
+func applyAssistantOverrides(assistants map[string]AssistantConfig, overrides map[string]assistantConfigRaw) {
+	for name, override := range overrides {
 		normalized := normalizeAssistantName(name)
 		if normalized == "" {
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -54,12 +56,11 @@ func DefaultConfig() (*Config, error) {
 		return nil, err
 	}
 
-	// The config file is parsed exactly once; each section loader receives
-	// its slice of the parsed structure. A corrupted file therefore surfaces
-	// one warning here instead of two independent silent default fallbacks.
+	// The config file is read exactly once; section decode errors are isolated
+	// so valid sections can still override their defaults.
 	file, err := readConfigFile(paths.ConfigPath)
 	if err != nil {
-		logging.Warn("config: failed to parse %s; using defaults: %v", paths.ConfigPath, err)
+		logging.Warn("config: failed to parse %s; using valid sections and defaults: %v", paths.ConfigPath, err)
 	}
 
 	assistants := defaultAssistants()
@@ -81,8 +82,14 @@ type configFile struct {
 	UI         uiSettingsRaw                 `json:"ui"`
 }
 
-// readConfigFile parses the config file once. A missing file is not an
-// error; a corrupted file returns the parse error along with zero contents.
+type configFileSections struct {
+	Assistants json.RawMessage `json:"assistants"`
+	UI         json.RawMessage `json:"ui"`
+}
+
+// readConfigFile reads the config file once. A missing file is not an error;
+// malformed top-level JSON returns zero contents, while per-section decode
+// errors leave unrelated sections available to callers.
 func readConfigFile(path string) (configFile, error) {
 	var file configFile
 	data, err := os.ReadFile(path)
@@ -92,10 +99,29 @@ func readConfigFile(path string) (configFile, error) {
 		}
 		return file, err
 	}
-	if err := json.Unmarshal(data, &file); err != nil {
+	var sections configFileSections
+	if err := json.Unmarshal(data, &sections); err != nil {
 		return configFile{}, err
 	}
-	return file, nil
+
+	var errs []error
+	if len(sections.Assistants) > 0 {
+		var assistants map[string]assistantConfigRaw
+		if err := json.Unmarshal(sections.Assistants, &assistants); err != nil {
+			errs = append(errs, fmt.Errorf("assistants: %w", err))
+		} else {
+			file.Assistants = assistants
+		}
+	}
+	if len(sections.UI) > 0 {
+		var ui uiSettingsRaw
+		if err := json.Unmarshal(sections.UI, &ui); err != nil {
+			errs = append(errs, fmt.Errorf("ui: %w", err))
+		} else {
+			file.UI = ui
+		}
+	}
+	return file, errors.Join(errs...)
 }
 
 // AssistantNames returns assistant IDs in deterministic display order.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,90 @@ func TestDefaultConfigLoadsAssistantOverrides(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigKeepsAssistantOverridesWhenUISectionIsInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(home, ".amux", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+	  "assistants": {
+	    "myagent": {
+	      "command": "myagent",
+	      "interrupt_count": 3
+	    }
+	  },
+	  "ui": {
+	    "show_keymap_hints": "true"
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+
+	custom, ok := cfg.Assistants["myagent"]
+	if !ok {
+		t.Fatalf("expected valid assistant override to survive invalid ui section")
+	}
+	if custom.Command != "myagent" || custom.InterruptCount != 3 {
+		t.Fatalf("custom assistant = %+v, want command myagent and interrupt_count 3", custom)
+	}
+	if cfg.UI.ShowKeymapHints {
+		t.Fatalf("ShowKeymapHints = true, want default false after invalid ui section")
+	}
+}
+
+func TestDefaultConfigKeepsUISettingsWhenAssistantSectionIsInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(home, ".amux", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+	  "assistants": {
+	    "myagent": {
+	      "command": "myagent",
+	      "interrupt_count": "3"
+	    }
+	  },
+	  "ui": {
+	    "show_keymap_hints": true,
+	    "tmux_server": "amux-test"
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	if _, ok := cfg.Assistants["myagent"]; ok {
+		t.Fatalf("expected invalid assistant section to be ignored")
+	}
+	if !cfg.UI.ShowKeymapHints {
+		t.Fatalf("ShowKeymapHints = false, want true from valid ui section")
+	}
+	if cfg.UI.TmuxServer != "amux-test" {
+		t.Fatalf("TmuxServer = %q, want %q", cfg.UI.TmuxServer, "amux-test")
+	}
+
+	persisted := cfg.PersistedUISettings()
+	if !persisted.ShowKeymapHints || persisted.TmuxServer != "amux-test" {
+		t.Fatalf("PersistedUISettings() = %+v, want valid ui section despite assistant error", persisted)
+	}
+}
+
 func TestDefaultConfigIgnoresDefaultAssistantSetting(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -25,39 +25,32 @@ func defaultUISettings() UISettings {
 	}
 }
 
-func loadUISettings(path string) UISettings {
-	settings := defaultUISettings()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return settings
-	}
+// uiSettingsRaw is the on-disk shape of the "ui" config section. Pointer
+// fields distinguish "absent" from zero values.
+type uiSettingsRaw struct {
+	ShowKeymapHints  *bool   `json:"show_keymap_hints"`
+	Theme            *string `json:"theme"`
+	TmuxServer       *string `json:"tmux_server"`
+	TmuxConfigPath   *string `json:"tmux_config"`
+	TmuxSyncInterval *string `json:"tmux_sync_interval"`
+}
 
-	var raw struct {
-		UI struct {
-			ShowKeymapHints  *bool   `json:"show_keymap_hints"`
-			Theme            *string `json:"theme"`
-			TmuxServer       *string `json:"tmux_server"`
-			TmuxConfigPath   *string `json:"tmux_config"`
-			TmuxSyncInterval *string `json:"tmux_sync_interval"`
-		} `json:"ui"`
+// applyUISettings overlays the parsed config-file section onto the defaults.
+func applyUISettings(settings UISettings, raw uiSettingsRaw) UISettings {
+	if raw.ShowKeymapHints != nil {
+		settings.ShowKeymapHints = *raw.ShowKeymapHints
 	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return settings
+	if raw.Theme != nil {
+		settings.Theme = *raw.Theme
 	}
-	if raw.UI.ShowKeymapHints != nil {
-		settings.ShowKeymapHints = *raw.UI.ShowKeymapHints
+	if raw.TmuxServer != nil {
+		settings.TmuxServer = *raw.TmuxServer
 	}
-	if raw.UI.Theme != nil {
-		settings.Theme = *raw.UI.Theme
+	if raw.TmuxConfigPath != nil {
+		settings.TmuxConfigPath = *raw.TmuxConfigPath
 	}
-	if raw.UI.TmuxServer != nil {
-		settings.TmuxServer = *raw.UI.TmuxServer
-	}
-	if raw.UI.TmuxConfigPath != nil {
-		settings.TmuxConfigPath = *raw.UI.TmuxConfigPath
-	}
-	if raw.UI.TmuxSyncInterval != nil {
-		settings.TmuxSyncInterval = *raw.UI.TmuxSyncInterval
+	if raw.TmuxSyncInterval != nil {
+		settings.TmuxSyncInterval = *raw.TmuxSyncInterval
 	}
 	return settings
 }
@@ -103,5 +96,9 @@ func (c *Config) PersistedUISettings() UISettings {
 	if c == nil || c.Paths == nil {
 		return defaultUISettings()
 	}
-	return loadUISettings(c.Paths.ConfigPath)
+	file, err := readConfigFile(c.Paths.ConfigPath)
+	if err != nil {
+		return defaultUISettings()
+	}
+	return applyUISettings(defaultUISettings(), file.UI)
 }

--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -96,9 +96,6 @@ func (c *Config) PersistedUISettings() UISettings {
 	if c == nil || c.Paths == nil {
 		return defaultUISettings()
 	}
-	file, err := readConfigFile(c.Paths.ConfigPath)
-	if err != nil {
-		return defaultUISettings()
-	}
+	file, _ := readConfigFile(c.Paths.ConfigPath)
 	return applyUISettings(defaultUISettings(), file.UI)
 }


### PR DESCRIPTION
readConfigFile parses config.json into one structure and hands each
section to its loader, so a corrupted file surfaces a single warning
instead of two independent silent default fallbacks (assistants and UI
settings each re-reading the file).

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G8**, 34/36). Stacked on `rp/g7-noise-filter-dedup`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.