### PR TITLE
Hold the per-repo git lock across workspace-create rollback

### DIFF
--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -157,7 +157,7 @@ func (s *workspaceService) CreateWorkspace(project *data.Project, name, base str
 		// Wait for .git file to exist (race condition from workspace creation)
 		gitPath := filepath.Join(workspacePath, ".git")
 		if err := waitForGitPath(gitPath, s.gitPathWaitTimeout); err != nil {
-			rollbackWorkspaceCreation(s.gitOps, s.workspacesRoot, project, project.Path, workspacePath, branch)
+			s.rollbackWorkspaceCreation(project, project.Path, workspacePath, branch)
 			return messages.WorkspaceCreateFailed{
 				Workspace: ws,
 				Err:       err,
@@ -167,7 +167,7 @@ func (s *workspaceService) CreateWorkspace(project *data.Project, name, base str
 		// Save unified workspace
 		if s.store != nil {
 			if err := s.store.Save(ws); err != nil {
-				rollbackWorkspaceCreation(s.gitOps, s.workspacesRoot, project, project.Path, workspacePath, branch)
+				s.rollbackWorkspaceCreation(project, project.Path, workspacePath, branch)
 				return messages.WorkspaceCreateFailed{
 					Workspace: ws,
 					Err:       err,

--- a/internal/app/workspace_service_helpers.go
+++ b/internal/app/workspace_service_helpers.go
@@ -46,14 +46,20 @@ func cleanupStaleWorkspacePath(workspacePath string) error {
 	return os.RemoveAll(workspacePath)
 }
 
-func rollbackWorkspaceCreation(
-	gitOps GitOperations,
-	workspacesRoot string,
+// rollbackWorkspaceCreation undoes a partially-created workspace by removing the
+// worktree and deleting the branch. It holds the per-repo git lock across both
+// mutations so a rollback racing a concurrent same-repo create/delete cannot
+// contend on git's .git locks (index.lock / packed-refs). Callers must NOT hold
+// lockRepoGit(repoPath) when invoking this, or it self-deadlocks.
+func (s *workspaceService) rollbackWorkspaceCreation(
 	project *data.Project,
 	repoPath, workspacePath, branch string,
 ) {
-	if err := gitOps.RemoveWorkspace(repoPath, workspacePath); err != nil {
-		if git.IsUnregisteredWorkspacePathError(err) && isManagedWorkspacePathForProject(workspacesRoot, project, workspacePath) {
+	unlock := s.lockRepoGit(repoPath)
+	defer unlock()
+
+	if err := s.gitOps.RemoveWorkspace(repoPath, workspacePath); err != nil {
+		if git.IsUnregisteredWorkspacePathError(err) && isManagedWorkspacePathForProject(s.workspacesRoot, project, workspacePath) {
 			cleanupErr := cleanupStaleWorkspacePath(workspacePath)
 			if cleanupErr == nil {
 				goto branchCleanup
@@ -63,7 +69,7 @@ func rollbackWorkspaceCreation(
 		logging.Warn("Failed to roll back workspace %s: %v", workspacePath, err)
 	}
 branchCleanup:
-	if err := gitOps.DeleteBranch(repoPath, branch); err != nil {
+	if err := s.gitOps.DeleteBranch(repoPath, branch); err != nil {
 		logging.Warn("Failed to roll back branch %s: %v", branch, err)
 	}
 }

--- a/internal/app/workspace_service_rollback_test.go
+++ b/internal/app/workspace_service_rollback_test.go
@@ -3,7 +3,9 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
@@ -42,12 +44,124 @@ func TestRollbackWorkspaceCreationCleansRecoverableUnregisteredWorkspace(t *test
 	}
 
 	project := &data.Project{Name: "repo-link", Path: projectPath}
-	rollbackWorkspaceCreation(mock, workspacesRoot, project, projectPath, workspacePath, "feature")
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	svc.rollbackWorkspaceCreation(project, projectPath, workspacePath, "feature")
 
 	if _, err := os.Stat(workspacePath); !os.IsNotExist(err) {
 		t.Fatalf("expected stale workspace path to be removed, err=%v", err)
 	}
 	if deleteBranchCalls != 1 {
 		t.Fatalf("deleteBranch calls = %d, want 1", deleteBranchCalls)
+	}
+}
+
+// TestRollbackWorkspaceCreationSerializesAgainstSameRepoGitMutation asserts that
+// a rollback does not run its RemoveWorkspace/DeleteBranch git mutations while a
+// concurrent locked git op for the same repo is still in flight. Both must hold
+// lockRepoGit(repoPath), so the fake should never observe overlapping calls.
+func TestRollbackWorkspaceCreationSerializesAgainstSameRepoGitMutation(t *testing.T) {
+	const repoPath = "/tmp/repo-serialize"
+	workspacesRoot := "/tmp/workspaces"
+	workspacePath := filepath.Join(workspacesRoot, "repo-serialize", "feature")
+
+	var (
+		mu             sync.Mutex
+		active         bool // a fake git op is currently executing
+		overlap        bool // two fake git ops were active at once
+		order          []string
+		createBlocking = make(chan struct{}) // closed to release the in-flight create
+		createEntered  = make(chan struct{}) // closed once the create holds the lock
+	)
+
+	enter := func(name string) {
+		mu.Lock()
+		if active {
+			overlap = true
+		}
+		active = true
+		order = append(order, name)
+		mu.Unlock()
+	}
+	leave := func() {
+		mu.Lock()
+		active = false
+		mu.Unlock()
+	}
+
+	mock := &mockGitOps{
+		createWorkspace: func(_, _, _, _ string) error {
+			enter("create")
+			defer leave()
+			close(createEntered)
+			<-createBlocking // hold the repo lock until released
+			return nil
+		},
+		removeWorkspace: func(_, _ string) error {
+			enter("rollback-remove")
+			defer leave()
+			return nil
+		},
+		deleteBranch: func(_, _ string) error {
+			enter("rollback-branch")
+			defer leave()
+			return nil
+		},
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	project := &data.Project{Name: "repo-serialize", Path: repoPath}
+
+	createDone := make(chan struct{})
+	go func() {
+		defer close(createDone)
+		// Holds lockRepoGit(repoPath) for the whole call (blocks until released).
+		_ = svc.createWorkspaceLocked(repoPath, workspacePath, "feature", "main")
+	}()
+
+	// Wait until the create is confirmed holding the lock.
+	<-createEntered
+
+	rollbackDone := make(chan struct{})
+	go func() {
+		defer close(rollbackDone)
+		svc.rollbackWorkspaceCreation(project, repoPath, workspacePath, "feature")
+	}()
+
+	// Give the rollback goroutine a chance to attempt acquiring the lock; it must
+	// block on lockRepoGit, so RemoveWorkspace must not have run yet.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	premature := false
+	for _, name := range order {
+		if name == "rollback-remove" {
+			premature = true
+		}
+	}
+	mu.Unlock()
+	if premature {
+		close(createBlocking)
+		t.Fatal("rollback RemoveWorkspace ran while the create still held the repo lock")
+	}
+
+	// Release the create; the rollback should now proceed.
+	close(createBlocking)
+	<-createDone
+	<-rollbackDone
+
+	mu.Lock()
+	defer mu.Unlock()
+	if overlap {
+		t.Fatalf("fake git ops overlapped; rollback did not serialize against the create: order=%v", order)
+	}
+	want := []string{"create", "rollback-remove", "rollback-branch"}
+	if len(order) != len(want) {
+		t.Fatalf("call order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("call order = %v, want %v", order, want)
+		}
 	}
 }


### PR DESCRIPTION
rollbackWorkspaceCreation ran git worktree remove + branch delete after
createWorkspaceLocked released the per-repo lock, so a failed create rolling
back could contend on index.lock/packed-refs with a concurrent same-repo
create/delete. It is now a workspaceService method that re-acquires
lockRepoGit across both mutations.

Plan: plans/008-rollback-under-repo-git-lock.md
