### PR TITLE
test: cover ptyio/reader_lifecycle.go (ptyio)

### DIFF
--- a/internal/ui/ptyio/reader_lifecycle_start_test.go
+++ b/internal/ui/ptyio/reader_lifecycle_start_test.go
@@ -1,0 +1,258 @@
+package ptyio
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// startReaderHarness wires StartReaderOptions around a scripted reader so
+// StartReader's spawned goroutines run a real (in-process) read loop and drain
+// path without any tmux/PTY/Bubble Tea dependency. The Forward closure records
+// every message and signals forwardDone when the channel closes, which proves
+// the reader and forwarder both ran to completion.
+type startReaderHarness struct {
+	opts        StartReaderOptions
+	forwardDone chan struct{}
+
+	mu      sync.Mutex
+	outputs [][]byte
+	stops   []error
+}
+
+func newStartReaderHarness(term io.Reader) *startReaderHarness {
+	h := &startReaderHarness{forwardDone: make(chan struct{})}
+	factory := PTYMsgFactory{
+		Output: func(data []byte) tea.Msg {
+			cp := make([]byte, len(data))
+			copy(cp, data)
+			return testOutputMsg{data: cp}
+		},
+		Stopped: func(err error) tea.Msg { return testStoppedMsg{err: err} },
+	}
+	merger := OutputMerger{
+		ExtractData: func(msg tea.Msg) ([]byte, bool) {
+			o, ok := msg.(testOutputMsg)
+			if !ok {
+				return nil, false
+			}
+			return o.data, true
+		},
+		CanMerge:   func(_, _ tea.Msg) bool { return true },
+		Build:      func(_ tea.Msg, data []byte) tea.Msg { return testOutputMsg{data: data} },
+		MaxPending: 1 << 20,
+	}
+	h.opts = StartReaderOptions{
+		AcquireTerm:  func() io.Reader { return term },
+		Config:       baseReaderCfg(),
+		Factory:      factory,
+		ReaderLabel:  "test-reader",
+		ForwardLabel: "test-forward",
+		Forward: func(ch <-chan tea.Msg) {
+			ForwardPTYMsgs(ch, func(m tea.Msg) {
+				h.mu.Lock()
+				defer h.mu.Unlock()
+				switch v := m.(type) {
+				case testOutputMsg:
+					h.outputs = append(h.outputs, v.data)
+				case testStoppedMsg:
+					h.stops = append(h.stops, v.err)
+				}
+			}, merger)
+			close(h.forwardDone)
+		},
+	}
+	return h
+}
+
+// waitForward blocks until the Forward goroutine returns (msgCh closed) or the
+// timeout elapses, failing the test on timeout.
+func (h *startReaderHarness) waitForward(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.forwardDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Forward did not return within 2s (reader never closed msgCh)")
+	}
+}
+
+func (h *startReaderHarness) outputBytes() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var b []byte
+	for _, o := range h.outputs {
+		b = append(b, o...)
+	}
+	return b
+}
+
+func (h *startReaderHarness) stopErrs() []error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]error, len(h.stops))
+	copy(out, h.stops)
+	return out
+}
+
+func TestStartReaderRunsAndMarksStopped(t *testing.T) {
+	var mu sync.Mutex
+	st := &State{}
+	h := newStartReaderHarness(&scriptedReader{chunks: [][]byte{[]byte("hello")}})
+
+	st.StartReader(&mu, h.opts)
+
+	// The reader starts active with a fresh heartbeat and a live cancel channel.
+	mu.Lock()
+	if !st.ReaderActive {
+		mu.Unlock()
+		t.Fatal("ReaderActive = false immediately after StartReader, want true")
+	}
+	if st.MsgCh == nil {
+		mu.Unlock()
+		t.Fatal("MsgCh = nil after StartReader, want a channel")
+	}
+	if st.ReaderCancel == nil {
+		mu.Unlock()
+		t.Fatal("ReaderCancel = nil after StartReader, want a channel")
+	}
+	mu.Unlock()
+
+	h.waitForward(t)
+
+	if got := string(h.outputBytes()); got != "hello" {
+		t.Fatalf("forwarded output = %q, want %q", got, "hello")
+	}
+	if errs := h.stopErrs(); len(errs) != 1 || errs[0] != io.EOF {
+		t.Fatalf("stop errs = %v, want exactly one io.EOF", errs)
+	}
+
+	// MarkReaderStopped ran on reader exit: state cleared, heartbeat zeroed.
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderActive {
+		t.Fatal("ReaderActive = true after reader exit, want false")
+	}
+	if st.MsgCh != nil {
+		t.Fatal("MsgCh != nil after reader exit, want nil")
+	}
+	if hb := atomic.LoadInt64(&st.Heartbeat); hb != 0 {
+		t.Fatalf("Heartbeat = %d after reader exit, want 0", hb)
+	}
+}
+
+func TestStartReaderResetsBackoffOnStart(t *testing.T) {
+	var mu sync.Mutex
+	st := &State{RestartBackoff: 3 * time.Second}
+	h := newStartReaderHarness(&scriptedReader{chunks: [][]byte{[]byte("x")}})
+
+	st.StartReader(&mu, h.opts)
+	h.waitForward(t)
+
+	// StartReader clears RestartBackoff to 0 before launching the reader.
+	mu.Lock()
+	defer mu.Unlock()
+	if st.RestartBackoff != 0 {
+		t.Fatalf("RestartBackoff = %v after StartReader, want 0", st.RestartBackoff)
+	}
+}
+
+func TestStartReaderNilTermDoesNotStart(t *testing.T) {
+	var mu sync.Mutex
+	st := &State{}
+	opts := newStartReaderHarness(nil).opts
+	opts.AcquireTerm = func() io.Reader { return nil }
+
+	st.StartReader(&mu, opts)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderActive {
+		t.Fatal("ReaderActive = true when AcquireTerm returned nil, want false")
+	}
+	if st.MsgCh != nil {
+		t.Fatal("MsgCh != nil when AcquireTerm returned nil, want nil")
+	}
+	if st.ReaderCancel != nil {
+		t.Fatal("ReaderCancel != nil when AcquireTerm returned nil, want nil")
+	}
+}
+
+func TestStartReaderSkipsWhenAlreadyActive(t *testing.T) {
+	var mu sync.Mutex
+	existingCancel := make(chan struct{})
+	existingCh := make(chan tea.Msg)
+	st := &State{
+		ReaderActive: true,
+		ReaderCancel: existingCancel,
+		MsgCh:        existingCh,
+	}
+	acquired := false
+	opts := newStartReaderHarness(&scriptedReader{}).opts
+	opts.AcquireTerm = func() io.Reader {
+		acquired = true
+		return &scriptedReader{}
+	}
+
+	st.StartReader(&mu, opts)
+
+	if acquired {
+		t.Fatal("AcquireTerm was called for an already-active reader, want skipped")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderCancel != existingCancel {
+		t.Fatal("ReaderCancel was replaced while a reader was active")
+	}
+	if st.MsgCh != existingCh {
+		t.Fatal("MsgCh was replaced while a reader was active")
+	}
+}
+
+func TestStartReaderRearmsInconsistentActiveState(t *testing.T) {
+	var mu sync.Mutex
+	// ReaderActive is set but the bookkeeping channels are nil: a leftover
+	// inconsistent state that StartReader must treat as "not running" and rearm.
+	st := &State{ReaderActive: true, ReaderCancel: nil, MsgCh: nil}
+	h := newStartReaderHarness(&scriptedReader{chunks: [][]byte{[]byte("rearm")}})
+
+	st.StartReader(&mu, h.opts)
+	h.waitForward(t)
+
+	if got := string(h.outputBytes()); got != "rearm" {
+		t.Fatalf("output = %q, want %q (reader should have rearmed)", got, "rearm")
+	}
+}
+
+func TestStartReaderClosesLeftoverCancel(t *testing.T) {
+	var mu sync.Mutex
+	// Realistic post-MarkReaderStopped shape: the previous reader exited on its
+	// own, so ReaderActive is false and MsgCh is nil, but ReaderCancel was left
+	// in place (an open channel) for the next StartReader to close. StartReader
+	// must close that leftover channel and swap in a fresh, distinct one.
+	leftoverCancel := make(chan struct{})
+	st := &State{ReaderActive: false, ReaderCancel: leftoverCancel, MsgCh: nil}
+	h := newStartReaderHarness(&scriptedReader{chunks: [][]byte{[]byte("swap")}})
+
+	st.StartReader(&mu, h.opts)
+	h.waitForward(t)
+
+	// The leftover cancel channel was closed (a receive succeeds, not blocks).
+	select {
+	case <-leftoverCancel:
+	default:
+		t.Fatal("leftover ReaderCancel was not closed by StartReader")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderCancel == nil {
+		t.Fatal("ReaderCancel = nil after StartReader, want a fresh channel")
+	}
+	if st.ReaderCancel == leftoverCancel {
+		t.Fatal("ReaderCancel still points at the leftover channel, want a fresh distinct one")
+	}
+}

--- a/internal/ui/ptyio/reader_lifecycle_test.go
+++ b/internal/ui/ptyio/reader_lifecycle_test.go
@@ -1,0 +1,306 @@
+package ptyio
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestStopReaderClearsStateAndSignalsCancel(t *testing.T) {
+	var mu sync.Mutex
+	cancel := make(chan struct{})
+	st := &State{
+		ReaderActive: true,
+		ReaderCancel: cancel,
+		MsgCh:        make(chan tea.Msg),
+		Heartbeat:    time.Now().UnixNano(),
+	}
+
+	st.StopReader(&mu)
+
+	// Cancel channel is closed so the reader can observe it.
+	select {
+	case <-cancel:
+	default:
+		t.Fatal("ReaderCancel was not closed by StopReader")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderActive {
+		t.Fatal("ReaderActive = true after StopReader, want false")
+	}
+	if st.ReaderCancel != nil {
+		t.Fatal("ReaderCancel != nil after StopReader, want nil")
+	}
+	if st.MsgCh != nil {
+		t.Fatal("MsgCh != nil after StopReader, want nil")
+	}
+	if hb := atomic.LoadInt64(&st.Heartbeat); hb != 0 {
+		t.Fatalf("Heartbeat = %d after StopReader, want 0", hb)
+	}
+}
+
+func TestStopReaderWithNilCancelIsSafe(t *testing.T) {
+	var mu sync.Mutex
+	st := &State{ReaderActive: true, ReaderCancel: nil, Heartbeat: 42}
+
+	// No cancel channel to close: StopReader must not panic and still clear state.
+	st.StopReader(&mu)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderActive {
+		t.Fatal("ReaderActive = true after StopReader with nil cancel, want false")
+	}
+	if hb := atomic.LoadInt64(&st.Heartbeat); hb != 0 {
+		t.Fatalf("Heartbeat = %d, want 0", hb)
+	}
+}
+
+func TestMarkReaderStopped(t *testing.T) {
+	var mu sync.Mutex
+	cancel := make(chan struct{})
+	st := &State{
+		ReaderActive: true,
+		ReaderCancel: cancel,
+		MsgCh:        make(chan tea.Msg),
+		Heartbeat:    time.Now().UnixNano(),
+	}
+
+	st.MarkReaderStopped(&mu)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if st.ReaderActive {
+		t.Fatal("ReaderActive = true after MarkReaderStopped, want false")
+	}
+	if st.MsgCh != nil {
+		t.Fatal("MsgCh != nil after MarkReaderStopped, want nil")
+	}
+	if hb := atomic.LoadInt64(&st.Heartbeat); hb != 0 {
+		t.Fatalf("Heartbeat = %d after MarkReaderStopped, want 0", hb)
+	}
+	// ReaderCancel is intentionally left intact for the next StartReader to close.
+	if st.ReaderCancel != cancel {
+		t.Fatal("ReaderCancel was cleared by MarkReaderStopped, want it left in place")
+	}
+	// The channel must still be open (not closed by MarkReaderStopped).
+	select {
+	case <-st.ReaderCancel:
+		t.Fatal("ReaderCancel was closed by MarkReaderStopped, want left open")
+	default:
+	}
+}
+
+func TestReaderStalled(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name         string
+		active       bool
+		heartbeat    int64
+		stallTimeout time.Duration
+		want         bool
+	}{
+		{
+			name:         "inactive reader is never stalled",
+			active:       false,
+			heartbeat:    now.Add(-time.Hour).UnixNano(),
+			stallTimeout: time.Second,
+			want:         false,
+		},
+		{
+			name:         "active with zero heartbeat is not stalled",
+			active:       true,
+			heartbeat:    0,
+			stallTimeout: time.Second,
+			want:         false,
+		},
+		{
+			name:         "active with recent heartbeat is not stalled",
+			active:       true,
+			heartbeat:    now.UnixNano(),
+			stallTimeout: time.Second,
+			want:         false,
+		},
+		{
+			name:         "active with old heartbeat past timeout is stalled",
+			active:       true,
+			heartbeat:    now.Add(-time.Minute).UnixNano(),
+			stallTimeout: time.Second,
+			want:         true,
+		},
+		{
+			name:         "inactive flag overrides old heartbeat",
+			active:       false,
+			heartbeat:    now.Add(-time.Minute).UnixNano(),
+			stallTimeout: time.Second,
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			st := &State{ReaderActive: tt.active, Heartbeat: tt.heartbeat}
+			if got := st.ReaderStalled(&mu, tt.stallTimeout); got != tt.want {
+				t.Fatalf("ReaderStalled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextRestartBackoffLockedExponential(t *testing.T) {
+	st := &State{}
+	window := time.Minute
+	maxRestarts := 5
+
+	// First restart returns the initial delay; each subsequent doubles up to cap.
+	want := []time.Duration{
+		RestartBackoffInitial,     // 200ms
+		RestartBackoffInitial * 2, // 400ms
+		RestartBackoffInitial * 4, // 800ms
+		RestartBackoffInitial * 8, // 1.6s
+	}
+	for i, w := range want {
+		got, ok := st.NextRestartBackoffLocked(window, maxRestarts)
+		if !ok {
+			t.Fatalf("attempt %d: ok = false, want true (within budget)", i+1)
+		}
+		if got != w {
+			t.Fatalf("attempt %d: backoff = %v, want %v", i+1, got, w)
+		}
+		if st.RestartCount != i+1 {
+			t.Fatalf("attempt %d: RestartCount = %d, want %d", i+1, st.RestartCount, i+1)
+		}
+	}
+
+	// Fifth attempt would double to 3.2s and is the last within budget (max 5).
+	got, ok := st.NextRestartBackoffLocked(window, maxRestarts)
+	if !ok {
+		t.Fatalf("attempt 5: ok = false, want true (still within budget)")
+	}
+	if got != RestartBackoffInitial*16 {
+		t.Fatalf("attempt 5: backoff = %v, want %v", got, RestartBackoffInitial*16)
+	}
+}
+
+func TestNextRestartBackoffLockedCaps(t *testing.T) {
+	st := &State{RestartBackoff: RestartBackoffCap}
+	// Already at the cap: doubling must clamp back to the cap, not overflow it.
+	got, ok := st.NextRestartBackoffLocked(time.Minute, 100)
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if got != RestartBackoffCap {
+		t.Fatalf("backoff = %v, want capped at %v", got, RestartBackoffCap)
+	}
+	if st.RestartBackoff != RestartBackoffCap {
+		t.Fatalf("RestartBackoff = %v, want %v", st.RestartBackoff, RestartBackoffCap)
+	}
+}
+
+func TestNextRestartBackoffLockedExhaustsBudget(t *testing.T) {
+	st := &State{}
+	window := time.Minute
+	maxRestarts := 3
+
+	for i := 0; i < maxRestarts; i++ {
+		if _, ok := st.NextRestartBackoffLocked(window, maxRestarts); !ok {
+			t.Fatalf("attempt %d: ok = false, want true (within budget)", i+1)
+		}
+	}
+	// The (maxRestarts+1)-th attempt exceeds the budget: give up and reset delay.
+	got, ok := st.NextRestartBackoffLocked(window, maxRestarts)
+	if ok {
+		t.Fatal("ok = true after exhausting budget, want false")
+	}
+	if got != 0 {
+		t.Fatalf("backoff = %v after exhausting budget, want 0", got)
+	}
+	if st.RestartBackoff != 0 {
+		t.Fatalf("RestartBackoff = %v after exhausting budget, want 0", st.RestartBackoff)
+	}
+}
+
+func TestNextRestartBackoffLockedZeroMaxRestarts(t *testing.T) {
+	st := &State{}
+	// A zero budget means the very first attempt already exceeds it.
+	got, ok := st.NextRestartBackoffLocked(time.Minute, 0)
+	if ok {
+		t.Fatal("ok = true with maxRestarts=0, want false")
+	}
+	if got != 0 {
+		t.Fatalf("backoff = %v, want 0", got)
+	}
+}
+
+func TestNextRestartBackoffLockedWindowReset(t *testing.T) {
+	window := time.Minute
+	maxRestarts := 2
+
+	// A window that opened longer ago than `window`: the count is reset so the
+	// per-window restart budget refreshes and ok stays true even though the
+	// previous count had exceeded the budget.
+	st := &State{
+		RestartSince: time.Now().Add(-2 * window), // last window opened long ago
+		RestartCount: 99,
+	}
+	got, ok := st.NextRestartBackoffLocked(window, maxRestarts)
+	if !ok {
+		t.Fatal("ok = false after window reset, want true (budget refreshed)")
+	}
+	if got != RestartBackoffInitial {
+		t.Fatalf("backoff = %v after window reset, want fresh %v", got, RestartBackoffInitial)
+	}
+	// The count is reset to zero by the rollover, then incremented for this call.
+	if st.RestartCount != 1 {
+		t.Fatalf("RestartCount = %d after window reset, want 1", st.RestartCount)
+	}
+	if st.RestartSince.IsZero() {
+		t.Fatal("RestartSince is zero after window reset, want it set to now")
+	}
+}
+
+func TestNextRestartBackoffLockedFirstCallSetsWindow(t *testing.T) {
+	st := &State{} // zero RestartSince
+	before := time.Now()
+	if _, ok := st.NextRestartBackoffLocked(time.Minute, 5); !ok {
+		t.Fatal("ok = false on first call, want true")
+	}
+	if st.RestartSince.Before(before) {
+		t.Fatal("RestartSince was not set to ~now on first call")
+	}
+	if st.RestartCount != 1 {
+		t.Fatalf("RestartCount = %d, want 1", st.RestartCount)
+	}
+}
+
+func TestResetRestartBackoffLocked(t *testing.T) {
+	st := &State{
+		RestartBackoff: 4 * time.Second,
+		RestartCount:   7,
+		RestartSince:   time.Now(),
+	}
+	st.ResetRestartBackoffLocked()
+
+	if st.RestartBackoff != 0 {
+		t.Fatalf("RestartBackoff = %v, want 0", st.RestartBackoff)
+	}
+	if st.RestartCount != 0 {
+		t.Fatalf("RestartCount = %d, want 0", st.RestartCount)
+	}
+	if !st.RestartSince.IsZero() {
+		t.Fatalf("RestartSince = %v, want zero time", st.RestartSince)
+	}
+}
+
+func TestResetRestartBackoffLockedOnZeroValueIsIdempotent(t *testing.T) {
+	st := &State{}
+	st.ResetRestartBackoffLocked()
+	if st.RestartBackoff != 0 || st.RestartCount != 0 || !st.RestartSince.IsZero() {
+		t.Fatalf("zero-value State changed after reset: %+v", st)
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for the previously-untested reader lifecycle and restart-backoff logic in `internal/ui/ptyio/reader_lifecycle.go`: StartReader, StopReader, MarkReaderStopped, ReaderStalled, NextRestartBackoffLocked, ResetRestartBackoffLocked. Per-function coverage on this file goes from 0% to 96-100%.

StartReader is exercised through an in-process harness (scriptedReader + a real Forward drain) so no tmux/PTY or live Bubble Tea program is required; no listed function had to be skipped. No production code was changed. Tests are split across reader_lifecycle_test.go and reader_lifecycle_start_test.go to respect the 500-line-per-file cap.

Part of the quality stacked diff. Stacked on improve/057-test-ptyio-flush. Ticket 058 (testability).