### PR TITLE
refactor: delete dead StatusManager async-refresh machinery + idle goroutine

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -83,8 +83,8 @@ func New(version, commit, date string) (*App, error) {
 	scripts := process.NewScriptRunner(cfg.PortStart, cfg.PortRangeSize)
 	workspaceService := newWorkspaceService(registry, workspaces, scripts, cfg.Paths.WorkspacesRoot)
 
-	// Create status manager (callback will be nil, we use it for caching only)
-	statusManager := git.NewStatusManager(nil)
+	// Create status manager (used for synchronous status caching only).
+	statusManager := git.NewStatusManager()
 	gitStatus := newGitStatusService(statusManager)
 
 	var tmuxSvc TmuxOps = tmuxOps{}
@@ -157,9 +157,6 @@ func New(version, commit, date string) (*App, error) {
 	app.center.SetTmuxOptions(tmuxOpts)
 	app.sidebarTerminal.SetTmuxOptions(tmuxOpts)
 	app.supervisor.Start("center.tab_actor", app.center.RunTabActor, supervisor.WithRestartPolicy(supervisor.RestartAlways))
-	if app.gitStatus != nil {
-		app.supervisor.Start("git.status_manager", app.gitStatus.Run)
-	}
 	if fileWatcher != nil {
 		app.supervisor.Start("git.file_watcher", fileWatcher.Run, supervisor.WithBackoff(supervisorBackoff))
 	}

--- a/internal/app/app_input_pty_file_watcher_test.go
+++ b/internal/app/app_input_pty_file_watcher_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
@@ -16,8 +15,6 @@ type fileWatcherGitStatusStub struct {
 	refreshFastRoots []string
 	cacheByRoot      map[string]*git.StatusResult
 }
-
-func (s *fileWatcherGitStatusStub) Run(context.Context) error { return nil }
 
 func (s *fileWatcherGitStatusStub) GetCached(root string) *git.StatusResult {
 	if s.cacheByRoot == nil {

--- a/internal/app/service_git.go
+++ b/internal/app/service_git.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"context"
-
 	"github.com/andyrewlee/amux/internal/git"
 )
 
@@ -12,13 +10,6 @@ type gitStatusService struct {
 
 func newGitStatusService(manager *git.StatusManager) *gitStatusService {
 	return &gitStatusService{manager: manager}
-}
-
-func (s *gitStatusService) Run(ctx context.Context) error {
-	if s == nil || s.manager == nil {
-		return nil
-	}
-	return s.manager.Run(ctx)
 }
 
 func (s *gitStatusService) GetCached(root string) *git.StatusResult {

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
@@ -30,7 +29,6 @@ type WorkspaceStore interface {
 
 // GitStatusService provides cached status reads and fresh refreshes.
 type GitStatusService interface {
-	Run(ctx context.Context) error
 	GetCached(root string) *git.StatusResult
 	UpdateCache(root string, status *git.StatusResult)
 	Invalidate(root string)

--- a/internal/git/status_manager.go
+++ b/internal/git/status_manager.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"sync"
 	"time"
 )
@@ -17,35 +16,22 @@ func (c *StatusCache) IsExpired(ttl time.Duration) bool {
 	return time.Since(c.FetchedAt) > ttl
 }
 
-// StatusManager manages async git status with caching and debouncing
+// StatusManager caches git status results by workspace root with a TTL.
 type StatusManager struct {
 	mu sync.RWMutex
 
 	// Cache of status results by workspace root
 	cache map[string]*StatusCache
 
-	// Pending refresh requests (for debouncing)
-	pending map[string]time.Time
-
 	// Configuration
-	cacheTTL      time.Duration
-	debounceDelay time.Duration
-
-	// Callback for status updates
-	onUpdate func(root string, status *StatusResult, err error)
-
-	reqCh chan string
+	cacheTTL time.Duration
 }
 
 // NewStatusManager creates a new status manager
-func NewStatusManager(onUpdate func(root string, status *StatusResult, err error)) *StatusManager {
+func NewStatusManager() *StatusManager {
 	return &StatusManager{
-		cache:         make(map[string]*StatusCache),
-		pending:       make(map[string]time.Time),
-		cacheTTL:      5 * time.Second,
-		debounceDelay: 500 * time.Millisecond,
-		onUpdate:      onUpdate,
-		reqCh:         make(chan string, 64),
+		cache:    make(map[string]*StatusCache),
+		cacheTTL: 5 * time.Second,
 	}
 }
 
@@ -58,139 +44,6 @@ func (m *StatusManager) GetCached(root string) *StatusResult {
 		return cache.Status
 	}
 	return nil
-}
-
-// RequestRefresh requests an async status refresh for a workspace
-// Uses debouncing to prevent too frequent refreshes
-func (m *StatusManager) RequestRefresh(root string) {
-	if root == "" {
-		return
-	}
-	if m.reqCh == nil {
-		return
-	}
-	select {
-	case m.reqCh <- root:
-	default:
-		// Drop if backlogged; next tick will pick up further changes.
-	}
-}
-
-// Run processes refresh requests until the context is canceled.
-func (m *StatusManager) Run(ctx context.Context) error {
-	if m == nil || m.reqCh == nil {
-		return nil
-	}
-	timer := time.NewTimer(time.Hour)
-	timer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return nil
-		case root := <-m.reqCh:
-			m.mu.Lock()
-			m.pending[root] = time.Now().Add(m.debounceDelay)
-			next, ok := m.nextPendingLocked()
-			m.mu.Unlock()
-			resetTimer(timer, next, ok)
-		case <-timer.C:
-			due := m.popDue(time.Now())
-			for _, root := range due {
-				m.refreshNow(root)
-			}
-			m.mu.Lock()
-			next, ok := m.nextPendingLocked()
-			m.mu.Unlock()
-			resetTimer(timer, next, ok)
-		}
-	}
-}
-
-func (m *StatusManager) nextPendingLocked() (time.Time, bool) {
-	var next time.Time
-	for _, t := range m.pending {
-		if next.IsZero() || t.Before(next) {
-			next = t
-		}
-	}
-	if next.IsZero() {
-		return time.Time{}, false
-	}
-	return next, true
-}
-
-func (m *StatusManager) popDue(now time.Time) []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	var due []string
-	for root, t := range m.pending {
-		if !t.After(now) {
-			due = append(due, root)
-			delete(m.pending, root)
-		}
-	}
-	return due
-}
-
-func (m *StatusManager) refreshNow(root string) {
-	status, err := GetStatusFast(root)
-	m.mu.Lock()
-	if err == nil {
-		m.cache[root] = &StatusCache{
-			Status:    status,
-			FetchedAt: time.Now(),
-		}
-	}
-	m.mu.Unlock()
-	if m.onUpdate != nil {
-		m.onUpdate(root, status, err)
-	}
-}
-
-func resetTimer(t *time.Timer, next time.Time, ok bool) {
-	if t == nil {
-		return
-	}
-	if !ok {
-		if !t.Stop() {
-			select {
-			case <-t.C:
-			default:
-			}
-		}
-		return
-	}
-	d := time.Until(next)
-	if d < 0 {
-		d = 0
-	}
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
-	}
-	t.Reset(d)
-}
-
-// RefreshAll refreshes status for all cached workspaces
-func (m *StatusManager) RefreshAll() {
-	m.mu.RLock()
-	roots := make([]string, 0, len(m.cache))
-	for root := range m.cache {
-		roots = append(roots, root)
-	}
-	m.mu.RUnlock()
-
-	for _, root := range roots {
-		m.RequestRefresh(root)
-	}
 }
 
 // Invalidate removes a workspace from the cache
@@ -222,11 +75,4 @@ func (m *StatusManager) SetCacheTTL(ttl time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.cacheTTL = ttl
-}
-
-// SetDebounceDelay sets the debounce delay
-func (m *StatusManager) SetDebounceDelay(delay time.Duration) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.debounceDelay = delay
 }

--- a/internal/git/status_manager_test.go
+++ b/internal/git/status_manager_test.go
@@ -1,15 +1,12 @@
 package git
 
 import (
-	"context"
-	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestStatusManagerCacheAndInvalidate(t *testing.T) {
-	m := NewStatusManager(nil)
+	m := NewStatusManager()
 	status := &StatusResult{Clean: true}
 
 	if cached := m.GetCached("/tmp"); cached != nil {
@@ -28,7 +25,7 @@ func TestStatusManagerCacheAndInvalidate(t *testing.T) {
 }
 
 func TestStatusManagerCacheExpiry(t *testing.T) {
-	m := NewStatusManager(nil)
+	m := NewStatusManager()
 	m.SetCacheTTL(10 * time.Millisecond)
 	m.UpdateCache("/tmp", &StatusResult{Clean: true})
 
@@ -39,82 +36,5 @@ func TestStatusManagerCacheExpiry(t *testing.T) {
 	time.Sleep(15 * time.Millisecond)
 	if cached := m.GetCached("/tmp"); cached != nil {
 		t.Fatalf("expected cache to expire")
-	}
-}
-
-func TestStatusManagerRequestRefreshDebounced(t *testing.T) {
-	skipIfNoGit(t)
-	repo := initRepo(t)
-
-	var count int32
-	done := make(chan struct{}, 1)
-	m := NewStatusManager(func(root string, status *StatusResult, err error) {
-		atomic.AddInt32(&count, 1)
-		done <- struct{}{}
-	})
-	m.SetDebounceDelay(10 * time.Millisecond)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = m.Run(ctx)
-	}()
-
-	m.RequestRefresh(repo)
-	m.RequestRefresh(repo)
-
-	select {
-	case <-done:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatalf("timed out waiting for status refresh")
-	}
-
-	// Give a little extra time for any duplicate callbacks.
-	time.Sleep(50 * time.Millisecond)
-	if got := atomic.LoadInt32(&count); got != 1 {
-		t.Fatalf("expected 1 refresh callback after debouncing, got %d", got)
-	}
-}
-
-func TestStatusManagerRefreshUsesFastMode(t *testing.T) {
-	skipIfNoGit(t)
-	repo := initRepo(t)
-
-	// Create a dirty file so we can verify line stats are zero (fast mode).
-	if err := os.WriteFile(repo+"/dirty.txt", []byte("line1\nline2\n"), 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-
-	var result *StatusResult
-	done := make(chan struct{}, 1)
-	m := NewStatusManager(func(root string, status *StatusResult, err error) {
-		result = status
-		done <- struct{}{}
-	})
-	m.SetDebounceDelay(10 * time.Millisecond)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = m.Run(ctx)
-	}()
-
-	m.RequestRefresh(repo)
-	select {
-	case <-done:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatalf("timed out waiting for status refresh")
-	}
-
-	if result == nil {
-		t.Fatal("expected non-nil status result")
-	}
-	if result.Clean {
-		t.Error("expected dirty repo")
-	}
-	// Fast mode should leave line stats at zero.
-	if result.TotalAdded != 0 || result.TotalDeleted != 0 {
-		t.Errorf("expected zero line stats from fast mode, got added=%d deleted=%d", result.TotalAdded, result.TotalDeleted)
-	}
-	if result.HasLineStats {
-		t.Errorf("expected HasLineStats=false for fast mode refresh")
 	}
 }


### PR DESCRIPTION
Deletes the unused async refresh pipeline from internal/git/status_manager.go (Run/RequestRefresh/RefreshAll/nextPendingLocked/popDue/refreshNow/resetTimer/SetDebounceDelay plus the reqCh/pending/debounceDelay fields and the now-unused onUpdate callback). These had zero non-test callers: the real refresh path is synchronous (app_operations.go RefreshFast -> git.GetStatusFast inside Bubble Tea cmds, using UpdateCache/GetCached/Invalidate). The supervised "git.status_manager" goroutine spawned in app_init.go just blocked forever on an unfed channel, so its spawn block and the Run method on the GitStatusService interface/gitStatusService are removed too. Keeps the synchronous cache surface (StatusCache/IsExpired, GetCached, UpdateCache, Invalidate, InvalidateAll, SetCacheTTL) and the two tests that exercise it. Part of the quality stacked diff. Stacked on improve/007-delete-dead-theme-agent-style-fields. Ticket 008 (simplicity).