### PR TITLE
refactor: unexport test-only activity wrappers

### DIFF
--- a/internal/app/activity/logic.go
+++ b/internal/app/activity/logic.go
@@ -6,14 +6,17 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-// ActiveWorkspaceIDsFromTags uses the @amux_last_output_at tag when present.
+// activeIDsFromTags uses the @amux_last_output_at tag when present.
 // Sessions with missing tags always fall back to screen-delta hysteresis
 // (compatibility mode). Sessions with stale tags fall back when they have
 // recent tmux window activity (or if that prefilter is unavailable).
 // Fresh tags are trusted only when tmux reports recent window activity
 // (or if that prefilter is unavailable), preventing control-sequence noise
 // from holding sessions in an always-active state.
-func ActiveWorkspaceIDsFromTags(
+//
+// It is a 2-return convenience wrapper over activeWorkspaceIDsFromTags for
+// same-package tests; production calls ActiveWorkspaceIDsFromTagsWithRemoved.
+func activeIDsFromTags(
 	infoBySession map[string]SessionInfo,
 	sessions []TaggedSession,
 	recentActivityBySession map[string]bool,
@@ -26,9 +29,10 @@ func ActiveWorkspaceIDsFromTags(
 	return active, updated
 }
 
-// ActiveWorkspaceIDsFromTagsWithRemoved is ActiveWorkspaceIDsFromTags but also
-// returns the names of session states pruned this scan (unseen beyond
-// pruneAfterScans) so the caller can delete them from its persistent map.
+// ActiveWorkspaceIDsFromTagsWithRemoved is the production entry point. It
+// returns the active workspace IDs, updated session states, and the names of
+// session states pruned this scan (unseen beyond pruneAfterScans) so the caller
+// can delete them from its persistent map.
 func ActiveWorkspaceIDsFromTagsWithRemoved(
 	infoBySession map[string]SessionInfo,
 	sessions []TaggedSession,
@@ -247,11 +251,14 @@ func PrepareStaleTagFallbackState(sessionName string, states map[string]*Session
 	state.LastActiveAt = time.Time{}
 }
 
-// ActiveWorkspaceIDsWithHysteresis uses screen-delta detection with hysteresis
+// activeIDsWithHysteresis uses screen-delta detection with hysteresis
 // to determine which workspaces have actively working agents. This prevents
 // false positives from periodic terminal refreshes (like sponsor messages).
 // Returns both the active workspace IDs and the updated session states.
-func ActiveWorkspaceIDsWithHysteresis(
+//
+// It is a 2-return convenience wrapper over activeWorkspaceIDsWithHysteresisWithSeen
+// for same-package tests; production routes through activeWorkspaceIDsFromTags.
+func activeIDsWithHysteresis(
 	infoBySession map[string]SessionInfo,
 	sessions []tmux.SessionActivity,
 	states map[string]*SessionState,

--- a/internal/app/activity/logic_test.go
+++ b/internal/app/activity/logic_test.go
@@ -50,7 +50,7 @@ func TestHysteresisWorkspaceExtraction(t *testing.T) {
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "", false }
 	hashFn := func(string) [16]byte { return [16]byte{} }
 
-	active, updated := ActiveWorkspaceIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
 
 	// Workspace ID from session.WorkspaceID
 	if !active["ws-direct"] {
@@ -103,7 +103,7 @@ func TestHysteresisNewSessionImmediatelyActive(t *testing.T) {
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "some output", true }
 	hashFn := func(content string) [16]byte { return [16]byte{1} }
 
-	active, updated := ActiveWorkspaceIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
 
 	if !active["ws-abc"] {
 		t.Fatal("newly discovered session with successful capture should be immediately active")
@@ -217,7 +217,7 @@ func TestActiveWorkspaceIDsFromTags_UsesTagWindowAndFallback(t *testing.T) {
 		"sess-tag": true,
 		"sess-old": true,
 	}
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
 
 	if !active["ws-tag"] {
 		t.Fatal("expected ws-tag to be active from last-output tag")
@@ -255,7 +255,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagWithoutRecentWindowActivityFallsBack
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "same", true }
 	hashFn := func(string) [16]byte { return hashValue }
 
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-fresh"] {
 		t.Fatal("expected fresh tag without recent window activity to fall back and remain inactive on unchanged content")
 	}
@@ -290,7 +290,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagWithoutRecentWindowActivity_DoesNotB
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "same", true }
 	hashFn := func(string) [16]byte { return hashValue }
 
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
 	if active[workspaceID] {
 		t.Fatal("expected no first-scan active blip for fresh tag without recent window activity when state is uninitialized")
 	}
@@ -320,7 +320,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagActiveWhenPrefilterUnavailable(t *te
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "output", true }
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, nil, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, nil, states, tmux.Options{}, captureFn, hashFn)
 	if !active["ws-fresh"] {
 		t.Fatal("expected fresh tag to remain active when prefilter is unavailable")
 	}
@@ -353,7 +353,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagWithRecentWindowButNoVisibleDeltaSta
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "same", true }
 	hashFn := func(string) [16]byte { return hashValue }
 
-	active, updated := ActiveWorkspaceIDsFromTags(
+	active, updated := activeIDsFromTags(
 		infoBySession,
 		sessions,
 		map[string]bool{sessionName: true},
@@ -393,7 +393,7 @@ func TestActiveWorkspaceIDsFromTags_StaleTagFallsBackToHysteresis(t *testing.T) 
 	recentActivity := map[string]bool{
 		"sess-old": true,
 	}
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
 	if !active["ws-old"] {
 		t.Fatal("expected ws-old to be active when stale-tag session shows live pane changes")
 	}
@@ -415,7 +415,7 @@ func TestActiveWorkspaceIDsFromTags_StaleTagFallsBackWhenPrefilterUnavailable(t 
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "output", true }
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, nil, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, nil, states, tmux.Options{}, captureFn, hashFn)
 	if !active["ws-stale"] {
 		t.Fatal("expected stale-tag session to fall back when prefilter is unavailable")
 	}
@@ -445,7 +445,7 @@ func TestActiveWorkspaceIDsFromTags_KnownStaleTagFallsBackWithoutRecentActivity(
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
 	// Empty prefilter set should skip stale fallback to avoid idle capture churn.
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
 	if captureCalls != 0 {
 		t.Fatalf("expected no fallback capture without recent activity, got %d calls", captureCalls)
 	}

--- a/internal/app/activity/state_test.go
+++ b/internal/app/activity/state_test.go
@@ -31,7 +31,7 @@ func TestActiveWorkspaceIDsFromTags_StaleTagFallbackClearsHoldAndDecaysQuickly(t
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "same", true }
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
-	active, _ := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
+	active, _ := activeIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-stale-hold"] {
 		t.Fatal("expected stale-tag unchanged session to stop being active without hold carryover")
 	}
@@ -80,7 +80,7 @@ func TestActiveWorkspaceIDsFromTags_FreshOutputImmediatelyAfterInputSuppressed(t
 	}
 	hashFn := func(string) [16]byte { return [16]byte{2} }
 
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, sessions, map[string]bool{}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-echo"] {
 		t.Fatal("fresh output immediately after input should be treated as local echo, not activity")
 	}
@@ -129,7 +129,7 @@ func TestActiveWorkspaceIDsFromTags_RecentInputSuppressesStaleFallbackCapture(t 
 	}
 	hashFn := func(string) [16]byte { return [16]byte{2} }
 
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, sessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, sessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-recent-input"] {
 		t.Fatal("stale-tag fallback should be suppressed while user input is recent")
 	}
@@ -156,7 +156,7 @@ func TestHysteresisInitDoesNotSetHoldTimer(t *testing.T) {
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "output", true }
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
-	active, updated := ActiveWorkspaceIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsWithHysteresis(infoBySession, sessions, states, tmux.Options{}, captureFn, hashFn)
 	if !active["ws-init"] {
 		t.Fatal("expected newly discovered session to be active immediately")
 	}
@@ -170,7 +170,7 @@ func TestHysteresisInitDoesNotSetHoldTimer(t *testing.T) {
 
 	// No further output; should decay below threshold on the next scan
 	// without being held active.
-	active, _ = ActiveWorkspaceIDsWithHysteresis(infoBySession, sessions, updated, tmux.Options{}, captureFn, hashFn)
+	active, _ = activeIDsWithHysteresis(infoBySession, sessions, updated, tmux.Options{}, captureFn, hashFn)
 	if active["ws-init"] {
 		t.Fatal("expected session to stop being active after one unchanged scan")
 	}
@@ -202,7 +202,7 @@ func TestActiveWorkspaceIDsFromTags_DoesNotResetFreshTagState(t *testing.T) {
 		LastOutputAt:  now.Add(-500 * time.Millisecond),
 		HasLastOutput: true,
 	}}
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, freshSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, freshSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-tagged"] {
 		t.Fatal("expected single fresh-tag delta for known session to remain below active threshold")
 	}
@@ -223,7 +223,7 @@ func TestActiveWorkspaceIDsFromTags_DoesNotResetFreshTagState(t *testing.T) {
 		HasLastOutput: true,
 	}}
 	currentHash = changedHash
-	active, updated = ActiveWorkspaceIDsFromTags(infoBySession, staleSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated = activeIDsFromTags(infoBySession, staleSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
 	for name, state := range updated {
 		states[name] = state
 	}
@@ -250,7 +250,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagSeedsFallbackBaseline(t *testing.T) 
 		LastOutputAt:  now.Add(-500 * time.Millisecond),
 		HasLastOutput: true,
 	}}
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, freshSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, freshSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-fresh-seed"] {
 		t.Fatal("expected known fresh-tag baseline seeding to remain inactive")
 	}
@@ -274,7 +274,7 @@ func TestActiveWorkspaceIDsFromTags_FreshTagSeedsFallbackBaseline(t *testing.T) 
 		LastOutputAt:  now.Add(-10 * time.Second),
 		HasLastOutput: true,
 	}}
-	active, _ = ActiveWorkspaceIDsFromTags(infoBySession, staleSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
+	active, _ = activeIDsFromTags(infoBySession, staleSessions, map[string]bool{sessionName: true}, states, tmux.Options{}, captureFn, hashFn)
 	if active["ws-fresh-seed"] {
 		t.Fatal("expected stale fallback with unchanged content to stay inactive after fresh-tag seeding")
 	}
@@ -304,7 +304,7 @@ func TestActiveWorkspaceIDsFromTags_StaleTagWithoutRecentActivitySkipsFallback(t
 	hashFn := func(string) [16]byte { return [16]byte{1} }
 
 	recentActivity := map[string]bool{}
-	active, updated := ActiveWorkspaceIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
+	active, updated := activeIDsFromTags(infoBySession, sessions, recentActivity, states, tmux.Options{}, captureFn, hashFn)
 
 	if captureCalls != 0 {
 		t.Fatalf("expected no capture fallback without recent activity, got %d calls", captureCalls)
@@ -347,7 +347,7 @@ func TestActiveWorkspaceIDsFromTags_KnownFreshUnchangedAcrossScansRemainInactive
 			LastOutputAt:  time.Now().Add(-500 * time.Millisecond),
 			HasLastOutput: true,
 		}}
-		active, updated := ActiveWorkspaceIDsFromTags(
+		active, updated := activeIDsFromTags(
 			infoBySession,
 			sessions,
 			map[string]bool{sessionName: true},
@@ -399,7 +399,7 @@ func TestActiveWorkspaceIDsFromTags_KnownFreshConsecutiveDeltasBecomeActive(t *t
 			LastOutputAt:  time.Now().Add(-400 * time.Millisecond),
 			HasLastOutput: true,
 		}}
-		active, updated := ActiveWorkspaceIDsFromTags(
+		active, updated := activeIDsFromTags(
 			infoBySession,
 			sessions,
 			map[string]bool{sessionName: true},
@@ -446,7 +446,7 @@ func TestActiveWorkspaceIDsFromTags_KnownFreshTagCaptureFailurePreservesActivity
 	}
 	captureFn := func(string, int, tmux.Options) (string, bool) { return "", false } // transient failure
 	hashFn := func(string) [16]byte { return hashValue }
-	active, updated := ActiveWorkspaceIDsFromTags(
+	active, updated := activeIDsFromTags(
 		infoBySession,
 		sessions,
 		map[string]bool{sessionName: true},

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -397,7 +397,7 @@ func recordSessionMiss(missBySession map[string]int, sessionName string, info ac
 // syncActivitySessionStates reconciles the in-memory session info map with live
 // tmux state. It mutates infoBySession in place — setting Status to "stopped" for
 // dead/disappeared sessions and "running" for revived ones — so that the subsequent
-// ActiveWorkspaceIDsFromTags call (which filters via IsRunningSession) sees corrected
+// ActiveWorkspaceIDsFromTagsWithRemoved call (which filters via IsRunningSession) sees corrected
 // statuses. It returns TabSessionStatus messages for sessions whose status changed
 // from a running-like state to stopped.
 func syncActivitySessionStates(


### PR DESCRIPTION
Unexport the two activity wrappers that have only same-package test callers: ActiveWorkspaceIDsFromTags -> activeIDsFromTags and ActiveWorkspaceIDsWithHysteresis -> activeIDsWithHysteresis. Production code uses ActiveWorkspaceIDsFromTagsWithRemoved and the unexported activeWorkspaceIDsWithHysteresisWithSeen, so these exported 2-return convenience wrappers added package surface area without any production caller. Doc comments are kept (and clarified to note they are test-only convenience wrappers); no production behavior change. Part of the quality stacked diff. Stacked on improve/008-delete-dead-statusmanager-async-machinery. Ticket 009 (simplicity).