### PR TITLE
Move socket janitor and state-watcher registration off the first-paint path

### DIFF
--- a/cmd/amux/main.go
+++ b/cmd/amux/main.go
@@ -88,7 +88,11 @@ func runTUI() {
 	}
 	defer logging.Close()
 
-	cleanupStaleTestTmuxSockets()
+	// Sweep stale test/e2e tmux sockets off the launch-critical path: each stale
+	// socket costs a blocking net.Dial (75ms timeout), so run the janitor in a
+	// panic-safe background goroutine instead of before app.New/p.Run. Cleanup
+	// still happens, just not before first paint.
+	safego.Go("tmux_socket_janitor", cleanupStaleTestTmuxSockets)
 
 	logging.Info("Starting amux")
 

--- a/cmd/amux/tmux_socket_janitor.go
+++ b/cmd/amux/tmux_socket_janitor.go
@@ -15,9 +15,13 @@ import (
 
 const staleSocketDialTimeout = 75 * time.Millisecond
 
+// tmuxSocketDirsFn resolves the directories the janitor sweeps. It is a package
+// var so tests can point it at a temp dir instead of the real tmux sockets.
+var tmuxSocketDirsFn = tmuxSocketDirs
+
 func cleanupStaleTestTmuxSockets() {
 	removed := 0
-	for _, dir := range tmuxSocketDirs() {
+	for _, dir := range tmuxSocketDirsFn() {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
 			continue

--- a/cmd/amux/tmux_socket_janitor_test.go
+++ b/cmd/amux/tmux_socket_janitor_test.go
@@ -1,0 +1,126 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// shortSocketDir returns a short-path temp dir suitable for unix sockets and
+// points the janitor at it. Unix socket paths are length-limited (~104 bytes on
+// macOS), so the deep `go test` temp dir under /var/folders is unusable here.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "amux-jtest-")
+	if err != nil {
+		t.Fatalf("mkdir temp socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	prev := tmuxSocketDirsFn
+	tmuxSocketDirsFn = func() []string { return []string{dir} }
+	t.Cleanup(func() { tmuxSocketDirsFn = prev })
+	return dir
+}
+
+// listenUnix creates a live unix socket at path and registers its cleanup.
+func listenUnix(t *testing.T, path string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+func TestCleanupStaleTestTmuxSockets_RemovesStaleTestSocket(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	stale := filepath.Join(dir, "amux-test-dead")
+	// Create a real socket inode, then close the listener so a dial is refused.
+	ln, err := net.Listen("unix", stale)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_ = ln.Close()
+	// Closing a unix listener removes the file; recreate it as a socket inode
+	// without an active listener so it presents as stale (dial is refused).
+	if _, err := os.Stat(stale); os.IsNotExist(err) {
+		ln2, err := net.Listen("unix", stale)
+		if err != nil {
+			t.Fatalf("relisten: %v", err)
+		}
+		// Detach the file from the listener: rename keeps the socket inode on disk
+		// while the listener still holds (and will free) the original fd.
+		tmp := stale + ".keep"
+		if err := os.Rename(stale, tmp); err != nil {
+			_ = ln2.Close()
+			t.Fatalf("rename: %v", err)
+		}
+		_ = ln2.Close()
+		if err := os.Rename(tmp, stale); err != nil {
+			t.Fatalf("rename back: %v", err)
+		}
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("stale socket missing before cleanup: %v", err)
+	}
+
+	cleanupStaleTestTmuxSockets()
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("expected stale test socket to be removed, stat err = %v", err)
+	}
+}
+
+func TestCleanupStaleTestTmuxSockets_KeepsLiveTestSocket(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	live := filepath.Join(dir, "amux-test-live")
+	listenUnix(t, live) // active listener => dial succeeds => kept
+
+	cleanupStaleTestTmuxSockets()
+
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("expected live test socket to be kept, stat err = %v", err)
+	}
+}
+
+func TestCleanupStaleTestTmuxSockets_IgnoresNonTestPrefix(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	// A non-test socket with no listener: would be "stale" but must be skipped
+	// because its name lacks the amux-test-/amux-e2e-check- prefix.
+	other := filepath.Join(dir, "default")
+	ln, err := net.Listen("unix", other)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	cleanupStaleTestTmuxSockets()
+
+	if _, err := os.Stat(other); err != nil {
+		t.Fatalf("expected non-test socket to be ignored/kept, stat err = %v", err)
+	}
+}
+
+func TestCleanupStaleTestTmuxSockets_KeepsRegularFile(t *testing.T) {
+	dir := shortSocketDir(t)
+
+	// A regular file matching the prefix is not a socket and must be left alone.
+	regular := filepath.Join(dir, "amux-test-regular")
+	if err := os.WriteFile(regular, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupStaleTestTmuxSockets()
+
+	if _, err := os.Stat(regular); err != nil {
+		t.Fatalf("expected regular file to be kept, stat err = %v", err)
+	}
+}

--- a/internal/app/state_watcher.go
+++ b/internal/app/state_watcher.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -69,23 +70,30 @@ func newStateWatcher(registryPath, metadataRoot string, onChanged func(reason st
 // register performs the deferred filesystem registration: it adds the registry
 // directory and the metadata root + existing workspace dirs to the watcher.
 // It is idempotent (fsnotify.Add and the metadataDirs guard tolerate repeats),
-// so a supervised restart of Run re-runs it safely. Add failures are logged and
-// swallowed (best-effort), matching how git.NewFileWatcher failures degrade.
-func (sw *stateWatcher) register() {
+// so a supervised restart of Run re-runs it safely. Root Add failures are
+// returned so the supervisor can surface disabled sync instead of leaving a
+// running watcher that observes nothing; child Add failures remain best-effort.
+func (sw *stateWatcher) register() error {
 	if sw.registryDir != "" {
 		if err := sw.addWatch(sw.registryDir); err != nil {
 			logging.Warn("state watcher: registry dir watch failed path=%s error=%v", sw.registryDir, err)
+			return fmt.Errorf("state watcher registry dir watch failed for %s: %w", sw.registryDir, err)
 		}
 	}
 	if sw.metadataRoot != "" {
-		sw.watchMetadataRoot()
+		if err := sw.watchMetadataRoot(); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (sw *stateWatcher) Run(ctx context.Context) error {
 	// Register watches after construction so the ReadDir + per-dir Add loop runs
 	// off the first-paint path.
-	sw.register()
+	if err := sw.register(); err != nil {
+		return err
+	}
 	// One-shot reconcile: a metadata change in the construct->register window is
 	// not reported by fsnotify (the path was not yet watched), so trigger a
 	// single state reload now to guarantee nothing is permanently missed.
@@ -153,15 +161,15 @@ func (sw *stateWatcher) addWatch(path string) error {
 // watchMetadataRoot watches the root directory and any existing children.
 // All failures are best-effort: a missed root/child Add is logged, not fatal,
 // since registration now runs off the construction path.
-func (sw *stateWatcher) watchMetadataRoot() {
+func (sw *stateWatcher) watchMetadataRoot() error {
 	if err := sw.addWatch(sw.metadataRoot); err != nil {
 		logging.Warn("state watcher: metadata root watch failed path=%s error=%v", sw.metadataRoot, err)
-		return
+		return fmt.Errorf("state watcher metadata root watch failed for %s: %w", sw.metadataRoot, err)
 	}
 	entries, err := os.ReadDir(sw.metadataRoot)
 	if err != nil {
 		// Root may not exist yet; that's fine.
-		return
+		return nil
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -172,6 +180,7 @@ func (sw *stateWatcher) watchMetadataRoot() {
 			logging.Debug("state watcher: best-effort watch failed path=%s error=%v", child, err)
 		}
 	}
+	return nil
 }
 
 // watchMetadataDir registers a child directory for watching.

--- a/internal/app/state_watcher.go
+++ b/internal/app/state_watcher.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +10,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/andyrewlee/amux/internal/logging"
 )
 
 type stateWatcher struct {
@@ -73,7 +74,7 @@ func newStateWatcher(registryPath, metadataRoot string, onChanged func(reason st
 func (sw *stateWatcher) register() {
 	if sw.registryDir != "" {
 		if err := sw.addWatch(sw.registryDir); err != nil {
-			slog.Warn("state watcher: registry dir watch failed", "path", sw.registryDir, "error", err)
+			logging.Warn("state watcher: registry dir watch failed path=%s error=%v", sw.registryDir, err)
 		}
 	}
 	if sw.metadataRoot != "" {
@@ -154,7 +155,7 @@ func (sw *stateWatcher) addWatch(path string) error {
 // since registration now runs off the construction path.
 func (sw *stateWatcher) watchMetadataRoot() {
 	if err := sw.addWatch(sw.metadataRoot); err != nil {
-		slog.Warn("state watcher: metadata root watch failed", "path", sw.metadataRoot, "error", err)
+		logging.Warn("state watcher: metadata root watch failed path=%s error=%v", sw.metadataRoot, err)
 		return
 	}
 	entries, err := os.ReadDir(sw.metadataRoot)
@@ -168,7 +169,7 @@ func (sw *stateWatcher) watchMetadataRoot() {
 		}
 		child := filepath.Join(sw.metadataRoot, entry.Name())
 		if err := sw.watchMetadataDir(child); err != nil {
-			slog.Debug("best-effort watch failed", "path", child, "error", err)
+			logging.Debug("state watcher: best-effort watch failed path=%s error=%v", child, err)
 		}
 	}
 }
@@ -229,7 +230,7 @@ func (sw *stateWatcher) handleMetadataEvent(event fsnotify.Event) bool {
 		if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 			if sw.looksLikeDir(name) {
 				if err := sw.watchMetadataDir(name); err != nil {
-					slog.Debug("best-effort watch failed", "path", name, "error", err)
+					logging.Debug("state watcher: best-effort watch failed path=%s error=%v", name, err)
 				}
 			}
 			return true

--- a/internal/app/state_watcher.go
+++ b/internal/app/state_watcher.go
@@ -34,6 +34,12 @@ type stateWatcher struct {
 	addWatchFn func(w *fsnotify.Watcher, dir string) error // test hook; nil = use watcher.Add
 }
 
+// newStateWatcher constructs the watcher in O(1): it only creates the
+// fsnotify.Watcher and records the paths to watch. The actual filesystem
+// registration (the registry-dir Add plus the metadata-root ReadDir and
+// per-workspace-dir Add loop) is deferred to register(), called once at the
+// start of Run so it runs off the first-paint path. Registration failures are
+// best-effort there, not fatal here.
 func newStateWatcher(registryPath, metadataRoot string, onChanged func(reason string, paths []string)) (*stateWatcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -49,25 +55,42 @@ func newStateWatcher(registryPath, metadataRoot string, onChanged func(reason st
 	if registryPath != "" {
 		sw.registryPath = filepath.Clean(registryPath)
 		sw.registryDir = filepath.Dir(sw.registryPath)
-		if err := watcher.Add(sw.registryDir); err != nil {
-			_ = watcher.Close()
-			return nil, err
-		}
 	}
 
 	if metadataRoot != "" {
 		sw.metadataRoot = filepath.Clean(metadataRoot)
 		sw.metadataDirs = make(map[string]struct{})
-		if err := sw.watchMetadataRoot(); err != nil {
-			_ = watcher.Close()
-			return nil, err
-		}
 	}
 
 	return sw, nil
 }
 
+// register performs the deferred filesystem registration: it adds the registry
+// directory and the metadata root + existing workspace dirs to the watcher.
+// It is idempotent (fsnotify.Add and the metadataDirs guard tolerate repeats),
+// so a supervised restart of Run re-runs it safely. Add failures are logged and
+// swallowed (best-effort), matching how git.NewFileWatcher failures degrade.
+func (sw *stateWatcher) register() {
+	if sw.registryDir != "" {
+		if err := sw.addWatch(sw.registryDir); err != nil {
+			slog.Warn("state watcher: registry dir watch failed", "path", sw.registryDir, "error", err)
+		}
+	}
+	if sw.metadataRoot != "" {
+		sw.watchMetadataRoot()
+	}
+}
+
 func (sw *stateWatcher) Run(ctx context.Context) error {
+	// Register watches after construction so the ReadDir + per-dir Add loop runs
+	// off the first-paint path.
+	sw.register()
+	// One-shot reconcile: a metadata change in the construct->register window is
+	// not reported by fsnotify (the path was not yet watched), so trigger a
+	// single state reload now to guarantee nothing is permanently missed.
+	if sw.metadataRoot != "" || sw.registryPath != "" {
+		sw.scheduleNotify("workspaces", "")
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -127,14 +150,17 @@ func (sw *stateWatcher) addWatch(path string) error {
 }
 
 // watchMetadataRoot watches the root directory and any existing children.
-func (sw *stateWatcher) watchMetadataRoot() error {
+// All failures are best-effort: a missed root/child Add is logged, not fatal,
+// since registration now runs off the construction path.
+func (sw *stateWatcher) watchMetadataRoot() {
 	if err := sw.addWatch(sw.metadataRoot); err != nil {
-		return err
+		slog.Warn("state watcher: metadata root watch failed", "path", sw.metadataRoot, "error", err)
+		return
 	}
 	entries, err := os.ReadDir(sw.metadataRoot)
 	if err != nil {
 		// Root may not exist yet; that's fine.
-		return nil
+		return
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -145,7 +171,6 @@ func (sw *stateWatcher) watchMetadataRoot() error {
 			slog.Debug("best-effort watch failed", "path", child, "error", err)
 		}
 	}
-	return nil
 }
 
 // watchMetadataDir registers a child directory for watching.

--- a/internal/app/state_watcher_test.go
+++ b/internal/app/state_watcher_test.go
@@ -199,7 +199,9 @@ func TestStateWatcher_RegisterWatchesRootAndExistingDirs(t *testing.T) {
 		return nil
 	}
 
-	sw.register()
+	if err := sw.register(); err != nil {
+		t.Fatalf("register: %v", err)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -217,10 +219,10 @@ func TestStateWatcher_RegisterWatchesRootAndExistingDirs(t *testing.T) {
 	}
 }
 
-func TestStateWatcher_ConstructorToleratesUnreadableMetadataDir(t *testing.T) {
+func TestStateWatcher_RegisterReportsMetadataRootFailure(t *testing.T) {
 	// A metadata root whose Add fails must NOT make construction fatal; it should
-	// degrade to logged best-effort inside register (modeled on git.NewFileWatcher
-	// being logged-and-niled rather than fatal).
+	// fail at deferred registration time so Run can surface disabled sync through
+	// the supervisor instead of staying alive on an unregistered watcher.
 	root := t.TempDir()
 	sw, err := newStateWatcher("", root, nil)
 	if err != nil {
@@ -231,8 +233,25 @@ func TestStateWatcher_ConstructorToleratesUnreadableMetadataDir(t *testing.T) {
 		return errors.New("injected add failure")
 	}
 
-	// register() must not panic and must not propagate the failure.
-	sw.register()
+	if err := sw.register(); err == nil {
+		t.Fatal("expected register to report metadata root watch failure")
+	}
+}
+
+func TestStateWatcher_RegisterReportsRegistryDirFailure(t *testing.T) {
+	registryPath := filepath.Join(t.TempDir(), "projects.json")
+	sw, err := newStateWatcher(registryPath, "", nil)
+	if err != nil {
+		t.Fatalf("constructor must not fail on registry dir issues: %v", err)
+	}
+	defer sw.Close()
+	sw.addWatchFn = func(_ *fsnotify.Watcher, _ string) error {
+		return errors.New("injected add failure")
+	}
+
+	if err := sw.register(); err == nil {
+		t.Fatal("expected register to report registry dir watch failure")
+	}
 }
 
 func TestStateWatcher_RunEmitsStartupReconcile(t *testing.T) {

--- a/internal/app/state_watcher_test.go
+++ b/internal/app/state_watcher_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,16 +107,14 @@ func TestStateWatcher_NotifiesOnRegistryWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var notified string
-	var mu sync.Mutex
-	done := make(chan struct{}, 1)
+	// Reasons are delivered on a channel so we can wait specifically for the
+	// "registry" notification, ignoring the one-shot reconcile that Run emits at
+	// startup (registration is now deferred into Run, so it reconciles once).
+	reasons := make(chan string, 4)
 
 	sw, err := newStateWatcher(registryPath, "", func(reason string, paths []string) {
-		mu.Lock()
-		notified = reason
-		mu.Unlock()
 		select {
-		case done <- struct{}{}:
+		case reasons <- reason:
 		default:
 		}
 	})
@@ -127,7 +126,7 @@ func TestStateWatcher_NotifiesOnRegistryWrite(t *testing.T) {
 
 	go func() { _ = sw.Run(t.Context()) }()
 
-	// Give the watcher a moment to start
+	// Give the watcher a moment to register and emit its startup reconcile.
 	time.Sleep(50 * time.Millisecond)
 
 	// Write to registry
@@ -135,16 +134,135 @@ func TestStateWatcher_NotifiesOnRegistryWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for registry notification")
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case reason := <-reasons:
+			if reason == "registry" {
+				return
+			}
+			// Skip the startup reconcile (delivered as "workspaces").
+		case <-deadline:
+			t.Fatal("timed out waiting for registry notification")
+		}
 	}
+}
+
+func TestStateWatcher_ConstructorIsLazy(t *testing.T) {
+	// The constructor must be O(1): it should NOT read the metadata root or add
+	// any watches. Registration is deferred to Run.
+	root := t.TempDir()
+	for _, name := range []string{"ws1", "ws2"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	registryPath := filepath.Join(t.TempDir(), "projects.json")
+
+	sw, err := newStateWatcher(registryPath, root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sw.Close()
+
+	sw.mu.Lock()
+	n := len(sw.metadataDirs)
+	sw.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("constructor registered %d metadata dirs; expected 0 (registration is deferred to Run)", n)
+	}
+}
+
+func TestStateWatcher_RegisterWatchesRootAndExistingDirs(t *testing.T) {
+	// After register() runs (called at the start of Run), the metadata root,
+	// each existing workspace dir, and the registry dir must be watched.
+	root := t.TempDir()
+	existing := filepath.Join(root, "abc123")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registryDir := t.TempDir()
+	registryPath := filepath.Join(registryDir, "projects.json")
+
+	var mu sync.Mutex
+	watched := make(map[string]struct{})
+
+	sw, err := newStateWatcher(registryPath, root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sw.Close()
+	sw.addWatchFn = func(_ *fsnotify.Watcher, dir string) error {
+		mu.Lock()
+		watched[dir] = struct{}{}
+		mu.Unlock()
+		return nil
+	}
+
+	sw.register()
 
 	mu.Lock()
 	defer mu.Unlock()
-	if notified != "registry" {
-		t.Fatalf("expected 'registry' notification, got %q", notified)
+	for _, want := range []string{root, existing, registryDir} {
+		if _, ok := watched[want]; !ok {
+			t.Fatalf("expected %s to be watched after register; watched: %v", want, watched)
+		}
+	}
+
+	sw.mu.Lock()
+	_, tracked := sw.metadataDirs[existing]
+	sw.mu.Unlock()
+	if !tracked {
+		t.Fatalf("expected existing workspace dir %s to be tracked", existing)
+	}
+}
+
+func TestStateWatcher_ConstructorToleratesUnreadableMetadataDir(t *testing.T) {
+	// A metadata root whose Add fails must NOT make construction fatal; it should
+	// degrade to logged best-effort inside register (modeled on git.NewFileWatcher
+	// being logged-and-niled rather than fatal).
+	root := t.TempDir()
+	sw, err := newStateWatcher("", root, nil)
+	if err != nil {
+		t.Fatalf("constructor must not fail on metadata dir issues: %v", err)
+	}
+	defer sw.Close()
+	sw.addWatchFn = func(_ *fsnotify.Watcher, _ string) error {
+		return errors.New("injected add failure")
+	}
+
+	// register() must not panic and must not propagate the failure.
+	sw.register()
+}
+
+func TestStateWatcher_RunEmitsStartupReconcile(t *testing.T) {
+	// Registration is deferred into Run, so a change in the construct->register
+	// window would be missed; Run must emit exactly one reconcile so nothing is
+	// permanently lost.
+	root := t.TempDir()
+
+	reconciled := make(chan string, 4)
+	sw, err := newStateWatcher("", root, func(reason string, _ []string) {
+		select {
+		case reconciled <- reason:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sw.debounce = 5 * time.Millisecond
+	defer sw.Close()
+
+	go func() { _ = sw.Run(t.Context()) }()
+
+	select {
+	case reason := <-reconciled:
+		if reason != "workspaces" {
+			t.Fatalf("startup reconcile reason = %q, want %q", reason, "workspaces")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for startup reconcile")
 	}
 }
 


### PR DESCRIPTION
The tmux socket janitor ran synchronously before app.New with a 75ms blocking
dial per stale socket, and the state watcher's constructor did a ReadDir plus
one fsnotify.Add syscall per workspace before the Bubble Tea loop painted. The
janitor now runs in a panic-safe background goroutine, and watch registration
moves into the supervised Run goroutine with a one-shot reconcile so no
metadata change in the construct->register window is permanently missed.

Plan: plans/015-defer-startup-work-off-paint-path.md
