### PR TITLE
feat(dx): self-bootstrap the pinned golangci-lint so make lint just works

### DIFF
--- a/LINTING.md
+++ b/LINTING.md
@@ -19,6 +19,31 @@ This runs:
 
 CI enforces the same lint checks in `.github/workflows/ci.yml`.
 
+## One-Time Setup: Pinned golangci-lint
+
+`make lint` / `make devcheck` need the golangci-lint version pinned in
+`.golangci-version`. A system golangci-lint is frequently the wrong version and
+fails confusingly: a v2.x binary cannot read this repo's v1 `.golangci.yml`
+(`unsupported version of the configuration`), and even a prebuilt v1.64.8 can be
+rejected because it was built with an older Go than the `go.mod` target
+(`build Go < target Go`).
+
+Run this once (and again only if `.golangci-version` changes):
+
+```bash
+make lint-tools
+```
+
+It builds the pinned version **from source** with your local Go toolchain into
+the gitignored `./.cache/bin/`. It is idempotent (a no-op when the local binary
+already reports the pinned version) and never deletes an existing good binary.
+
+`make lint`, `make lint-strict`, and `make lint-strict-new` then prefer
+`./.cache/bin/golangci-lint` when it matches `.golangci-version`, otherwise they
+fall back to a `golangci-lint` on `PATH`. CI is unaffected: it has no
+`./.cache/bin` binary (it is gitignored) and uses `golangci-lint-action`, so the
+Makefile resolves to the action-installed `PATH` binary there.
+
 ## Phase 2: Strict Ratchet
 
 Phase 2 is enabled as a stricter profile in `.golangci.strict.yml`.
@@ -118,6 +143,7 @@ Escalation is path-based and automated by CI jobs. For local confidence, use:
 For any non-trivial code change, agents should run:
 
 ```bash
+make lint-tools   # one-time; idempotent, builds the pinned linter into ./.cache/bin
 make devcheck
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,22 @@ HARNESS_SCROLLBACK_FRAMES ?= 600
 GOFUMPT ?= go run mvdan.cc/gofumpt@v0.9.2
 STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 
-.PHONY: build install test bench lint lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
+# GOLANGCI resolves to the repo-local pinned golangci-lint (built from source by
+# `make lint-tools` into the gitignored ./.cache/bin) when it exists AND reports
+# the exact version in .golangci-version; otherwise it falls back to a PATH
+# golangci-lint. This keeps CI unaffected: CI has no ./.cache/bin binary (it is
+# gitignored and uses golangci-lint-action), so it resolves to the PATH binary
+# the action installs.
+#
+# The probe is scoped to the lint targets via a target-specific := assignment so
+# that unrelated targets (build/test/run/vet/...) never pay the shell-out cost,
+# and the := form evaluates it exactly once per lint invocation (a plain
+# recursive GOLANGCI = $(shell ...) would re-run the probe on every $(GOLANGCI)
+# expansion, which lint-strict-new/lint-ci-parity reference multiple times).
+GOLANGCI ?= golangci-lint
+lint lint-strict lint-strict-new lint-ci-parity check-golangci-version: GOLANGCI := $(shell want=`tr -d '[:space:]' < .golangci-version 2>/dev/null | sed 's/^v//'`; local="$$PWD/.cache/bin/golangci-lint"; have=`"$$local" version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//'`; if [ -x "$$local" ] && [ "$$have" = "$$want" ]; then echo "$$local"; else echo golangci-lint; fi)
+
+.PHONY: build install test bench lint lint-tools lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
 
 build:
 	go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
@@ -80,33 +95,40 @@ perf-check:
 	bash scripts/perf_compare.sh
 
 check-golangci-version:
-	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint is required (install: https://golangci-lint.run/welcome/install/)"; exit 1)
+	@command -v $(GOLANGCI) >/dev/null 2>&1 || (echo "golangci-lint is required: run 'make lint-tools' to build the pinned version locally, or install from https://golangci-lint.run/welcome/install/"; exit 1)
 	@want_raw="$$(cat .golangci-version)"; \
 	want="$${want_raw#v}"; \
-	have_raw="$$(golangci-lint version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)"; \
+	have_raw="$$($(GOLANGCI) version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)"; \
 	have="$${have_raw#v}"; \
 	if [ "$$have" != "$$want" ]; then \
-		echo "WARNING: golangci-lint $${have_raw:-unknown} installed but .golangci-version pins $$want_raw (CI uses $$want_raw; diagnostics may differ)"; \
+		echo "WARNING: golangci-lint $${have_raw:-unknown} resolved but .golangci-version pins $$want_raw (run 'make lint-tools' to build the pinned version; diagnostics may differ)"; \
 	fi
 
+# lint-tools self-bootstraps the pinned golangci-lint (from .golangci-version)
+# from source into the gitignored ./.cache/bin so `make lint` just works even
+# when the system golangci-lint is the wrong version. Idempotent: a no-op when
+# the local binary already reports the pinned version.
+lint-tools:
+	bash scripts/install-golangci-lint.sh
+
 lint: check-golangci-version
-	golangci-lint run
+	$(GOLANGCI) run
 	$(MAKE) check-file-length
 
 lint-strict: check-golangci-version
-	golangci-lint run -c .golangci.strict.yml
+	$(GOLANGCI) run -c .golangci.strict.yml
 
 lint-strict-new: check-golangci-version
 	@if [ -n "$(BASE)" ]; then \
 		echo "Running strict lint against changes since $(BASE)"; \
-		golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$(BASE)" --timeout=10m; \
+		$(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$(BASE)" --timeout=10m; \
 	else \
 		echo "Running strict lint on current unstaged/staged changes (--new)"; \
-		golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m; \
+		$(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m; \
 	fi
 
 lint-ci-parity: check-golangci-version # CACHE_ROOT defaults to a gitignored local directory (/.cache/).
-	@command -v golangci-lint >/dev/null 2>&1 || (echo "golangci-lint is required (install: https://golangci-lint.run/welcome/install/)"; exit 1)
+	@command -v $(GOLANGCI) >/dev/null 2>&1 || (echo "golangci-lint is required: run 'make lint-tools' to build the pinned version locally, or install from https://golangci-lint.run/welcome/install/"; exit 1)
 	@BASE_REF="$${BASE_REF:-origin/main}"; \
 	CACHE_ROOT="$${CACHE_ROOT:-$$(pwd)/.cache}"; \
 	GO_CACHE_DIR="$$CACHE_ROOT/go-build"; \
@@ -116,11 +138,11 @@ lint-ci-parity: check-golangci-version # CACHE_ROOT defaults to a gitignored loc
 		BASE=$$(git merge-base HEAD "$$BASE_REF"); \
 		echo "Running CI-parity strict lint against changes since $$BASE_REF ($$BASE)"; \
 		OUTPUT=$$(mktemp); trap 'rm -f "$$OUTPUT"' EXIT INT TERM; \
-		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m >"$$OUTPUT" 2>&1; then \
+		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" $(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m >"$$OUTPUT" 2>&1; then \
 				cat "$$OUTPUT"; \
 				if grep -q "no go files to analyze" "$$OUTPUT"; then \
 					echo "golangci-lint test loader failed locally; retrying with --tests=false"; \
-					if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m --tests=false; then \
+					if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" $(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new-from-rev "$$BASE" --timeout=10m --tests=false; then \
 						exit 1; \
 					fi; \
 				else \
@@ -131,11 +153,11 @@ lint-ci-parity: check-golangci-version # CACHE_ROOT defaults to a gitignored loc
 	else \
 		echo "Base ref $$BASE_REF not found; falling back to strict lint on current unstaged/staged changes"; \
 		OUTPUT=$$(mktemp); trap 'rm -f "$$OUTPUT"' EXIT INT TERM; \
-		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m >"$$OUTPUT" 2>&1; then \
+		if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" $(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m >"$$OUTPUT" 2>&1; then \
 			cat "$$OUTPUT"; \
 			if grep -q "no go files to analyze" "$$OUTPUT"; then \
 				echo "golangci-lint test loader failed locally; retrying with --tests=false"; \
-				if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" golangci-lint run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m --tests=false; then \
+				if ! GOCACHE="$$GO_CACHE_DIR" GOLANGCI_LINT_CACHE="$$GOLANGCI_CACHE_DIR" $(GOLANGCI) run -c .golangci.strict.yml $(STRICT_RATCHET_LINTERS) --new --timeout=10m --tests=false; then \
 					exit 1; \
 				fi; \
 			else \
@@ -173,6 +195,7 @@ help:
 	@echo "  build      - Build the binary"
 	@echo "  test       - Run all tests"
 	@echo "  lint       - Run golangci-lint and file length checks (max 500 lines)"
+	@echo "  lint-tools - Build the pinned golangci-lint (.golangci-version) into ./.cache/bin (idempotent)"
 	@echo "  lint-strict - Run stricter lint profile across the whole repo"
 	@echo "  lint-strict-new - Run stricter lint profile only on changed code (optionally BASE=<git-rev>)"
 	@echo "  lint-ci-parity - Run strict changed-code lint using merge-base with BASE_REF (default origin/main)"

--- a/scripts/install-golangci-lint.sh
+++ b/scripts/install-golangci-lint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# install-golangci-lint.sh — self-bootstrap the pinned golangci-lint.
+#
+# The version is the single source of truth in .golangci-version. A system
+# golangci-lint is often the wrong version: a v2.x binary cannot read this
+# repo's v1 .golangci.yml ("unsupported version of the configuration"), and even
+# a prebuilt v1.64.8 can be rejected because it was built with an older Go than
+# the go.mod target ("build Go < target Go"). Building the pinned version FROM
+# SOURCE with the local Go toolchain into a repo-local, gitignored dir sidesteps
+# both problems.
+#
+# This script is idempotent: if ./.cache/bin/golangci-lint already reports the
+# pinned version it does nothing and never deletes an existing good binary.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+version_file=".golangci-version"
+if [[ ! -f "$version_file" ]]; then
+  echo "install-golangci-lint: $version_file not found" >&2
+  exit 1
+fi
+
+want="$(tr -d '[:space:]' <"$version_file")"
+if [[ -z "$want" ]]; then
+  echo "install-golangci-lint: $version_file is empty" >&2
+  exit 1
+fi
+want_bare="${want#v}"
+
+bindir="$root/.cache/bin"
+binary="$bindir/golangci-lint"
+
+# Idempotent fast path: an existing binary that already reports the pinned
+# version is good — do nothing and leave it untouched.
+if [[ -x "$binary" ]]; then
+  have_raw="$("$binary" version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  have_bare="${have_raw#v}"
+  if [[ "$have_bare" == "$want_bare" ]]; then
+    echo "install-golangci-lint: ./.cache/bin/golangci-lint already at $want; nothing to do"
+    exit 0
+  fi
+  echo "install-golangci-lint: ./.cache/bin/golangci-lint is ${have_raw:-unknown}, rebuilding to $want"
+fi
+
+command -v go >/dev/null 2>&1 || {
+  echo "install-golangci-lint: go toolchain is required to build golangci-lint" >&2
+  exit 1
+}
+
+mkdir -p "$bindir"
+echo "install-golangci-lint: building github.com/golangci/golangci-lint@$want into $bindir"
+GOBIN="$bindir" go install "github.com/golangci/golangci-lint/cmd/golangci-lint@$want"
+
+# Confirm the freshly built binary reports the pinned version.
+got_raw="$("$binary" version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+got_bare="${got_raw#v}"
+if [[ "$got_bare" != "$want_bare" ]]; then
+  echo "install-golangci-lint: built ${got_raw:-unknown} but expected $want" >&2
+  exit 1
+fi
+echo "install-golangci-lint: ./.cache/bin/golangci-lint now at $want"


### PR DESCRIPTION
Builds the pinned golangci-lint (from .golangci-version) FROM SOURCE with the local Go toolchain into the gitignored ./.cache/bin, so `make lint`/`make devcheck` just work even when the system golangci-lint is the wrong version (a v2.x binary can't read the v1 .golangci.yml, and a prebuilt v1.64.8 is rejected as 'build Go < target Go').

What:
- `scripts/install-golangci-lint.sh`: idempotent — does nothing if ./.cache/bin/golangci-lint already reports the pinned version; otherwise `GOBIN=$PWD/.cache/bin go install ...@<version>`. Never deletes an existing good binary.
- `make lint-tools` PHONY target invoking the script.
- A `GOLANGCI` Makefile variable that prefers ./.cache/bin/golangci-lint when it matches .golangci-version, else falls back to a PATH `golangci-lint`; `lint`/`lint-strict`/`lint-strict-new` use it.
- LINTING.md documents the one-time `make lint-tools` step.

Why CI is unaffected: CI uses golangci-lint-action (its own setup) and has no ./.cache/bin binary (gitignored), so the Makefile resolves to the PATH binary the action installs.

Verified: `make lint-tools` (idempotent no-op), `make lint` (resolves to the pinned local binary and passes), `go build/vet ./...`, `golangci-lint run ./...`, `bash -n scripts/install-golangci-lint.sh`, `make check-file-length` all green; the existing ./.cache/bin/golangci-lint is left intact.

Part of the quality stacked diff. Stacked on improve/022-make-perf-check-target. Ticket 023 (agent-feedback-loop).