### PR TITLE
refactor: delete deprecated no-op CloseAllTabs

### DIFF
--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -321,9 +321,3 @@ func (m *Model) HasActiveTerminal() bool {
 	defer tab.mu.Unlock()
 	return tab.Terminal != nil
 }
-
-// CloseAllTabs is deprecated - tabs now persist per-workspace
-// This is kept for compatibility but does nothing
-func (m *Model) CloseAllTabs() {
-	// No-op: tabs now persist per-workspace and are not closed when switching
-}


### PR DESCRIPTION
Deletes the dead no-op `CloseAllTabs` method and its comment block in `internal/ui/center/model_tabs_actions.go`. The method did nothing (tabs now persist per-workspace), has zero callers in source or tests, and satisfies no interface. Removing it drops dead code. Part of the quality stacked diff. Stacked on `improve/003-delete-unused-terminalsnapshotfrompane`. Ticket 004 (simplicity).