### PR TITLE
refactor: delete dead per-agent theme Style fields

### DIFF
--- a/internal/ui/theme/styles.go
+++ b/internal/ui/theme/styles.go
@@ -44,16 +44,7 @@ type Styles struct {
 	TabPlus   lipgloss.Style
 
 	// Center pane - Agent indicators
-	AgentClaude   lipgloss.Style
-	AgentCodex    lipgloss.Style
-	AgentGemini   lipgloss.Style
-	AgentAmp      lipgloss.Style
-	AgentOpencode lipgloss.Style
-	AgentDroid    lipgloss.Style
-	AgentCline    lipgloss.Style
-	AgentCursor   lipgloss.Style
-	AgentPi       lipgloss.Style
-	AgentTerm     lipgloss.Style
+	AgentTerm lipgloss.Style
 
 	// Sidebar
 	SidebarHeader lipgloss.Style
@@ -193,33 +184,6 @@ func DefaultStyles() Styles {
 			Foreground(ColorMuted()),
 
 		// Center pane - Agent indicators
-		AgentClaude: lipgloss.NewStyle().
-			Foreground(ColorClaude),
-
-		AgentCodex: lipgloss.NewStyle().
-			Foreground(ColorCodex),
-
-		AgentGemini: lipgloss.NewStyle().
-			Foreground(ColorGemini),
-
-		AgentAmp: lipgloss.NewStyle().
-			Foreground(ColorAmp),
-
-		AgentOpencode: lipgloss.NewStyle().
-			Foreground(ColorOpencode),
-
-		AgentDroid: lipgloss.NewStyle().
-			Foreground(ColorDroid),
-
-		AgentCline: lipgloss.NewStyle().
-			Foreground(ColorCline),
-
-		AgentCursor: lipgloss.NewStyle().
-			Foreground(ColorCursor),
-
-		AgentPi: lipgloss.NewStyle().
-			Foreground(ColorPi),
-
 		AgentTerm: lipgloss.NewStyle().
 			Foreground(ColorForeground()),
 


### PR DESCRIPTION
Delete the per-agent lipgloss.Style fields (AgentClaude, AgentCodex, AgentGemini, AgentAmp, AgentOpencode, AgentDroid, AgentCline, AgentCursor, AgentPi) from theme.Styles plus their constructor assignments. They had zero readers anywhere in the tree; the live per-agent color path is theme.AgentColor(). The ColorClaude..ColorPi palette constants and AgentColor() are untouched. Pure dead-code deletion. Part of the quality stacked diff. Stacked on improve/006-dedup-markdetached-fsm-helper. Ticket 007 (simplicity).