### PR TITLE
Surface self-update restore failures and test InstallBinary recovery

### DIFF
--- a/internal/update/install.go
+++ b/internal/update/install.go
@@ -108,7 +108,7 @@ func InstallBinary(newBinaryPath, currentBinaryPath string) error {
 		if restoreErr := renameFile(backupPath, currentBinaryPath); restoreErr != nil {
 			return fmt.Errorf(
 				"installing new binary: %w; restoring backup also failed: %w (your previous binary is at %s — restore it manually with: mv %s %s)",
-				err, restoreErr, backupPath, backupPath, currentBinaryPath,
+				err, restoreErr, backupPath, shellQuote(backupPath), shellQuote(currentBinaryPath),
 			)
 		}
 		return fmt.Errorf("installing new binary: %w (previous binary restored)", err)
@@ -118,6 +118,10 @@ func InstallBinary(newBinaryPath, currentBinaryPath string) error {
 	_ = os.Remove(backupPath)
 
 	return nil
+}
+
+func shellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
 }
 
 // copyFile copies a file from src to dst, preserving executable permissions.

--- a/internal/update/install.go
+++ b/internal/update/install.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 )
 
+// renameFile is a seam for tests to inject rename failures.
+var renameFile = os.Rename
+
 // ExtractBinary extracts the amux binary from a tar.gz archive.
 // Returns the path to the extracted binary.
 func ExtractBinary(archivePath, destDir string) (string, error) {
@@ -96,15 +99,19 @@ func InstallBinary(newBinaryPath, currentBinaryPath string) error {
 
 	// Create backup of current binary
 	backupPath := currentBinaryPath + ".bak"
-	if err := os.Rename(currentBinaryPath, backupPath); err != nil {
+	if err := renameFile(currentBinaryPath, backupPath); err != nil {
 		return fmt.Errorf("backing up current binary: %w", err)
 	}
 
 	// Atomically replace with staged binary (same filesystem, so rename works)
-	if err := os.Rename(stagedPath, currentBinaryPath); err != nil {
-		// Try to restore backup
-		_ = os.Rename(backupPath, currentBinaryPath)
-		return fmt.Errorf("installing new binary: %w", err)
+	if err := renameFile(stagedPath, currentBinaryPath); err != nil {
+		if restoreErr := renameFile(backupPath, currentBinaryPath); restoreErr != nil {
+			return fmt.Errorf(
+				"installing new binary: %w; restoring backup also failed: %w (your previous binary is at %s — restore it manually with: mv %s %s)",
+				err, restoreErr, backupPath, backupPath, currentBinaryPath,
+			)
+		}
+		return fmt.Errorf("installing new binary: %w (previous binary restored)", err)
 	}
 
 	// Remove backup

--- a/internal/update/updater_test.go
+++ b/internal/update/updater_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -316,5 +317,146 @@ func TestInstallBinaryCrossDir(t *testing.T) {
 	}
 	if string(content) != "new binary content" {
 		t.Errorf("Expected 'new binary content', got %s", string(content))
+	}
+}
+
+func TestInstallBinaryBackupFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "new-amux")
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatalf("Failed to create source: %v", err)
+	}
+	destPath := filepath.Join(tmpDir, "amux")
+	if err := os.WriteFile(destPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("Failed to create dest: %v", err)
+	}
+	backupPath := destPath + ".bak"
+
+	injected := errors.New("injected backup failure")
+	t.Cleanup(func() { renameFile = os.Rename })
+	renameFile = func(oldpath, newpath string) error {
+		// Fail the backup-create rename: current binary -> .bak
+		if oldpath == destPath && newpath == backupPath {
+			return injected
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	err := InstallBinary(srcPath, destPath)
+	if err == nil {
+		t.Fatal("InstallBinary() should have failed when backup rename fails")
+	}
+	if !strings.Contains(err.Error(), "backing up current binary") {
+		t.Errorf("Expected error to mention backing up, got: %v", err)
+	}
+
+	// Current binary still exists with original content
+	content, readErr := os.ReadFile(destPath)
+	if readErr != nil {
+		t.Fatalf("Current binary should still exist: %v", readErr)
+	}
+	if string(content) != "old" {
+		t.Errorf("Expected current binary to remain 'old', got %q", string(content))
+	}
+
+	// No backup file should exist
+	if _, statErr := os.Stat(backupPath); !os.IsNotExist(statErr) {
+		t.Error("No backup file should exist after backup rename failure")
+	}
+}
+
+func TestInstallBinarySwapFailsRestoreSucceeds(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "new-amux")
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatalf("Failed to create source: %v", err)
+	}
+	destPath := filepath.Join(tmpDir, "amux")
+	if err := os.WriteFile(destPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("Failed to create dest: %v", err)
+	}
+	stagedPath := filepath.Join(tmpDir, ".amux-upgrade-new")
+
+	injected := errors.New("injected swap failure")
+	t.Cleanup(func() { renameFile = os.Rename })
+	renameFile = func(oldpath, newpath string) error {
+		// Fail only the swap: staged -> current binary. Restore is allowed.
+		if oldpath == stagedPath && newpath == destPath {
+			return injected
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	err := InstallBinary(srcPath, destPath)
+	if err == nil {
+		t.Fatal("InstallBinary() should have failed when swap rename fails")
+	}
+	if !strings.Contains(err.Error(), "previous binary restored") {
+		t.Errorf("Expected error to mention restore, got: %v", err)
+	}
+
+	// Target restored to original content
+	content, readErr := os.ReadFile(destPath)
+	if readErr != nil {
+		t.Fatalf("Target should be restored: %v", readErr)
+	}
+	if string(content) != "old" {
+		t.Errorf("Expected target restored to 'old', got %q", string(content))
+	}
+
+	// Staged file cleaned up by defer
+	if _, statErr := os.Stat(stagedPath); !os.IsNotExist(statErr) {
+		t.Error("Staged file should have been cleaned up")
+	}
+}
+
+func TestInstallBinarySwapFailsRestoreFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "new-amux")
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatalf("Failed to create source: %v", err)
+	}
+	destPath := filepath.Join(tmpDir, "amux")
+	if err := os.WriteFile(destPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("Failed to create dest: %v", err)
+	}
+	stagedPath := filepath.Join(tmpDir, ".amux-upgrade-new")
+	backupPath := destPath + ".bak"
+
+	swapErr := errors.New("injected swap failure")
+	restoreErr := errors.New("injected restore failure")
+	t.Cleanup(func() { renameFile = os.Rename })
+	renameFile = func(oldpath, newpath string) error {
+		// Fail the swap (staged -> current) and the restore (backup -> current).
+		if oldpath == stagedPath && newpath == destPath {
+			return swapErr
+		}
+		if oldpath == backupPath && newpath == destPath {
+			return restoreErr
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	err := InstallBinary(srcPath, destPath)
+	if err == nil {
+		t.Fatal("InstallBinary() should have failed when both swap and restore fail")
+	}
+	if !strings.Contains(err.Error(), backupPath) {
+		t.Errorf("Expected error to name backup path %q, got: %v", backupPath, err)
+	}
+	if !strings.Contains(err.Error(), "mv ") {
+		t.Errorf("Expected error to include a manual mv recovery hint, got: %v", err)
+	}
+
+	// Backup file still holds the original binary content
+	content, readErr := os.ReadFile(backupPath)
+	if readErr != nil {
+		t.Fatalf("Backup file should still exist: %v", readErr)
+	}
+	if string(content) != "old" {
+		t.Errorf("Expected backup to retain 'old', got %q", string(content))
 	}
 }

--- a/internal/update/updater_test.go
+++ b/internal/update/updater_test.go
@@ -259,7 +259,7 @@ func TestInstallBinary(t *testing.T) {
 	}
 
 	// Create destination binary
-	destPath := filepath.Join(tmpDir, "amux")
+	destPath := filepath.Join(tmpDir, "am ux'bin")
 	if err := os.WriteFile(destPath, []byte("old binary"), 0o755); err != nil {
 		t.Fatalf("Failed to create dest: %v", err)
 	}
@@ -447,8 +447,9 @@ func TestInstallBinarySwapFailsRestoreFails(t *testing.T) {
 	if !strings.Contains(err.Error(), backupPath) {
 		t.Errorf("Expected error to name backup path %q, got: %v", backupPath, err)
 	}
-	if !strings.Contains(err.Error(), "mv ") {
-		t.Errorf("Expected error to include a manual mv recovery hint, got: %v", err)
+	wantHint := "mv " + shellQuote(backupPath) + " " + shellQuote(destPath)
+	if !strings.Contains(err.Error(), wantHint) {
+		t.Errorf("Expected error to include quoted manual recovery hint %q, got: %v", wantHint, err)
 	}
 
 	// Backup file still holds the original binary content


### PR DESCRIPTION
When the binary swap failed, InstallBinary discarded the backup-restore error
(_ = os.Rename), so a double failure left the user with no binary and no
diagnostic. The restore error is now captured and, on double failure, the
returned error names the .bak path and a manual mv recovery command. A
renameFile seam enables three failure-mode tests (backup-fails, swap-fails-
restore-ok, swap-fails-restore-fails).

Plan: plans/003-updater-restore-error-and-failure-tests.md
