### PR TITLE
refactor: centralize truly-shared PTY tuning constants; document divergences

### DIFF
--- a/internal/ui/center/model_pty_config.go
+++ b/internal/ui/center/model_pty_config.go
@@ -1,13 +1,35 @@
 package center
 
-import "time"
+import (
+	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+)
+
+// Shared PTY tuning constants identical to the sidebar pane live in
+// internal/ui/ptyio (ptyio.PtyFlushQuiet etc.); they are aliased here so the
+// call sites keep their short package-local names.
+const (
+	ptyFlushQuiet         = ptyio.PtyFlushQuiet
+	ptyFlushChunkSize     = ptyio.PtyFlushChunkSize
+	ptyReadBufferSize     = ptyio.PtyReadBufferSize
+	ptyFrameInterval      = ptyio.PtyFrameInterval
+	ptyReaderStallTimeout = ptyio.PtyReaderStallTimeout
+	ptyRestartMax         = ptyio.PtyRestartMax
+	ptyRestartWindow      = ptyio.PtyRestartWindow
+)
 
 // PTY constants
 const (
-	ptyFlushQuiet       = 12 * time.Millisecond
+	// Diverges from sidebar (50ms): center runs the steady-state flush ceiling
+	// tighter so one busy agent tab cannot starve the others' frame cadence.
 	ptyFlushMaxInterval = 48 * time.Millisecond
-	ptyFlushQuietAlt    = 24 * time.Millisecond
-	ptyFlushMaxAlt      = 96 * time.Millisecond
+	// Diverges from sidebar (30ms): center's catch-up quiet period is shorter
+	// to drain backlogged tabs sooner when the active tab switches.
+	ptyFlushQuietAlt = 24 * time.Millisecond
+	// Diverges from sidebar (120ms): paired with ptyFlushQuietAlt, center caps
+	// catch-up latency lower so a backlogged tab becomes visible faster.
+	ptyFlushMaxAlt = 96 * time.Millisecond
 	// Inactive tabs still need to advance their terminal state, but can flush less frequently.
 	ptyFlushInactiveMultiplier          = 4
 	ptyFlushInactiveHeavyMultiplier     = 8
@@ -16,21 +38,21 @@ const (
 	ptyHeavyLoadTabThreshold            = 4
 	ptyVeryHeavyLoadTabThreshold        = 8
 	ptyLoadSampleInterval               = 100 * time.Millisecond
-	ptyFlushChunkSize                   = 32 * 1024
 	// Active tab catch-up should drain backlog quickly to avoid visible replay.
 	ptyFlushChunkSizeActive = 256 * 1024
 	// Catch-up can exceed the steady-state active cap, but it still needs a
 	// ceiling so a single actor write cannot monopolize input/scroll handling.
 	ptyFlushChunkSizeCatchUp = 1024 * 1024
-	ptyReadBufferSize        = 32 * 1024
-	ptyReadQueueSize         = 64
-	ptyFrameInterval         = time.Second / 24
-	ptyMaxPendingBytes       = 512 * 1024
-	ptyMaxBufferedBytes      = 8 * 1024 * 1024
-	ptyReaderStallTimeout    = 10 * time.Second
-	tabActorStallTimeout     = 10 * time.Second
-	ptyRestartMax            = 5
-	ptyRestartWindow         = time.Minute
+	// Diverges from sidebar (32): center fans reads across N concurrent agent
+	// tabs, so it buffers a deeper read queue per reader.
+	ptyReadQueueSize = 64
+	// Diverges from sidebar (256K): center allows more in-flight pending bytes
+	// because multiple tabs share the backpressure/load-sampling machinery.
+	ptyMaxPendingBytes = 512 * 1024
+	// Diverges from sidebar (4M): center's larger buffered ceiling absorbs
+	// bursts from many tabs before overflow trimming kicks in.
+	ptyMaxBufferedBytes  = 8 * 1024 * 1024
+	tabActorStallTimeout = 10 * time.Second
 
 	// Backpressure thresholds (inspired by tmux's TTY_BLOCK_START/STOP)
 	// When pending output exceeds this, we throttle rendering frequency

--- a/internal/ui/ptyio/tuning.go
+++ b/internal/ui/ptyio/tuning.go
@@ -1,0 +1,27 @@
+package ptyio
+
+import "time"
+
+// Shared PTY flush/buffer tuning constants used by both the center (agent
+// tabs) and sidebar (single terminal) panes. Only values that are genuinely
+// identical in both panes live here; pane-specific overrides (e.g. center's
+// concurrent-tab backpressure or sidebar's single-terminal buffer sizing) stay
+// local to their config files and are documented there with a one-line reason.
+const (
+	// PtyFlushQuiet is the quiet period output must be idle for before a steady
+	// flush fires.
+	PtyFlushQuiet = 12 * time.Millisecond
+	// PtyFlushChunkSize bounds the bytes drained per steady-state flush.
+	PtyFlushChunkSize = 32 * 1024
+	// PtyReadBufferSize is the size of the PTY reader's read buffer.
+	PtyReadBufferSize = 32 * 1024
+	// PtyFrameInterval is the render cadence (24 fps) for PTY output.
+	PtyFrameInterval = time.Second / 24
+	// PtyReaderStallTimeout is how long a reader may go silent before it is
+	// treated as stalled.
+	PtyReaderStallTimeout = 10 * time.Second
+	// PtyRestartMax is the max reader restarts allowed within PtyRestartWindow.
+	PtyRestartMax = 5
+	// PtyRestartWindow is the sliding window for counting reader restarts.
+	PtyRestartWindow = time.Minute
+)

--- a/internal/ui/sidebar/terminal_pty_config.go
+++ b/internal/ui/sidebar/terminal_pty_config.go
@@ -5,22 +5,40 @@ import (
 
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+)
+
+// Shared PTY tuning constants identical to the center pane live in
+// internal/ui/ptyio (ptyio.PtyFlushQuiet etc.); they are aliased here so the
+// call sites keep their short package-local names.
+const (
+	ptyFlushQuiet         = ptyio.PtyFlushQuiet
+	ptyFlushChunkSize     = ptyio.PtyFlushChunkSize
+	ptyReadBufferSize     = ptyio.PtyReadBufferSize
+	ptyFrameInterval      = ptyio.PtyFrameInterval
+	ptyReaderStallTimeout = ptyio.PtyReaderStallTimeout
+	ptyRestartMax         = ptyio.PtyRestartMax
+	ptyRestartWindow      = ptyio.PtyRestartWindow
 )
 
 const (
-	ptyFlushQuiet         = 12 * time.Millisecond
-	ptyFlushMaxInterval   = 50 * time.Millisecond
-	ptyFlushQuietAlt      = 30 * time.Millisecond
-	ptyFlushMaxAlt        = 120 * time.Millisecond
-	ptyFlushChunkSize     = 32 * 1024
-	ptyReadBufferSize     = 32 * 1024
-	ptyReadQueueSize      = 32
-	ptyFrameInterval      = time.Second / 24
-	ptyMaxPendingBytes    = 256 * 1024
-	ptyReaderStallTimeout = 10 * time.Second
-	ptyMaxBufferedBytes   = 4 * 1024 * 1024
-	ptyRestartMax         = 5
-	ptyRestartWindow      = time.Minute
+	// Diverges from center (48ms): the sidebar drives a single terminal, so it
+	// can afford a slightly looser flush ceiling than center's N-tab cadence.
+	ptyFlushMaxInterval = 50 * time.Millisecond
+	// Diverges from center (24ms): single-terminal catch-up has no competing
+	// tabs, so the quiet period can be longer to coalesce more output.
+	ptyFlushQuietAlt = 30 * time.Millisecond
+	// Diverges from center (96ms): paired with ptyFlushQuietAlt, the sidebar
+	// tolerates higher catch-up latency for a single terminal.
+	ptyFlushMaxAlt = 120 * time.Millisecond
+	// Diverges from center (64): a single terminal needs a shallower read queue.
+	ptyReadQueueSize = 32
+	// Diverges from center (512K): one terminal needs fewer in-flight pending
+	// bytes than center's shared multi-tab backpressure budget.
+	ptyMaxPendingBytes = 256 * 1024
+	// Diverges from center (8M): a single terminal needs a smaller buffered
+	// ceiling before overflow trimming.
+	ptyMaxBufferedBytes = 4 * 1024 * 1024
 )
 
 // SidebarTerminalCreated is a message for terminal creation


### PR DESCRIPTION
Move the seven PTY flush/buffer tuning constants that hold identical values in both the center and sidebar panes (ptyFlushQuiet, ptyFlushChunkSize, ptyReadBufferSize, ptyFrameInterval, ptyReaderStallTimeout, ptyRestartMax, ptyRestartWindow) into the already-shared internal/ui/ptyio package as exported constants, and alias them in each config file so existing call sites keep their short names. The six constants that genuinely diverge (ptyFlushMaxInterval, ptyFlushQuietAlt, ptyFlushMaxAlt, ptyReadQueueSize, ptyMaxPendingBytes, ptyMaxBufferedBytes) stay as documented package-local overrides — center hosts N concurrent agent tabs with backpressure/load-sampling; the sidebar is a single terminal — each now carries a one-line comment explaining why it differs. Center-only load/backpressure constants stay in center. ptyio gains no new imports (no import cycle). Build, vet, package tests, golangci-lint, and check-file-length all pass. Part of the quality stacked diff. Stacked on improve/012-canonical-agent-registry. Ticket 013 (maintainability).