### PR TITLE
fix: renew the activity owner lease at scan start to avoid mid-scan flapping

### DIFF
--- a/internal/app/app_tmux_activity_shared.go
+++ b/internal/app/app_tmux_activity_shared.go
@@ -47,6 +47,17 @@ func (a *App) resolveTmuxActivityScanRole(
 		if epoch < 1 {
 			epoch = 1
 		}
+		// Renew the heartbeat at scan START, not only after publish. A scan can
+		// outlive the lease TTL (~7s) while the heartbeat tick (~5s) is gated
+		// behind the scan; without renewing up front a long scan lets the lease
+		// expire mid-scan and a follower legitimately claims it, causing
+		// ownership flapping (spinner blanking, duplicate scans). The heartbeat
+		// is a single tmux global-option write owned solely by this instance,
+		// and publish still re-validates ownership/epoch before its own renew,
+		// so refreshing here cannot create a second owner or a double-renew race.
+		if err := activity.RenewOwnerLeaseHeartbeat(opts, now); err != nil {
+			return tmuxActivityRoleOwner, nil, false, epoch, err
+		}
 		return tmuxActivityRoleOwner, nil, false, epoch, nil
 	}
 

--- a/internal/app/app_tmux_activity_shared_test.go
+++ b/internal/app/app_tmux_activity_shared_test.go
@@ -147,11 +147,11 @@ func TestResolveTmuxActivityScanRole_FollowerWithoutSnapshotSkipsApply(t *testin
 	}
 }
 
-func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testing.T) {
+func TestResolveTmuxActivityScanRole_OwnerResolveRenewsHeartbeatAtScanStart(t *testing.T) {
 	skipIfNoTmux(t)
 	opts := gcTestServer(t)
 
-	owner := &App{instanceID: "owner-no-resolve-heartbeat"}
+	owner := &App{instanceID: "owner-resolve-heartbeat"}
 	now := time.Now()
 	_, _, _, epoch, err := owner.resolveTmuxActivityScanRole(opts, now)
 	if err != nil {
@@ -170,7 +170,10 @@ func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testin
 		t.Fatalf("parse heartbeat before resolve: %v", err)
 	}
 
-	role, _, _, renewedEpoch, err := owner.resolveTmuxActivityScanRole(opts, now.Add(2*time.Second))
+	// A long scan: re-resolving 2s later (beyond the heartbeat tick) must push
+	// the heartbeat forward so the lease cannot expire mid-scan.
+	renewAt := now.Add(2 * time.Second)
+	role, _, _, renewedEpoch, err := owner.resolveTmuxActivityScanRole(opts, renewAt)
 	if err != nil {
 		t.Fatalf("resolve owner role again: %v", err)
 	}
@@ -189,8 +192,24 @@ func TestResolveTmuxActivityScanRole_OwnerResolveDoesNotRenewHeartbeat(t *testin
 	if err != nil {
 		t.Fatalf("parse heartbeat after resolve: %v", err)
 	}
-	if afterHeartbeat != beforeHeartbeat {
-		t.Fatalf("expected owner resolve to keep heartbeat at %d, got %d", beforeHeartbeat, afterHeartbeat)
+	if afterHeartbeat != renewAt.UnixMilli() {
+		t.Fatalf("expected owner resolve to renew heartbeat to %d, got %d", renewAt.UnixMilli(), afterHeartbeat)
+	}
+	if afterHeartbeat <= beforeHeartbeat {
+		t.Fatalf("expected owner resolve to advance heartbeat past %d, got %d", beforeHeartbeat, afterHeartbeat)
+	}
+
+	// Ownership must remain single-owner after the scan-start renew: re-reading
+	// the lease shows the same owner/epoch, just a fresher heartbeat.
+	lease, err := activity.ReadOwnerLease(opts)
+	if err != nil {
+		t.Fatalf("read owner lease: %v", err)
+	}
+	if lease.OwnerID != owner.instanceID {
+		t.Fatalf("expected lease owner %q, got %q", owner.instanceID, lease.OwnerID)
+	}
+	if lease.Epoch != epoch {
+		t.Fatalf("expected lease epoch %d, got %d", epoch, lease.Epoch)
 	}
 }
 


### PR DESCRIPTION
The activity owner-lease heartbeat was renewed only after a scan completed (in `publishTmuxActivitySnapshot`). With a ~7s TTL and a ~5s tick, an owner whose scan exceeds ~2s let the lease go stale mid-scan, allowing a follower to legitimately claim ownership and causing flapping (spinner blanking, duplicate scans).

This renews the heartbeat at scan START in `resolveTmuxActivityScanRole` when this instance already owns a live lease, while keeping the end-of-scan renew. The heartbeat write is owned solely by this instance, and publish still re-validates ownership/epoch before its own renew, so single-owner semantics are preserved with no double-renew race. Updated the prior test that locked the no-renew behavior to assert the heartbeat now advances at scan start while owner/epoch stay stable.

Part of the quality stacked diff. Stacked on improve/014-atomic-upsertfromdiscovery-under-flock. Ticket 015 (maintainability).