### PR TITLE
test: injectable HTTP seam + httptest coverage for the self-update GitHub client

### DIFF
--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -44,6 +44,7 @@ type GitHubClient struct {
 	httpClient *http.Client
 	owner      string
 	repo       string
+	baseURL    string
 }
 
 // NewGitHubClient creates a new GitHub client.
@@ -52,14 +53,31 @@ func NewGitHubClient() *GitHubClient {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		owner: GitHubOwner,
-		repo:  GitHubRepo,
+		owner:   GitHubOwner,
+		repo:    GitHubRepo,
+		baseURL: GitHubAPIBase,
+	}
+}
+
+// newGitHubClientForTest creates a GitHub client whose API base URL and HTTP
+// client are injectable, so tests can point FetchLatestRelease at an
+// httptest.Server. It is unexported and intended for tests only; production
+// callers use NewGitHubClient.
+func newGitHubClientForTest(baseURL string, httpClient *http.Client) *GitHubClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &GitHubClient{
+		httpClient: httpClient,
+		owner:      GitHubOwner,
+		repo:       GitHubRepo,
+		baseURL:    baseURL,
 	}
 }
 
 // FetchLatestRelease fetches the latest release from GitHub.
 func (c *GitHubClient) FetchLatestRelease() (*Release, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", GitHubAPIBase, c.owner, c.repo)
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", c.baseURL, c.owner, c.repo)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/update/github_test.go
+++ b/internal/update/github_test.go
@@ -1,0 +1,195 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestServer spins up an httptest.Server with the given handler and returns
+// a GitHubClient whose API base URL points at it.
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*GitHubClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return newGitHubClientForTest(srv.URL, srv.Client()), srv
+}
+
+func TestFetchLatestReleaseSuccess(t *testing.T) {
+	var srvURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/andyrewlee/amux/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		rel := Release{
+			TagName: "v1.2.3",
+			Assets: []Asset{
+				{Name: "amux_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srvURL + "/dl/amux.tar.gz"},
+				{Name: "checksums.txt", BrowserDownloadURL: srvURL + "/dl/checksums.txt"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	srvURL = srv.URL
+	c := newGitHubClientForTest(srv.URL, srv.Client())
+
+	rel, err := c.FetchLatestRelease()
+	if err != nil {
+		t.Fatalf("FetchLatestRelease() error = %v", err)
+	}
+	if rel.TagName != "v1.2.3" {
+		t.Errorf("TagName = %q, want %q", rel.TagName, "v1.2.3")
+	}
+	if len(rel.Assets) != 2 {
+		t.Fatalf("len(Assets) = %d, want 2", len(rel.Assets))
+	}
+
+	// The checksums asset URL must point back at the test server so a
+	// follow-up FetchChecksums call is exercisable end-to-end.
+	var checksumURL string
+	for _, a := range rel.Assets {
+		if a.Name == "checksums.txt" {
+			checksumURL = a.BrowserDownloadURL
+		}
+	}
+	if !strings.HasPrefix(checksumURL, srv.URL) {
+		t.Errorf("checksums.txt URL = %q, want prefix %q", checksumURL, srv.URL)
+	}
+}
+
+func TestFetchLatestReleaseNotFound(t *testing.T) {
+	c, _ := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, err := c.FetchLatestRelease()
+	if err == nil {
+		t.Fatal("FetchLatestRelease() expected error for 404, got nil")
+	}
+	if got := err.Error(); got != "no releases found" {
+		t.Errorf("error = %q, want %q", got, "no releases found")
+	}
+}
+
+func TestFetchLatestReleaseServerError(t *testing.T) {
+	c, _ := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := c.FetchLatestRelease()
+	if err == nil {
+		t.Fatal("FetchLatestRelease() expected error for 500, got nil")
+	}
+	if got := err.Error(); !strings.HasPrefix(got, "unexpected status:") {
+		t.Errorf("error = %q, want prefix %q", got, "unexpected status:")
+	}
+}
+
+func TestFetchLatestReleaseMalformedJSON(t *testing.T) {
+	c, _ := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{not valid json"))
+	})
+
+	_, err := c.FetchLatestRelease()
+	if err == nil {
+		t.Fatal("FetchLatestRelease() expected error for malformed JSON, got nil")
+	}
+	if got := err.Error(); !strings.HasPrefix(got, "decoding response:") {
+		t.Errorf("error = %q, want prefix %q", got, "decoding response:")
+	}
+}
+
+func TestDownloadAssetSuccess(t *testing.T) {
+	payload := []byte("binary-asset-bytes")
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	})
+
+	var buf bytes.Buffer
+	if err := c.DownloadAsset(srv.URL+"/dl/amux.tar.gz", &buf); err != nil {
+		t.Fatalf("DownloadAsset() error = %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Errorf("downloaded = %q, want %q", buf.Bytes(), payload)
+	}
+}
+
+func TestDownloadAssetNon200(t *testing.T) {
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	var buf bytes.Buffer
+	err := c.DownloadAsset(srv.URL+"/dl/amux.tar.gz", &buf)
+	if err == nil {
+		t.Fatal("DownloadAsset() expected error for non-200, got nil")
+	}
+	if got := err.Error(); !strings.HasPrefix(got, "unexpected status:") {
+		t.Errorf("error = %q, want prefix %q", got, "unexpected status:")
+	}
+}
+
+func TestFetchChecksumsSuccess(t *testing.T) {
+	const body = "abc123  amux_1.2.3_linux_amd64.tar.gz\n" +
+		"def456  amux_1.2.3_darwin_arm64.tar.gz\n"
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	})
+
+	rel := &Release{Assets: []Asset{
+		{Name: "checksums.txt", BrowserDownloadURL: srv.URL + "/dl/checksums.txt"},
+	}}
+
+	sums, err := c.FetchChecksums(rel)
+	if err != nil {
+		t.Fatalf("FetchChecksums() error = %v", err)
+	}
+	if got := sums["amux_1.2.3_linux_amd64.tar.gz"]; got != "abc123" {
+		t.Errorf("linux checksum = %q, want %q", got, "abc123")
+	}
+	if got := sums["amux_1.2.3_darwin_arm64.tar.gz"]; got != "def456" {
+		t.Errorf("darwin checksum = %q, want %q", got, "def456")
+	}
+}
+
+func TestFetchChecksumsMissingAsset(t *testing.T) {
+	c := newGitHubClientForTest("http://unused.invalid", http.DefaultClient)
+
+	rel := &Release{Assets: []Asset{
+		{Name: "amux_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: "http://unused.invalid/dl"},
+	}}
+
+	_, err := c.FetchChecksums(rel)
+	if err == nil {
+		t.Fatal("FetchChecksums() expected error when checksums.txt absent, got nil")
+	}
+	if got := err.Error(); got != "checksums.txt not found in release" {
+		t.Errorf("error = %q, want %q", got, "checksums.txt not found in release")
+	}
+}
+
+func TestFetchChecksumsNon200(t *testing.T) {
+	c, srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	rel := &Release{Assets: []Asset{
+		{Name: "checksums.txt", BrowserDownloadURL: srv.URL + "/dl/checksums.txt"},
+	}}
+
+	_, err := c.FetchChecksums(rel)
+	if err == nil {
+		t.Fatal("FetchChecksums() expected error for non-200, got nil")
+	}
+	if got := err.Error(); !strings.HasPrefix(got, "unexpected status:") {
+		t.Errorf("error = %q, want prefix %q", got, "unexpected status:")
+	}
+}


### PR DESCRIPTION
Adds an injectable HTTP seam so the self-update GitHub client's three network methods can be tested. GitHubClient gains an unexported `baseURL` field (defaulted to `GitHubAPIBase` in `NewGitHubClient`, public behavior unchanged); `FetchLatestRelease` now builds its URL from `c.baseURL`. A test-only `newGitHubClientForTest(baseURL, httpClient)` constructor lets tests point `FetchLatestRelease` at an httptest.Server, whose returned asset URLs (incl. checksums.txt) loop back so DownloadAsset/FetchChecksums are exercisable end-to-end.

New github_test.go covers FetchLatestRelease (success, 404, 500, malformed JSON), DownloadAsset (success bytes land in writer, non-200), and FetchChecksums (parse 'sha256 name' lines, missing checksums.txt asset, non-200). The three methods go from 0% to 80-89% coverage. Part of the quality stacked diff. Stacked on improve/015-renew-activity-lease-at-scan-start. Ticket 016 (testability).