### PR TITLE
Make per-tab workspace saves atomic and cover the durability paths

### DIFF
--- a/internal/data/workspace_store_metadata_test.go
+++ b/internal/data/workspace_store_metadata_test.go
@@ -268,6 +268,145 @@ func TestWorkspaceStore_UpsertFromDiscovery_PreservesDiscoveredAssistantWhenStor
 	}
 }
 
+func TestWorkspaceStore_UpsertFromDiscovery_StoreWinsAndClearsArchived(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	// Stored workspace carries user-owned metadata and is archived.
+	stored := &Workspace{
+		Name:       "kept-name",
+		Branch:     "old-branch",
+		Repo:       "/repo",
+		Root:       "/root",
+		Assistant:  "codex",
+		Scripts:    ScriptsConfig{Setup: "npm install", Run: "npm start", Archive: "cleanup.sh"},
+		ScriptMode: "concurrent",
+		Env:        map[string]string{"API_KEY": "secret123"},
+		OpenTabs: []TabInfo{
+			{Assistant: "codex", Name: "codex", SessionName: "session-x", Status: "running"},
+		},
+		Archived:   true,
+		ArchivedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := store.Save(stored); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Discovery re-finds the same workspace (same Repo/Root → same ID) but with
+	// a new Branch and no metadata.
+	discovered := &Workspace{
+		Name:   "discovered-name",
+		Branch: "new-branch",
+		Repo:   "/repo",
+		Root:   "/root",
+	}
+	if err := store.UpsertFromDiscovery(discovered); err != nil {
+		t.Fatalf("UpsertFromDiscovery() error = %v", err)
+	}
+
+	loaded, err := store.Load(stored.ID())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Store-owned fields survive the rescan.
+	if loaded.Scripts.Setup != "npm install" || loaded.Scripts.Run != "npm start" || loaded.Scripts.Archive != "cleanup.sh" {
+		t.Errorf("Scripts = %#v, want stored scripts preserved", loaded.Scripts)
+	}
+	if loaded.ScriptMode != "concurrent" {
+		t.Errorf("ScriptMode = %q, want concurrent (store-owned)", loaded.ScriptMode)
+	}
+	if loaded.Env["API_KEY"] != "secret123" {
+		t.Errorf("Env[API_KEY] = %q, want secret123 (store-owned)", loaded.Env["API_KEY"])
+	}
+	if len(loaded.OpenTabs) != 1 || loaded.OpenTabs[0].SessionName != "session-x" {
+		t.Errorf("OpenTabs = %#v, want stored tab preserved", loaded.OpenTabs)
+	}
+	if loaded.Assistant != "codex" {
+		t.Errorf("Assistant = %q, want codex (store-owned)", loaded.Assistant)
+	}
+	if loaded.Name != "kept-name" {
+		t.Errorf("Name = %q, want kept-name (store-owned when non-empty)", loaded.Name)
+	}
+
+	// Discovery updates Branch and clears Archived.
+	if loaded.Branch != "new-branch" {
+		t.Errorf("Branch = %q, want new-branch (discovery-updated)", loaded.Branch)
+	}
+	if loaded.Archived {
+		t.Errorf("Archived = true, want cleared by discovery")
+	}
+	if !loaded.ArchivedAt.IsZero() {
+		t.Errorf("ArchivedAt = %v, want zero after un-archive", loaded.ArchivedAt)
+	}
+}
+
+func TestWorkspaceStore_UpsertFromDiscovery_RebindDeletesOldID(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	// Plant stored metadata under a legacy directory whose name is NOT the
+	// canonical Repo+Root hash, so discovery is found via the fallback scan and
+	// the recomputed ID differs (forcing the rebind-delete branch).
+	legacyID := WorkspaceID("legacy_rebind_id")
+	dir := filepath.Join(root, string(legacyID))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	legacyMetadata := `{
+		"name": "rebind-ws",
+		"branch": "old-branch",
+		"repo": "/repo",
+		"root": "/root",
+		"assistant": "codex",
+		"env": {"API_KEY": "secret123"}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "workspace.json"), []byte(legacyMetadata), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	discovered := &Workspace{
+		Name:   "rebind-ws",
+		Branch: "new-branch",
+		Repo:   "/repo",
+		Root:   "/root",
+	}
+	if err := store.UpsertFromDiscovery(discovered); err != nil {
+		t.Fatalf("UpsertFromDiscovery() error = %v", err)
+	}
+
+	// The recomputed canonical ID differs from the legacy one.
+	newID := (Workspace{Repo: "/repo", Root: "/root"}).ID()
+	if newID == legacyID {
+		t.Fatalf("test setup: legacy and canonical IDs must differ")
+	}
+
+	// Exactly one workspace remains — the rebound canonical record. The old
+	// legacy dir must be gone (no orphan).
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("List() = %v, want exactly one workspace after rebind", ids)
+	}
+	if ids[0] != newID {
+		t.Fatalf("remaining id = %s, want canonical %s", ids[0], newID)
+	}
+
+	// Store-owned metadata survives the rebind; Branch is discovery-updated.
+	loaded, err := store.Load(newID)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.Env["API_KEY"] != "secret123" {
+		t.Errorf("Env[API_KEY] = %q, want secret123 preserved across rebind", loaded.Env["API_KEY"])
+	}
+	if loaded.Branch != "new-branch" {
+		t.Errorf("Branch = %q, want new-branch", loaded.Branch)
+	}
+}
+
 func TestWorkspaceStore_LoadMetadataFor_CorruptedFile(t *testing.T) {
 	root := t.TempDir()
 	store := NewWorkspaceStore(root)

--- a/internal/data/workspace_store_tabs.go
+++ b/internal/data/workspace_store_tabs.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/andyrewlee/amux/internal/fsatomic"
 )
 
 // Update atomically loads a workspace, passes it to fn for modification, and
@@ -81,12 +83,10 @@ func (s *WorkspaceStore) saveWorkspaceLocked(id WorkspaceID, ws *Workspace) erro
 	if err != nil {
 		return err
 	}
-	tempPath := path + ".tmp"
-	if err := os.WriteFile(tempPath, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tempPath, path); err != nil {
-		_ = os.Remove(tempPath)
+	// Atomic replace (temp + fsync + rename, with backup recovery on platforms
+	// that need it), matching Save. The caller already holds the workspace lock.
+	// A crash mid-save can never leave a truncated workspace.json behind.
+	if err := fsatomic.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
 	return nil

--- a/internal/data/workspace_store_tabs_test.go
+++ b/internal/data/workspace_store_tabs_test.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -68,6 +70,67 @@ func TestWorkspaceStoreAppendOpenTabDedupesSessionName(t *testing.T) {
 	if len(loaded.OpenTabs) != 1 {
 		t.Fatalf("open tabs = %d, want 1", len(loaded.OpenTabs))
 	}
+}
+
+// TestWorkspaceStoreSaveLockedStaleTmpDoesNotShadowCommitted is a
+// characterization test for the locked save path (Update/AppendOpenTab). It
+// pins the invariant that a leftover <id>/workspace.json.tmp from a crashed
+// write never shadows the committed workspace.json: the committed metadata must
+// still load. This holds both before and after routing the write through
+// fsatomic (fsatomic uses a randomized temp name and fsync, so the safety only
+// improves).
+func TestWorkspaceStoreSaveLockedStaleTmpDoesNotShadowCommitted(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	ws := NewWorkspace("ws-a", "main", "origin/main", "/repo", "/repo/ws-a")
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Write through the locked path so the committed file is produced by it.
+	tab := TabInfo{
+		Assistant:   "claude",
+		Name:        "claude",
+		SessionName: "session-a",
+		Status:      "running",
+		CreatedAt:   time.Now().Unix(),
+	}
+	if err := store.AppendOpenTab(ws.ID(), tab); err != nil {
+		t.Fatalf("AppendOpenTab() error = %v", err)
+	}
+	if err := store.Update(ws.ID(), func(w *Workspace) error {
+		w.Branch = "feature"
+		return nil
+	}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	// Plant a stale, truncated .tmp artifact next to the committed file, as a
+	// crashed write would leave behind.
+	committedPath := store.workspacePath(ws.ID())
+	stalePath := committedPath + ".tmp"
+	if err := os.WriteFile(stalePath, []byte("{truncated"), 0o644); err != nil {
+		t.Fatalf("plant stale tmp: %v", err)
+	}
+
+	// The committed metadata must still load — the stale .tmp must not shadow it.
+	loaded, err := store.Load(ws.ID())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.Branch != "feature" {
+		t.Fatalf("Branch = %q, want feature", loaded.Branch)
+	}
+	if len(loaded.OpenTabs) != 1 || loaded.OpenTabs[0].SessionName != "session-a" {
+		t.Fatalf("OpenTabs = %#v, want one tab session-a", loaded.OpenTabs)
+	}
+
+	// Sanity: the committed file is intact JSON regardless of the stale artifact.
+	if _, statErr := os.Stat(committedPath); statErr != nil {
+		t.Fatalf("committed workspace.json missing: %v", statErr)
+	}
+	_ = filepath.Base(stalePath)
 }
 
 func TestWorkspaceStoreAppendOpenTabConcurrentWriters(t *testing.T) {

--- a/internal/fsatomic/fsatomic.go
+++ b/internal/fsatomic/fsatomic.go
@@ -12,6 +12,10 @@ import (
 	"runtime"
 )
 
+// renameFile is a test seam over os.Rename so the rename-failure restore branch
+// can be exercised. Production never reassigns it.
+var renameFile = os.Rename
+
 // WriteFile atomically replaces path with data. The temp file is created in
 // path's directory so the final rename never crosses filesystems. Replacement
 // files keep os.CreateTemp's private permissions; perm is accepted for parity
@@ -50,7 +54,7 @@ func writeFileForGOOS(goos, path string, data []byte, perm os.FileMode) error {
 		if err := replaceFileWindows(path, tmpPath); err != nil {
 			return err
 		}
-	} else if err := os.Rename(tmpPath, path); err != nil {
+	} else if err := renameFile(tmpPath, path); err != nil {
 		return err
 	}
 	cleanup = false
@@ -68,15 +72,15 @@ func replaceFileWindows(path, tmpPath string) error {
 		if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		if err := os.Rename(path, backupPath); err != nil {
+		if err := renameFile(path, backupPath); err != nil {
 			return err
 		}
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renameFile(tmpPath, path); err != nil {
 		if hadPrimary {
-			_ = os.Rename(backupPath, path)
+			_ = renameFile(backupPath, path)
 		}
 		return err
 	}

--- a/internal/fsatomic/fsatomic_test.go
+++ b/internal/fsatomic/fsatomic_test.go
@@ -1,6 +1,7 @@
 package fsatomic
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,4 +69,90 @@ func TestWriteFileWindowsBackupShuffle(t *testing.T) {
 	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
 		t.Fatalf("expected backup removed after successful replace, err=%v", err)
 	}
+}
+
+// TestWriteFileUnixRenameFailureLeavesTargetUntouched drives the Unix rename
+// failure: WriteFile must surface the error, leave the existing target intact,
+// and clean up the temp file it created.
+func TestWriteFileUnixRenameFailureLeavesTargetUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { renameFile = os.Rename })
+	sentinel := errors.New("rename failed")
+	renameFile = func(_, _ string) error { return sentinel }
+
+	err := writeFileForGOOS("linux", path, []byte("new"), 0o644)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WriteFile error = %v, want %v", err, sentinel)
+	}
+
+	// The original target survives untouched.
+	if got, _ := os.ReadFile(path); string(got) != "old" {
+		t.Fatalf("content = %q, want old (target must be untouched)", got)
+	}
+
+	// Only the original target remains; the temp file was cleaned up.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "state.json" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected only state.json to remain, found %v", names)
+	}
+}
+
+// TestWriteFileWindowsRestoresBackupOnFinalRenameFailure drives the Windows
+// shuffle's restore branch: the existing file is moved to .bak, the final
+// rename of the temp into place fails, and the backup must be restored to the
+// primary path so the previous contents survive.
+func TestWriteFileWindowsRestoresBackupOnFinalRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { renameFile = os.Rename })
+	sentinel := errors.New("final rename failed")
+	// Let the path->backup shuffle and the backup->path restore use the real
+	// rename; only the temp->path move fails. tmp paths carry the ".tmp-"
+	// marker that the real target/backup paths never do.
+	realRename := os.Rename
+	renameFile = func(oldPath, newPath string) error {
+		if filepath.Base(newPath) == filepath.Base(path) &&
+			containsTmpMarker(filepath.Base(oldPath)) {
+			return sentinel
+		}
+		return realRename(oldPath, newPath)
+	}
+
+	err := writeFileForGOOS("windows", path, []byte("new"), 0o644)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WriteFile error = %v, want %v", err, sentinel)
+	}
+
+	// The backup was restored to the primary path with the old contents.
+	if got, _ := os.ReadFile(path); string(got) != "old" {
+		t.Fatalf("content = %q, want old (backup must be restored)", got)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("expected backup consumed by restore, err=%v", err)
+	}
+}
+
+func containsTmpMarker(name string) bool {
+	for i := 0; i+5 <= len(name); i++ {
+		if name[i:i+5] == ".tmp-" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
saveWorkspaceLocked (the Update/AppendOpenTab write path) used a bare
os.WriteFile+rename with no fsync or backup, so a crash mid-save could leave a
truncated workspace.json with nothing to recover; it now goes through
fsatomic.WriteFile like Save. Adds a renameFile seam so fsatomic's
rename-failure restore branch is testable, plus store-wins / rebind tests for
UpsertFromDiscovery.

Plan: plans/010-persistence-durability-tests.md
