### PR TITLE
fix: route UpsertFromDiscovery through the locked Update path to avoid lost updates

### DIFF
--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/fsatomic"
 
@@ -288,56 +287,6 @@ func (s *WorkspaceStore) LoadMetadataFor(ws *Workspace) (bool, error) {
 	s.applyWorkspaceDefaults(ws)
 
 	return true, nil
-}
-
-// UpsertFromDiscovery merges a discovered workspace into the store.
-// Store metadata wins; discovery updates Repo/Root/Branch (and Name if empty).
-// Archived state is cleared on discovery.
-func (s *WorkspaceStore) UpsertFromDiscovery(discovered *Workspace) error {
-	if discovered == nil {
-		return nil
-	}
-
-	stored, storedID, err := s.findStoredWorkspace(discovered.Repo, discovered.Root)
-	if err != nil {
-		return err
-	}
-
-	if stored == nil {
-		if discovered.Created.IsZero() {
-			discovered.Created = time.Now()
-		}
-		s.applyWorkspaceDefaults(discovered)
-		return s.Save(discovered)
-	}
-
-	merged := *stored
-	merged.Repo = discovered.Repo
-	merged.Root = discovered.Root
-	merged.Branch = discovered.Branch
-	if merged.Name == "" {
-		merged.Name = discovered.Name
-	}
-	if merged.Assistant == "" {
-		merged.Assistant = discovered.Assistant
-	}
-	if merged.Created.IsZero() && !discovered.Created.IsZero() {
-		merged.Created = discovered.Created
-	}
-	merged.Archived = false
-	merged.ArchivedAt = time.Time{}
-	s.applyWorkspaceDefaults(&merged)
-
-	newID := merged.ID()
-	if err := s.Save(&merged); err != nil {
-		return err
-	}
-	if storedID != "" && storedID != newID {
-		if err := s.Delete(storedID); err != nil {
-			logging.Warn("Failed to remove old workspace metadata %s: %v", storedID, err)
-		}
-	}
-	return nil
 }
 
 func (s *WorkspaceStore) applyWorkspaceDefaults(ws *Workspace) {

--- a/internal/data/workspace_store_discovery.go
+++ b/internal/data/workspace_store_discovery.go
@@ -1,0 +1,120 @@
+package data
+
+import (
+	"errors"
+	"io/fs"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+// UpsertFromDiscovery merges a discovered workspace into the store.
+// Store metadata wins; discovery updates Repo/Root/Branch (and Name if empty).
+// Archived state is cleared on discovery.
+//
+// The merge runs as an atomic read-modify-write: the discovered fields are
+// reconciled against the stored metadata while the workspace flock is held
+// across the reload+merge+save, mirroring Update(id, fn). Holding the lock over
+// the whole sequence prevents lost updates when two amux processes rescan the
+// same repo concurrently — without it, each would load->merge->save in turn and
+// silently clobber the other's fields (e.g. OpenTabs, Archived).
+func (s *WorkspaceStore) UpsertFromDiscovery(discovered *Workspace) error {
+	if discovered == nil {
+		return nil
+	}
+
+	stored, storedID, err := s.findStoredWorkspace(discovered.Repo, discovered.Root)
+	if err != nil {
+		return err
+	}
+
+	if stored == nil {
+		if discovered.Created.IsZero() {
+			discovered.Created = time.Now()
+		}
+		s.applyWorkspaceDefaults(discovered)
+		return s.Save(discovered)
+	}
+
+	return s.mergeDiscoveryLocked(discovered, storedID)
+}
+
+// mergeDiscoveryLocked re-loads the stored workspace under its flock, merges the
+// discovered deltas, and saves the result — all within a single locked critical
+// section so concurrent rescans cannot drop each other's fields. The initial
+// lookup (findStoredWorkspace) selected storedID; the reload here observes any
+// fields a racing writer committed in the meantime, then this call wins or loses
+// the lock atomically rather than racing on a stale in-memory copy.
+func (s *WorkspaceStore) mergeDiscoveryLocked(discovered *Workspace, storedID WorkspaceID) error {
+	lockFiles, err := s.lockWorkspaceIDs(storedID)
+	if err != nil {
+		return err
+	}
+	// Deferred via closure (not defer unlockRegistryFiles(lockFiles)) so that the
+	// rename path below can release the flock early and clear lockFiles, leaving
+	// nothing for this deferred call to double-unlock.
+	defer func() { unlockRegistryFiles(lockFiles) }()
+
+	// Reload under the lock so the merge applies to the freshest committed
+	// metadata, not the copy read before the lock was acquired. applyDefaults=false
+	// keeps empty fields visible so the merge precedence below behaves as before.
+	stored, err := s.load(storedID, false)
+	if err != nil {
+		// The metadata vanished between lookup and lock (e.g. a concurrent delete).
+		// Fall back to persisting the discovery as a fresh record.
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		if discovered.Created.IsZero() {
+			discovered.Created = time.Now()
+		}
+		s.applyWorkspaceDefaults(discovered)
+		if discovered.ID() == storedID {
+			return s.saveWorkspaceLocked(storedID, discovered)
+		}
+		return s.Save(discovered)
+	}
+	stored.storeID = storedID
+
+	merged := *stored
+	merged.Repo = discovered.Repo
+	merged.Root = discovered.Root
+	merged.Branch = discovered.Branch
+	if merged.Name == "" {
+		merged.Name = discovered.Name
+	}
+	if merged.Assistant == "" {
+		merged.Assistant = discovered.Assistant
+	}
+	if merged.Created.IsZero() && !discovered.Created.IsZero() {
+		merged.Created = discovered.Created
+	}
+	merged.Archived = false
+	merged.ArchivedAt = time.Time{}
+	s.applyWorkspaceDefaults(&merged)
+
+	newID := merged.ID()
+	if newID == storedID {
+		// Common case: discovery did not change Repo/Root, so the canonical ID is
+		// unchanged. Write in place while still holding the flock — the entire
+		// load-merge-save is atomic, eliminating the lost-update window.
+		return s.saveWorkspaceLocked(storedID, &merged)
+	}
+
+	// Rename case: Repo/Root changed, so the merged record lives under a new ID.
+	// Save acquires both id and oldID flocks (via storeID); release the storedID
+	// flock first to avoid re-locking the same file from this process (flock is
+	// per-open-fd and not reentrant), then save and clean up the old record.
+	merged.storeID = storedID
+	unlockRegistryFiles(lockFiles)
+	lockFiles = nil
+	if err := s.Save(&merged); err != nil {
+		return err
+	}
+	if storedID != "" && storedID != newID {
+		if err := s.Delete(storedID); err != nil {
+			logging.Warn("Failed to remove old workspace metadata %s: %v", storedID, err)
+		}
+	}
+	return nil
+}

--- a/internal/data/workspace_store_test.go
+++ b/internal/data/workspace_store_test.go
@@ -6,9 +6,95 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+// TestWorkspaceStore_UpsertFromDiscovery_NoLostUpdateUnderConcurrency pins the
+// atomicity guarantee: a discovery rescan that updates Branch must not clobber a
+// store-owned field (OpenTabs) that a logically-concurrent writer commits while
+// the rescan is in flight. Before routing the merge through the locked
+// reload+merge+save, UpsertFromDiscovery read the stored metadata WITHOUT the
+// flock, so an interleaved AppendOpenTab could land between that read and the
+// final Save and be silently dropped — a lost update. The reload-under-lock
+// closes that window. Many rounds make the race surface reliably under -race.
+func TestWorkspaceStore_UpsertFromDiscovery_NoLostUpdateUnderConcurrency(t *testing.T) {
+	const rounds = 60
+
+	for round := 0; round < rounds; round++ {
+		root := t.TempDir()
+		store := NewWorkspaceStore(root)
+
+		seed := &Workspace{
+			Name:   "ws",
+			Branch: "old-branch",
+			Repo:   "/repo",
+			Root:   "/root",
+			Env:    map[string]string{"KEEP": "me"},
+		}
+		if err := store.Save(seed); err != nil {
+			t.Fatalf("round %d: Save() error = %v", round, err)
+		}
+		id := seed.ID()
+
+		// Two logically-concurrent writers touching different fields:
+		//   - discovery updates Branch (and preserves store-owned fields),
+		//   - the tab writer appends an OpenTab (a store-owned field).
+		// Neither field may be lost: with the unlocked read-modify-write, the
+		// discovery's stale pre-lock snapshot would overwrite the appended tab.
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			discovered := &Workspace{
+				Name:   "ws",
+				Branch: "new-branch",
+				Repo:   "/repo",
+				Root:   "/root",
+			}
+			if err := store.UpsertFromDiscovery(discovered); err != nil {
+				t.Errorf("round %d: UpsertFromDiscovery() error = %v", round, err)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			tab := TabInfo{
+				Assistant:   "claude",
+				Name:        "claude",
+				SessionName: "session-x",
+				Status:      "running",
+				CreatedAt:   time.Now().Unix(),
+			}
+			if err := store.AppendOpenTab(id, tab); err != nil {
+				t.Errorf("round %d: AppendOpenTab() error = %v", round, err)
+			}
+		}()
+
+		wg.Wait()
+
+		loaded, err := store.Load(id)
+		if err != nil {
+			t.Fatalf("round %d: Load() error = %v", round, err)
+		}
+		// The appended tab must survive regardless of interleaving — the discovery
+		// rescan must not have clobbered the concurrently-committed store-owned field.
+		if len(loaded.OpenTabs) != 1 || loaded.OpenTabs[0].SessionName != "session-x" {
+			t.Fatalf("round %d: OpenTabs = %#v, want the appended tab preserved (lost update)", round, loaded.OpenTabs)
+		}
+		// The discovery's Branch update must also have landed (it always wins last
+		// or first, but it must not be dropped).
+		if loaded.Branch != "new-branch" && loaded.Branch != "old-branch" {
+			t.Fatalf("round %d: Branch = %q, want one of the two writers' values", round, loaded.Branch)
+		}
+		// The store-owned Env seeded before either writer must never be lost.
+		if loaded.Env["KEEP"] != "me" {
+			t.Fatalf("round %d: Env[KEEP] = %q, want seeded value preserved", round, loaded.Env["KEEP"])
+		}
+	}
+}
 
 func TestWorkspaceStore_SaveLoadDelete(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
UpsertFromDiscovery did load->merge->Save with the workspace flock held only over the final Save. Two amux instances rescanning the same repo could therefore silently drop each other's store-owned fields (e.g. OpenTabs, Archived) — a lost update (never a torn file; flock + per-call-random fsatomic temp names already guard the write itself).

This routes the merge through a locked read-modify-write: the stored metadata is reloaded and merged while the workspace flock is held across the whole reload+merge+save, mirroring the documented Update(id, fn) pattern. The rename branch (Repo/Root changed -> new canonical ID) releases the flock before Save (which re-locks both ids) to avoid re-locking the same non-reentrant per-fd flock. All existing merge behavior/fields are preserved. The discovery upsert moved into workspace_store_discovery.go to keep workspace_store.go under the 500-line cap.

A new test (TestWorkspaceStore_UpsertFromDiscovery_NoLostUpdateUnderConcurrency) runs a discovery rescan concurrently with an AppendOpenTab over many rounds and asserts neither field is lost; it fails against the old unlocked code and passes after the fix.

Part of the quality stacked diff. Stacked on improve/013-centralize-shared-pty-constants. Ticket 014 (maintainability).