### PR TITLE
refactor: use markDetachedLocked in sendMouseToTerminal error branch

### DIFF
--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -289,8 +289,7 @@ func (m *Model) sendMouseToTerminal(tab *Tab, data string, tabID TabID, workspac
 	if err := agent.Terminal.SendString(data); err != nil {
 		logging.Warn("Mouse input failed for tab %s: %v", tab.ID, err)
 		tab.mu.Lock()
-		tab.Running = false
-		tab.Detached = true
+		tab.markDetachedLocked()
 		tab.mu.Unlock()
 		if m.msgSink != nil {
 			m.msgSink(TabInputFailed{TabID: tabID, WorkspaceID: workspaceID, Err: err})


### PR DESCRIPTION
Replace the inline `tab.Running = false` / `tab.Detached = true` pair in sendMouseToTerminal's SendString error branch with a single `tab.markDetachedLocked()` call, mirroring sendToTerminal. This centralizes the documented running->detached FSM transition in model_tab_phase.go, which is now the only site asserting `Detached = true`. Part of the quality stacked diff. Stacked on `improve/005-fix-godoc-attribution-activity`. Ticket 006 (clean-code).