### PR TITLE
test: cover compositor/canvas_drawable.go (compositor)

### DIFF
--- a/internal/ui/compositor/canvas_drawable_sgr_test.go
+++ b/internal/ui/compositor/canvas_drawable_sgr_test.go
@@ -1,0 +1,328 @@
+package compositor
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestApplySGR exercises applySGR directly across every SGR family it handles:
+// attribute set/reset, basic/bright/256/truecolor fg+bg, default resets, and
+// malformed/truncated extended-color sequences. colorEqualRGBA and the
+// rgbColorVal/ansiColor helpers live in canvas_drawable_test.go (same package).
+func TestApplySGR(t *testing.T) {
+	bold := uv.Style{Attrs: uv.AttrBold}
+
+	tests := []struct {
+		name   string
+		start  uv.Style
+		params ansi.Params
+		check  func(t *testing.T, got uv.Style)
+	}{
+		{
+			name:   "no params resets to zero style",
+			start:  bold,
+			params: ansi.Params{},
+			check: func(t *testing.T, got uv.Style) {
+				if (got != uv.Style{}) {
+					t.Errorf("expected zero style, got %#v", got)
+				}
+			},
+		},
+		{
+			name:   "reset param 0 clears existing style",
+			start:  bold,
+			params: ansi.Params{ansi.Param(0)},
+			check: func(t *testing.T, got uv.Style) {
+				if (got != uv.Style{}) {
+					t.Errorf("expected zero style after reset, got %#v", got)
+				}
+			},
+		},
+		{
+			name:   "bold sets bold attr",
+			params: ansi.Params{ansi.Param(1)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrBold == 0 {
+					t.Errorf("expected bold, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "faint sets faint attr",
+			params: ansi.Params{ansi.Param(2)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrFaint == 0 {
+					t.Errorf("expected faint, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "italic sets italic attr",
+			params: ansi.Params{ansi.Param(3)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrItalic == 0 {
+					t.Errorf("expected italic, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "underline sets single underline",
+			params: ansi.Params{ansi.Param(4)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Underline != uv.UnderlineSingle {
+					t.Errorf("expected single underline, got %v", got.Underline)
+				}
+			},
+		},
+		{
+			name:   "blink sets blink attr",
+			params: ansi.Params{ansi.Param(5)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrBlink == 0 {
+					t.Errorf("expected blink, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "reverse sets reverse attr",
+			params: ansi.Params{ansi.Param(7)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrReverse == 0 {
+					t.Errorf("expected reverse, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "conceal sets conceal attr",
+			params: ansi.Params{ansi.Param(8)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrConceal == 0 {
+					t.Errorf("expected conceal, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "strikethrough sets strikethrough attr",
+			params: ansi.Params{ansi.Param(9)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrStrikethrough == 0 {
+					t.Errorf("expected strikethrough, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "22 clears bold and faint but keeps others",
+			start:  uv.Style{Attrs: uv.AttrBold | uv.AttrFaint | uv.AttrItalic},
+			params: ansi.Params{ansi.Param(22)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&(uv.AttrBold|uv.AttrFaint) != 0 {
+					t.Errorf("expected bold/faint cleared, attrs = %d", got.Attrs)
+				}
+				if got.Attrs&uv.AttrItalic == 0 {
+					t.Errorf("expected italic preserved, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "23 clears italic",
+			start:  uv.Style{Attrs: uv.AttrItalic},
+			params: ansi.Params{ansi.Param(23)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrItalic != 0 {
+					t.Errorf("expected italic cleared, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "24 clears underline",
+			start:  uv.Style{Underline: uv.UnderlineSingle},
+			params: ansi.Params{ansi.Param(24)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Underline != uv.UnderlineNone {
+					t.Errorf("expected underline none, got %v", got.Underline)
+				}
+			},
+		},
+		{
+			name:   "25 clears blink",
+			start:  uv.Style{Attrs: uv.AttrBlink},
+			params: ansi.Params{ansi.Param(25)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrBlink != 0 {
+					t.Errorf("expected blink cleared, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "27 clears reverse",
+			start:  uv.Style{Attrs: uv.AttrReverse},
+			params: ansi.Params{ansi.Param(27)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrReverse != 0 {
+					t.Errorf("expected reverse cleared, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "28 clears conceal",
+			start:  uv.Style{Attrs: uv.AttrConceal},
+			params: ansi.Params{ansi.Param(28)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrConceal != 0 {
+					t.Errorf("expected conceal cleared, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "29 clears strikethrough",
+			start:  uv.Style{Attrs: uv.AttrStrikethrough},
+			params: ansi.Params{ansi.Param(29)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrStrikethrough != 0 {
+					t.Errorf("expected strikethrough cleared, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "30-37 sets basic foreground",
+			params: ansi.Params{ansi.Param(32)}, // green
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Fg, ansiColor(2)) {
+					t.Errorf("expected ansi color 2, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "39 resets foreground to default (nil)",
+			start:  uv.Style{Fg: ansiColor(5)},
+			params: ansi.Params{ansi.Param(39)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Fg != nil {
+					t.Errorf("expected nil fg, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "40-47 sets basic background",
+			params: ansi.Params{ansi.Param(44)}, // blue bg
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Bg, ansiColor(4)) {
+					t.Errorf("expected ansi color 4 bg, got %#v", got.Bg)
+				}
+			},
+		},
+		{
+			name:   "49 resets background to default (nil)",
+			start:  uv.Style{Bg: ansiColor(5)},
+			params: ansi.Params{ansi.Param(49)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Bg != nil {
+					t.Errorf("expected nil bg, got %#v", got.Bg)
+				}
+			},
+		},
+		{
+			name:   "90-97 sets bright foreground (offset by 8)",
+			params: ansi.Params{ansi.Param(91)}, // bright red -> ansi 9
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Fg, ansiColor(9)) {
+					t.Errorf("expected ansi color 9, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "100-107 sets bright background (offset by 8)",
+			params: ansi.Params{ansi.Param(105)}, // bright magenta bg -> ansi 13
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Bg, ansiColor(13)) {
+					t.Errorf("expected ansi color 13 bg, got %#v", got.Bg)
+				}
+			},
+		},
+		{
+			name:   "38;5;n sets 256-color foreground",
+			params: ansi.Params{ansi.Param(38), ansi.Param(5), ansi.Param(200)},
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Fg, ansiColor(200)) {
+					t.Errorf("expected ansi color 200, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "38;2;r;g;b sets truecolor foreground",
+			params: ansi.Params{ansi.Param(38), ansi.Param(2), ansi.Param(10), ansi.Param(20), ansi.Param(30)},
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Fg, rgbColorVal{10, 20, 30}) {
+					t.Errorf("expected rgb(10,20,30), got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "48;5;n sets 256-color background",
+			params: ansi.Params{ansi.Param(48), ansi.Param(5), ansi.Param(123)},
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Bg, ansiColor(123)) {
+					t.Errorf("expected ansi color 123 bg, got %#v", got.Bg)
+				}
+			},
+		},
+		{
+			name:   "48;2;r;g;b sets truecolor background",
+			params: ansi.Params{ansi.Param(48), ansi.Param(2), ansi.Param(1), ansi.Param(2), ansi.Param(3)},
+			check: func(t *testing.T, got uv.Style) {
+				if !colorEqualRGBA(t, got.Bg, rgbColorVal{1, 2, 3}) {
+					t.Errorf("expected rgb(1,2,3) bg, got %#v", got.Bg)
+				}
+			},
+		},
+		{
+			name:   "38 with truncated 256-color params is ignored safely",
+			params: ansi.Params{ansi.Param(38), ansi.Param(5)}, // missing index
+			check: func(t *testing.T, got uv.Style) {
+				if got.Fg != nil {
+					t.Errorf("expected no fg from truncated params, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "38;2 with truncated rgb params is ignored safely",
+			params: ansi.Params{ansi.Param(38), ansi.Param(2), ansi.Param(10)}, // missing g,b
+			check: func(t *testing.T, got uv.Style) {
+				if got.Fg != nil {
+					t.Errorf("expected no fg from truncated rgb params, got %#v", got.Fg)
+				}
+			},
+		},
+		{
+			name:   "unknown param is a no-op",
+			start:  bold,
+			params: ansi.Params{ansi.Param(73)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrBold == 0 {
+					t.Errorf("expected bold preserved through unknown param, attrs = %d", got.Attrs)
+				}
+			},
+		},
+		{
+			name:   "compound params apply in sequence",
+			params: ansi.Params{ansi.Param(1), ansi.Param(3), ansi.Param(31)},
+			check: func(t *testing.T, got uv.Style) {
+				if got.Attrs&uv.AttrBold == 0 || got.Attrs&uv.AttrItalic == 0 {
+					t.Errorf("expected bold+italic, attrs = %d", got.Attrs)
+				}
+				if !colorEqualRGBA(t, got.Fg, ansiColor(1)) {
+					t.Errorf("expected red fg, got %#v", got.Fg)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applySGR(tt.start, tt.params)
+			tt.check(t, got)
+		})
+	}
+}

--- a/internal/ui/compositor/canvas_drawable_test.go
+++ b/internal/ui/compositor/canvas_drawable_test.go
@@ -1,0 +1,303 @@
+package compositor
+
+import (
+	"image/color"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// colorEqualRGBA compares two color.Color values by their RGBA components.
+// A nil color is only equal to another nil color.
+func colorEqualRGBA(t *testing.T, got, want color.Color) bool {
+	t.Helper()
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	gr, gg, gb, ga := got.RGBA()
+	wr, wg, wb, wa := want.RGBA()
+	return gr == wr && gg == wg && gb == wb && ga == wa
+}
+
+func TestNewStringDrawable(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		x, y       int
+		wantWidth  int
+		wantHeight int
+		wantLines  []string
+	}{
+		{
+			name:       "empty string yields single empty line",
+			content:    "",
+			x:          0,
+			y:          0,
+			wantWidth:  0,
+			wantHeight: 1,
+			wantLines:  []string{""},
+		},
+		{
+			name:       "single line uses its display width",
+			content:    "hello",
+			x:          3,
+			y:          7,
+			wantWidth:  5,
+			wantHeight: 1,
+			wantLines:  []string{"hello"},
+		},
+		{
+			name:       "width is the max of all lines",
+			content:    "ab\nabcd\nabc",
+			x:          0,
+			y:          0,
+			wantWidth:  4,
+			wantHeight: 3,
+			wantLines:  []string{"ab", "abcd", "abc"},
+		},
+		{
+			name:       "ansi escapes do not count toward display width",
+			content:    "\x1b[31mred\x1b[0m",
+			x:          0,
+			y:          0,
+			wantWidth:  3,
+			wantHeight: 1,
+			wantLines:  []string{"\x1b[31mred\x1b[0m"},
+		},
+		{
+			name:       "wide runes count as two columns",
+			content:    "你好",
+			x:          0,
+			y:          0,
+			wantWidth:  4,
+			wantHeight: 1,
+			wantLines:  []string{"你好"},
+		},
+		{
+			name:       "trailing newline produces an empty final line",
+			content:    "line\n",
+			x:          2,
+			y:          5,
+			wantWidth:  4,
+			wantHeight: 2,
+			wantLines:  []string{"line", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewStringDrawable(tt.content, tt.x, tt.y)
+			if d == nil {
+				t.Fatal("NewStringDrawable returned nil")
+			}
+			if d.content != tt.content {
+				t.Errorf("content = %q, want %q", d.content, tt.content)
+			}
+			if d.x != tt.x || d.y != tt.y {
+				t.Errorf("position = (%d,%d), want (%d,%d)", d.x, d.y, tt.x, tt.y)
+			}
+			if d.width != tt.wantWidth {
+				t.Errorf("width = %d, want %d", d.width, tt.wantWidth)
+			}
+			if d.height != tt.wantHeight {
+				t.Errorf("height = %d, want %d", d.height, tt.wantHeight)
+			}
+			if len(d.lines) != len(tt.wantLines) {
+				t.Fatalf("lines = %#v, want %#v", d.lines, tt.wantLines)
+			}
+			for i := range tt.wantLines {
+				if d.lines[i] != tt.wantLines[i] {
+					t.Errorf("lines[%d] = %q, want %q", i, d.lines[i], tt.wantLines[i])
+				}
+			}
+			// height always equals the number of lines.
+			if d.height != len(d.lines) {
+				t.Errorf("height %d should equal len(lines) %d", d.height, len(d.lines))
+			}
+		})
+	}
+}
+
+func TestStringDrawableImplementsDrawable(t *testing.T) {
+	var _ uv.Drawable = NewStringDrawable("x", 0, 0)
+}
+
+func TestStringDrawableDrawEmptyIsNoop(t *testing.T) {
+	buf := uv.NewScreenBuffer(4, 1)
+	// Pre-fill with a sentinel so we can detect any unexpected writes.
+	sentinel := &uv.Cell{Content: "Z", Width: 1}
+	buf.Fill(sentinel)
+
+	d := NewStringDrawable("", 0, 0)
+	d.Draw(buf, buf.Bounds())
+
+	for x := 0; x < 4; x++ {
+		if got := buf.CellAt(x, 0).Content; got != "Z" {
+			t.Errorf("empty Draw modified cell %d: got %q, want sentinel", x, got)
+		}
+	}
+}
+
+func TestStringDrawableDrawPlainText(t *testing.T) {
+	buf := uv.NewScreenBuffer(5, 1)
+	d := NewStringDrawable("hi", 1, 0)
+	d.Draw(buf, buf.Bounds())
+
+	if got := buf.CellAt(1, 0).Content; got != "h" {
+		t.Errorf("cell (1,0) = %q, want %q", got, "h")
+	}
+	if got := buf.CellAt(2, 0).Content; got != "i" {
+		t.Errorf("cell (2,0) = %q, want %q", got, "i")
+	}
+	// Cell at the offset x=0 should be untouched (empty space).
+	if got := buf.CellAt(0, 0).Content; got == "h" || got == "i" {
+		t.Errorf("cell (0,0) should be untouched, got %q", got)
+	}
+}
+
+func TestStringDrawableDrawMultiLine(t *testing.T) {
+	buf := uv.NewScreenBuffer(3, 3)
+	d := NewStringDrawable("ab\ncd", 0, 0)
+	d.Draw(buf, buf.Bounds())
+
+	want := map[[2]int]string{
+		{0, 0}: "a", {1, 0}: "b",
+		{0, 1}: "c", {1, 1}: "d",
+	}
+	for pos, ch := range want {
+		if got := buf.CellAt(pos[0], pos[1]).Content; got != ch {
+			t.Errorf("cell (%d,%d) = %q, want %q", pos[0], pos[1], got, ch)
+		}
+	}
+}
+
+func TestStringDrawableDrawClipsOutOfBounds(t *testing.T) {
+	// A 3-line drawable positioned so only the middle row falls inside the
+	// clip rectangle [y=1, y=2).
+	buf := uv.NewScreenBuffer(2, 3)
+	d := NewStringDrawable("aa\nbb\ncc", 0, 0)
+	clip := uv.Rect(0, 1, 2, 1) // only row y=1 is drawable
+
+	d.Draw(buf, clip)
+
+	// Row 0 and row 2 must be untouched; row 1 ("bb") must be written.
+	if got := buf.CellAt(0, 0).Content; got == "a" {
+		t.Errorf("row 0 should be clipped out, got %q", got)
+	}
+	if got := buf.CellAt(0, 2).Content; got == "c" {
+		t.Errorf("row 2 should be clipped out, got %q", got)
+	}
+	if got := buf.CellAt(0, 1).Content; got != "b" {
+		t.Errorf("row 1 should be drawn, got %q", got)
+	}
+	if got := buf.CellAt(1, 1).Content; got != "b" {
+		t.Errorf("row 1 col 1 should be drawn, got %q", got)
+	}
+}
+
+func TestStringDrawableDrawClipsHorizontally(t *testing.T) {
+	// Draw "abcd" at x=0 into a clip window that only allows columns [1,3).
+	buf := uv.NewScreenBuffer(4, 1)
+	d := NewStringDrawable("abcd", 0, 0)
+	clip := uv.Rect(1, 0, 2, 1) // columns 1 and 2 only
+
+	d.Draw(buf, clip)
+
+	if got := buf.CellAt(0, 0).Content; got == "a" {
+		t.Errorf("col 0 should be clipped, got %q", got)
+	}
+	if got := buf.CellAt(1, 0).Content; got != "b" {
+		t.Errorf("col 1 = %q, want %q", got, "b")
+	}
+	if got := buf.CellAt(2, 0).Content; got != "c" {
+		t.Errorf("col 2 = %q, want %q", got, "c")
+	}
+	if got := buf.CellAt(3, 0).Content; got == "d" {
+		t.Errorf("col 3 should be clipped, got %q", got)
+	}
+}
+
+func TestStringDrawableDrawAppliesStyle(t *testing.T) {
+	// "\x1b[1;31mX" -> bold + red foreground on X.
+	buf := uv.NewScreenBuffer(1, 1)
+	d := NewStringDrawable("\x1b[1;31mX", 0, 0)
+	d.Draw(buf, buf.Bounds())
+
+	cell := buf.CellAt(0, 0)
+	if cell.Content != "X" {
+		t.Fatalf("content = %q, want %q", cell.Content, "X")
+	}
+	if cell.Style.Attrs&uv.AttrBold == 0 {
+		t.Errorf("expected bold attribute on cell, attrs = %d", cell.Style.Attrs)
+	}
+	if !colorEqualRGBA(t, cell.Style.Fg, ansiColor(1)) {
+		t.Errorf("expected red (ansi 1) foreground, got %#v", cell.Style.Fg)
+	}
+}
+
+func TestStringDrawableDrawWideRune(t *testing.T) {
+	buf := uv.NewScreenBuffer(4, 1)
+	d := NewStringDrawable("你x", 0, 0)
+	d.Draw(buf, buf.Bounds())
+
+	wide := buf.CellAt(0, 0)
+	if wide.Content != "你" {
+		t.Errorf("cell (0,0) = %q, want %q", wide.Content, "你")
+	}
+	if wide.Width != 2 {
+		t.Errorf("wide cell width = %d, want 2", wide.Width)
+	}
+	// The narrow rune lands at x=2 because the wide rune occupied 0..1.
+	if got := buf.CellAt(2, 0).Content; got != "x" {
+		t.Errorf("cell (2,0) = %q, want %q", got, "x")
+	}
+}
+
+func TestRGBColorValRGBA(t *testing.T) {
+	tests := []struct {
+		name                   string
+		c                      rgbColorVal
+		wantR, wantG, wantB, a uint32
+	}{
+		{
+			name:  "zero is fully black, opaque",
+			c:     rgbColorVal{0, 0, 0},
+			wantR: 0, wantG: 0, wantB: 0, a: 65535,
+		},
+		{
+			name:  "max is fully white, opaque",
+			c:     rgbColorVal{255, 255, 255},
+			wantR: 65535, wantG: 65535, wantB: 65535, a: 65535,
+		},
+		{
+			name:  "mid value scales by 257",
+			c:     rgbColorVal{1, 2, 3},
+			wantR: 257, wantG: 514, wantB: 771, a: 65535,
+		},
+		{
+			name:  "distinct channels are independent",
+			c:     rgbColorVal{10, 20, 30},
+			wantR: 2570, wantG: 5140, wantB: 7710, a: 65535,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, g, b, a := tt.c.RGBA()
+			if r != tt.wantR || g != tt.wantG || b != tt.wantB || a != tt.a {
+				t.Errorf("RGBA() = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
+					r, g, b, a, tt.wantR, tt.wantG, tt.wantB, tt.a)
+			}
+			// Alpha is always fully opaque.
+			if a != 65535 {
+				t.Errorf("alpha = %d, want 65535 (opaque)", a)
+			}
+		})
+	}
+}
+
+// TestRGBColorValImplementsColor ensures rgbColorVal satisfies color.Color so
+// it can be assigned to a uv.Style's Fg/Bg fields.
+func TestRGBColorValImplementsColor(t *testing.T) {
+	var _ color.Color = rgbColorVal{1, 2, 3}
+}


### PR DESCRIPTION
Adds table-driven unit tests for the previously-untested functions in internal/ui/compositor/canvas_drawable.go: NewStringDrawable, Draw, applySGR, and rgbColorVal.RGBA. Draw is verified against a real uv.ScreenBuffer with ANSI-styled input (cell content/style/width + vertical/horizontal clipping); applySGR is driven directly across every attribute, basic/bright/256/truecolor and reset path plus malformed extended-color sequences; RGBA checks 257x scaling and opaque alpha. No production code changed; no functions skipped. Tests split into canvas_drawable_test.go and canvas_drawable_sgr_test.go to respect the 500-line file cap. Part of the quality stacked diff. Stacked on improve/054-test-compositor-cache. Ticket 055 (testability).