### PR TITLE
Release git file watches on workspace switch and delete

### DIFF
--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -252,6 +252,14 @@ func canonicalPathForMatch(path string) string {
 func (a *App) handleWorkspaceActivated(msg messages.WorkspaceActivated) []tea.Cmd {
 	var cmds []tea.Cmd
 	centerFocusQueuedReattach := false
+	// Capture the previously-active workspace root before it is overwritten so
+	// its file watch can be released below: the watcher follows the single
+	// active workspace, so the prior root must be unwatched on switch or its OS
+	// watch descriptor leaks for the rest of the session.
+	var previousActiveRoot string
+	if a.activeWorkspace != nil {
+		previousActiveRoot = a.activeWorkspace.Root
+	}
 	a.activeProject = msg.Project
 	a.activeWorkspace = msg.Workspace
 	a.showWelcome = false
@@ -321,6 +329,13 @@ func (a *App) handleWorkspaceActivated(msg messages.WorkspaceActivated) []tea.Cm
 		cmds = append(cmds, a.requestGitStatusFull(msg.Workspace.Root))
 		// Set up file watching for this workspace
 		if a.fileWatcher != nil {
+			// Release the previously-active workspace's watch before watching the
+			// new one. Without this, switching workspaces leaks an OS watch
+			// descriptor per distinct workspace until the watch limit is hit and
+			// git-status watching is disabled app-wide. Unwatch is idempotent.
+			if previousActiveRoot != "" && previousActiveRoot != msg.Workspace.Root {
+				a.fileWatcher.Unwatch(previousActiveRoot)
+			}
 			if err := a.fileWatcher.Watch(msg.Workspace.Root); err != nil {
 				logging.Warn("File watcher error: %v", err)
 				if errors.Is(err, git.ErrWatchLimit) && a.fileWatcherErr == nil {

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -115,6 +115,11 @@ func (a *App) handleWorkspaceDeleted(msg messages.WorkspaceDeleted) []tea.Cmd {
 		if a.gitStatus != nil {
 			a.gitStatus.Invalidate(msg.Workspace.Root)
 		}
+		// Release the deleted workspace's file watch: the worktree is gone, so
+		// keeping the OS watch descriptor only leaks it. Unwatch is idempotent.
+		if a.fileWatcher != nil {
+			a.fileWatcher.Unwatch(msg.Workspace.Root)
+		}
 		newCenter, cmd := a.center.Update(msg)
 		a.center = newCenter
 		if cmd != nil {

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -127,6 +127,9 @@ func (a *App) removeProject(project *data.Project) tea.Cmd {
 // It runs only from message handlers (workspace deleted, project removed,
 // selection rebind), never from view code.
 func (a *App) goHome() {
+	if a.fileWatcher != nil && a.activeWorkspace != nil {
+		a.fileWatcher.Unwatch(a.activeWorkspace.Root)
+	}
 	a.showWelcome = true
 	a.activeWorkspace = nil
 	if a.center != nil {

--- a/internal/app/app_operations_test.go
+++ b/internal/app/app_operations_test.go
@@ -8,8 +8,42 @@ import (
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
 )
+
+func TestGoHomeReleasesActiveWorkspaceFileWatch(t *testing.T) {
+	root := t.TempDir()
+	gitDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "index"), nil, 0o644); err != nil {
+		t.Fatalf("write git index: %v", err)
+	}
+
+	fileWatcher, err := git.NewFileWatcher(nil)
+	if err != nil {
+		t.Fatalf("NewFileWatcher: %v", err)
+	}
+	defer func() {
+		_ = fileWatcher.Close()
+	}()
+	if err := fileWatcher.Watch(root); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	app := &App{
+		activeWorkspace: data.NewWorkspace("feature", "feature", "main", root, root),
+		fileWatcher:     fileWatcher,
+	}
+
+	app.goHome()
+
+	if fileWatcher.IsWatching(root) {
+		t.Fatal("expected goHome to release active workspace file watch")
+	}
+}
 
 func TestLoadProjects_StoreFirstMerge(t *testing.T) {
 	skipIfNoGit(t)

--- a/internal/git/watcher.go
+++ b/internal/git/watcher.go
@@ -142,6 +142,7 @@ func (fw *FileWatcher) Unwatch(root string) {
 
 	delete(fw.watching, root)
 	delete(fw.watchPaths, root)
+	delete(fw.lastChange, root)
 }
 
 // run processes file system events

--- a/internal/git/watcher_test.go
+++ b/internal/git/watcher_test.go
@@ -240,6 +240,114 @@ func TestFileWatcher(t *testing.T) {
 	})
 }
 
+func newGitRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	gitDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "index"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	return root
+}
+
+func TestFileWatcherUnwatchReleasesState(t *testing.T) {
+	root := newGitRoot(t)
+
+	fw, err := NewFileWatcher(nil)
+	if err != nil {
+		t.Fatalf("NewFileWatcher() error = %v", err)
+	}
+	defer func() {
+		_ = fw.Close()
+	}()
+
+	if err := fw.Watch(root); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+	if fw.watchCount == 0 {
+		t.Fatalf("expected watchCount to increment after Watch, got 0")
+	}
+	// Simulate a debounced change recording a lastChange entry, mirroring Run.
+	fw.mu.Lock()
+	fw.lastChange[root] = time.Now()
+	fw.mu.Unlock()
+
+	fw.Unwatch(root)
+
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	if fw.watchCount != 0 {
+		t.Fatalf("expected watchCount = 0 after Unwatch, got %d", fw.watchCount)
+	}
+	if _, ok := fw.watching[root]; ok {
+		t.Fatalf("expected watching[root] removed after Unwatch")
+	}
+	if _, ok := fw.watchPaths[root]; ok {
+		t.Fatalf("expected watchPaths[root] removed after Unwatch")
+	}
+	if _, ok := fw.lastChange[root]; ok {
+		t.Fatalf("expected lastChange[root] removed after Unwatch (M2 leak)")
+	}
+}
+
+// TestFileWatcherSwitchChurnBounded is the regression guard for the watch leak:
+// repeatedly switching between two workspace roots (Unwatch(prev) + Watch(next),
+// mirroring the workspace-switch path) must not grow watchCount with the number
+// of switches.
+func TestFileWatcherSwitchChurnBounded(t *testing.T) {
+	rootA := newGitRoot(t)
+	rootB := newGitRoot(t)
+
+	fw, err := NewFileWatcher(nil)
+	if err != nil {
+		t.Fatalf("NewFileWatcher() error = %v", err)
+	}
+	defer func() {
+		_ = fw.Close()
+	}()
+
+	if err := fw.Watch(rootA); err != nil {
+		t.Fatalf("Watch(A) error = %v", err)
+	}
+
+	// Establish the single-active-workspace ceiling: exactly one root watched.
+	fw.mu.Lock()
+	maxCount := fw.watchCount
+	fw.mu.Unlock()
+
+	current := rootA
+	const switches = 50
+	for i := 0; i < switches; i++ {
+		next := rootB
+		if current == rootB {
+			next = rootA
+		}
+		fw.Unwatch(current)
+		if err := fw.Watch(next); err != nil {
+			t.Fatalf("Watch() error on switch %d: %v", i, err)
+		}
+		current = next
+
+		fw.mu.Lock()
+		count := fw.watchCount
+		fw.mu.Unlock()
+		if count > maxCount {
+			t.Fatalf("watchCount grew to %d on switch %d (ceiling %d); watch leak", count, i, maxCount)
+		}
+	}
+
+	// After churn, only the final active root is watched.
+	fw.Unwatch(current)
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	if fw.watchCount != 0 {
+		t.Fatalf("expected watchCount = 0 after final Unwatch, got %d", fw.watchCount)
+	}
+}
+
 // waitForNotifyCount polls c until it reaches at least want or the timeout
 // elapses, failing the test on timeout. Used in place of a fixed sleep plus an
 // immediate Load, which is flaky on slow CI and wastes time on fast machines.


### PR DESCRIPTION
FileWatcher.Watch ran on every workspace activation but the prior active
root was never Unwatched, and DeleteWorkspace never unwatched at all, leaking
an OS fsnotify descriptor per workspace opened until the watch limit tripped
and disabled git-status watching app-wide. Activation now releases the prior
active root, delete unwatches the removed root, and Unwatch clears its
lastChange entry. A churn test pins watchCount bounded across switches.

Plan: plans/014-release-file-watches-on-switch-and-delete.md
