### PR TITLE
refactor: delete unused GetCombinedDiff

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -194,38 +194,6 @@ func parseDiff(path, content string) *DiffResult {
 	return result
 }
 
-// GetCombinedDiff returns the combined diff for a file that has both staged and unstaged changes
-func GetCombinedDiff(repoPath, path string) (*DiffResult, error) {
-	// Get staged changes
-	staged, err := GetFileDiff(repoPath, path, DiffModeStaged)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get unstaged changes
-	unstaged, err := GetFileDiff(repoPath, path, DiffModeUnstaged)
-	if err != nil {
-		return nil, err
-	}
-
-	// If both have content, combine them
-	if !staged.Empty && !unstaged.Empty {
-		return &DiffResult{
-			Path:    path,
-			Content: "=== Staged Changes ===\n" + staged.Content + "\n\n=== Unstaged Changes ===\n" + unstaged.Content,
-			Hunks:   append(staged.Hunks, unstaged.Hunks...),
-			Binary:  staged.Binary || unstaged.Binary,
-			Large:   staged.Large || unstaged.Large,
-		}, nil
-	}
-
-	// Return whichever has content
-	if !staged.Empty {
-		return staged, nil
-	}
-	return unstaged, nil
-}
-
 // HunkCount returns the number of hunks in the diff
 func (d *DiffResult) HunkCount() int {
 	return len(d.Hunks)


### PR DESCRIPTION
Deletes the exported `GetCombinedDiff` function from `internal/git/diff.go`. It has zero callers anywhere in the tree (verified by `grep -rn GetCombinedDiff .` across internal/ and cmd/, including *_test.go), so removing it trims dead code and shrinks the package's exported surface. `GetFileDiff` (its only dependency, still live, called from internal/ui/diff/model.go) is untouched. Part of the quality stacked diff. Stacked on `improve/001-remove-unused-tmux-version-seam`. Ticket 002 (simplicity).