### PR TITLE
test: assert the real uniqueness invariant in TestPortAllocator_ConcurrentAccess

### DIFF
--- a/internal/process/ports_test.go
+++ b/internal/process/ports_test.go
@@ -1,6 +1,9 @@
 package process
 
 import (
+	"fmt"
+	"sort"
+	"sync"
 	"testing"
 )
 
@@ -71,21 +74,89 @@ func TestPortAllocator_PortRange(t *testing.T) {
 }
 
 func TestPortAllocator_ConcurrentAccess(t *testing.T) {
-	p := NewPortAllocator(6200, 10)
+	const (
+		n         = 50
+		portStart = 6200
+		rangeSize = 10
+	)
+	p := NewPortAllocator(portStart, rangeSize)
 
-	// Run concurrent allocations
-	done := make(chan bool)
-	for i := 0; i < 10; i++ {
-		go func(n int) {
-			p.AllocatePort("/workspace" + string(rune('0'+n)))
-			done <- true
+	// Each goroutine allocates a distinct workspaceRoot. The real invariant is
+	// that distinct workspaces receive distinct, non-overlapping port ranges,
+	// regardless of the order the mutex serializes concurrent callers in.
+	bases := make([]int, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			bases[i] = p.AllocatePort(fmt.Sprintf("/ws%d", i))
 		}(i)
 	}
+	wg.Wait()
 
-	// Wait for all goroutines
-	for i := 0; i < 10; i++ {
-		<-done
+	// (1) Exactly N distinct bases (no duplicate handed to two workspaces).
+	seen := make(map[int]int, n)
+	for i, base := range bases {
+		if prev, dup := seen[base]; dup {
+			t.Fatalf("duplicate base port %d allocated to /ws%d and /ws%d", base, prev, i)
+		}
+		seen[base] = i
+	}
+	if len(seen) != n {
+		t.Fatalf("got %d distinct bases, want %d", len(seen), n)
 	}
 
-	// Verify no crashes occurred (mutex protection)
+	// (2) Every base lies within [portStart, portStart+N*rangeSize).
+	limit := portStart + n*rangeSize
+	for i, base := range bases {
+		if base < portStart || base >= limit {
+			t.Errorf("/ws%d base %d out of range [%d, %d)", i, base, portStart, limit)
+		}
+		// A valid base must sit on a rangeSize boundary from portStart.
+		if (base-portStart)%rangeSize != 0 {
+			t.Errorf("/ws%d base %d not aligned to rangeSize %d from %d", i, base, rangeSize, portStart)
+		}
+	}
+
+	// (3) Ranges [base, base+rangeSize-1] are pairwise non-overlapping.
+	sorted := append([]int(nil), bases...)
+	sort.Ints(sorted)
+	for i := 1; i < len(sorted); i++ {
+		prevEnd := sorted[i-1] + rangeSize - 1
+		if sorted[i] <= prevEnd {
+			t.Errorf("overlapping ranges: [%d, %d] and [%d, %d]",
+				sorted[i-1], prevEnd, sorted[i], sorted[i]+rangeSize-1)
+		}
+	}
+}
+
+// TestPortAllocator_ConcurrentSameWorkspace asserts the already-allocated
+// branch is idempotent: many goroutines racing to allocate the SAME workspace
+// must all observe one identical base port.
+func TestPortAllocator_ConcurrentSameWorkspace(t *testing.T) {
+	const n = 50
+	p := NewPortAllocator(6200, 10)
+
+	results := make([]int, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			results[i] = p.AllocatePort("/shared")
+		}(i)
+	}
+	wg.Wait()
+
+	want := results[0]
+	for i, got := range results {
+		if got != want {
+			t.Errorf("goroutine %d got base %d, want identical base %d", i, got, want)
+		}
+	}
+	// Only one range should have been consumed for the single workspace.
+	if base, ok := p.GetPort("/shared"); !ok || base != want {
+		t.Errorf("GetPort(/shared) = (%d, %v), want (%d, true)", base, ok, want)
+	}
 }


### PR DESCRIPTION
Rewrite TestPortAllocator_ConcurrentAccess (previously an assertion-free '// Verify no crashes occurred' stub) to assert the genuine invariant: 50 goroutines allocating distinct workspaceRoots must each receive a distinct, in-range, rangeSize-aligned base port with pairwise non-overlapping ranges. Adds TestPortAllocator_ConcurrentSameWorkspace to assert the already-allocated branch is idempotent under concurrency. Clean under -race; no production change. Part of the quality stacked diff. Stacked on improve/010-dedup-computechecksum-into-hashfile. Ticket 011 (testability).