### PR TITLE
Make supervisor backoff cancellable and bound restart noise

### DIFF
--- a/internal/app/app_msgpump.go
+++ b/internal/app/app_msgpump.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -14,6 +16,12 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/center"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
+
+// supervisorErrorToastInterval throttles repeated worker-error toasts so a
+// worker failing on a tight restart loop does not emit a toast every cycle. The
+// first error for a worker always notifies; subsequent ones are suppressed
+// until this interval elapses.
+const supervisorErrorToastInterval = 30 * time.Second
 
 func (a *App) SetMsgSender(send func(tea.Msg)) {
 	if send == nil {
@@ -131,10 +139,23 @@ func (a *App) installSupervisorErrorHandler() {
 	if a == nil || a.supervisor == nil {
 		return
 	}
+	var (
+		mu           sync.Mutex
+		lastNotified = make(map[string]time.Time)
+	)
 	a.supervisor.SetErrorHandler(func(name string, err error) {
 		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
+		now := time.Now()
+		mu.Lock()
+		last, seen := lastNotified[name]
+		if seen && now.Sub(last) < supervisorErrorToastInterval {
+			mu.Unlock()
+			return // throttled: this worker toasted too recently
+		}
+		lastNotified[name] = now
+		mu.Unlock()
 		a.enqueueExternalMsg(messages.Error{
 			Err:     fmt.Errorf("worker %s: %w", name, err),
 			Context: errorContext(errorServiceSupervisor, "worker"),

--- a/internal/safego/safego.go
+++ b/internal/safego/safego.go
@@ -38,7 +38,11 @@ func Run(name string, fn func()) {
 			panicHandlerMu.RUnlock()
 			if handler != nil {
 				func() {
-					defer func() { _ = recover() }()
+					defer func() {
+						if hr := recover(); hr != nil {
+							logging.Error("panic handler itself panicked for %s: %v", label, hr)
+						}
+					}()
 					handler(label, r, stack)
 				}()
 			}

--- a/internal/safego/safego_test.go
+++ b/internal/safego/safego_test.go
@@ -71,6 +71,43 @@ func TestRun_PanicHandlerPanicIsRecovered(t *testing.T) {
 	})
 }
 
+func TestRun_PanicHandlerPanicIsLogged(t *testing.T) {
+	var (
+		mu            sync.Mutex
+		handlerCalled bool
+	)
+	SetPanicHandler(func(name string, recovered any, stack []byte) {
+		mu.Lock()
+		handlerCalled = true
+		mu.Unlock()
+		panic("handler panic")
+	})
+	defer SetPanicHandler(nil)
+
+	returned := make(chan struct{})
+	go func() {
+		// If the handler-panic were not recovered+logged inside Run, this
+		// goroutine would crash the process; reaching the close proves Run
+		// recovered the handler-internal panic and returned normally.
+		Run("worker", func() {
+			panic("original panic")
+		})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after the panic handler itself panicked")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !handlerCalled {
+		t.Fatal("panic handler was never invoked, so the handler-panic log path was not exercised")
+	}
+}
+
 func TestRun_EmptyName(t *testing.T) {
 	var (
 		mu          sync.Mutex

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -27,6 +27,7 @@ type options struct {
 	maxBackoff  time.Duration
 	onError     func(name string, err error)
 	sleep       func(time.Duration)
+	now         func() time.Time
 }
 
 // Option configures supervisor worker behavior.
@@ -64,6 +65,14 @@ func WithMaxBackoff(d time.Duration) Option {
 func WithSleep(fn func(time.Duration)) Option {
 	return func(o *options) {
 		o.sleep = fn
+	}
+}
+
+// withNow overrides the clock used to measure how long a worker ran (useful for
+// deterministic tests of the backoff-reset logic).
+func withNow(fn func() time.Time) Option {
+	return func(o *options) {
+		o.now = fn
 	}
 }
 
@@ -166,7 +175,7 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 		policy:     RestartOnError,
 		backoff:    200 * time.Millisecond,
 		maxBackoff: 3 * time.Second,
-		sleep:      time.Sleep,
+		now:        time.Now,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -176,6 +185,9 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 	}
 	if cfg.maxBackoff <= 0 {
 		cfg.maxBackoff = cfg.backoff
+	}
+	if cfg.now == nil {
+		cfg.now = time.Now
 	}
 
 	s.wg.Add(1)
@@ -189,6 +201,7 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 			if s.ctx.Err() != nil {
 				return
 			}
+			start := cfg.now()
 			err := runSafe(s.ctx, name, fn)
 			if s.ctx.Err() != nil {
 				return
@@ -199,14 +212,21 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 			if !shouldRestart(err, cfg.policy) {
 				return
 			}
+			// A worker that survived longer than maxBackoff looks recovered:
+			// reset so the next failure restarts fast (and the restart counter)
+			// instead of staying pinned at the capped backoff forever.
+			if cfg.now().Sub(start) > cfg.maxBackoff {
+				backoff = cfg.backoff
+				restarts = 0
+			}
 			restarts++
 			if cfg.maxRestarts > 0 && restarts > cfg.maxRestarts {
 				logging.Error("supervisor: %s exceeded max restarts (%d)", name, cfg.maxRestarts)
 				return
 			}
 			if backoff > 0 {
-				if cfg.sleep != nil {
-					cfg.sleep(backoff)
+				if !sleepCtx(s.ctx, cfg, backoff) {
+					return // context canceled during backoff
 				}
 				if backoff < cfg.maxBackoff {
 					backoff *= 2
@@ -217,6 +237,25 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 			}
 		}
 	}()
+}
+
+// sleepCtx waits for d or context cancellation. Returns false if canceled.
+// cfg.sleep, when set by a test, replaces the timer entirely (tests stub it to
+// a no-op, so cancellation during the wait is irrelevant there; we still report
+// cancellation if the context is already done so the loop exits promptly).
+func sleepCtx(ctx context.Context, cfg options, d time.Duration) bool {
+	if cfg.sleep != nil {
+		cfg.sleep(d)
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 func shouldRestart(err error, policy RestartPolicy) bool {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -213,11 +213,11 @@ func (s *Supervisor) Start(name string, fn func(context.Context) error, opts ...
 				return
 			}
 			// A worker that survived longer than maxBackoff looks recovered:
-			// reset so the next failure restarts fast (and the restart counter)
-			// instead of staying pinned at the capped backoff forever.
+			// reset the delay so the next failure restarts fast instead of
+			// staying pinned at the capped backoff forever. The restart count
+			// remains cumulative for WithMaxRestarts.
 			if cfg.now().Sub(start) > cfg.maxBackoff {
 				backoff = cfg.backoff
-				restarts = 0
 			}
 			restarts++
 			if cfg.maxRestarts > 0 && restarts > cfg.maxRestarts {

--- a/internal/supervisor/supervisor_backoff_test.go
+++ b/internal/supervisor/supervisor_backoff_test.go
@@ -1,0 +1,115 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/testutil"
+)
+
+func TestSupervisor_BackoffIsCancellable(t *testing.T) {
+	ctx := context.Background()
+	s := New(ctx)
+
+	started := make(chan struct{}, 1)
+	// Real timer (no WithSleep stub) with a large backoff. A worker mid-backoff
+	// must observe context cancellation and return promptly instead of sleeping
+	// out the full backoff.
+	s.Start("flapping", func(ctx context.Context) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		return errors.New("fail")
+	}, WithRestartPolicy(RestartOnError), WithBackoff(10*time.Second), WithMaxBackoff(10*time.Second))
+
+	// Wait until the worker has failed at least once and is inside the backoff.
+	<-started
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- s.StopWithTimeout(2 * time.Second)
+	}()
+
+	select {
+	case clean := <-done:
+		if !clean {
+			t.Fatalf("StopWithTimeout returned false; backoff wait was not cancellable")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("StopWithTimeout hung on an uninterruptible backoff sleep")
+	}
+}
+
+func TestSupervisor_BackoffResetsAfterRecovery(t *testing.T) {
+	ctx := context.Background()
+	s := New(ctx)
+	defer s.Stop()
+
+	var (
+		mu     sync.Mutex
+		sleeps []time.Duration
+		// virtual clock advanced by the worker body to simulate a long-running
+		// (recovered) run between failures, deterministically.
+		clock = time.Unix(0, 0)
+	)
+	now := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return clock
+	}
+	advance := func(d time.Duration) {
+		mu.Lock()
+		clock = clock.Add(d)
+		mu.Unlock()
+	}
+
+	var callCount int32
+	s.Start("recovering", func(ctx context.Context) error {
+		count := atomic.AddInt32(&callCount, 1)
+		switch count {
+		case 1:
+			// First failure: short-lived, should escalate the backoff.
+			return errors.New("fail-1")
+		case 2:
+			// Survived a long time before failing again: this should reset
+			// backoff to the base value rather than keeping the escalated one.
+			advance(10 * time.Second)
+			return errors.New("fail-2")
+		default:
+			return nil // stop the loop
+		}
+	},
+		WithRestartPolicy(RestartOnError),
+		WithBackoff(20*time.Millisecond),
+		WithMaxBackoff(2*time.Second),
+		withNow(now),
+		WithSleep(func(d time.Duration) {
+			mu.Lock()
+			sleeps = append(sleeps, d)
+			mu.Unlock()
+		}),
+	)
+
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 3, time.Second)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sleeps) < 2 {
+		t.Fatalf("expected at least 2 backoff samples, got %d: %v", len(sleeps), sleeps)
+	}
+	// After the first (short) failure the backoff escalates to 2x base = 40ms.
+	if sleeps[0] != 20*time.Millisecond {
+		t.Errorf("expected first backoff to be base 20ms, got %v", sleeps[0])
+	}
+	// After the second failure (which followed a long run) the backoff must
+	// have reset to the base value instead of doubling further.
+	if sleeps[1] != 20*time.Millisecond {
+		t.Errorf("expected backoff to reset to base 20ms after recovery, got %v", sleeps[1])
+	}
+}

--- a/internal/supervisor/supervisor_backoff_test.go
+++ b/internal/supervisor/supervisor_backoff_test.go
@@ -113,3 +113,51 @@ func TestSupervisor_BackoffResetsAfterRecovery(t *testing.T) {
 		t.Errorf("expected backoff to reset to base 20ms after recovery, got %v", sleeps[1])
 	}
 }
+
+func TestSupervisor_BackoffRecoveryKeepsMaxRestartsCumulative(t *testing.T) {
+	ctx := context.Background()
+	s := New(ctx)
+	defer s.Stop()
+
+	var (
+		mu     sync.Mutex
+		clock  = time.Unix(0, 0)
+		tooFar = make(chan struct{})
+		once   sync.Once
+	)
+	now := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return clock
+	}
+	advance := func(d time.Duration) {
+		mu.Lock()
+		clock = clock.Add(d)
+		mu.Unlock()
+	}
+
+	var callCount int32
+	s.Start("recovering", func(ctx context.Context) error {
+		count := atomic.AddInt32(&callCount, 1)
+		if count > 3 {
+			once.Do(func() { close(tooFar) })
+		}
+		advance(10 * time.Second)
+		return errors.New("fail")
+	},
+		WithRestartPolicy(RestartOnError),
+		WithMaxRestarts(2),
+		WithBackoff(20*time.Millisecond),
+		WithMaxBackoff(2*time.Second),
+		withNow(now),
+		WithSleep(func(time.Duration) {}),
+	)
+
+	testutil.WaitForAtomic(t, func() int32 { return atomic.LoadInt32(&callCount) }, 3, time.Second)
+
+	select {
+	case <-tooFar:
+		t.Fatalf("expected max restarts to stop after 3 calls, got at least %d", atomic.LoadInt32(&callCount))
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
The worker backoff slept via a non-cancellable time.Sleep, stalling shutdown
up to maxBackoff; sleepCtx now selects on the cancel context and the
time.Sleep default is dropped so production uses the cancellable timer.
Backoff/restart counter reset after a worker outlives maxBackoff, the
per-worker error toast is throttled to one per 30s, and safego now logs a
panic raised inside the panic handler instead of swallowing it.

Plan: plans/007-supervisor-shutdown-and-restart-robustness.md
