### PR TITLE
Snapshot tab.Agent under lock in the actor send funnels

### DIFF
--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -23,7 +23,10 @@ func (m *Model) HasRunningAgents() bool {
 			if !m.isChatTab(tab) {
 				continue
 			}
-			if tab.Running {
+			tab.mu.Lock()
+			running := tab.Running
+			tab.mu.Unlock()
+			if running {
 				return true
 			}
 		}
@@ -138,8 +141,15 @@ func (m *Model) GetRunningWorkspaceRoots() []string {
 			if !m.isChatTab(tab) {
 				continue
 			}
-			if tab.Running && tab.Workspace != nil {
-				running = append(running, tab.Workspace.Root)
+			tab.mu.Lock()
+			isRunning := tab.Running
+			var root string
+			if tab.Workspace != nil {
+				root = tab.Workspace.Root
+			}
+			tab.mu.Unlock()
+			if isRunning && root != "" {
+				running = append(running, root)
 				break // Only need one per workspace
 			}
 		}

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -57,7 +57,7 @@ type Tab struct {
 	reattachInFlight bool
 	Terminal         *vterm.VTerm // Virtual terminal emulator with scrollback
 	DiffViewer       *diff.Model  // Native diff viewer (replaces PTY-based viewer)
-	mu               sync.Mutex   // Protects Terminal
+	mu               sync.Mutex   // Protects Terminal, Agent, Running, Detached, Workspace, DiffViewer and the embedded state groups
 	closed           uint32
 	closing          uint32
 	Running          bool // Whether the agent is actively running

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -276,10 +276,17 @@ func (m *Model) handlePaste(ev tabEvent) {
 }
 
 func (m *Model) sendMouseToTerminal(tab *Tab, data string, tabID TabID, workspaceID string) {
-	if tab == nil || tab.Agent == nil || tab.Agent.Terminal == nil || data == "" {
+	if tab == nil || data == "" {
 		return
 	}
-	if err := tab.Agent.Terminal.SendString(data); err != nil {
+	tab.mu.Lock()
+	agent := tab.Agent
+	closed := tab.isClosed()
+	tab.mu.Unlock()
+	if closed || agent == nil || agent.Terminal == nil {
+		return
+	}
+	if err := agent.Terminal.SendString(data); err != nil {
 		logging.Warn("Mouse input failed for tab %s: %v", tab.ID, err)
 		tab.mu.Lock()
 		tab.Running = false
@@ -292,13 +299,17 @@ func (m *Model) sendMouseToTerminal(tab *Tab, data string, tabID TabID, workspac
 }
 
 func (m *Model) sendToTerminal(tab *Tab, data string, tabID TabID, workspaceID, label string) {
-	if tab == nil || tab.Agent == nil || tab.Agent.Terminal == nil {
+	if tab == nil || data == "" {
 		return
 	}
-	if data == "" {
+	tab.mu.Lock()
+	agent := tab.Agent
+	closed := tab.isClosed()
+	tab.mu.Unlock()
+	if closed || agent == nil || agent.Terminal == nil {
 		return
 	}
-	if err := tab.Agent.Terminal.SendString(data); err != nil {
+	if err := agent.Terminal.SendString(data); err != nil {
 		logging.Warn("%s failed for tab %s: %v", label, tab.ID, err)
 		tab.mu.Lock()
 		tab.markDetachedLocked()

--- a/internal/ui/center/tab_actor_agent_race_test.go
+++ b/internal/ui/center/tab_actor_agent_race_test.go
@@ -1,0 +1,67 @@
+package center
+
+import (
+	"sync"
+	"testing"
+
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// TestSendToTerminal_AgentNilledConcurrently exercises the cross-goroutine race
+// between the tab-actor send funnel (sendToTerminal) reading tab.Agent and the
+// Update goroutine reassigning/nilling tab.Agent under tab.mu (detach/stop).
+//
+// Before the snapshot-under-lock fix, sendToTerminal loaded tab.Agent several
+// times across its nil-check and dereference with no lock, so an interleaved
+// `tab.Agent = nil` could nil-panic the actor goroutine; -race also reports the
+// unsynchronized access. After the fix it snapshots the agent once under
+// tab.mu, so this test runs clean.
+func TestSendToTerminal_AgentNilledConcurrently(t *testing.T) {
+	dir := t.TempDir()
+	term, err := appPty.NewWithSize("cat >/dev/null", dir, nil, 24, 80)
+	if err != nil {
+		t.Fatalf("expected test PTY terminal: %v", err)
+	}
+	defer func() { _ = term.Close() }()
+
+	m := newTestModel()
+	ws := newTestWorkspace("ws", dir)
+	tabID := TabID("tab-agent-race")
+	workspaceID := string(ws.ID())
+
+	agent := &appPty.Agent{Terminal: term}
+	tab := &Tab{
+		ID:        tabID,
+		Assistant: "codex",
+		Workspace: ws,
+		Agent:     agent,
+	}
+
+	const iterations = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: the tab-actor send funnel.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			m.sendToTerminal(tab, "x", tabID, workspaceID, "Input")
+		}
+	}()
+
+	// Goroutine 2: the Update goroutine nilling/restoring tab.Agent under lock,
+	// as detach/stop/reattach do.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			tab.mu.Lock()
+			tab.Agent = nil
+			tab.mu.Unlock()
+			tab.mu.Lock()
+			tab.Agent = agent
+			tab.mu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes a cross-goroutine race: sendToTerminal/sendMouseToTerminal read
tab.Agent and tab.Agent.Terminal unlocked on the tab-actor goroutine while
the Update goroutine nils/reassigns tab.Agent under tab.mu, risking a
nil-deref panic that drops in-flight input. Also locks the Running/Workspace
reads in HasRunningAgents/GetRunningWorkspaceRoots and corrects the mu doc.

Plan: plans/006-tab-field-lock-discipline.md
