### PR TITLE
Capture pane tails by session target with a pane-ID fallback

### DIFF
--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -378,18 +378,30 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 	if sessionName == "" || lines <= 0 {
 		return "", false
 	}
-	paneID, err := sessionPaneID(sessionName, opts)
-	if err != nil || paneID == "" {
-		return "", false
-	}
 	startLine := -lines
-	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", paneID, "-S", strconv.Itoa(startLine))
-	defer cancel()
+	// Fast path: target the session's active pane directly — one fork. This is
+	// the dominant per-scan cost (called per working agent on the 5s cadence), so
+	// we avoid the extra sessionPaneID forks (has-session + list-panes) here.
+	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionTarget(sessionName), "-S", strconv.Itoa(startLine))
 	output, err := cmd.Output()
-	if err != nil {
+	cancel()
+	if err == nil {
+		// Normalize: trim trailing whitespace and trailing empty lines.
+		return strings.TrimRight(string(output), " \t\n\r"), true
+	}
+	// Fallback: resolve the pane ID explicitly (handles tmux versions / detached
+	// sessions where session-target capture misbehaves), then capture. This
+	// reproduces exactly the old 3-fork behavior so the detached-session caveat
+	// that motivated pane-ID targeting can't regress.
+	paneID, perr := sessionPaneID(sessionName, opts)
+	if perr != nil || paneID == "" {
 		return "", false
 	}
-	// Normalize: trim trailing whitespace from each line and trailing empty lines
-	text := strings.TrimRight(string(output), " \t\n\r")
-	return text, true
+	cmd2, cancel2 := tmuxCommand(opts, "capture-pane", "-p", "-t", paneID, "-S", strconv.Itoa(startLine))
+	defer cancel2()
+	out2, err2 := cmd2.Output()
+	if err2 != nil {
+		return "", false
+	}
+	return strings.TrimRight(string(out2), " \t\n\r"), true
 }

--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -90,6 +90,16 @@ func sessionPaneID(sessionName string, opts Options) (string, error) {
 	return firstAlive, nil
 }
 
+func sessionActivePaneLive(sessionName string, opts Options) bool {
+	cmd, cancel := tmuxCommand(opts, "display-message", "-p", "-t", sessionTarget(sessionName), "#{pane_dead}")
+	defer cancel()
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "0"
+}
+
 // parseTabFields splits a tab-separated tmux -F output line into trimmed
 // fields and verifies it has at least want of them. It exists so positional
 // indexing into tmux output can never panic and malformed lines surface as
@@ -379,15 +389,17 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 		return "", false
 	}
 	startLine := -lines
-	// Fast path: target the session's active pane directly — one fork. This is
-	// the dominant per-scan cost (called per working agent on the 5s cadence), so
-	// we avoid the extra sessionPaneID forks (has-session + list-panes) here.
-	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionTarget(sessionName), "-S", strconv.Itoa(startLine))
-	output, err := cmd.Output()
-	cancel()
-	if err == nil {
-		// Normalize: trim trailing whitespace and trailing empty lines.
-		return strings.TrimRight(string(output), " \t\n\r"), true
+	// Fast path: target the session's active pane directly after confirming it is
+	// live. If the active pane is dead (remain-on-exit or a dead split), fall back
+	// to sessionPaneID so we preserve the old first-live-pane behavior.
+	if sessionActivePaneLive(sessionName, opts) {
+		cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionTarget(sessionName), "-S", strconv.Itoa(startLine))
+		output, err := cmd.Output()
+		cancel()
+		if err == nil {
+			// Normalize: trim trailing whitespace and trailing empty lines.
+			return strings.TrimRight(string(output), " \t\n\r"), true
+		}
 	}
 	// Fallback: resolve the pane ID explicitly (handles tmux versions / detached
 	// sessions where session-target capture misbehaves), then capture. This

--- a/internal/tmux/capture_integration_test.go
+++ b/internal/tmux/capture_integration_test.go
@@ -66,6 +66,55 @@ func TestCapturePaneTail_CapturesDetachedSession(t *testing.T) {
 	}
 }
 
+func TestCapturePaneTail_FallsBackFromDeadActivePane(t *testing.T) {
+	opts := realTmuxServerWithKeepalive(t)
+
+	createSession(t, opts, "tail-dead-active", "exec sh")
+	args := tmuxArgs(opts, "set-option", "-t", "tail-dead-active", "remain-on-exit", "on")
+	cmd := exec.Command("tmux", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("set remain-on-exit: %v\n%s", err, out)
+	}
+
+	args = tmuxArgs(opts, "split-window", "-d", "-t", "tail-dead-active", "printf live-marker; sleep 300")
+	cmd = exec.Command("tmux", args...)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("split-window: %v\n%s", err, out)
+	}
+
+	args = tmuxArgs(opts, "send-keys", "-t", "tail-dead-active:.0", "printf dead-marker; exit", "C-m")
+	cmd = exec.Command("tmux", args...)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("send-keys: %v\n%s", err, out)
+	}
+
+	if !eventually(5*time.Second, func() bool {
+		args := tmuxArgs(opts, "display-message", "-p", "-t", "tail-dead-active:.0", "#{pane_dead}")
+		cmd := exec.Command("tmux", args...)
+		out, err := cmd.Output()
+		return err == nil && strings.TrimSpace(string(out)) == "1"
+	}) {
+		t.Fatal("timed out waiting for active pane to become dead")
+	}
+
+	var text string
+	if !eventually(5*time.Second, func() bool {
+		out, ok := CapturePaneTail("tail-dead-active", 10, opts)
+		if ok {
+			text = out
+		}
+		return ok && strings.Contains(text, "live-marker")
+	}) {
+		t.Fatalf("expected live fallback pane capture to contain %q, got %q", "live-marker", text)
+	}
+	if strings.Contains(text, "dead-marker") {
+		t.Fatalf("expected dead active pane to be ignored, got %q", text)
+	}
+}
+
 func TestSessionPaneID_ResolvesForDetachedSession(t *testing.T) {
 	skipIfNoTmux(t)
 	opts := testServer(t)

--- a/internal/tmux/capture_integration_test.go
+++ b/internal/tmux/capture_integration_test.go
@@ -45,6 +45,27 @@ func TestCapturePaneTail_ResolvesActivePaneID(t *testing.T) {
 	}
 }
 
+func TestCapturePaneTail_CapturesDetachedSession(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	// createSession makes a detached session (new-session -d, no attached
+	// client). The session-target fast path must capture its pane content; if
+	// it can't, the pane-ID fallback must. Either way the known content returns.
+	createSession(t, opts, "tail-detached", "echo detached-marker; sleep 300")
+
+	var text string
+	if !eventually(5*time.Second, func() bool {
+		out, ok := CapturePaneTail("tail-detached", 10, opts)
+		if ok {
+			text = out
+		}
+		return ok && strings.Contains(text, "detached-marker")
+	}) {
+		t.Fatalf("expected detached-session tail to contain %q, got %q", "detached-marker", text)
+	}
+}
+
 func TestSessionPaneID_ResolvesForDetachedSession(t *testing.T) {
 	skipIfNoTmux(t)
 	opts := testServer(t)


### PR DESCRIPTION
CapturePaneTail forked sessionPaneID (has-session + list-panes) before every
capture-pane, costing 3 forks per working agent on the 5s activity scan. It now
tries a single session-targeted capture-pane -t =session and only falls back to
explicit pane-ID resolution when that errors, preserving the original behavior
for detached sessions where session targeting is unreliable on some tmux
versions. Net: one fork for attached sessions, unchanged for the fallback.

Plan: plans/017-single-fork-capture-pane-tail.md
