### PR TITLE
Test sidebar file-tree input and the PTY restart/detach FSM

### DIFF
--- a/internal/ui/sidebar/model_input_test.go
+++ b/internal/ui/sidebar/model_input_test.go
@@ -1,0 +1,232 @@
+package sidebar
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// twoSectionStatus builds a status with two sections (Staged + Unstaged) so the
+// display list contains header rows separating change rows:
+//
+//	index 0: header "Staged (2)"
+//	index 1: a.go  (Staged[0])
+//	index 2: b.go  (Staged[1])
+//	index 3: header "Unstaged (2)"
+//	index 4: c.go  (Unstaged[0])
+//	index 5: d.go  (Unstaged[1])
+func twoSectionStatus() *git.StatusResult {
+	return &git.StatusResult{
+		Clean: false,
+		Staged: []git.Change{
+			{Path: "a.go", Kind: git.ChangeModified, Staged: true},
+			{Path: "b.go", Kind: git.ChangeModified, Staged: true},
+		},
+		Unstaged: []git.Change{
+			{Path: "c.go", Kind: git.ChangeModified},
+			{Path: "d.go", Kind: git.ChangeModified},
+		},
+	}
+}
+
+func newInputModel(t *testing.T) *Model {
+	t.Helper()
+	m := New()
+	m.SetSize(80, 20)
+	m.Focus()
+	m.SetGitStatus(twoSectionStatus())
+	// Sanity-check the layout the cursor math depends on.
+	if len(m.displayItems) != 6 {
+		t.Fatalf("expected 6 display items (2 headers + 4 changes), got %d", len(m.displayItems))
+	}
+	if !m.displayItems[0].isHeader || !m.displayItems[3].isHeader {
+		t.Fatalf("expected headers at indices 0 and 3, got %+v", m.displayItems)
+	}
+	return m
+}
+
+func keyPress(code rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: code, Text: string(code)}
+}
+
+func TestInputNavSkipsHeaders(t *testing.T) {
+	m := newInputModel(t)
+
+	// After SetGitStatus the cursor lands on the first non-header row.
+	if m.cursor != 1 {
+		t.Fatalf("expected initial cursor on first change (index 1), got %d", m.cursor)
+	}
+
+	// Walk all the way down with 'j' and assert the cursor never rests on a
+	// header row, and that it crosses the Staged/Unstaged header boundary.
+	seen := map[int]bool{}
+	for i := 0; i < 10; i++ {
+		m, _ = m.Update(keyPress('j'))
+		if m.displayItems[m.cursor].isHeader {
+			t.Fatalf("cursor landed on a header at index %d after %d down moves", m.cursor, i+1)
+		}
+		seen[m.cursor] = true
+	}
+	// Should have reached and stopped on the last change row (index 5),
+	// and visited the first row after the second header (index 4).
+	if m.cursor != 5 {
+		t.Fatalf("expected cursor clamped to last change (index 5), got %d", m.cursor)
+	}
+	if !seen[4] {
+		t.Fatalf("expected cursor to cross the header boundary onto index 4, visited %v", seen)
+	}
+
+	// Walk back up with 'k' and assert the same header-skip invariant, and that
+	// it clamps to the first change row (index 1), never to the header at 0.
+	for i := 0; i < 10; i++ {
+		m, _ = m.Update(keyPress('k'))
+		if m.displayItems[m.cursor].isHeader {
+			t.Fatalf("cursor landed on a header at index %d after %d up moves", m.cursor, i+1)
+		}
+	}
+	if m.cursor != 1 {
+		t.Fatalf("expected cursor clamped to first change (index 1), got %d", m.cursor)
+	}
+}
+
+func TestInputNavArrowKeys(t *testing.T) {
+	m := newInputModel(t)
+
+	// down arrow behaves like 'j'.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.cursor != 2 {
+		t.Fatalf("expected down arrow to move cursor to index 2, got %d", m.cursor)
+	}
+	// up arrow behaves like 'k'.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if m.cursor != 1 {
+		t.Fatalf("expected up arrow to move cursor to index 1, got %d", m.cursor)
+	}
+}
+
+func TestInputOpenEmitsOpenDiffForSelectedChange(t *testing.T) {
+	m := newInputModel(t)
+
+	// Move onto the first Unstaged change (index 4 == c.go).
+	m, _ = m.Update(keyPress('j')) // 2 (b.go)
+	m, _ = m.Update(keyPress('j')) // 4 (c.go, skipping header at 3)
+	if m.cursor != 4 {
+		t.Fatalf("expected cursor on index 4 (c.go), got %d", m.cursor)
+	}
+
+	// 'enter' opens the current item; assert the emitted message is OpenDiff for
+	// c.go with the Unstaged diff mode.
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from open key")
+	}
+	msg := cmd()
+	open, ok := msg.(messages.OpenDiff)
+	if !ok {
+		t.Fatalf("expected messages.OpenDiff, got %T", msg)
+	}
+	if open.Change == nil || open.Change.Path != "c.go" {
+		t.Fatalf("expected OpenDiff for c.go, got %+v", open.Change)
+	}
+	if open.Mode != git.DiffModeUnstaged {
+		t.Fatalf("expected DiffModeUnstaged for unstaged change, got %v", open.Mode)
+	}
+}
+
+func TestInputOpenViaOAndSpaceKeys(t *testing.T) {
+	// 'o' and 'space' are also bound to open; assert they emit OpenDiff for the
+	// initially-selected staged change (index 1 == a.go).
+	for _, key := range []tea.KeyPressMsg{
+		keyPress('o'),
+		{Code: tea.KeySpace},
+	} {
+		m := newInputModel(t)
+		_, cmd := m.Update(key)
+		if cmd == nil {
+			t.Fatalf("expected non-nil cmd for open key %+v", key)
+		}
+		open, ok := cmd().(messages.OpenDiff)
+		if !ok {
+			t.Fatalf("expected messages.OpenDiff for key %+v, got %T", key, cmd())
+		}
+		if open.Change == nil || open.Change.Path != "a.go" {
+			t.Fatalf("expected OpenDiff for a.go, got %+v", open.Change)
+		}
+		if open.Mode != git.DiffModeStaged {
+			t.Fatalf("expected DiffModeStaged for staged change, got %v", open.Mode)
+		}
+	}
+}
+
+func TestInputClickResolvesRowToChange(t *testing.T) {
+	m := newInputModel(t)
+
+	// listHeaderLines() == 1 here (no workspace branch, not filtering, +1 for the
+	// "changed files" line) and helpLineCount() == 0 (hints disabled by default),
+	// so screen row Y maps to displayItems[Y-1]. Click Y=5 -> index 4 (c.go).
+	_, cmd := m.Update(tea.MouseClickMsg{X: 2, Y: 5, Button: tea.MouseLeft})
+	if m.cursor != 4 {
+		t.Fatalf("expected click on Y=5 to move cursor to index 4, got %d", m.cursor)
+	}
+	if cmd == nil {
+		t.Fatal("expected click on a change row to emit an open cmd")
+	}
+	open, ok := cmd().(messages.OpenDiff)
+	if !ok {
+		t.Fatalf("expected messages.OpenDiff from click, got %T", cmd())
+	}
+	if open.Change == nil || open.Change.Path != "c.go" {
+		t.Fatalf("expected click to open c.go, got %+v", open.Change)
+	}
+}
+
+func TestInputClickOnHeaderIsNoOpOpen(t *testing.T) {
+	m := newInputModel(t)
+	start := m.cursor
+
+	// Y=4 maps to displayItems[3], which is the "Unstaged" header. rowIndexAt
+	// still resolves the row, but openCurrentItem must refuse to open a header.
+	_, cmd := m.Update(tea.MouseClickMsg{X: 2, Y: 4, Button: tea.MouseLeft})
+	if m.cursor != 3 {
+		t.Fatalf("expected click on header row to set cursor to header index 3, got %d", m.cursor)
+	}
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			t.Fatalf("expected no OpenDiff when clicking a header, got %T", msg)
+		}
+	}
+	_ = start
+}
+
+func TestInputClickOutsideRowsIsNoOp(t *testing.T) {
+	m := newInputModel(t)
+	before := m.cursor
+
+	// Y=0 is above the list content (within the header area), so rowIndexAt
+	// returns !ok and the click is ignored.
+	_, cmd := m.Update(tea.MouseClickMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for click above the change list, got non-nil")
+	}
+	if m.cursor != before {
+		t.Fatalf("expected cursor unchanged on out-of-range click, got %d (was %d)", m.cursor, before)
+	}
+}
+
+func TestInputIgnoredWhenUnfocused(t *testing.T) {
+	m := New()
+	m.SetSize(80, 20)
+	m.SetGitStatus(twoSectionStatus())
+	// not focused
+	before := m.cursor
+	m, cmd := m.Update(keyPress('j'))
+	if m.cursor != before {
+		t.Fatalf("expected unfocused key press to be ignored, cursor moved to %d", m.cursor)
+	}
+	if cmd != nil {
+		t.Fatal("expected nil cmd when unfocused")
+	}
+}

--- a/internal/ui/sidebar/terminal_update_pty_test.go
+++ b/internal/ui/sidebar/terminal_update_pty_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -117,5 +118,92 @@ func TestHandlePTYRestart_TrimsSecondaryDAContinuationAfterEscapeCarry(t *testin
 
 	if string(state.PendingOutput) != "visible" {
 		t.Fatalf("expected secondary DA continuation trimmed after restart, got %q", state.PendingOutput)
+	}
+}
+
+// liveTerminalState returns a TerminalState whose Terminal is a zero-value
+// *pty.Terminal. A freshly constructed terminal has closed==false, so
+// IsClosed() reports false and handlePTYStopped takes the termAlive
+// restart-backoff branch. This is the same fake the attach tests rely on.
+func liveTerminalState() *TerminalState {
+	return &TerminalState{
+		Terminal: &pty.Terminal{},
+		Running:  true,
+	}
+}
+
+func TestHandlePTYStopped_RestartBackoffSchedulesTickAndGrows(t *testing.T) {
+	if (&pty.Terminal{}).IsClosed() {
+		t.Fatal("precondition: a zero-value *pty.Terminal must report IsClosed()==false")
+	}
+
+	m := NewTerminalModel()
+	wsID := "ws-restart"
+	tabID := TerminalTabID("term-tab-restart")
+	state := liveTerminalState()
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+
+	// Each of the first ptyRestartMax calls must schedule a restart tick and
+	// leave the terminal attached (not detached). Backoff must grow each time
+	// until it reaches the cap.
+	lastBackoff := -1 // sentinel below any real backoff
+	for i := 0; i < ptyRestartMax; i++ {
+		cmd := m.handlePTYStopped(messages.SidebarPTYStopped{
+			WorkspaceID: wsID,
+			TabID:       string(tabID),
+		})
+		if cmd == nil {
+			t.Fatalf("call %d: expected a non-nil restart tick cmd while under the limit", i+1)
+		}
+		if state.Detached {
+			t.Fatalf("call %d: expected Detached==false while restarting, got true", i+1)
+		}
+		if !state.Running {
+			t.Fatalf("call %d: expected Running to stay true while restarting", i+1)
+		}
+		got := int(state.RestartBackoff)
+		if got <= 0 {
+			t.Fatalf("call %d: expected positive backoff, got %d", i+1, got)
+		}
+		// Backoff doubles until it saturates at the cap, so it must be
+		// non-decreasing across calls.
+		if got < lastBackoff {
+			t.Fatalf("call %d: expected backoff to grow or hold, got %d after %d", i+1, got, lastBackoff)
+		}
+		lastBackoff = got
+	}
+}
+
+func TestHandlePTYStopped_DetachesAfterRestartLimit(t *testing.T) {
+	m := NewTerminalModel()
+	wsID := "ws-restart-limit"
+	tabID := TerminalTabID("term-tab-restart-limit")
+	state := liveTerminalState()
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{{ID: tabID, State: state}}
+
+	// Exhaust the restart budget; these all schedule ticks.
+	for i := 0; i < ptyRestartMax; i++ {
+		if cmd := m.handlePTYStopped(messages.SidebarPTYStopped{WorkspaceID: wsID, TabID: string(tabID)}); cmd == nil {
+			t.Fatalf("call %d: expected restart tick while under the limit", i+1)
+		}
+	}
+	if state.Detached {
+		t.Fatal("expected terminal to remain attached up to the restart limit")
+	}
+
+	// One more stop within the window exceeds ptyRestartMax: the FSM gives up
+	// and marks the terminal detached with no restart scheduled.
+	cmd := m.handlePTYStopped(messages.SidebarPTYStopped{WorkspaceID: wsID, TabID: string(tabID)})
+	if cmd != nil {
+		t.Fatal("expected nil cmd once the restart limit is exceeded")
+	}
+	if !state.Detached {
+		t.Fatal("expected Detached==true after exceeding the restart limit")
+	}
+	if state.Running {
+		t.Fatal("expected Running==false after exceeding the restart limit")
+	}
+	if state.UserDetached {
+		t.Fatal("expected UserDetached==false (give-up detach is not user-initiated)")
 	}
 }


### PR DESCRIPTION
The file-tree input dispatch (header-skip nav, enter/open emitting OpenDiff,
mouse-row resolution) and the handlePTYStopped restart-backoff branch were
uncovered. Adds dispatch tests proving the cursor never lands on a header and
the right OpenDiff is emitted, plus FSM tests that a live terminal schedules a
growing-backoff restart below the limit and detaches once it is exceeded.

Plan: plans/013-sidebar-restart-fsm-and-input-tests.md
