### PR TITLE
G10: Share the identifier validation rule and make theme/perf init explicit

### DIFF
--- a/cmd/amux-harness/main.go
+++ b/cmd/amux-harness/main.go
@@ -47,6 +47,7 @@ type stats struct {
 }
 
 func main() {
+	perf.Init()
 	startPprof()
 
 	mode := flag.String("mode", app.HarnessCenter, "render mode: center, sidebar, or monitor")

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/perf"
 	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/supervisor"
 	"github.com/andyrewlee/amux/internal/tmux"
@@ -21,6 +22,7 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/dashboard"
 	"github.com/andyrewlee/amux/internal/ui/layout"
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
+	"github.com/andyrewlee/amux/internal/ui/theme"
 )
 
 // newAppShell constructs an App with its UI components built and wired in the
@@ -29,6 +31,10 @@ import (
 // layers the services on top; the headless harness uses the shell directly so
 // component construction and ordering changes are exercised by harness runs.
 func newAppShell(cfg *config.Config) *App {
+	// Explicit one-time package setup (no package init side effects): install
+	// the default theme and arm perf profiling from the environment.
+	theme.Init()
+	perf.Init()
 	app := &App{
 		config:               cfg,
 		layout:               layout.NewManager(),

--- a/internal/perf/perf.go
+++ b/internal/perf/perf.go
@@ -71,11 +71,28 @@ var (
 	initOnce   sync.Once
 )
 
-func init() {
+// Init reads the AMUX_PROFILE / AMUX_PROFILE_INTERVAL_MS environment and arms
+// profiling accordingly. The app calls this explicitly during construction;
+// it is idempotent, so library users and tests may also call it directly.
+func Init() {
 	initOnce.Do(func() {
 		enabled.Store(isEnabled())
 		logInterval.Store(int64(defaultLogInterval()))
 	})
+}
+
+// Reset clears all recorded stats and counters and re-reads the environment.
+// Intended for tests that toggle AMUX_PROFILE between cases.
+func Reset() {
+	statsMu.Lock()
+	statsMap = map[string]*stat{}
+	statsMu.Unlock()
+	countersMu.Lock()
+	counterMap = map[string]*counter{}
+	countersMu.Unlock()
+	lastLog.Store(0)
+	enabled.Store(isEnabled())
+	logInterval.Store(int64(defaultLogInterval()))
 }
 
 // Enabled reports whether profiling is enabled.

--- a/internal/ui/theme/colors.go
+++ b/internal/ui/theme/colors.go
@@ -11,12 +11,13 @@ import (
 // themePtr holds the active color theme, protected by atomic access.
 var themePtr atomic.Pointer[Theme]
 
-// Init installs the default theme. The app calls this explicitly during
-// construction (rather than relying on package init side effects); direct
-// library/test use is still safe because currentTheme falls back lazily.
+// Init installs the default theme if no theme has been selected yet. The app
+// calls this explicitly during construction (rather than relying on package
+// init side effects); direct library/test use is still safe because
+// currentTheme falls back lazily.
 func Init() {
 	t := GetTheme(ThemeGruvbox)
-	themePtr.Store(&t)
+	themePtr.CompareAndSwap(nil, &t)
 }
 
 // currentTheme returns the active theme, installing the default on first use

--- a/internal/ui/theme/colors.go
+++ b/internal/ui/theme/colors.go
@@ -11,31 +11,45 @@ import (
 // themePtr holds the active color theme, protected by atomic access.
 var themePtr atomic.Pointer[Theme]
 
-func init() {
+// Init installs the default theme. The app calls this explicitly during
+// construction (rather than relying on package init side effects); direct
+// library/test use is still safe because currentTheme falls back lazily.
+func Init() {
 	t := GetTheme(ThemeGruvbox)
 	themePtr.Store(&t)
 }
 
+// currentTheme returns the active theme, installing the default on first use
+// when Init was not called.
+func currentTheme() *Theme {
+	if t := themePtr.Load(); t != nil {
+		return t
+	}
+	t := GetTheme(ThemeGruvbox)
+	themePtr.CompareAndSwap(nil, &t)
+	return themePtr.Load()
+}
+
 // Theme-dependent color accessors (read from the current theme atomically).
 
-func ColorBackground() color.Color    { return themePtr.Load().Colors.Background }
-func ColorForeground() color.Color    { return themePtr.Load().Colors.Foreground }
-func ColorMuted() color.Color         { return themePtr.Load().Colors.Muted }
-func ColorBorder() color.Color        { return themePtr.Load().Colors.Border }
-func ColorBorderFocused() color.Color { return themePtr.Load().Colors.BorderFocused }
+func ColorBackground() color.Color    { return currentTheme().Colors.Background }
+func ColorForeground() color.Color    { return currentTheme().Colors.Foreground }
+func ColorMuted() color.Color         { return currentTheme().Colors.Muted }
+func ColorBorder() color.Color        { return currentTheme().Colors.Border }
+func ColorBorderFocused() color.Color { return currentTheme().Colors.BorderFocused }
 
-func ColorPrimary() color.Color   { return themePtr.Load().Colors.Primary }
-func ColorSecondary() color.Color { return themePtr.Load().Colors.Secondary }
-func ColorSuccess() color.Color   { return themePtr.Load().Colors.Success }
-func ColorWarning() color.Color   { return themePtr.Load().Colors.Warning }
-func ColorError() color.Color     { return themePtr.Load().Colors.Error }
-func ColorInfo() color.Color      { return themePtr.Load().Colors.Info }
+func ColorPrimary() color.Color   { return currentTheme().Colors.Primary }
+func ColorSecondary() color.Color { return currentTheme().Colors.Secondary }
+func ColorSuccess() color.Color   { return currentTheme().Colors.Success }
+func ColorWarning() color.Color   { return currentTheme().Colors.Warning }
+func ColorError() color.Color     { return currentTheme().Colors.Error }
+func ColorInfo() color.Color      { return currentTheme().Colors.Info }
 
-func ColorSurface0() color.Color { return themePtr.Load().Colors.Surface0 }
-func ColorSurface1() color.Color { return themePtr.Load().Colors.Surface1 }
-func ColorSurface2() color.Color { return themePtr.Load().Colors.Surface2 }
+func ColorSurface0() color.Color { return currentTheme().Colors.Surface0 }
+func ColorSurface1() color.Color { return currentTheme().Colors.Surface1 }
+func ColorSurface2() color.Color { return currentTheme().Colors.Surface2 }
 
-func ColorSelection() color.Color { return themePtr.Load().Colors.Selection }
+func ColorSelection() color.Color { return currentTheme().Colors.Selection }
 
 // Agent colors remain constant across themes for brand recognition.
 var (
@@ -52,7 +66,7 @@ var (
 
 // GetCurrentTheme returns the currently active theme.
 func GetCurrentTheme() Theme {
-	return *themePtr.Load()
+	return *currentTheme()
 }
 
 // SetCurrentTheme atomically applies a new theme.

--- a/internal/ui/theme/theme_palettes_test.go
+++ b/internal/ui/theme/theme_palettes_test.go
@@ -44,3 +44,15 @@ func TestThemePalettesComplete(t *testing.T) {
 		t.Fatal("unknown theme must fall back to gruvbox")
 	}
 }
+
+func TestInitDoesNotOverwriteSelectedTheme(t *testing.T) {
+	prev := GetCurrentTheme().ID
+	defer SetCurrentTheme(prev)
+
+	SetCurrentTheme(ThemeTokyoNight)
+	Init()
+
+	if got := GetCurrentTheme().ID; got != ThemeTokyoNight {
+		t.Fatalf("current theme after Init() = %q, want %q", got, ThemeTokyoNight)
+	}
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -21,20 +21,28 @@ func (e *ValidationError) Error() string {
 // workspaceNameRegex matches valid workspace/branch names
 var workspaceNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
+// validateIdentifier applies the shared name rule (non-empty, max 100 chars,
+// letter/number start, [a-zA-Z0-9._-] body) used by workspace and assistant
+// names. field labels the error messages.
+func validateIdentifier(field, value string) error {
+	if value == "" {
+		return &ValidationError{Field: field, Message: field + " cannot be empty"}
+	}
+	if len(value) > 100 {
+		return &ValidationError{Field: field, Message: field + " too long (max 100 characters)"}
+	}
+	if !workspaceNameRegex.MatchString(value) {
+		return &ValidationError{Field: field, Message: field + " must start with letter/number and contain only letters, numbers, dots, dashes, or underscores"}
+	}
+	return nil
+}
+
 // ValidateWorkspaceName validates a workspace name
 func ValidateWorkspaceName(name string) error {
 	name = strings.TrimSpace(name)
 
-	if name == "" {
-		return &ValidationError{Field: "name", Message: "name cannot be empty"}
-	}
-
-	if len(name) > 100 {
-		return &ValidationError{Field: "name", Message: "name too long (max 100 characters)"}
-	}
-
-	if !workspaceNameRegex.MatchString(name) {
-		return &ValidationError{Field: "name", Message: "name must start with letter/number and contain only letters, numbers, dots, dashes, or underscores"}
+	if err := validateIdentifier("name", name); err != nil {
+		return err
 	}
 
 	// Disallow consecutive dots (..)
@@ -134,21 +142,7 @@ func ValidateBaseRef(ref string) error {
 
 // ValidateAssistant validates an assistant name
 func ValidateAssistant(assistant string) error {
-	assistant = strings.TrimSpace(assistant)
-
-	if assistant == "" {
-		return &ValidationError{Field: "assistant", Message: "assistant cannot be empty"}
-	}
-
-	if len(assistant) > 100 {
-		return &ValidationError{Field: "assistant", Message: "assistant too long (max 100 characters)"}
-	}
-
-	if !workspaceNameRegex.MatchString(assistant) {
-		return &ValidationError{Field: "assistant", Message: "assistant must start with letter/number and contain only letters, numbers, dots, dashes, or underscores"}
-	}
-
-	return nil
+	return validateIdentifier("assistant", strings.TrimSpace(assistant))
 }
 
 // SanitizeInput removes potentially dangerous characters from input


### PR DESCRIPTION
validateIdentifier carries the name rule (non-empty, max 100, regex)
used by both ValidateWorkspaceName and ValidateAssistant. The theme
package's init() becomes an explicit theme.Init() (with a lazy fallback
for direct library/test use) and perf's env sniffing becomes perf.Init()
plus perf.Reset() for tests; the app shell and harness main call both
explicitly.

---
Part of the REFACTOR_PLAN stacked-PR chain (item **G10**, 36/36). Stacked on `rp/g9-theme-palettes`; merge in chain order, base branches retarget automatically as predecessors merge. Replaces #325. The chain tip is byte-identical to the previously validated combined branch; every link passes go build and go vet (tests compile). Note: make verify-loop and real-tmux e2e need a machine with tmux.