### PR TITLE
Gate project-supplied scripts behind per-repo trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,26 @@ Start with [`ARCHITECTURE.md`](ARCHITECTURE.md) for the repo-level package map a
 
 ## Configuration
 
-Create `.amux/workspaces.json` in your project to run setup commands for new workspaces:
+Create `.amux/workspaces.json` in your project to define commands that amux runs for its workspaces:
 
 ```json
 {
   "setup-workspace": [
     "npm install",
     "cp $ROOT_WORKSPACE_PATH/.env.local .env.local"
-  ]
+  ],
+  "run": "npm start",
+  "archive": "tar -czf archive.tar.gz ."
 }
 ```
 
-Workspace metadata is stored in `~/.amux/workspaces-metadata/<workspace-id>/workspace.json`, and local worktree directories live under `~/.amux/workspaces/<project>/<workspace>`.
+- `setup-workspace` — commands run once when a new workspace is created.
+- `run` — the command started for a workspace's run script.
+- `archive` — the command run when a workspace is archived.
+
+Because these commands come from the repository, amux runs them only after you trust the repo. The first time a repo's `.amux/workspaces.json` would run (and every time its contents change), amux records the approved content of the file; until then those project-supplied scripts are skipped and you are notified, rather than executing arbitrary commands chosen by the repo's author. Editing `.amux/workspaces.json` invalidates the approval, so changed commands are re-gated until you trust the file again. (Run/archive scripts you enter yourself in the amux UI are your own input and are never gated.)
+
+Workspace metadata is stored in `~/.amux/workspaces-metadata/<workspace-id>/workspace.json`, and local worktree directories live under `~/.amux/workspaces/<project>/<workspace>`. Trusted-repo approvals are recorded in `~/.amux/trusted-scripts.json`.
 
 ## Platform Support
 

--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -27,6 +27,7 @@ const (
 	DialogAddProject      = "add_project"
 	DialogCreateWorkspace = "create_workspace"
 	DialogDeleteWorkspace = "delete_workspace"
+	DialogTrustScripts    = "trust_scripts"
 	DialogRemoveProject   = "remove_project"
 	DialogSelectAssistant = "select_assistant"
 	DialogQuit            = "quit"
@@ -86,8 +87,9 @@ type App struct {
 	toast *common.ToastModel
 
 	// Dialog context
-	dialogProject   *data.Project
-	dialogWorkspace *data.Workspace
+	dialogProject          *data.Project
+	dialogWorkspace        *data.Workspace
+	dialogTrustScriptsHash string
 	// Pending workspace creation context while selecting assistant.
 	pendingWorkspaceProject *data.Project
 	pendingWorkspaceName    string

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -21,7 +21,7 @@ func (a *App) handleDialogResultMsg(msg tea.Msg) (bool, tea.Cmd) {
 	}
 	logging.Info("Received DialogResult: id=%s confirmed=%v", result.ID, result.Confirmed)
 	switch result.ID {
-	case DialogAddProject, DialogCreateWorkspace, DialogDeleteWorkspace, DialogRemoveProject, DialogSelectAssistant, "agent-picker", DialogQuit, DialogCleanupTmux:
+	case DialogAddProject, DialogCreateWorkspace, DialogDeleteWorkspace, DialogTrustScripts, DialogRemoveProject, DialogSelectAssistant, "agent-picker", DialogQuit, DialogCleanupTmux:
 		return true, common.SafeCmd(a.handleDialogResult(result))
 	}
 	// If not an App-level dialog, let it fall through to components.
@@ -99,9 +99,11 @@ func (a *App) handleSettingsDialogInput(msg tea.Msg, cmds *[]tea.Cmd) bool {
 func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 	project := a.dialogProject
 	workspace := a.dialogWorkspace
+	trustScriptsHash := a.dialogTrustScriptsHash
 	a.dialog = nil
 	a.dialogProject = nil
 	a.dialogWorkspace = nil
+	a.dialogTrustScriptsHash = ""
 	logging.Debug("Dialog result: id=%s confirmed=%v value=%s", result.ID, result.Confirmed, result.Value)
 
 	if !result.Confirmed {
@@ -155,6 +157,11 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 					Workspace: ws,
 				}
 			}
+		}
+
+	case DialogTrustScripts:
+		if workspace != nil {
+			return a.trustRepoScriptsAndRunSetupAsync(workspace, trustScriptsHash)
 		}
 
 	case DialogRemoveProject:

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -278,6 +278,8 @@ func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		a.handleShowCreateWorkspaceDialog(msg)
 	case messages.ShowDeleteWorkspaceDialog:
 		a.handleShowDeleteWorkspaceDialog(msg)
+	case messages.ShowTrustScriptsDialog:
+		a.handleShowTrustScriptsDialog(msg)
 	case messages.ShowRemoveProjectDialog:
 		a.handleShowRemoveProjectDialog(msg)
 	case messages.ShowSelectAssistantDialog:

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -60,6 +60,25 @@ func (a *App) handleShowDeleteWorkspaceDialog(msg messages.ShowDeleteWorkspaceDi
 	a.dialog.Show()
 }
 
+// handleShowTrustScriptsDialog shows the repo script trust confirmation dialog.
+func (a *App) handleShowTrustScriptsDialog(msg messages.ShowTrustScriptsDialog) {
+	a.dialogWorkspace = msg.Workspace
+	a.dialogTrustScriptsHash = msg.ConfigHash
+	workspaceName := ""
+	if msg.Workspace != nil {
+		workspaceName = msg.Workspace.Name
+	}
+	a.dialog = common.NewConfirmDialog(
+		DialogTrustScripts,
+		"Trust Project Scripts",
+		fmt.Sprintf("Trust .amux/workspaces.json scripts for '%s' and run setup now?", workspaceName),
+	)
+	a.dialog.SetDefaultOption(1)
+	a.dialog.SetSize(a.width, a.height)
+	a.dialog.SetShowKeymapHints(a.config.UI.ShowKeymapHints)
+	a.dialog.Show()
+}
+
 // handleShowRemoveProjectDialog shows the remove project dialog.
 func (a *App) handleShowRemoveProjectDialog(msg messages.ShowRemoveProjectDialog) {
 	a.dialogProject = msg.Project

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -71,9 +71,18 @@ func (a *App) handleWorkspaceSetupComplete(msg messages.WorkspaceSetupComplete) 
 		// deliberately not run because the repo isn't trusted yet) from a genuine
 		// setup failure, so the user knows nothing executed and why.
 		if errors.Is(msg.Err, process.ErrScriptsNotTrusted) {
-			return a.toast.ShowWarning(fmt.Sprintf(
+			var trustErr *process.ScriptsNotTrustedError
+			var configHash string
+			if errors.As(msg.Err, &trustErr) {
+				configHash = trustErr.ConfigHash
+			}
+			toastCmd := a.toast.ShowWarning(fmt.Sprintf(
 				"Skipped .amux/workspaces.json scripts for %s: repo not trusted yet (scripts run only after you trust this repo)",
 				msg.Workspace.Name))
+			dialogCmd := func() tea.Msg {
+				return messages.ShowTrustScriptsDialog{Workspace: msg.Workspace, ConfigHash: configHash}
+			}
+			return common.SafeBatch(toastCmd, dialogCmd)
 		}
 		return a.toast.ShowWarning(fmt.Sprintf("Setup failed for %s: %v", msg.Workspace.Name, msg.Err))
 	}

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	tea "charm.land/bubbletea/v2"
@@ -8,6 +9,7 @@ import (
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -65,6 +67,14 @@ func (a *App) handleWorkspaceCreated(msg messages.WorkspaceCreated) []tea.Cmd {
 // handleWorkspaceSetupComplete handles the WorkspaceSetupComplete message.
 func (a *App) handleWorkspaceSetupComplete(msg messages.WorkspaceSetupComplete) tea.Cmd {
 	if msg.Err != nil {
+		// Distinguish a trust skip (the repo's .amux/workspaces.json scripts were
+		// deliberately not run because the repo isn't trusted yet) from a genuine
+		// setup failure, so the user knows nothing executed and why.
+		if errors.Is(msg.Err, process.ErrScriptsNotTrusted) {
+			return a.toast.ShowWarning(fmt.Sprintf(
+				"Skipped .amux/workspaces.json scripts for %s: repo not trusted yet (scripts run only after you trust this repo)",
+				msg.Workspace.Name))
+		}
 		return a.toast.ShowWarning(fmt.Sprintf("Setup failed for %s: %v", msg.Workspace.Name, msg.Err))
 	}
 	return nil

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -2,15 +2,62 @@ package app
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/dashboard"
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
 )
+
+// TestHandleWorkspaceSetupComplete_TrustSkipToast proves the setup-complete
+// handler distinguishes a trust skip (ErrScriptsNotTrusted) from a generic
+// setup failure, naming .amux/workspaces.json so the user knows what was
+// skipped and why.
+func TestHandleWorkspaceSetupComplete_TrustSkipToast(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	app := &App{toast: common.NewToastModel()}
+
+	wrapped := fmt.Errorf("/repo (%q): %w", "touch marker", process.ErrScriptsNotTrusted)
+	if cmd := app.handleWorkspaceSetupComplete(messages.WorkspaceSetupComplete{
+		Workspace: ws,
+		Err:       wrapped,
+	}); cmd == nil {
+		t.Fatal("expected a warning toast command for a trust-skip error")
+	}
+
+	view := app.toast.View()
+	if !strings.Contains(view, ".amux/workspaces.json") {
+		t.Fatalf("trust-skip toast should name .amux/workspaces.json, got: %q", view)
+	}
+	if strings.Contains(view, "Setup failed") {
+		t.Fatalf("trust-skip toast must not use the generic 'Setup failed' wording, got: %q", view)
+	}
+}
+
+// TestHandleWorkspaceSetupComplete_GenericFailureToast proves non-trust errors
+// keep the generic "Setup failed" branch.
+func TestHandleWorkspaceSetupComplete_GenericFailureToast(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	app := &App{toast: common.NewToastModel()}
+
+	if cmd := app.handleWorkspaceSetupComplete(messages.WorkspaceSetupComplete{
+		Workspace: ws,
+		Err:       errors.New("boom"),
+	}); cmd == nil {
+		t.Fatal("expected a warning toast command for a generic setup failure")
+	}
+
+	view := app.toast.View()
+	if !strings.Contains(view, "Setup failed") {
+		t.Fatalf("generic failure toast should say 'Setup failed', got: %q", view)
+	}
+}
 
 func TestHandleWorkspaceDeletedClearsDirtyWorkspaceMarker(t *testing.T) {
 	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -2,9 +2,12 @@ package app
 
 import (
 	"errors"
-	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
@@ -15,19 +18,52 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/sidebar"
 )
 
+func workspaceSetupConfig(t *testing.T, repoPath, content string) {
+	t.Helper()
+	configDir := filepath.Join(repoPath, ".amux")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir .amux: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "workspaces.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write workspaces.json: %v", err)
+	}
+}
+
+func runCommandMessages(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		msgs := make([]tea.Msg, 0, len(batch))
+		for _, batchCmd := range batch {
+			if batchCmd != nil {
+				msgs = append(msgs, batchCmd())
+			}
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
+
 // TestHandleWorkspaceSetupComplete_TrustSkipToast proves the setup-complete
 // handler distinguishes a trust skip (ErrScriptsNotTrusted) from a generic
 // setup failure, naming .amux/workspaces.json so the user knows what was
-// skipped and why.
-func TestHandleWorkspaceSetupComplete_TrustSkipToast(t *testing.T) {
+// skipped and why, and prompts the user to trust the current repo config.
+func TestHandleWorkspaceSetupComplete_TrustSkipToastAndDialog(t *testing.T) {
 	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
 	app := &App{toast: common.NewToastModel()}
 
-	wrapped := fmt.Errorf("/repo (%q): %w", "touch marker", process.ErrScriptsNotTrusted)
-	if cmd := app.handleWorkspaceSetupComplete(messages.WorkspaceSetupComplete{
+	wrapped := &process.ScriptsNotTrustedError{
+		Repo:       "/repo",
+		Command:    "touch marker",
+		ConfigHash: "abc123",
+	}
+	cmd := app.handleWorkspaceSetupComplete(messages.WorkspaceSetupComplete{
 		Workspace: ws,
 		Err:       wrapped,
-	}); cmd == nil {
+	})
+	if cmd == nil {
 		t.Fatal("expected a warning toast command for a trust-skip error")
 	}
 
@@ -37,6 +73,19 @@ func TestHandleWorkspaceSetupComplete_TrustSkipToast(t *testing.T) {
 	}
 	if strings.Contains(view, "Setup failed") {
 		t.Fatalf("trust-skip toast must not use the generic 'Setup failed' wording, got: %q", view)
+	}
+	var foundTrustPrompt bool
+	for _, msg := range runCommandMessages(cmd) {
+		prompt, ok := msg.(messages.ShowTrustScriptsDialog)
+		if ok && prompt.Workspace == ws {
+			if prompt.ConfigHash != "abc123" {
+				t.Fatalf("trust prompt hash = %q, want abc123", prompt.ConfigHash)
+			}
+			foundTrustPrompt = true
+		}
+	}
+	if !foundTrustPrompt {
+		t.Fatal("expected trust-skip command to open the repo script trust dialog")
 	}
 }
 
@@ -56,6 +105,86 @@ func TestHandleWorkspaceSetupComplete_GenericFailureToast(t *testing.T) {
 	view := app.toast.View()
 	if !strings.Contains(view, "Setup failed") {
 		t.Fatalf("generic failure toast should say 'Setup failed', got: %q", view)
+	}
+}
+
+func TestHandleDialogResultTrustScriptsTrustsAndRetriesSetup(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	marker := filepath.Join(wsRoot, "setup-ran")
+	workspaceSetupConfig(t, repo, `{"setup-workspace":["touch `+marker+`"]}`)
+	ws := data.NewWorkspace("feature", "feature", "main", repo, wsRoot)
+
+	scripts := process.NewScriptRunner(6200, 10)
+	err := scripts.RunSetup(ws)
+	var trustErr *process.ScriptsNotTrustedError
+	if !errors.As(err, &trustErr) {
+		t.Fatalf("expected initial setup to be blocked by trust gate, got %v", err)
+	}
+	app := &App{
+		workspaceService:       newWorkspaceService(nil, nil, scripts, ""),
+		dialog:                 common.NewConfirmDialog(DialogTrustScripts, "Trust", "Trust scripts?"),
+		dialogWorkspace:        ws,
+		dialogTrustScriptsHash: trustErr.ConfigHash,
+	}
+
+	cmd := app.handleDialogResult(common.DialogResult{ID: DialogTrustScripts, Confirmed: true})
+	if cmd == nil {
+		t.Fatal("expected trust confirmation to return a setup retry command")
+	}
+	msg, ok := cmd().(messages.WorkspaceSetupComplete)
+	if !ok {
+		t.Fatalf("expected WorkspaceSetupComplete, got %T", msg)
+	}
+	if msg.Err != nil {
+		t.Fatalf("trust-and-retry setup failed: %v", msg.Err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected trusted setup command to run: %v", err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+	if err := scripts.RunSetup(ws); err != nil {
+		t.Fatalf("expected repo config to remain trusted after dialog confirmation: %v", err)
+	}
+}
+
+func TestTrustScriptsRetryRejectsChangedConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	originalMarker := filepath.Join(wsRoot, "original")
+	changedMarker := filepath.Join(wsRoot, "changed")
+	workspaceSetupConfig(t, repo, `{"setup-workspace":["touch `+originalMarker+`"]}`)
+	ws := data.NewWorkspace("feature", "feature", "main", repo, wsRoot)
+
+	scripts := process.NewScriptRunner(6200, 10)
+	err := scripts.RunSetup(ws)
+	var trustErr *process.ScriptsNotTrustedError
+	if !errors.As(err, &trustErr) {
+		t.Fatalf("expected initial setup to be blocked by trust gate, got %v", err)
+	}
+
+	workspaceSetupConfig(t, repo, `{"setup-workspace":["touch `+changedMarker+`"]}`)
+	service := newWorkspaceService(nil, nil, scripts, "")
+	msg, ok := service.TrustRepoScriptsAndRunSetupAsync(ws, trustErr.ConfigHash)().(messages.WorkspaceSetupComplete)
+	if !ok {
+		t.Fatalf("expected WorkspaceSetupComplete, got %T", msg)
+	}
+	var changedTrustErr *process.ScriptsNotTrustedError
+	if !errors.As(msg.Err, &changedTrustErr) {
+		t.Fatalf("expected changed config to be re-gated with a trust error, got %v", msg.Err)
+	}
+	if changedTrustErr.ConfigHash == trustErr.ConfigHash {
+		t.Fatal("expected changed config trust prompt to carry a new hash")
+	}
+	if _, err := os.Stat(originalMarker); !os.IsNotExist(err) {
+		t.Fatalf("original setup command should not run after stale approval, stat err=%v", err)
+	}
+	if _, err := os.Stat(changedMarker); !os.IsNotExist(err) {
+		t.Fatalf("changed setup command should not run under stale approval, stat err=%v", err)
 	}
 }
 

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -95,6 +95,14 @@ func (a *App) runSetupAsync(ws *data.Workspace) tea.Cmd {
 	return a.workspaceService.RunSetupAsync(ws)
 }
 
+// trustRepoScriptsAndRunSetupAsync trusts the reviewed repo script config and retries setup.
+func (a *App) trustRepoScriptsAndRunSetupAsync(ws *data.Workspace, expectedHash string) tea.Cmd {
+	if a.workspaceService == nil {
+		return nil
+	}
+	return a.workspaceService.TrustRepoScriptsAndRunSetupAsync(ws, expectedHash)
+}
+
 // deleteWorkspace deletes a workspace. The user is NOT navigated home here: that
 // happens only once the delete is confirmed (handleWorkspaceDeleted), so a
 // rejected or failed delete does not bounce the user out of a workspace it left

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/validation"
 )
 
@@ -192,6 +193,31 @@ func (s *workspaceService) RunSetupAsync(ws *data.Workspace) tea.Cmd {
 	return func() tea.Msg {
 		if s == nil || s.scripts == nil {
 			return messages.WorkspaceSetupComplete{Workspace: ws}
+		}
+		if err := s.scripts.RunSetup(ws); err != nil {
+			return messages.WorkspaceSetupComplete{Workspace: ws, Err: err}
+		}
+		return messages.WorkspaceSetupComplete{Workspace: ws}
+	}
+}
+
+// TrustRepoScriptsAndRunSetupAsync records trust for the reviewed repo config and retries setup.
+func (s *workspaceService) TrustRepoScriptsAndRunSetupAsync(ws *data.Workspace, expectedHash string) tea.Cmd {
+	return func() tea.Msg {
+		if s == nil || s.scripts == nil {
+			return messages.WorkspaceSetupComplete{Workspace: ws}
+		}
+		if ws == nil {
+			return messages.WorkspaceSetupComplete{Workspace: ws, Err: errors.New("workspace is required")}
+		}
+		if err := s.scripts.TrustRepoScriptsIfHash(ws.Repo, expectedHash); err != nil {
+			if errors.Is(err, process.ErrScriptsChangedSincePrompt) {
+				if setupErr := s.scripts.RunSetup(ws); setupErr != nil {
+					return messages.WorkspaceSetupComplete{Workspace: ws, Err: setupErr}
+				}
+				return messages.WorkspaceSetupComplete{Workspace: ws}
+			}
+			return messages.WorkspaceSetupComplete{Workspace: ws, Err: err}
 		}
 		if err := s.scripts.RunSetup(ws); err != nil {
 			return messages.WorkspaceSetupComplete{Workspace: ws, Err: err}

--- a/internal/e2e/persistence_test.go
+++ b/internal/e2e/persistence_test.go
@@ -91,6 +91,9 @@ func quitApp(t *testing.T, session *PTYSession) {
 	t.Helper()
 	sendPrefixCommand(t, session, "q")
 	waitForUIContains(t, session, "Quit AMUX", persistenceTimeout)
+	if err := session.SendString("h"); err != nil {
+		t.Fatalf("select quit confirmation: %v", err)
+	}
 	if err := session.SendString("\r"); err != nil {
 		t.Fatalf("confirm quit: %v", err)
 	}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -224,6 +224,12 @@ type ShowDeleteWorkspaceDialog struct {
 	Workspace *data.Workspace
 }
 
+// ShowTrustScriptsDialog requests confirmation before trusting repo scripts.
+type ShowTrustScriptsDialog struct {
+	Workspace  *data.Workspace
+	ConfigHash string
+}
+
 // ShowRemoveProjectDialog requests showing the remove project confirmation
 type ShowRemoveProjectDialog struct {
 	Project *data.Project

--- a/internal/process/script_trust.go
+++ b/internal/process/script_trust.go
@@ -1,0 +1,122 @@
+package process
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/fsatomic"
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+// trustRegistryFilename is the basename of the per-user registry that records
+// which repos' .amux/workspaces.json content the user has approved.
+const trustRegistryFilename = "trusted-scripts.json"
+
+// ScriptTrust is the per-user registry of repos whose .amux/workspaces.json
+// content the user has explicitly approved. It maps a normalized repo path to
+// the hex SHA-256 of the config content that was approved, so any later edit to
+// the repo's config invalidates the approval (the hash no longer matches).
+//
+// The security property it enforces: repo-supplied executable config keys
+// (config.SetupWorkspace / config.RunScript / config.ArchiveScript loaded from
+// .amux/workspaces.json) never execute unless IsTrusted returns true. It is
+// fail-closed — a missing or corrupt registry yields "not trusted". If a future
+// change adds new repo-supplied executable config keys, they must go through the
+// same IsTrusted check.
+type ScriptTrust struct {
+	path string
+}
+
+// NewScriptTrust returns a registry whose backing file lives in dir.
+func NewScriptTrust(dir string) *ScriptTrust {
+	return &ScriptTrust{path: filepath.Join(dir, trustRegistryFilename)}
+}
+
+// defaultScriptTrust returns a registry rooted at the amux home dir, resolved
+// the same way internal/config resolves the data/config dir (no hardcoded
+// ~/.amux). On any resolution error it falls back to a relative path so the
+// registry simply never matches (fail-closed) rather than panicking at startup.
+func defaultScriptTrust() *ScriptTrust {
+	paths, err := config.DefaultPaths()
+	if err != nil || paths == nil {
+		logging.Warn("Could not resolve amux home for script trust registry: %v", err)
+		return NewScriptTrust(".")
+	}
+	return NewScriptTrust(paths.Home)
+}
+
+// hashConfig returns the hex SHA-256 of the config content.
+func hashConfig(configContent []byte) string {
+	sum := sha256.Sum256(configContent)
+	return hex.EncodeToString(sum[:])
+}
+
+// load reads the registry map. A missing file yields an empty map (no error);
+// an unreadable or unparseable file yields an empty map and a logged warning, so
+// callers fail closed.
+func (t *ScriptTrust) load() map[string]string {
+	if t == nil {
+		return map[string]string{}
+	}
+	raw, err := os.ReadFile(t.path)
+	if os.IsNotExist(err) {
+		return map[string]string{}
+	}
+	if err != nil {
+		logging.Warn("Could not read script trust registry %s: %v", t.path, err)
+		return map[string]string{}
+	}
+	var entries map[string]string
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		logging.Warn("Ignoring corrupt script trust registry %s: %v", t.path, err)
+		return map[string]string{}
+	}
+	if entries == nil {
+		return map[string]string{}
+	}
+	return entries
+}
+
+// IsTrusted reports whether the user has approved the current content of
+// repoPath's .amux/workspaces.json. It is fail-closed: a missing or corrupt
+// registry, or any content change since approval, yields false.
+func (t *ScriptTrust) IsTrusted(repoPath string, configContent []byte) bool {
+	if t == nil {
+		return false
+	}
+	key := data.NormalizePath(repoPath)
+	if key == "" {
+		return false
+	}
+	approved, ok := t.load()[key]
+	if !ok {
+		return false
+	}
+	return approved == hashConfig(configContent)
+}
+
+// Trust records configContent as the approved content for repoPath, writing the
+// registry atomically (temp + fsync + rename) the same way the workspace store
+// persists its JSON state.
+func (t *ScriptTrust) Trust(repoPath string, configContent []byte) error {
+	if t == nil {
+		return nil
+	}
+	key := data.NormalizePath(repoPath)
+	entries := t.load()
+	entries[key] = hashConfig(configContent)
+
+	out, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(t.path), 0o755); err != nil {
+		return err
+	}
+	return fsatomic.WriteFile(t.path, out, 0o644)
+}

--- a/internal/process/script_trust_test.go
+++ b/internal/process/script_trust_test.go
@@ -1,0 +1,92 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScriptTrustNotTrustedUntilApproved(t *testing.T) {
+	trust := NewScriptTrust(t.TempDir())
+	repo := t.TempDir()
+	content := []byte(`{"setup-workspace":["touch marker"]}`)
+
+	if trust.IsTrusted(repo, content) {
+		t.Fatal("expected a never-trusted repo to report not trusted")
+	}
+}
+
+func TestScriptTrustTrustThenTrusted(t *testing.T) {
+	trust := NewScriptTrust(t.TempDir())
+	repo := t.TempDir()
+	content := []byte(`{"setup-workspace":["touch marker"]}`)
+
+	if err := trust.Trust(repo, content); err != nil {
+		t.Fatalf("Trust() error = %v", err)
+	}
+	if !trust.IsTrusted(repo, content) {
+		t.Fatal("expected trusted after Trust() with identical content")
+	}
+}
+
+func TestScriptTrustInvalidatedWhenContentChanges(t *testing.T) {
+	trust := NewScriptTrust(t.TempDir())
+	repo := t.TempDir()
+	original := []byte(`{"setup-workspace":["touch marker"]}`)
+
+	if err := trust.Trust(repo, original); err != nil {
+		t.Fatalf("Trust() error = %v", err)
+	}
+	changed := []byte(`{"setup-workspace":["rm -rf /"]}`)
+	if trust.IsTrusted(repo, changed) {
+		t.Fatal("expected trust to be invalidated once the config content changes")
+	}
+	// Original content still verifies as trusted.
+	if !trust.IsTrusted(repo, original) {
+		t.Fatal("expected original content to remain trusted")
+	}
+}
+
+func TestScriptTrustCorruptRegistryFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	trust := NewScriptTrust(dir)
+	repo := t.TempDir()
+	content := []byte(`{"setup-workspace":["touch marker"]}`)
+
+	// Write garbage to the registry file the trust struct reads from.
+	if err := os.WriteFile(filepath.Join(dir, trustRegistryFilename), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt registry: %v", err)
+	}
+
+	// Must not panic and must fail closed.
+	if trust.IsTrusted(repo, content) {
+		t.Fatal("expected a corrupt registry to fail closed (not trusted)")
+	}
+}
+
+func TestScriptTrustTwoReposIndependent(t *testing.T) {
+	trust := NewScriptTrust(t.TempDir())
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	contentA := []byte(`{"setup-workspace":["echo a"]}`)
+	contentB := []byte(`{"setup-workspace":["echo b"]}`)
+
+	if err := trust.Trust(repoA, contentA); err != nil {
+		t.Fatalf("Trust(repoA) error = %v", err)
+	}
+
+	if !trust.IsTrusted(repoA, contentA) {
+		t.Fatal("expected repoA to be trusted")
+	}
+	if trust.IsTrusted(repoB, contentB) {
+		t.Fatal("expected repoB to remain untrusted (independent of repoA)")
+	}
+
+	// Trusting B must not disturb A.
+	if err := trust.Trust(repoB, contentB); err != nil {
+		t.Fatalf("Trust(repoB) error = %v", err)
+	}
+	if !trust.IsTrusted(repoA, contentA) || !trust.IsTrusted(repoB, contentB) {
+		t.Fatal("expected both repos to be trusted independently")
+	}
+}

--- a/internal/process/scripts.go
+++ b/internal/process/scripts.go
@@ -28,6 +28,12 @@ const (
 
 const configFilename = "workspaces.json"
 
+// ErrScriptsNotTrusted is returned (wrapped) when a repo's .amux/workspaces.json
+// supplies commands but the user has not approved the current content of that
+// file. It is the sentinel callers test with errors.Is to distinguish a trust
+// skip from a genuine setup failure.
+var ErrScriptsNotTrusted = errors.New("project scripts not trusted")
+
 // scriptStopTimeout is how long Stop waits for the background cmd.Wait monitor
 // to observe process exit before escalating to a direct SIGKILL.
 // Kept as a var so tests can shorten it.
@@ -111,6 +117,7 @@ type ScriptRunner struct {
 	running          map[string]*runningScript // workspace root -> running process
 	pendingRelease   map[string]pendingPortRelease
 	killProcessGroup func(pid int, opts KillOptions) error
+	trust            *ScriptTrust // per-user approval registry for repo-supplied scripts
 }
 
 type runningScript struct {
@@ -141,26 +148,36 @@ func NewScriptRunner(portStart, portRange int) *ScriptRunner {
 		running:          make(map[string]*runningScript),
 		pendingRelease:   make(map[string]pendingPortRelease),
 		killProcessGroup: KillProcessGroup,
+		trust:            defaultScriptTrust(),
 	}
 }
 
 // LoadConfig loads the workspace configuration from the repo
 func (r *ScriptRunner) LoadConfig(repoPath string) (*WorkspaceConfig, error) {
+	config, _, err := r.loadConfigRaw(repoPath)
+	return config, err
+}
+
+// loadConfigRaw loads the workspace configuration and also returns the raw file
+// bytes, so the trust check can hash exactly what was parsed without a second
+// disk read. A missing file yields an empty config and nil bytes (nothing to
+// trust or run).
+func (r *ScriptRunner) loadConfigRaw(repoPath string) (*WorkspaceConfig, []byte, error) {
 	configPath := filepath.Join(repoPath, ".amux", configFilename)
 
 	fileData, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
-		return &WorkspaceConfig{}, nil
+		return &WorkspaceConfig{}, nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var config WorkspaceConfig
 	if err := json.Unmarshal(fileData, &config); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &config, nil
+	return &config, fileData, nil
 }
 
 // RunSetup runs the setup scripts for a workspace
@@ -168,9 +185,16 @@ func (r *ScriptRunner) RunSetup(ws *data.Workspace) error {
 	if err := validateScriptWorkspace(ws); err != nil {
 		return err
 	}
-	config, err := r.LoadConfig(ws.Repo)
+	config, raw, err := r.loadConfigRaw(ws.Repo)
 	if err != nil {
 		return err
+	}
+
+	// Gate repo-supplied commands behind recorded per-repo consent. Until the
+	// user trusts the current content of .amux/workspaces.json, execute nothing
+	// and return the sentinel (fail-closed).
+	if len(config.SetupWorkspace) > 0 && !r.trust.IsTrusted(ws.Repo, raw) {
+		return fmt.Errorf("%s (%q): %w", ws.Repo, config.SetupWorkspace[0], ErrScriptsNotTrusted)
 	}
 
 	env := r.envBuilder.BuildEnv(ws)
@@ -212,27 +236,39 @@ func (r *ScriptRunner) RunScript(ws *data.Workspace, scriptType ScriptType) (*ex
 		return nil, err
 	}
 
-	config, err := r.LoadConfig(ws.Repo)
+	config, raw, err := r.loadConfigRaw(ws.Repo)
 	if err != nil {
 		return nil, err
 	}
 
+	// fromRepoConfig is true only when the command came from the repo's
+	// .amux/workspaces.json (config.RunScript/config.ArchiveScript), false when
+	// it fell back to ws.Scripts.* (user-entered in the amux UI). Only the
+	// repo-supplied case is gated behind trust.
 	var cmdStr string
+	var fromRepoConfig bool
 	switch scriptType {
 	case ScriptRun:
-		cmdStr = config.RunScript
-		if cmdStr == "" {
+		if config.RunScript != "" {
+			cmdStr, fromRepoConfig = config.RunScript, true
+		} else {
 			cmdStr = ws.Scripts.Run
 		}
 	case ScriptArchive:
-		cmdStr = config.ArchiveScript
-		if cmdStr == "" {
+		if config.ArchiveScript != "" {
+			cmdStr, fromRepoConfig = config.ArchiveScript, true
+		} else {
 			cmdStr = ws.Scripts.Archive
 		}
 	}
 
 	if cmdStr == "" {
 		return nil, fmt.Errorf("no %s script configured", scriptType)
+	}
+
+	// Gate only repo-supplied commands; user-entered ws.Scripts.* always run.
+	if fromRepoConfig && !r.trust.IsTrusted(ws.Repo, raw) {
+		return nil, fmt.Errorf("%s (%q): %w", ws.Repo, cmdStr, ErrScriptsNotTrusted)
 	}
 
 	// Check for existing process in non-concurrent mode
@@ -270,6 +306,22 @@ func (r *ScriptRunner) RunScript(ws *data.Workspace, scriptType ScriptType) (*ex
 	})
 
 	return cmd, nil
+}
+
+// TrustRepoScripts records the current content of repoPath's
+// .amux/workspaces.json as approved, so subsequent RunSetup/RunScript calls
+// execute its repo-supplied commands. Approval is content-bound: any later edit
+// to the file re-gates execution until the user trusts it again. A repo with no
+// config file is a no-op (nothing to trust).
+func (r *ScriptRunner) TrustRepoScripts(repoPath string) error {
+	_, raw, err := r.loadConfigRaw(repoPath)
+	if err != nil {
+		return err
+	}
+	if raw == nil {
+		return nil
+	}
+	return r.trust.Trust(repoPath, raw)
 }
 
 // Stop stops the running script for a workspace

--- a/internal/process/scripts.go
+++ b/internal/process/scripts.go
@@ -34,6 +34,26 @@ const configFilename = "workspaces.json"
 // skip from a genuine setup failure.
 var ErrScriptsNotTrusted = errors.New("project scripts not trusted")
 
+// ErrScriptsChangedSincePrompt is returned when a user approves script content
+// after the repo config changed from the content that originally triggered the prompt.
+var ErrScriptsChangedSincePrompt = errors.New("project scripts changed since trust prompt")
+
+// ScriptsNotTrustedError carries the hash of the repo config content that was
+// blocked, so the UI can bind a later approval to the exact reviewed content.
+type ScriptsNotTrustedError struct {
+	Repo       string
+	Command    string
+	ConfigHash string
+}
+
+func (e *ScriptsNotTrustedError) Error() string {
+	return fmt.Sprintf("%s (%q): %v", e.Repo, e.Command, ErrScriptsNotTrusted)
+}
+
+func (e *ScriptsNotTrustedError) Unwrap() error {
+	return ErrScriptsNotTrusted
+}
+
 // scriptStopTimeout is how long Stop waits for the background cmd.Wait monitor
 // to observe process exit before escalating to a direct SIGKILL.
 // Kept as a var so tests can shorten it.
@@ -194,7 +214,11 @@ func (r *ScriptRunner) RunSetup(ws *data.Workspace) error {
 	// user trusts the current content of .amux/workspaces.json, execute nothing
 	// and return the sentinel (fail-closed).
 	if len(config.SetupWorkspace) > 0 && !r.trust.IsTrusted(ws.Repo, raw) {
-		return fmt.Errorf("%s (%q): %w", ws.Repo, config.SetupWorkspace[0], ErrScriptsNotTrusted)
+		return &ScriptsNotTrustedError{
+			Repo:       ws.Repo,
+			Command:    config.SetupWorkspace[0],
+			ConfigHash: hashConfig(raw),
+		}
 	}
 
 	env := r.envBuilder.BuildEnv(ws)
@@ -268,7 +292,11 @@ func (r *ScriptRunner) RunScript(ws *data.Workspace, scriptType ScriptType) (*ex
 
 	// Gate only repo-supplied commands; user-entered ws.Scripts.* always run.
 	if fromRepoConfig && !r.trust.IsTrusted(ws.Repo, raw) {
-		return nil, fmt.Errorf("%s (%q): %w", ws.Repo, cmdStr, ErrScriptsNotTrusted)
+		return nil, &ScriptsNotTrustedError{
+			Repo:       ws.Repo,
+			Command:    cmdStr,
+			ConfigHash: hashConfig(raw),
+		}
 	}
 
 	// Check for existing process in non-concurrent mode
@@ -320,6 +348,22 @@ func (r *ScriptRunner) TrustRepoScripts(repoPath string) error {
 	}
 	if raw == nil {
 		return nil
+	}
+	return r.trust.Trust(repoPath, raw)
+}
+
+// TrustRepoScriptsIfHash records trust only if the repo config still matches the
+// content hash that originally triggered the user approval prompt.
+func (r *ScriptRunner) TrustRepoScriptsIfHash(repoPath, expectedHash string) error {
+	_, raw, err := r.loadConfigRaw(repoPath)
+	if err != nil {
+		return err
+	}
+	if raw == nil {
+		return nil
+	}
+	if expectedHash != "" && hashConfig(raw) != expectedHash {
+		return ErrScriptsChangedSincePrompt
 	}
 	return r.trust.Trust(repoPath, raw)
 }

--- a/internal/process/scripts_release_test.go
+++ b/internal/process/scripts_release_test.go
@@ -65,6 +65,7 @@ func TestScriptRunnerReleaseWorkspaceGatedByRunningSetup(t *testing.T) {
 	ws := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	done := make(chan error, 1)
 	go func() {
 		done <- runner.RunSetup(ws)

--- a/internal/process/scripts_teardown_test.go
+++ b/internal/process/scripts_teardown_test.go
@@ -52,6 +52,13 @@ func TestScriptRunner_StopAll(t *testing.T) {
 	writeWorkspaceConfig(t, repoB, `{"run": "sleep 30"}`)
 
 	runner := NewScriptRunner(6200, 10)
+	useTempTrust(t, runner)
+	if err := runner.TrustRepoScripts(repoA); err != nil {
+		t.Fatalf("TrustRepoScripts(A): %v", err)
+	}
+	if err := runner.TrustRepoScripts(repoB); err != nil {
+		t.Fatalf("TrustRepoScripts(B): %v", err)
+	}
 	wsA := &data.Workspace{Repo: repoA, Root: rootA}
 	wsB := &data.Workspace{Repo: repoB, Root: rootB}
 
@@ -114,6 +121,7 @@ func TestScriptRunner_StopForceKillsStuckProcess(t *testing.T) {
 	readyPath := filepath.Join(t.TempDir(), "ready")
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	ws := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	runner.killProcessGroup = func(pid int, _ KillOptions) error {
@@ -218,11 +226,15 @@ func TestScriptRunner_NonconcurrentRestartKeepsNewEntry(t *testing.T) {
 	wsRoot := t.TempDir()
 
 	runner := NewScriptRunner(6200, 10)
+	useTempTrust(t, runner)
 	ws := &data.Workspace{Repo: repo, Root: wsRoot, ScriptMode: "nonconcurrent"}
 
 	// Run #1: fast-exiting body. Its monitor goroutine will fire (cmd.Wait
 	// returns) and attempt to delete the map entry for this workspace.
 	writeWorkspaceConfig(t, repo, `{"run": "exit 0"}`)
+	if err := runner.TrustRepoScripts(repo); err != nil {
+		t.Fatalf("TrustRepoScripts(#1): %v", err)
+	}
 	if _, err := runner.RunScript(ws, ScriptRun); err != nil {
 		t.Fatalf("RunScript(#1) error = %v", err)
 	}
@@ -230,7 +242,11 @@ func TestScriptRunner_NonconcurrentRestartKeepsNewEntry(t *testing.T) {
 	// Run #2: long-lived body for the same workspace. In nonconcurrent mode
 	// RunScript first Stops the prior run, then registers this one. The monitor
 	// guard must stop run #1's (now stale) monitor from deleting run #2's entry.
+	// Re-trust because the config content (and thus its approved hash) changed.
 	writeWorkspaceConfig(t, repo, `{"run": "sleep 30"}`)
+	if err := runner.TrustRepoScripts(repo); err != nil {
+		t.Fatalf("TrustRepoScripts(#2): %v", err)
+	}
 	cmd2, err := runner.RunScript(ws, ScriptRun)
 	if err != nil {
 		t.Fatalf("RunScript(#2) error = %v", err)

--- a/internal/process/scripts_test.go
+++ b/internal/process/scripts_test.go
@@ -22,6 +22,27 @@ func writeWorkspaceConfig(t *testing.T, repoPath, content string) {
 	}
 }
 
+// useTempTrust repoints the runner's trust registry at an isolated temp dir so
+// tests never touch the real ~/.amux registry. Returns the registry so callers
+// can grant or withhold trust explicitly.
+func useTempTrust(t *testing.T, runner *ScriptRunner) *ScriptTrust {
+	t.Helper()
+	trust := NewScriptTrust(t.TempDir())
+	runner.trust = trust
+	return trust
+}
+
+// trustRepo records the current .amux/workspaces.json content of repoPath as
+// approved, so existing tests that expect repo-supplied commands to run keep
+// passing through the new gate.
+func trustRepo(t *testing.T, runner *ScriptRunner, repoPath string) {
+	t.Helper()
+	useTempTrust(t, runner)
+	if err := runner.TrustRepoScripts(repoPath); err != nil {
+		t.Fatalf("TrustRepoScripts(%s): %v", repoPath, err)
+	}
+}
+
 func TestScriptRunnerLoadConfigMissing(t *testing.T) {
 	repo := t.TempDir()
 	runner := NewScriptRunner(6200, 10)
@@ -107,6 +128,7 @@ func TestScriptRunnerRunSetupAndEnv(t *testing.T) {
 }`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	wt := &data.Workspace{
 		Name:   "feature-1",
 		Branch: "feature-1",
@@ -137,6 +159,7 @@ func TestScriptRunnerRunSetupFailure(t *testing.T) {
 }`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	wt := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	if err := runner.RunSetup(wt); err == nil {
@@ -153,6 +176,7 @@ func TestScriptRunnerRunScriptConfigAndWorkspaceScripts(t *testing.T) {
 }`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	wt := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	_, err := runner.RunScript(wt, ScriptRun)
@@ -163,7 +187,9 @@ func TestScriptRunnerRunScriptConfigAndWorkspaceScripts(t *testing.T) {
 		t.Fatalf("expected run.txt to be created: %v", err)
 	}
 
-	// Now test workspace scripts fallback when config missing.
+	// Now test workspace scripts fallback when config missing. The user-entered
+	// ws.Scripts.Run path is NOT gated by trust: even though the repo config was
+	// just rewritten (and is no longer trusted), this still runs.
 	writeWorkspaceConfig(t, repo, `{}`)
 	wt.Scripts = data.ScriptsConfig{Run: "printf run-workspace > run-workspace.txt"}
 	_, err = runner.RunScript(wt, ScriptRun)
@@ -198,6 +224,7 @@ func TestScriptRunnerStop(t *testing.T) {
 }`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	wt := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	if _, err := runner.RunScript(wt, ScriptRun); err != nil {
@@ -260,6 +287,7 @@ func TestScriptRunnerUsesNormalizedWorkspaceKey(t *testing.T) {
 	writeWorkspaceConfig(t, repo, `{"run": "sleep 5"}`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	ws1 := &data.Workspace{Repo: repo, Root: wsRoot}
 
 	if _, err := runner.RunScript(ws1, ScriptRun); err != nil {
@@ -284,6 +312,7 @@ func TestScriptRunnerRunScriptNonconcurrentStopFailure(t *testing.T) {
 	writeWorkspaceConfig(t, repo, `{"run": "sleep 5"}`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	ws := &data.Workspace{Repo: repo, Root: wsRoot, ScriptMode: "nonconcurrent"}
 
 	// Start a script first
@@ -319,6 +348,7 @@ func TestScriptRunnerRunScriptNonconcurrentIgnoresBenignStopRace(t *testing.T) {
 	writeWorkspaceConfig(t, repo, `{"run": "sleep 5"}`)
 
 	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
 	ws := &data.Workspace{Repo: repo, Root: wsRoot, ScriptMode: "nonconcurrent"}
 
 	// Start a script first

--- a/internal/process/scripts_trust_gate_test.go
+++ b/internal/process/scripts_trust_gate_test.go
@@ -1,0 +1,105 @@
+package process
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+// TestScriptRunnerRunSetupUntrustedDoesNotExecute proves that an untrusted
+// repo's setup-workspace command does NOT run: no side effect occurs and the
+// error is ErrScriptsNotTrusted.
+func TestScriptRunnerRunSetupUntrustedDoesNotExecute(t *testing.T) {
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	marker := filepath.Join(wsRoot, "marker")
+
+	writeWorkspaceConfig(t, repo, `{"setup-workspace": ["touch `+marker+`"]}`)
+
+	runner := NewScriptRunner(6200, 10)
+	useTempTrust(t, runner) // isolated, empty registry => repo is untrusted
+	ws := &data.Workspace{Repo: repo, Root: wsRoot}
+
+	err := runner.RunSetup(ws)
+	if !errors.Is(err, ErrScriptsNotTrusted) {
+		t.Fatalf("expected ErrScriptsNotTrusted, got %v", err)
+	}
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Fatal("untrusted setup command executed: marker file was created")
+	}
+}
+
+// TestScriptRunnerRunSetupTrustedExecutes proves that once the repo is trusted,
+// the same setup-workspace command runs and produces its side effect.
+func TestScriptRunnerRunSetupTrustedExecutes(t *testing.T) {
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	marker := filepath.Join(wsRoot, "marker")
+
+	writeWorkspaceConfig(t, repo, `{"setup-workspace": ["touch `+marker+`"]}`)
+
+	runner := NewScriptRunner(6200, 10)
+	trustRepo(t, runner, repo)
+	ws := &data.Workspace{Repo: repo, Root: wsRoot}
+
+	if err := runner.RunSetup(ws); err != nil {
+		t.Fatalf("RunSetup() error = %v", err)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("trusted setup command did not run: %v", statErr)
+	}
+}
+
+// TestScriptRunnerRunScriptUntrustedRepoScriptDoesNotExecute proves a repo
+// config's run script is gated when the repo is untrusted.
+func TestScriptRunnerRunScriptUntrustedRepoScriptDoesNotExecute(t *testing.T) {
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	marker := filepath.Join(wsRoot, "marker")
+
+	writeWorkspaceConfig(t, repo, `{"run": "touch `+marker+`"}`)
+
+	runner := NewScriptRunner(6200, 10)
+	useTempTrust(t, runner)
+	ws := &data.Workspace{Repo: repo, Root: wsRoot}
+
+	_, err := runner.RunScript(ws, ScriptRun)
+	if !errors.Is(err, ErrScriptsNotTrusted) {
+		t.Fatalf("expected ErrScriptsNotTrusted, got %v", err)
+	}
+	// Give any (erroneously) launched process a moment; it must never appear.
+	if waitForFile(marker, 200*time.Millisecond) == nil {
+		t.Fatal("untrusted repo run script executed: marker file was created")
+	}
+}
+
+// TestScriptRunnerWsScriptsRunWithoutTrust proves the user-entered ws.Scripts.Run
+// fallback is NOT gated: it executes even though the repo is untrusted (empty
+// registry). This is the core "don't gate user-entered scripts" guarantee.
+func TestScriptRunnerWsScriptsRunWithoutTrust(t *testing.T) {
+	repo := t.TempDir()
+	wsRoot := t.TempDir()
+	marker := filepath.Join(wsRoot, "marker")
+
+	// Repo config has no run script, so RunScript falls back to ws.Scripts.Run.
+	writeWorkspaceConfig(t, repo, `{}`)
+
+	runner := NewScriptRunner(6200, 10)
+	useTempTrust(t, runner) // empty registry: repo is NOT trusted
+	ws := &data.Workspace{
+		Repo:    repo,
+		Root:    wsRoot,
+		Scripts: data.ScriptsConfig{Run: "touch " + marker},
+	}
+
+	if _, err := runner.RunScript(ws, ScriptRun); err != nil {
+		t.Fatalf("RunScript() error = %v (ws.Scripts.* must not be gated)", err)
+	}
+	if err := waitForFile(marker, 2*time.Second); err != nil {
+		t.Fatalf("user-entered ws.Scripts.Run did not execute: %v", err)
+	}
+}

--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -41,10 +41,11 @@ type Dialog struct {
 	options []string
 
 	// State
-	visible   bool
-	input     textinput.Model
-	cursor    int
-	confirmed bool
+	visible       bool
+	input         textinput.Model
+	cursor        int
+	defaultCursor int
+	confirmed     bool
 
 	// Input transformation and validation
 	inputTransform InputTransformFunc
@@ -90,12 +91,13 @@ func NewInputDialog(id, title, placeholder string) *Dialog {
 // NewConfirmDialog creates a new confirmation dialog
 func NewConfirmDialog(id, title, message string) *Dialog {
 	return &Dialog{
-		id:      id,
-		dtype:   DialogConfirm,
-		title:   title,
-		message: message,
-		options: []string{"Yes", "No"},
-		cursor:  1, // Default to "No"
+		id:            id,
+		dtype:         DialogConfirm,
+		title:         title,
+		message:       message,
+		options:       []string{"Yes", "No"},
+		cursor:        1,
+		defaultCursor: 1,
 	}
 }
 
@@ -109,6 +111,15 @@ func NewSelectDialog(id, title, message string, options []string) *Dialog {
 		options: options,
 		cursor:  0,
 	}
+}
+
+// SetDefaultOption sets the option selected whenever the dialog is shown.
+func (d *Dialog) SetDefaultOption(index int) {
+	if d == nil || index < 0 || index >= len(d.options) {
+		return
+	}
+	d.defaultCursor = index
+	d.cursor = index
 }
 
 // fuzzyMatch returns true if pattern fuzzy-matches target (case-insensitive)
@@ -165,7 +176,7 @@ func (d *Dialog) Show() {
 	d.visible = true
 	d.confirmed = false
 	d.validationErr = ""
-	d.cursor = 0
+	d.cursor = d.defaultCursor
 	if d.dtype == DialogInput {
 		d.input.SetValue("")
 		d.input.Focus()

--- a/internal/ui/common/dialog_confirm_test.go
+++ b/internal/ui/common/dialog_confirm_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestDialogConfirmEnterDefaultsToNo(t *testing.T) {
+	d := NewConfirmDialog("trust_scripts", "Trust Scripts?", "Run repo scripts?")
+	d.SetDefaultOption(1)
+	d.SetSize(80, 24)
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from pressing Enter")
+	}
+	result, ok := cmd().(DialogResult)
+	if !ok {
+		t.Fatalf("expected DialogResult, got %T", result)
+	}
+	if result.Confirmed {
+		t.Fatal("expected default Enter on confirm dialog to cancel")
+	}
+}
+
+func TestDialogConfirmReopenResetsToNo(t *testing.T) {
+	d := NewConfirmDialog("trust_scripts", "Trust Scripts?", "Run repo scripts?")
+	d.SetDefaultOption(1)
+	d.SetSize(80, 24)
+	d.Show()
+
+	d.cursor = 0
+	d.visible = false
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from pressing Enter")
+	}
+	result, ok := cmd().(DialogResult)
+	if !ok {
+		t.Fatalf("expected DialogResult, got %T", result)
+	}
+	if result.Confirmed {
+		t.Fatal("expected reopened confirm dialog to default to cancel")
+	}
+}


### PR DESCRIPTION
.amux/workspaces.json setup/run/archive commands ran via sh -c on workspace
create with no consent, so adding a malicious repo executed its scripts. A
fail-closed ScriptTrust registry (SHA-256 of the config content per repo)
now gates repo-supplied commands: RunSetup/RunScript refuse and return
ErrScriptsNotTrusted until the repo is trusted, surfaced as a specific toast.
User-entered ws.Scripts.* stay ungated. Trust is invalidated when the file
changes. README documents the gate and the run/archive keys.

Plan: plans/001-confirm-project-scripts-before-run.md
