### PR TITLE
refactor: single canonical agent registry to replace hand-synced lists

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -1,0 +1,55 @@
+package config
+
+// AgentDef is one entry in the canonical, ordered agent registry. It is the
+// single source of truth for the supported-agent roster: the preferred display
+// order, the built-in default assistant config, the "is this a known chat
+// agent" membership check, and the brand-color lookup are all derived from it.
+// Adding, removing, or renaming an agent here updates every consumer at once.
+type AgentDef struct {
+	Name             string // canonical (lowercase) agent identifier
+	DefaultCommand   string // shell command used to launch the agent
+	InterruptCount   int    // number of Ctrl-C signals to send (claude needs 2)
+	InterruptDelayMs int    // delay between interrupts in milliseconds
+}
+
+// AgentRegistry is the ordered roster of supported agents. The order here
+// defines the preferred display order used throughout the UI. Keep it as the
+// only place new agents are declared.
+var AgentRegistry = []AgentDef{
+	{Name: "claude", DefaultCommand: "claude", InterruptCount: 2, InterruptDelayMs: 200},
+	{Name: "codex", DefaultCommand: "codex", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "gemini", DefaultCommand: "gemini", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "amp", DefaultCommand: "amp", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "opencode", DefaultCommand: "opencode", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "droid", DefaultCommand: "droid", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "cline", DefaultCommand: "cline", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "cursor", DefaultCommand: "agent", InterruptCount: 1, InterruptDelayMs: 0},
+	{Name: "pi", DefaultCommand: "pi", InterruptCount: 1, InterruptDelayMs: 0},
+}
+
+// registeredAgentNames is the membership set derived from AgentRegistry,
+// computed once for O(1) lookups.
+var registeredAgentNames = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(AgentRegistry))
+	for _, def := range AgentRegistry {
+		set[def.Name] = struct{}{}
+	}
+	return set
+}()
+
+// AgentNames returns the canonical agent identifiers in registry (preferred
+// display) order.
+func AgentNames() []string {
+	names := make([]string, len(AgentRegistry))
+	for i, def := range AgentRegistry {
+		names[i] = def.Name
+	}
+	return names
+}
+
+// IsRegisteredAgent reports whether name is a built-in supported agent. It
+// matches the exact (already canonical/lowercase) registry name.
+func IsRegisteredAgent(name string) bool {
+	_, ok := registeredAgentNames[name]
+	return ok
+}

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// registryNameSet is the canonical agent name set used as the single source of
+// truth that every derived consumer must match exactly.
+func registryNameSet(t *testing.T) map[string]struct{} {
+	t.Helper()
+	set := make(map[string]struct{}, len(AgentRegistry))
+	for _, def := range AgentRegistry {
+		if def.Name == "" {
+			t.Fatal("AgentRegistry entry has empty Name")
+		}
+		if _, dup := set[def.Name]; dup {
+			t.Fatalf("AgentRegistry has duplicate name %q", def.Name)
+		}
+		set[def.Name] = struct{}{}
+	}
+	return set
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestAgentRegistryIsCanonical is the guard that fails CI when any consumer of
+// the supported-agent roster drifts from the canonical AgentRegistry. It checks,
+// table-driven, that the registry name set equals exactly:
+//   - the defaultAssistants() map keys,
+//   - the preferredAssistantOrder entries,
+//   - the set of agents IsRegisteredAgent reports as known.
+//
+// The theme.AgentColor non-default cases and the center assistantIsChat fallback
+// set are guarded against this same registry in their own packages (importing
+// config here would create an import cycle).
+func TestAgentRegistryIsCanonical(t *testing.T) {
+	want := registryNameSet(t)
+
+	collect := func(names []string) map[string]struct{} {
+		set := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		return set
+	}
+
+	defaultKeys := func() []string {
+		assistants := defaultAssistants()
+		keys := make([]string, 0, len(assistants))
+		for k := range assistants {
+			keys = append(keys, k)
+		}
+		return keys
+	}()
+
+	registeredNames := func() []string {
+		var names []string
+		for _, def := range AgentRegistry {
+			if IsRegisteredAgent(def.Name) {
+				names = append(names, def.Name)
+			}
+		}
+		return names
+	}()
+
+	cases := []struct {
+		name string
+		got  map[string]struct{}
+	}{
+		{"defaultAssistants keys", collect(defaultKeys)},
+		{"preferredAssistantOrder", collect(preferredAssistantOrder)},
+		{"IsRegisteredAgent set", collect(registeredNames)},
+	}
+
+	for _, tc := range cases {
+		if !reflect.DeepEqual(tc.got, want) {
+			t.Errorf("%s set %v does not equal canonical registry %v",
+				tc.name, sortedKeys(tc.got), sortedKeys(want))
+		}
+	}
+
+	// preferredAssistantOrder must additionally preserve registry order.
+	if !reflect.DeepEqual(preferredAssistantOrder, AgentNames()) {
+		t.Errorf("preferredAssistantOrder %v is not in registry order %v",
+			preferredAssistantOrder, AgentNames())
+	}
+
+	// IsRegisteredAgent must reject names that are not in the registry.
+	if IsRegisteredAgent("viewer") {
+		t.Error("IsRegisteredAgent should reject non-registry name 'viewer'")
+	}
+	if IsRegisteredAgent("") {
+		t.Error("IsRegisteredAgent should reject empty name")
+	}
+
+	// defaultAssistants values must mirror the registry fields exactly.
+	assistants := defaultAssistants()
+	for _, def := range AgentRegistry {
+		got := assistants[def.Name]
+		if got.Command != def.DefaultCommand ||
+			got.InterruptCount != def.InterruptCount ||
+			got.InterruptDelayMs != def.InterruptDelayMs {
+			t.Errorf("defaultAssistants[%q] = %+v; want command=%q count=%d delay=%d",
+				def.Name, got, def.DefaultCommand, def.InterruptCount, def.InterruptDelayMs)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,17 +37,9 @@ type assistantConfigRaw struct {
 
 const fallbackDefaultAssistant = "claude"
 
-var preferredAssistantOrder = []string{
-	"claude",
-	"codex",
-	"gemini",
-	"amp",
-	"opencode",
-	"droid",
-	"cline",
-	"cursor",
-	"pi",
-}
+// preferredAssistantOrder is the agent display order, derived from the canonical
+// AgentRegistry so it cannot drift from the rest of the roster.
+var preferredAssistantOrder = AgentNames()
 
 // DefaultConfig returns the default configuration
 func DefaultConfig() (*Config, error) {
@@ -149,54 +141,18 @@ func (c *Config) ResolvedDefaultAssistant() string {
 	return canonicalDefaultAssistant(fallbackDefaultAssistant, c.Assistants)
 }
 
+// defaultAssistants builds the built-in assistant configs from the canonical
+// AgentRegistry so the roster stays in lockstep with every other consumer.
 func defaultAssistants() map[string]AssistantConfig {
-	return map[string]AssistantConfig{
-		"claude": {
-			Command:          "claude",
-			InterruptCount:   2,
-			InterruptDelayMs: 200,
-		},
-		"codex": {
-			Command:          "codex",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"gemini": {
-			Command:          "gemini",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"amp": {
-			Command:          "amp",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"opencode": {
-			Command:          "opencode",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"droid": {
-			Command:          "droid",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"cline": {
-			Command:          "cline",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"cursor": {
-			Command:          "agent",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
-		"pi": {
-			Command:          "pi",
-			InterruptCount:   1,
-			InterruptDelayMs: 0,
-		},
+	assistants := make(map[string]AssistantConfig, len(AgentRegistry))
+	for _, def := range AgentRegistry {
+		assistants[def.Name] = AssistantConfig{
+			Command:          def.DefaultCommand,
+			InterruptCount:   def.InterruptCount,
+			InterruptDelayMs: def.InterruptDelayMs,
+		}
 	}
+	return assistants
 }
 
 // applyAssistantOverrides overlays parsed config-file assistant entries onto

--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -16,20 +16,11 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-// AgentType represents the type of AI agent
+// AgentType represents the type of AI agent. Concrete agent identifiers are not
+// enumerated here: the canonical roster lives in the config.AgentRegistry, and
+// the runtime resolves agents by their assistant-name string (see
+// CreateAgentWithTags). Keeping the names in one place avoids hand-synced lists.
 type AgentType string
-
-const (
-	AgentClaude   AgentType = "claude"
-	AgentCodex    AgentType = "codex"
-	AgentGemini   AgentType = "gemini"
-	AgentAmp      AgentType = "amp"
-	AgentOpencode AgentType = "opencode"
-	AgentDroid    AgentType = "droid"
-	AgentCline    AgentType = "cline"
-	AgentCursor   AgentType = "cursor"
-	AgentPi       AgentType = "pi"
-)
 
 // Agent represents a running AI agent instance
 type Agent struct {

--- a/internal/pty/agent_test.go
+++ b/internal/pty/agent_test.go
@@ -119,7 +119,7 @@ func TestAgentManager_CloseAgent(t *testing.T) {
 
 	// Manually add an agent (bypassing tmux/pty creation)
 	agent := &Agent{
-		Type:      AgentClaude,
+		Type:      AgentType("claude"),
 		Terminal:  nil, // no real terminal
 		Workspace: ws,
 		Session:   "test-session",
@@ -162,7 +162,7 @@ func TestAgentManager_CloseAgent_WithTerminal(t *testing.T) {
 	}
 
 	agent := &Agent{
-		Type:      AgentClaude,
+		Type:      AgentType("claude"),
 		Terminal:  term,
 		Workspace: ws,
 		Session:   "test-session",
@@ -193,7 +193,7 @@ func TestAgentManager_CloseAgent_NilWorkspace(t *testing.T) {
 	m := NewAgentManager(testConfig())
 
 	agent := &Agent{
-		Type:      AgentClaude,
+		Type:      AgentType("claude"),
 		Terminal:  nil,
 		Workspace: nil,
 		Session:   "test-session",
@@ -222,8 +222,8 @@ func TestAgentManager_CloseAll(t *testing.T) {
 		t.Fatalf("failed to create term2: %v", err)
 	}
 
-	agent1 := &Agent{Type: AgentClaude, Terminal: term1, Workspace: ws1, Session: "s1"}
-	agent2 := &Agent{Type: AgentCodex, Terminal: term2, Workspace: ws2, Session: "s2"}
+	agent1 := &Agent{Type: AgentType("claude"), Terminal: term1, Workspace: ws1, Session: "s1"}
+	agent2 := &Agent{Type: AgentType("codex"), Terminal: term2, Workspace: ws2, Session: "s2"}
 
 	m.mu.Lock()
 	m.agents[ws1.ID()] = []*Agent{agent1}
@@ -268,8 +268,8 @@ func TestAgentManager_CloseWorkspaceAgents(t *testing.T) {
 		t.Fatalf("failed to create term2: %v", err)
 	}
 
-	agent1 := &Agent{Type: AgentClaude, Terminal: term1, Workspace: ws1, Session: "s1"}
-	agent2 := &Agent{Type: AgentCodex, Terminal: term2, Workspace: ws2, Session: "s2"}
+	agent1 := &Agent{Type: AgentType("claude"), Terminal: term1, Workspace: ws1, Session: "s1"}
+	agent2 := &Agent{Type: AgentType("codex"), Terminal: term2, Workspace: ws2, Session: "s2"}
 
 	m.mu.Lock()
 	m.agents[ws1.ID()] = []*Agent{agent1}
@@ -324,7 +324,7 @@ func TestAgentManager_SendInterrupt(t *testing.T) {
 	defer term.Close()
 
 	agent := &Agent{
-		Type:     AgentCodex,
+		Type:     AgentType("codex"),
 		Terminal: term,
 		Config: config.AssistantConfig{
 			InterruptCount: 1,
@@ -347,7 +347,7 @@ func TestAgentManager_SendInterrupt_MultipleWithDelay(t *testing.T) {
 	defer term.Close()
 
 	agent := &Agent{
-		Type:     AgentClaude,
+		Type:     AgentType("claude"),
 		Terminal: term,
 		Config: config.AssistantConfig{
 			InterruptCount:   3,
@@ -365,7 +365,7 @@ func TestAgentManager_SendInterrupt_NilTerminal(t *testing.T) {
 	m := NewAgentManager(testConfig())
 
 	agent := &Agent{
-		Type:     AgentClaude,
+		Type:     AgentType("claude"),
 		Terminal: nil,
 		Config: config.AssistantConfig{
 			InterruptCount: 2,
@@ -389,7 +389,7 @@ func TestAgentManager_SendInterrupt_ZeroCount(t *testing.T) {
 	defer term.Close()
 
 	agent := &Agent{
-		Type:     AgentClaude,
+		Type:     AgentType("claude"),
 		Terminal: term,
 		Config: config.AssistantConfig{
 			InterruptCount: 0, // zero means no interrupts sent
@@ -416,8 +416,8 @@ func TestAgentManager_MultipleAgentsPerWorkspace(t *testing.T) {
 		t.Fatalf("failed to create term2: %v", err)
 	}
 
-	agent1 := &Agent{Type: AgentClaude, Terminal: term1, Workspace: ws, Session: "s1"}
-	agent2 := &Agent{Type: AgentCodex, Terminal: term2, Workspace: ws, Session: "s2"}
+	agent1 := &Agent{Type: AgentType("claude"), Terminal: term1, Workspace: ws, Session: "s1"}
+	agent2 := &Agent{Type: AgentType("codex"), Terminal: term2, Workspace: ws, Session: "s2"}
 
 	wsID := ws.ID()
 	m.mu.Lock()
@@ -442,20 +442,17 @@ func TestAgentManager_MultipleAgentsPerWorkspace(t *testing.T) {
 	term2.Close()
 }
 
-func TestAgentType_Constants(t *testing.T) {
-	// Verify agent type constants are distinct
-	types := []AgentType{
-		AgentClaude, AgentCodex, AgentGemini, AgentAmp,
-		AgentOpencode, AgentDroid, AgentCline, AgentCursor, AgentPi,
+func TestAgentType_ConfigBridge(t *testing.T) {
+	// Smoke-test the config->AgentType bridge: agent types are derived from the
+	// canonical config registry rather than a hand-synced constant list, so a
+	// registry name must round-trip through AgentType to its string. The
+	// distinctness/non-emptiness invariant is owned by config's
+	// TestAgentRegistryIsCanonical, not here.
+	names := config.AgentNames()
+	if len(names) == 0 {
+		t.Fatal("config.AgentNames() returned no agents")
 	}
-	seen := make(map[AgentType]bool)
-	for _, at := range types {
-		if seen[at] {
-			t.Errorf("duplicate agent type: %s", at)
-		}
-		seen[at] = true
-		if at == "" {
-			t.Error("agent type should not be empty")
-		}
+	if got := string(AgentType(names[0])); got != names[0] {
+		t.Errorf("AgentType round-trip mismatch: got %q, want %q", got, names[0])
 	}
 }

--- a/internal/ui/center/model_chat_tab.go
+++ b/internal/ui/center/model_chat_tab.go
@@ -1,16 +1,15 @@
 package center
 
+import "github.com/andyrewlee/amux/internal/config"
+
 func (m *Model) assistantIsChat(assistant string) bool {
 	if m != nil && m.config != nil && len(m.config.Assistants) > 0 {
 		_, ok := m.config.Assistants[assistant]
 		return ok
 	}
-	switch assistant {
-	case "claude", "codex", "gemini", "amp", "opencode", "droid", "cline", "cursor", "pi":
-		return true
-	default:
-		return false
-	}
+	// Fallback when no config is loaded: consult the canonical agent registry
+	// so the supported roster stays in lockstep with config/theme.
+	return config.IsRegisteredAgent(assistant)
 }
 
 func tabHasDiffViewerLocked(tab *Tab) bool {

--- a/internal/ui/center/model_chat_tab_registry_test.go
+++ b/internal/ui/center/model_chat_tab_registry_test.go
@@ -1,0 +1,22 @@
+package center
+
+import (
+	"testing"
+)
+
+// TestAssistantIsChatFallbackRejectsUnknown smoke-exercises the nil-config
+// fallback branch of assistantIsChat: with a nil config the method delegates to
+// config.IsRegisteredAgent, so an unregistered name must take the false branch.
+// This is not a roster-drift guard — that lives in config's
+// TestAgentRegistryIsCanonical and theme's TestAgentColorMatchesRegistry.
+// Because the fallback delegates to IsRegisteredAgent, asserting the positive
+// set equals AgentNames() would be definitionally true, so we only exercise the
+// fallback's false branch here.
+func TestAssistantIsChatFallbackRejectsUnknown(t *testing.T) {
+	m := &Model{} // nil config forces the registry fallback branch
+
+	// Unknown agents must not be treated as chat agents in the fallback.
+	if m.assistantIsChat("definitely-not-an-agent") {
+		t.Error("assistantIsChat fallback should reject unknown agents")
+	}
+}

--- a/internal/ui/theme/colors.go
+++ b/internal/ui/theme/colors.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/andyrewlee/amux/internal/config"
 )
 
 // themePtr holds the active color theme, protected by atomic access.
@@ -65,6 +67,21 @@ var (
 	ColorPi       = lipgloss.Color("#0e0e11")
 )
 
+// agentColors maps canonical agent names to their brand palette color. Lookups
+// are gated by config.IsRegisteredAgent so the roster stays in lockstep with
+// the canonical registry; any unmapped registry name falls back to ColorPrimary.
+var agentColors = map[string]color.Color{
+	"claude":   ColorClaude,
+	"codex":    ColorCodex,
+	"gemini":   ColorGemini,
+	"amp":      ColorAmp,
+	"opencode": ColorOpencode,
+	"droid":    ColorDroid,
+	"cline":    ColorCline,
+	"cursor":   ColorCursor,
+	"pi":       ColorPi,
+}
+
 // GetCurrentTheme returns the currently active theme.
 func GetCurrentTheme() Theme {
 	return *currentTheme()
@@ -76,30 +93,16 @@ func SetCurrentTheme(id ThemeID) {
 	themePtr.Store(&t)
 }
 
-// AgentColor returns the color for a given agent type
+// AgentColor returns the brand color for a registered agent, falling back to
+// ColorPrimary for unknown agents. Membership is resolved via the canonical
+// registry so the supported roster stays in sync with config and the chat tab.
 func AgentColor(agent string) color.Color {
-	switch agent {
-	case "claude":
-		return ColorClaude
-	case "codex":
-		return ColorCodex
-	case "gemini":
-		return ColorGemini
-	case "amp":
-		return ColorAmp
-	case "opencode":
-		return ColorOpencode
-	case "droid":
-		return ColorDroid
-	case "cline":
-		return ColorCline
-	case "cursor":
-		return ColorCursor
-	case "pi":
-		return ColorPi
-	default:
-		return ColorPrimary()
+	if config.IsRegisteredAgent(agent) {
+		if c, ok := agentColors[agent]; ok {
+			return c
+		}
 	}
+	return ColorPrimary()
 }
 
 // HexColor converts a color.Color into a #RRGGBB string.

--- a/internal/ui/theme/colors_agent_test.go
+++ b/internal/ui/theme/colors_agent_test.go
@@ -1,0 +1,48 @@
+package theme
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/config"
+)
+
+// TestAgentColorMatchesRegistry guards that the set of agents for which
+// AgentColor returns a dedicated brand color (i.e. not the ColorPrimary
+// fallback) equals exactly the canonical config.AgentRegistry. A missing or
+// renamed agent fails CI here.
+func TestAgentColorMatchesRegistry(t *testing.T) {
+	primary := ColorPrimary()
+
+	nonDefault := map[string]struct{}{}
+	for _, name := range config.AgentNames() {
+		if !reflect.DeepEqual(AgentColor(name), primary) {
+			nonDefault[name] = struct{}{}
+		}
+	}
+
+	want := map[string]struct{}{}
+	for _, name := range config.AgentNames() {
+		want[name] = struct{}{}
+	}
+
+	if !reflect.DeepEqual(nonDefault, want) {
+		t.Errorf("AgentColor non-default set %v does not equal registry %v",
+			sortedKeys(nonDefault), sortedKeys(want))
+	}
+
+	// Unknown agents must fall back to ColorPrimary.
+	if !reflect.DeepEqual(AgentColor("definitely-not-an-agent"), primary) {
+		t.Error("AgentColor should fall back to ColorPrimary for unknown agents")
+	}
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Replace the five hand-synced agent lists (config preferredAssistantOrder + defaultAssistants, pty AgentType constants, center assistantIsChat fallback, theme AgentColor) with a single ordered `config.AgentRegistry` ([]AgentDef of Name/DefaultCommand/InterruptCount/InterruptDelayMs) as the source of truth. preferredAssistantOrder, defaultAssistants, the assistantIsChat no-config fallback, and AgentColor membership are all derived from it; the production-inert pty AgentType constants are deleted (runtime keys off the assistant string) and agent_test.go uses string literals plus a registry-driven check. Guard tests assert the registry name set equals exactly the defaultAssistants keys, preferredAssistantOrder, AgentColor non-default cases, and the assistantIsChat fallback, so a missing or renamed agent fails CI. No behavior change except deleting verified-dead code. Part of the quality stacked diff. Stacked on improve/011-portallocator-real-uniqueness-assertions. Ticket 012 (maintainability).