### PR TITLE
feat(dx): add make perf-check for a host-native perf self-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,6 @@
 - Formatting baseline includes `gofumpt`; use `make fmt` for style-only cleanup.
 - Phase 2 strict lint: run `make lint-strict-new` for changed-code ratcheting before finalizing substantial edits.
 - Phase 3 CI gate is automated (no PR-body parsing). For local confidence, run path-relevant checks (`make harness-presets`, `go test ./internal/tmux ./internal/e2e`) when touching those areas.
+- Render-path changes: run `make perf-check` to self-verify on this host. It drives each harness preset and compares the measured p95 against the checked-in `${GOOS}_${GOARCH}` baselines (here, `DARWIN_ARM64_*` in `scripts/perf_baselines.env`) — PR-time CI only runs the perf job on Linux via cron, so the darwin-arm64 baselines have no automated gate. Set `PERF_STRICT=1` to fail (instead of silently skip) when a preset's baseline is missing. The checked-in `DARWIN_ARM64_*` numbers may be placeholders; re-baseline them on the dev machine before relying on `make perf-check` as a hard gate.
 - Lint policy source of truth: `LINTING.md`.
 - Release: use `make release VERSION=vX.Y.Z` (runs tests + harness, tags, pushes). Tag push triggers GitHub Actions release.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HARNESS_SCROLLBACK_FRAMES ?= 600
 GOFUMPT ?= go run mvdan.cc/gofumpt@v0.9.2
 STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 
-.PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden
+.PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
 
 build:
 	go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
@@ -67,6 +67,17 @@ harness-presets: harness-center harness-sidebar harness-monitor
 #   go test ./internal/app -run Golden -update
 harness-golden:
 	go test ./internal/app -count=1 -run Golden
+
+# perf-check runs the host-native perf self-check: it drives each harness
+# preset and compares the measured p95 against the checked-in baselines for the
+# current ${GOOS}_${GOARCH} (on this machine, DARWIN_ARM64_*). It is the local
+# gate for render-path changes that PR-time CI does not cover for darwin-arm64.
+# Set PERF_STRICT=1 to fail (rather than silently skip) when a baseline for a
+# preset is missing. Re-baseline the DARWIN_ARM64_* values on the dev machine
+# before relying on this as a hard gate; the checked-in numbers may be
+# placeholders.
+perf-check:
+	bash scripts/perf_compare.sh
 
 check-golangci-version:
 	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint is required (install: https://golangci-lint.run/welcome/install/)"; exit 1)
@@ -179,6 +190,7 @@ help:
 	@echo "  harness-monitor - Run monitor harness preset"
 	@echo "  harness-presets - Run all harness presets"
 	@echo "  harness-golden  - Run byte-exact golden-frame snapshot tests (pure render; -update to regenerate)"
+	@echo "  perf-check      - Compare harness p95 against host baselines (DARWIN_ARM64_* here; PERF_STRICT=1 to fail on missing baseline)"
 	@echo "  release-check - Run tests and harness smoke checks"
 	@echo "  release-tag   - Create an annotated tag (VERSION=vX.Y.Z)"
 	@echo "  release-push  - Push the tag to origin (VERSION=vX.Y.Z)"

--- a/scripts/perf_compare.sh
+++ b/scripts/perf_compare.sh
@@ -53,7 +53,12 @@ PY
   local baseline_var="${prefix}_${name}_P95_MS"
   local baseline="${!baseline_var:-}"
   if [[ -z "$baseline" ]]; then
-    echo "No baseline set for ${baseline_var}; skipping comparison."
+    if [[ "${PERF_STRICT:-0}" == "1" ]]; then
+      echo "No baseline set for ${baseline_var}; PERF_STRICT=1 requires one (measured=${measured_ms}ms)." >&2
+      failures=$((failures + 1))
+    else
+      echo "No baseline set for ${baseline_var}; skipping comparison (set PERF_STRICT=1 to fail instead)."
+    fi
     return
   fi
 


### PR DESCRIPTION
Adds a `make perf-check` target that runs `scripts/perf_compare.sh` to compare harness preset p95 against the host's checked-in baselines (on darwin-arm64, `DARWIN_ARM64_*`). PR-time CI only runs the perf job on Linux via cron, so those darwin-arm64 baselines had no automated gate and no make target invoked the script.

What changed:
- New `perf-check` PHONY target, wired into the help block.
- `scripts/perf_compare.sh`: the missing-baseline branch now fails loudly under opt-in `PERF_STRICT=1` (increments failures); default skip behavior is unchanged for back-compat.
- AGENTS.md documents `make perf-check` as the render-path self-verify step, noting the `DARWIN_ARM64_*` numbers may be placeholders and should be re-baselined on the dev machine first.

No CI workflow or baseline-number changes. `bash -n` clean.

Part of the quality stacked diff. Stacked on improve/021-golden-frame-harness-snapshot-tests. Ticket 022 (agent-feedback-loop).