### PR TITLE
test: cover diff/model.go (diff)

### DIFF
--- a/internal/ui/diff/model_lifecycle_test.go
+++ b/internal/ui/diff/model_lifecycle_test.go
@@ -1,0 +1,170 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+// TestNew asserts the constructor wires every field and seeds the loading +
+// default-styles state a freshly opened viewer expects.
+func TestNew(t *testing.T) {
+	ws := data.NewWorkspace("ws", "ws", "main", "/repo", "/repo")
+	change := &git.Change{Path: "main.go", Kind: git.ChangeModified}
+
+	m := New(ws, change, git.DiffModeStaged, 120, 40)
+
+	if m == nil {
+		t.Fatal("New returned nil model")
+	}
+	if m.workspace != ws {
+		t.Errorf("workspace = %p, want %p", m.workspace, ws)
+	}
+	if m.change != change {
+		t.Errorf("change = %p, want %p", m.change, change)
+	}
+	if m.mode != git.DiffModeStaged {
+		t.Errorf("mode = %v, want DiffModeStaged", m.mode)
+	}
+	if m.width != 120 {
+		t.Errorf("width = %d, want 120", m.width)
+	}
+	if m.height != 40 {
+		t.Errorf("height = %d, want 40", m.height)
+	}
+	if !m.loading {
+		t.Error("expected new model to start in loading state")
+	}
+	if m.focused {
+		t.Error("expected new model to start unfocused")
+	}
+	// DefaultStyles seeds a non-zero style set; compare against the package
+	// default to confirm SetStyles was effectively applied at construction.
+	if m.styles.Body.String() != common.DefaultStyles().Body.String() {
+		t.Error("expected new model to use DefaultStyles")
+	}
+}
+
+// TestNew_NilInputs proves the constructor tolerates nil workspace/change and
+// zero dimensions without panicking, since callers build a viewer before any
+// file is selected.
+func TestNew_NilInputs(t *testing.T) {
+	m := New(nil, nil, git.DiffModeUnstaged, 0, 0)
+	if m == nil {
+		t.Fatal("New returned nil model for nil inputs")
+	}
+	if m.workspace != nil || m.change != nil {
+		t.Error("expected nil workspace/change to be preserved")
+	}
+	if !m.loading {
+		t.Error("expected loading state even with nil inputs")
+	}
+	if got := m.GetPath(); got != "" {
+		t.Errorf("GetPath on nil change = %q, want empty", got)
+	}
+}
+
+// TestInit returns a non-nil load command and bumps the load generation so the
+// first async result is accepted by Update.
+func TestInit(t *testing.T) {
+	m := New(nil, nil, git.DiffModeUnstaged, 80, 24)
+	startID := m.loadID
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init returned nil command")
+	}
+	if m.loadID != startID+1 {
+		t.Fatalf("Init loadID = %d, want %d", m.loadID, startID+1)
+	}
+}
+
+// TestInitNilInputsProducesEmptyDiff executes the command returned by Init for a
+// viewer with no workspace/change. That branch short-circuits before touching
+// the git CLI, so it is safe to run and must yield an empty-diff completion that
+// carries the current load generation.
+func TestInitNilInputsProducesEmptyDiff(t *testing.T) {
+	m := New(nil, nil, git.DiffModeUnstaged, 80, 24)
+
+	cmd := m.Init()
+	msg := cmd()
+
+	loaded, ok := msg.(diffLoaded)
+	if !ok {
+		t.Fatalf("Init command produced %T, want diffLoaded", msg)
+	}
+	if loaded.err != nil {
+		t.Errorf("nil-input load err = %v, want nil", loaded.err)
+	}
+	if loaded.diff == nil || !loaded.diff.Empty {
+		t.Errorf("nil-input load diff = %+v, want Empty result", loaded.diff)
+	}
+	if loaded.loadID != m.loadID {
+		t.Errorf("nil-input load loadID = %d, want %d", loaded.loadID, m.loadID)
+	}
+
+	// Feeding the result back through Update must clear loading and record the
+	// empty diff under the matching generation.
+	updated, _ := m.Update(loaded)
+	if updated.loading {
+		t.Error("expected nil-input load to clear loading state")
+	}
+	if updated.diff == nil || !updated.diff.Empty {
+		t.Errorf("expected empty diff recorded, got %+v", updated.diff)
+	}
+}
+
+// TestLoadDiffIncrementsLoadID confirms each load bumps the generation counter
+// and hands back an executable command, the contract Update relies on to drop
+// stale completions.
+func TestLoadDiffIncrementsLoadID(t *testing.T) {
+	m := New(nil, nil, git.DiffModeUnstaged, 80, 24)
+
+	first := m.loadID
+	cmd1 := m.loadDiff()
+	if cmd1 == nil {
+		t.Fatal("loadDiff returned nil command")
+	}
+	if m.loadID != first+1 {
+		t.Fatalf("first loadDiff loadID = %d, want %d", m.loadID, first+1)
+	}
+
+	cmd2 := m.loadDiff()
+	if cmd2 == nil {
+		t.Fatal("second loadDiff returned nil command")
+	}
+	if m.loadID != first+2 {
+		t.Fatalf("second loadDiff loadID = %d, want %d", m.loadID, first+2)
+	}
+
+	// Each closure must capture its own generation: executing the first (nil
+	// inputs, no git CLI) carries the generation that was current when it was
+	// created, not the latest.
+	loaded, ok := cmd1().(diffLoaded)
+	if !ok {
+		t.Fatalf("loadDiff command produced %T, want diffLoaded", cmd1())
+	}
+	if loaded.loadID != first+1 {
+		t.Errorf("captured loadID = %d, want %d", loaded.loadID, first+1)
+	}
+}
+
+// TestLoadDiffNonNilInputsReturnsCommand verifies that with a real workspace and
+// change the loader still bumps the generation and returns a runnable command.
+// The command is intentionally not executed here because doing so shells out to
+// the git CLI; the executed git paths live in the git package's own tests.
+func TestLoadDiffNonNilInputsReturnsCommand(t *testing.T) {
+	ws := data.NewWorkspace("ws", "ws", "main", "/repo", "/repo")
+	change := &git.Change{Path: "main.go", Kind: git.ChangeModified}
+	m := New(ws, change, git.DiffModeUnstaged, 80, 24)
+
+	before := m.loadID
+	if cmd := m.loadDiff(); cmd == nil {
+		t.Fatal("loadDiff returned nil command for populated model")
+	}
+	if m.loadID != before+1 {
+		t.Fatalf("loadDiff loadID = %d, want %d", m.loadID, before+1)
+	}
+}

--- a/internal/ui/diff/model_state_test.go
+++ b/internal/ui/diff/model_state_test.go
@@ -1,0 +1,229 @@
+package diff
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+func TestNormalizeSourcePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "plain", in: "main.go", want: "main.go"},
+		{name: "dot-slash prefix", in: "./main.go", want: "main.go"},
+		{name: "redundant slashes", in: "a//b/c.go", want: "a/b/c.go"},
+		{name: "parent traversal", in: "a/b/../c.go", want: "a/c.go"},
+		{name: "trailing slash", in: "dir/sub/", want: "dir/sub"},
+		{name: "current dir", in: ".", want: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeSourcePath(tt.in); got != tt.want {
+				t.Fatalf("normalizeSourcePath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      *Model
+		changePath string
+		mode       git.DiffMode
+		want       bool
+	}{
+		{
+			name:       "nil model",
+			model:      nil,
+			changePath: "main.go",
+			mode:       git.DiffModeUnstaged,
+			want:       false,
+		},
+		{
+			name:       "nil change",
+			model:      &Model{change: nil, mode: git.DiffModeUnstaged},
+			changePath: "main.go",
+			mode:       git.DiffModeUnstaged,
+			want:       false,
+		},
+		{
+			name:       "exact match",
+			model:      &Model{change: &git.Change{Path: "main.go"}, mode: git.DiffModeUnstaged},
+			changePath: "main.go",
+			mode:       git.DiffModeUnstaged,
+			want:       true,
+		},
+		{
+			name:       "match after normalization",
+			model:      &Model{change: &git.Change{Path: "./a//b.go"}, mode: git.DiffModeStaged},
+			changePath: "a/b.go",
+			mode:       git.DiffModeStaged,
+			want:       true,
+		},
+		{
+			name:       "same path different mode",
+			model:      &Model{change: &git.Change{Path: "main.go"}, mode: git.DiffModeUnstaged},
+			changePath: "main.go",
+			mode:       git.DiffModeStaged,
+			want:       false,
+		},
+		{
+			name:       "different path same mode",
+			model:      &Model{change: &git.Change{Path: "main.go"}, mode: git.DiffModeBranch},
+			changePath: "other.go",
+			mode:       git.DiffModeBranch,
+			want:       false,
+		},
+		{
+			name:       "both empty paths match",
+			model:      &Model{change: &git.Change{Path: ""}, mode: git.DiffModeUnstaged},
+			changePath: "",
+			mode:       git.DiffModeUnstaged,
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.model.MatchesSource(tt.changePath, tt.mode); got != tt.want {
+				t.Fatalf("MatchesSource(%q, %v) = %v, want %v", tt.changePath, tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFocusHelpers covers the full focus lifecycle through every accessor and
+// mutator: SetFocused both ways, Focus, Blur, and the Focused reader.
+func TestFocusHelpers(t *testing.T) {
+	m := &Model{}
+
+	if m.Focused() {
+		t.Fatal("expected zero-value model to be unfocused")
+	}
+
+	m.Focus()
+	if !m.Focused() {
+		t.Fatal("Focus did not set focused state")
+	}
+
+	m.Blur()
+	if m.Focused() {
+		t.Fatal("Blur did not clear focused state")
+	}
+
+	m.SetFocused(true)
+	if !m.Focused() {
+		t.Fatal("SetFocused(true) did not focus model")
+	}
+
+	m.SetFocused(false)
+	if m.Focused() {
+		t.Fatal("SetFocused(false) did not blur model")
+	}
+}
+
+func TestSetSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		w, h  int
+		wantW int
+		wantH int
+	}{
+		{name: "typical", w: 100, h: 30, wantW: 100, wantH: 30},
+		{name: "zero", w: 0, h: 0, wantW: 0, wantH: 0},
+		{name: "negative", w: -5, h: -10, wantW: -5, wantH: -10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{width: 1, height: 1}
+			m.SetSize(tt.w, tt.h)
+			if m.width != tt.wantW || m.height != tt.wantH {
+				t.Fatalf("SetSize(%d,%d) => width=%d height=%d, want %d/%d",
+					tt.w, tt.h, m.width, m.height, tt.wantW, tt.wantH)
+			}
+		})
+	}
+}
+
+// TestSetSizeAffectsVisibleHeight is a behavioral check: resizing should feed
+// through to the derived visibleHeight used by scroll math.
+func TestSetSizeAffectsVisibleHeight(t *testing.T) {
+	m := &Model{}
+	m.SetSize(80, 13)
+	if got := m.visibleHeight(); got != 10 {
+		t.Fatalf("visibleHeight after SetSize = %d, want 10", got)
+	}
+}
+
+func TestSetStyles(t *testing.T) {
+	m := &Model{styles: common.DefaultStyles()}
+
+	custom := common.DefaultStyles()
+	custom.Body = lipgloss.NewStyle().Foreground(lipgloss.Color("#ABCDEF")).Bold(true)
+	m.SetStyles(custom)
+
+	if m.styles.Body.GetForeground() != lipgloss.Color("#ABCDEF") {
+		t.Fatalf("SetStyles did not apply custom foreground, got %v", m.styles.Body.GetForeground())
+	}
+	if !m.styles.Body.GetBold() {
+		t.Fatal("SetStyles did not apply custom bold attribute")
+	}
+}
+
+func TestGetPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		change *git.Change
+		want   string
+	}{
+		{name: "nil change", change: nil, want: ""},
+		{name: "empty path", change: &git.Change{Path: ""}, want: ""},
+		{name: "populated path", change: &git.Change{Path: "pkg/file.go"}, want: "pkg/file.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{change: tt.change}
+			if got := m.GetPath(); got != tt.want {
+				t.Fatalf("GetPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScrollToBottom(t *testing.T) {
+	t.Run("nil diff stays at zero", func(t *testing.T) {
+		m := &Model{height: 10}
+		m.scroll = 4
+		m.scrollToBottom()
+		if m.scroll != 0 {
+			t.Fatalf("scrollToBottom with nil diff = %d, want 0", m.scroll)
+		}
+	})
+
+	t.Run("long diff jumps to maxScroll", func(t *testing.T) {
+		m := newModelWithDiff(6, 10, nil)
+		m.scrollToBottom()
+		if m.scroll != m.maxScroll() {
+			t.Fatalf("scrollToBottom = %d, want maxScroll %d", m.scroll, m.maxScroll())
+		}
+		if m.scroll != 7 {
+			t.Fatalf("scrollToBottom = %d, want 7", m.scroll)
+		}
+	})
+
+	t.Run("short diff stays at zero", func(t *testing.T) {
+		m := newModelWithDiff(20, 3, nil)
+		m.scroll = 2
+		m.scrollToBottom()
+		if m.scroll != 0 {
+			t.Fatalf("scrollToBottom on short diff = %d, want 0", m.scroll)
+		}
+	})
+}


### PR DESCRIPTION
Adds thorough table-driven unit tests for the previously-untested pure/logic functions in internal/ui/diff/model.go: New, Init, normalizeSourcePath, MatchesSource, loadDiff, scrollToBottom, SetFocused, Focus, Blur, Focused, SetSize, SetStyles, GetPath. Assertions cover real behavior and return values across edge cases (nil/empty inputs, boundary sizes, path normalization, stale-load generations).

loadDiff/Init are exercised via the nil workspace/change branch (short-circuits before the git CLI) plus loadID-generation assertions for the populated path; the git-CLI-executing branches are not run here since they shell out to git and are covered by the git package's own tests. No production code changed.

Part of the quality stacked diff. Stacked on improve/060-test-ptyio-session-restore. Ticket 061 (testability).