### PR TITLE
test: cover the cleanup-FSM finalize persist-vs-clear branch at the FSM boundary

### DIFF
--- a/internal/git/workspace_cleanup_fsm_test.go
+++ b/internal/git/workspace_cleanup_fsm_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,6 +87,140 @@ func TestResumeWorkspaceCleanup_LegacyAmbiguousWorkspaceAliveFails(t *testing.T)
 
 	if err := resumeWorkspaceCleanup(context.Background(), dir, ws, state); err == nil {
 		t.Fatal("expected legacy marker with live workspace to require manual cleanup")
+	}
+}
+
+// The finalize phase is the persist-vs-clear branch that decides whether an
+// interrupted cleanup is declared done or must retry. A wrong choice here
+// leaks a git worktree, so the branch is exercised directly at the FSM
+// boundary (cleanupFinalizeStep) rather than only end-to-end through
+// RemoveWorkspace.
+
+// Outcome (1a): the unregister is satisfied and nothing else is pending, so
+// finalize clears the marker and declares the run done.
+func TestCleanupFinalizeStep_ClearsMarkerWhenDone(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	// A surviving marker from an earlier phase that finalize must clear.
+	if err := writeWorkspaceCleanupState(ws, workspaceCleanupState{NeedsUnregister: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	run := &workspaceCleanupRun{
+		ctx:                 context.Background(),
+		repoPath:            dir,
+		workspacePath:       ws,
+		state:               workspaceCleanupState{NeedsUnregister: false},
+		unregisterSatisfied: true,
+	}
+	next, err := cleanupFinalizeStep(run)
+	if err != nil {
+		t.Fatalf("cleanupFinalizeStep error = %v", err)
+	}
+	if next != cleanupPhaseDone {
+		t.Fatalf("expected finalize -> cleanupPhaseDone, got phase %d", next)
+	}
+	if _, marked, err := readWorkspaceCleanupState(ws); err != nil || marked {
+		t.Fatalf("expected marker cleared after clean finalize, marked=%v err=%v", marked, err)
+	}
+}
+
+// Outcome (1b): the unregister could not be satisfied, so finalize persists
+// the deferred-unregister state (NeedsUnregister=true) and reports the run as
+// still pending. A fresh resume from the persisted marker must then recompute
+// and retry instead of declaring the worktree gone.
+func TestCleanupFinalizeStep_PersistsDeferredUnregister(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+
+	run := &workspaceCleanupRun{
+		ctx:                 context.Background(),
+		repoPath:            dir,
+		workspacePath:       ws,
+		state:               workspaceCleanupState{NeedsUnregister: true},
+		unregisterSatisfied: false,
+	}
+	next, err := cleanupFinalizeStep(run)
+	if next != cleanupPhaseDone {
+		t.Fatalf("expected finalize -> cleanupPhaseDone, got phase %d", next)
+	}
+	if !IsWorkspaceCleanupPendingError(err) {
+		t.Fatalf("expected workspace-cleanup-pending error, got %v", err)
+	}
+	// The persisted marker keeps the unregister retry alive on the next resume.
+	persisted, marked, readErr := readWorkspaceCleanupState(ws)
+	if readErr != nil || !marked {
+		t.Fatalf("expected pending marker persisted, marked=%v err=%v", marked, readErr)
+	}
+	if !persisted.NeedsUnregister {
+		t.Fatalf("expected persisted state to keep NeedsUnregister, got %+v", persisted)
+	}
+}
+
+// Outcome (2): the finalize persist write fails (e.g. interrupted before the
+// marker rewrite). The in-memory state must not be trusted — the on-disk
+// marker is whatever it was before — so a subsequent resume recomputes from
+// disk and retries instead of treating the worktree as cleaned up.
+func TestCleanupFinalizeStep_WriteFailureLeavesDiskMarkerForRetry(t *testing.T) {
+	origWriteRetryMarkerFile := writeRetryMarkerFile
+	defer func() { writeRetryMarkerFile = origWriteRetryMarkerFile }()
+
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "ws")
+	// The pending state an earlier phase left on disk (unregister still owed).
+	preState := workspaceCleanupState{NeedsUnregister: true}
+	if err := writeWorkspaceCleanupState(ws, preState); err != nil {
+		t.Fatal(err)
+	}
+
+	writeRetryMarkerFile = func(string, []byte, os.FileMode) error {
+		return errors.New("marker write failed")
+	}
+
+	// The unregister is still unsatisfied, so finalize takes the persist branch
+	// (writePendingWorkspaceCleanupState -> writeRetryMarkerFile), which fails.
+	run := &workspaceCleanupRun{
+		ctx:                 context.Background(),
+		repoPath:            dir,
+		workspacePath:       ws,
+		state:               workspaceCleanupState{NeedsUnregister: true},
+		unregisterSatisfied: false,
+	}
+	next, err := cleanupFinalizeStep(run)
+	if next != cleanupPhaseDone {
+		t.Fatalf("expected finalize -> cleanupPhaseDone, got phase %d", next)
+	}
+	if err == nil || err.Error() != "marker write failed" {
+		t.Fatalf("expected marker write failure to propagate, got %v", err)
+	}
+
+	// On-disk marker must still report the pending unregister: the failed write
+	// did not advance the recorded state, so the next resume can recompute.
+	persisted, marked, readErr := readWorkspaceCleanupState(ws)
+	if readErr != nil || !marked {
+		t.Fatalf("expected pending marker to survive failed finalize, marked=%v err=%v", marked, readErr)
+	}
+	if !persisted.NeedsUnregister {
+		t.Fatalf("expected disk state to still need unregister after failed write, got %+v", persisted)
+	}
+
+	// Restore the write seam and model the next resume: the FSM recomputes from
+	// the persisted disk state and the unregister now succeeds on retry. The
+	// retried finalize then clears the marker, declaring the cleanup done — the
+	// worktree is not leaked.
+	writeRetryMarkerFile = origWriteRetryMarkerFile
+	retry := &workspaceCleanupRun{
+		ctx:                 context.Background(),
+		repoPath:            dir,
+		workspacePath:       ws,
+		state:               persisted,
+		unregisterSatisfied: true,
+	}
+	if next, err := cleanupFinalizeStep(retry); err != nil || next != cleanupPhaseDone {
+		t.Fatalf("retried finalize: next=%d err=%v", next, err)
+	}
+	if _, marked, err := readWorkspaceCleanupState(ws); err != nil || marked {
+		t.Fatalf("expected marker cleared after recompute+retry, marked=%v err=%v", marked, err)
 	}
 }
 


### PR DESCRIPTION
Adds focused tests that drive the workspace cleanup FSM's finalize phase (cleanupFinalizeStep) directly at the FSM boundary, rather than only end-to-end through RemoveWorkspace. The finalize step's deferred-unregister branch decides whether an interrupted cleanup is declared done or must retry; choosing wrong leaks a git worktree.

Covers three outcomes:
1. clean finalize that clears the marker and declares done;
2. persist that records the deferred unregister and reports the run still pending (IsWorkspaceCleanupPendingError);
3. persist whose marker write fails (interrupted) so the on-disk state is unchanged and the next resume recomputes from disk and retries to done.

Pure test change — reuses the existing writeRetryMarkerFile injectable seam; no production code touched. Part of the quality stacked diff. Stacked on improve/018-cross-process-flock-test. Ticket 019 (testability).