### PR TITLE
docs: fix godoc attribution for syncActivitySessionStates

### DIFF
--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -369,12 +369,6 @@ func (a *App) tabSessionInfoByName() map[string]activity.SessionInfo {
 	return infoBySession
 }
 
-// syncActivitySessionStates reconciles the in-memory session info map with live
-// tmux state. It mutates infoBySession in place — setting Status to "stopped" for
-// dead/disappeared sessions and "running" for revived ones — so that the subsequent
-// ActiveWorkspaceIDsFromTags call (which filters via IsRunningSession) sees corrected
-// statuses. It returns TabSessionStatus messages for sessions whose status changed
-// from a running-like state to stopped.
 // activityDemotionMissThreshold is the number of consecutive non-live activity
 // observations required before a running session is demoted to stopped. A single
 // best-effort AllSessionStates call can miss a live session under load, so one
@@ -400,6 +394,12 @@ func recordSessionMiss(missBySession map[string]int, sessionName string, info ac
 	return info, wasRunningLike
 }
 
+// syncActivitySessionStates reconciles the in-memory session info map with live
+// tmux state. It mutates infoBySession in place — setting Status to "stopped" for
+// dead/disappeared sessions and "running" for revived ones — so that the subsequent
+// ActiveWorkspaceIDsFromTags call (which filters via IsRunningSession) sees corrected
+// statuses. It returns TabSessionStatus messages for sessions whose status changed
+// from a running-like state to stopped.
 func syncActivitySessionStates(
 	infoBySession map[string]activity.SessionInfo,
 	sessions []activity.TaggedSession,


### PR DESCRIPTION
The `syncActivitySessionStates` doc comment was glued (no blank line) to the `activityDemotionMissThreshold` const's own doc comment, so `go doc` attributed the function's whole description to the const and reported the function as undocumented.

This moves the const together with its doc comment above the function's doc comment, and places the function's doc comment directly before `func syncActivitySessionStates(`, so each declaration documents itself. No behavior change — comment-only move.

Verified: `go doc -u ./internal/app syncActivitySessionStates` now prints the reconciliation doc, and `go doc -u ./internal/app activityDemotionMissThreshold` prints only the const's own description.

Part of the quality stacked diff. Stacked on `improve/004-delete-deprecated-closealltabs-noop`. Ticket 005 (clean-code).