### PR TITLE
test: cover common/settings.go (common)

### DIFF
--- a/internal/ui/common/settings_nav_test.go
+++ b/internal/ui/common/settings_nav_test.go
@@ -1,0 +1,239 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+func TestHandleSelectTheme(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	if len(d.themes) < 2 {
+		t.Skip("need at least two themes")
+	}
+	d.focusedItem = settingsItemTheme
+	d.themeCursor = 1
+
+	_, cmd := d.handleSelect()
+	// Selecting commits the cursor's theme into d.theme.
+	if d.theme != d.themes[1].ID {
+		t.Fatalf("theme after select = %v, want %v", d.theme, d.themes[1].ID)
+	}
+	preview, ok := cmd().(ThemePreview)
+	if !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+	if preview.Theme != d.themes[1].ID {
+		t.Fatalf("preview.Theme = %v, want %v", preview.Theme, d.themes[1].ID)
+	}
+}
+
+func TestHandleSelectThemeCursorOutOfRangeStillPreviews(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.focusedItem = settingsItemTheme
+	d.themeCursor = len(d.themes) // out of range
+	before := d.theme
+
+	_, cmd := d.handleSelect()
+	// Out-of-range cursor leaves d.theme untouched but still emits a preview.
+	if d.theme != before {
+		t.Fatalf("theme should be unchanged on out-of-range cursor, got %v", d.theme)
+	}
+	if _, ok := cmd().(ThemePreview); !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+}
+
+func TestHandleSelectUpdateAvailableTriggersUpgrade(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.SetUpdateInfo("v1", "v2", true)
+	d.Show()
+	d.focusedItem = settingsItemUpdate
+
+	_, cmd := d.handleSelect()
+	if d.Visible() {
+		t.Fatal("selecting available update should hide the dialog")
+	}
+	if cmd == nil {
+		t.Fatal("expected a TriggerUpgrade command")
+	}
+	if _, ok := cmd().(messages.TriggerUpgrade); !ok {
+		t.Fatalf("expected TriggerUpgrade, got %T", cmd())
+	}
+}
+
+func TestHandleSelectUpdateUnavailableIsNoop(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.SetUpdateInfo("v1", "", false)
+	d.Show()
+	d.focusedItem = settingsItemUpdate
+
+	_, cmd := d.handleSelect()
+	if !d.Visible() {
+		t.Fatal("selecting an unavailable update should not close the dialog")
+	}
+	if cmd != nil {
+		t.Fatal("unavailable update should produce no command")
+	}
+}
+
+func TestHandleSelectClose(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+	d.focusedItem = settingsItemClose
+
+	_, cmd := d.handleSelect()
+	if d.Visible() {
+		t.Fatal("selecting Close should hide the dialog")
+	}
+	if _, ok := cmd().(SettingsResult); !ok {
+		t.Fatalf("expected SettingsResult, got %T", cmd())
+	}
+}
+
+func TestHandleNextSectionSkipsUpdateWhenUnavailable(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.updateAvailable = false
+	d.focusedItem = settingsItemTheme
+
+	_, _ = d.handleNextSection()
+	// Theme -> (skip Update) -> Close
+	if d.focusedItem != settingsItemClose {
+		t.Fatalf("focusedItem = %d, want settingsItemClose", d.focusedItem)
+	}
+}
+
+func TestHandleNextSectionVisitsUpdateWhenAvailable(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.updateAvailable = true
+	d.focusedItem = settingsItemTheme
+
+	_, _ = d.handleNextSection()
+	if d.focusedItem != settingsItemUpdate {
+		t.Fatalf("focusedItem = %d, want settingsItemUpdate", d.focusedItem)
+	}
+}
+
+func TestHandleNextSectionWrapsFromClose(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.focusedItem = settingsItemClose
+
+	_, _ = d.handleNextSection()
+	if d.focusedItem != settingsItemTheme {
+		t.Fatalf("focusedItem = %d, want settingsItemTheme (wrap)", d.focusedItem)
+	}
+}
+
+func TestHandlePrevSectionSkipsUpdateWhenUnavailable(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.updateAvailable = false
+	d.focusedItem = settingsItemClose
+
+	_, _ = d.handlePrevSection()
+	// Close -> Update(skip) -> Theme
+	if d.focusedItem != settingsItemTheme {
+		t.Fatalf("focusedItem = %d, want settingsItemTheme", d.focusedItem)
+	}
+}
+
+func TestHandlePrevSectionVisitsUpdateWhenAvailable(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.updateAvailable = true
+	d.focusedItem = settingsItemClose
+
+	_, _ = d.handlePrevSection()
+	if d.focusedItem != settingsItemUpdate {
+		t.Fatalf("focusedItem = %d, want settingsItemUpdate", d.focusedItem)
+	}
+}
+
+func TestHandlePrevSectionWrapsFromTheme(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.focusedItem = settingsItemTheme
+
+	_, _ = d.handlePrevSection()
+	if d.focusedItem != settingsItemClose {
+		t.Fatalf("focusedItem = %d, want settingsItemClose (wrap)", d.focusedItem)
+	}
+}
+
+func TestHandleNextInThemeSectionCycles(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.focusedItem = settingsItemTheme
+	d.themeCursor = len(d.themes) - 1 // at the end
+
+	_, cmd := d.handleNext()
+	// Wraps back to 0 and updates theme.
+	if d.themeCursor != 0 {
+		t.Fatalf("themeCursor = %d, want 0 (wrap)", d.themeCursor)
+	}
+	if d.theme != d.themes[0].ID {
+		t.Fatalf("theme = %v, want %v", d.theme, d.themes[0].ID)
+	}
+	if _, ok := cmd().(ThemePreview); !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+}
+
+func TestHandleNextOutsideThemeDelegatesToSection(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.focusedItem = settingsItemClose
+
+	_, cmd := d.handleNext()
+	// Delegates to handleNextSection, which wraps Close -> Theme and returns nil.
+	if d.focusedItem != settingsItemTheme {
+		t.Fatalf("focusedItem = %d, want settingsItemTheme", d.focusedItem)
+	}
+	if cmd != nil {
+		t.Fatal("section move should not emit a command")
+	}
+}
+
+func TestHandlePrevInThemeSectionCyclesBackward(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.focusedItem = settingsItemTheme
+	d.themeCursor = 0 // at the start
+
+	_, cmd := d.handlePrev()
+	// Wraps to last theme.
+	if d.themeCursor != len(d.themes)-1 {
+		t.Fatalf("themeCursor = %d, want %d (wrap)", d.themeCursor, len(d.themes)-1)
+	}
+	if d.theme != d.themes[len(d.themes)-1].ID {
+		t.Fatalf("theme = %v, want last theme", d.theme)
+	}
+	if _, ok := cmd().(ThemePreview); !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+}
+
+func TestHandlePrevOutsideThemeDelegatesToSection(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.focusedItem = settingsItemClose
+
+	_, cmd := d.handlePrev()
+	// Delegates to handlePrevSection: Close -> (skip Update) -> Theme.
+	if d.focusedItem != settingsItemTheme {
+		t.Fatalf("focusedItem = %d, want settingsItemTheme", d.focusedItem)
+	}
+	if cmd != nil {
+		t.Fatal("section move should not emit a command")
+	}
+}
+
+func TestHandleNextThemeRoundTrip(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.focusedItem = settingsItemTheme
+
+	n := len(d.themes)
+	// Cycling forward exactly n times returns to the starting theme.
+	for i := 0; i < n; i++ {
+		_, _ = d.handleNext()
+	}
+	if d.themeCursor != 0 {
+		t.Fatalf("after %d forward cycles, cursor = %d, want 0", n, d.themeCursor)
+	}
+	if d.theme != d.themes[0].ID {
+		t.Fatalf("after round trip theme = %v, want %v", d.theme, d.themes[0].ID)
+	}
+}

--- a/internal/ui/common/settings_test.go
+++ b/internal/ui/common/settings_test.go
@@ -1,0 +1,307 @@
+package common
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// themeAt returns the ID of the theme at index i in AvailableThemes, used to
+// build expectations without hard-coding a specific theme order.
+func themeAt(t *testing.T, i int) ThemeID {
+	t.Helper()
+	themes := AvailableThemes()
+	if i < 0 || i >= len(themes) {
+		t.Fatalf("theme index %d out of range (have %d themes)", i, len(themes))
+	}
+	return themes[i].ID
+}
+
+func TestNewSettingsDialogPlacesCursorOnCurrentTheme(t *testing.T) {
+	themes := AvailableThemes()
+	if len(themes) < 2 {
+		t.Skip("need at least two themes for a meaningful cursor test")
+	}
+
+	// Pick the second theme so cursor != 0 proves the lookup ran.
+	want := themes[1].ID
+	d := NewSettingsDialog(want)
+
+	if d.theme != want {
+		t.Fatalf("theme = %v, want %v", d.theme, want)
+	}
+	if d.themeCursor != 1 {
+		t.Fatalf("themeCursor = %d, want 1", d.themeCursor)
+	}
+	if d.focusedItem != settingsItemTheme {
+		t.Fatalf("focusedItem = %d, want settingsItemTheme", d.focusedItem)
+	}
+	if len(d.themes) != len(themes) {
+		t.Fatalf("themes len = %d, want %d", len(d.themes), len(themes))
+	}
+}
+
+func TestNewSettingsDialogUnknownThemeDefaultsCursorToZero(t *testing.T) {
+	// ThemeID("") is not a real theme, so the cursor lookup never matches.
+	d := NewSettingsDialog(ThemeID("does-not-exist"))
+	if d.themeCursor != 0 {
+		t.Fatalf("themeCursor = %d, want 0 for unknown theme", d.themeCursor)
+	}
+	if d.theme != ThemeID("does-not-exist") {
+		t.Fatalf("theme = %v, want the unknown id preserved", d.theme)
+	}
+}
+
+func TestShowHideVisible(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	if d.Visible() {
+		t.Fatal("new dialog should be hidden")
+	}
+
+	d.Show()
+	if !d.Visible() {
+		t.Fatal("Show should make the dialog visible")
+	}
+
+	d.Hide()
+	if d.Visible() {
+		t.Fatal("Hide should make the dialog invisible")
+	}
+
+	// Show is idempotent.
+	d.Show()
+	d.Show()
+	if !d.Visible() {
+		t.Fatal("repeated Show should leave dialog visible")
+	}
+}
+
+func TestSetSize(t *testing.T) {
+	tests := []struct {
+		name string
+		w, h int
+	}{
+		{"zero", 0, 0},
+		{"typical", 80, 24},
+		{"negative", -5, -10},
+		{"large", 1000, 500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewSettingsDialog(ThemeAyuDark)
+			d.SetSize(tt.w, tt.h)
+			if d.width != tt.w || d.height != tt.h {
+				t.Fatalf("SetSize(%d,%d) => width=%d height=%d", tt.w, tt.h, d.width, d.height)
+			}
+		})
+	}
+}
+
+func TestCursorAlwaysNil(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	if d.Cursor() != nil {
+		t.Fatal("Cursor should always return nil")
+	}
+	d.Show()
+	if d.Cursor() != nil {
+		t.Fatal("Cursor should return nil even when visible")
+	}
+}
+
+func TestSetSession(t *testing.T) {
+	tests := []int{0, 1, 7, -3}
+	for _, sess := range tests {
+		d := NewSettingsDialog(ThemeAyuDark)
+		d.SetSession(sess)
+		if d.session != sess {
+			t.Fatalf("SetSession(%d) => session=%d", sess, d.session)
+		}
+	}
+}
+
+func TestSetSessionFlowsIntoThemePreview(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.SetSession(42)
+	d.Show()
+
+	// Selecting the theme section emits a ThemePreview carrying the session.
+	_, cmd := d.handleSelect()
+	if cmd == nil {
+		t.Fatal("expected a command from selecting the theme item")
+	}
+	preview, ok := cmd().(ThemePreview)
+	if !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+	if preview.Session != 42 {
+		t.Fatalf("preview.Session = %d, want 42", preview.Session)
+	}
+}
+
+func TestSelectedThemeReturnsCurrent(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	if d.SelectedTheme() != ThemeAyuDark {
+		t.Fatalf("SelectedTheme = %v, want %v", d.SelectedTheme(), ThemeAyuDark)
+	}
+}
+
+func TestSetSelectedThemeKnownThemeMovesCursor(t *testing.T) {
+	themes := AvailableThemes()
+	if len(themes) < 2 {
+		t.Skip("need at least two themes")
+	}
+	d := NewSettingsDialog(themes[0].ID)
+
+	want := themes[1].ID
+	d.SetSelectedTheme(want)
+	if d.SelectedTheme() != want {
+		t.Fatalf("SelectedTheme = %v, want %v", d.SelectedTheme(), want)
+	}
+	if d.themeCursor != 1 {
+		t.Fatalf("themeCursor = %d, want 1", d.themeCursor)
+	}
+}
+
+func TestSetSelectedThemeUnknownThemeLeavesCursor(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	// Move the cursor somewhere distinct first.
+	if len(d.themes) > 1 {
+		d.themeCursor = 1
+	}
+	before := d.themeCursor
+
+	d.SetSelectedTheme(ThemeID("nope"))
+	// theme is still updated to the requested value...
+	if d.SelectedTheme() != ThemeID("nope") {
+		t.Fatalf("SelectedTheme = %v, want the unknown id stored", d.SelectedTheme())
+	}
+	// ...but the cursor stays put because nothing matched.
+	if d.themeCursor != before {
+		t.Fatalf("themeCursor = %d, want unchanged %d", d.themeCursor, before)
+	}
+}
+
+func TestUpdateWhenHiddenIsNoop(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	// Not shown: every key is a no-op.
+	got, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if got != d {
+		t.Fatal("Update should return the same dialog pointer")
+	}
+	if cmd != nil {
+		t.Fatal("hidden dialog should ignore input and return nil cmd")
+	}
+}
+
+func TestUpdateEscClosesDialog(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if d.Visible() {
+		t.Fatal("esc should hide the dialog")
+	}
+	if cmd == nil {
+		t.Fatal("esc should emit a SettingsResult command")
+	}
+	if _, ok := cmd().(SettingsResult); !ok {
+		t.Fatalf("expected SettingsResult, got %T", cmd())
+	}
+}
+
+func TestUpdateEnterSelectsTheme(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on theme item should emit ThemePreview")
+	}
+	if _, ok := cmd().(ThemePreview); !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+}
+
+func TestUpdateTabAdvancesSection(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+	// No update available: Tab skips the update section straight to Close.
+	_, _ = d.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if d.focusedItem != settingsItemClose {
+		t.Fatalf("focusedItem after Tab = %d, want settingsItemClose", d.focusedItem)
+	}
+}
+
+func TestUpdateShiftTabRetreatsSection(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+	// From theme, Shift+Tab wraps backwards to Close.
+	_, _ = d.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	if d.focusedItem != settingsItemClose {
+		t.Fatalf("focusedItem after Shift+Tab = %d, want settingsItemClose", d.focusedItem)
+	}
+}
+
+func TestUpdateDownCyclesTheme(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if d.themeCursor != 1%len(d.themes) {
+		t.Fatalf("themeCursor after down = %d, want %d", d.themeCursor, 1%len(d.themes))
+	}
+	if cmd == nil {
+		t.Fatal("down within theme section should emit ThemePreview")
+	}
+	if _, ok := cmd().(ThemePreview); !ok {
+		t.Fatalf("expected ThemePreview, got %T", cmd())
+	}
+}
+
+func TestUpdateJKeyCyclesTheme(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.Show()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if d.themeCursor != 1%len(d.themes) {
+		t.Fatalf("themeCursor after 'j' = %d, want %d", d.themeCursor, 1%len(d.themes))
+	}
+	if cmd == nil {
+		t.Fatal("'j' within theme section should emit ThemePreview")
+	}
+}
+
+func TestUpdateUpCyclesThemeBackwards(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.Show()
+	// From cursor 0, up wraps to the last theme.
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if d.themeCursor != len(d.themes)-1 {
+		t.Fatalf("themeCursor after up = %d, want %d", d.themeCursor, len(d.themes)-1)
+	}
+	if cmd == nil {
+		t.Fatal("up within theme section should emit ThemePreview")
+	}
+}
+
+func TestUpdateKKeyCyclesThemeBackwards(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0))
+	d.Show()
+	_, _ = d.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if d.themeCursor != len(d.themes)-1 {
+		t.Fatalf("themeCursor after 'k' = %d, want %d", d.themeCursor, len(d.themes)-1)
+	}
+}
+
+func TestUpdateUnhandledKeyReturnsNil(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark)
+	d.Show()
+	before := d.focusedItem
+	_, cmd := d.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if cmd != nil {
+		t.Fatal("unhandled key should return nil cmd")
+	}
+	if d.focusedItem != before {
+		t.Fatal("unhandled key should not move focus")
+	}
+}


### PR DESCRIPTION
Adds thorough table-driven unit tests for the previously-untested SettingsDialog functions in internal/ui/common/settings.go: Show/Hide/Visible, SetSize, Cursor, SetSession, SelectedTheme/SetSelectedTheme, Update key routing, and the handleSelect/handleNext/handlePrev/handleNextSection/handlePrevSection navigation helpers. Tests assert real behavior (focus transitions, theme cursor wrap-around, emitted ThemePreview/SettingsResult/TriggerUpgrade commands, session plumbing) and cover edge cases (hidden no-op input, unknown themes, out-of-range cursor). All 14 listed target functions reach 100% coverage. handleClick is excluded because it requires rendered geometry (renderLines/hit regions) already exercised by settings_render_test.go. Split across settings_test.go and settings_nav_test.go to respect the 500-line file cap. No production code changed. Part of the quality stacked diff. Stacked on improve/042-test-tmux-tmux-sessions. Ticket 043 (testability).