### PR TITLE
test: cover sidebar/terminal_render.go (sidebar)

### DIFF
--- a/internal/ui/sidebar/terminal_render_test.go
+++ b/internal/ui/sidebar/terminal_render_test.go
@@ -1,0 +1,301 @@
+package sidebar
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// newTerminalModelWithWorkspace returns a model bound to a workspace so that
+// workspaceID() is non-empty and seedTabs installs into the right bucket.
+func newTerminalModelWithWorkspace(t *testing.T) *TerminalModel {
+	t.Helper()
+	m := NewTerminalModel()
+	m.setWorkspace(&data.Workspace{Repo: "/repo", Root: "/repo/ws"})
+	return m
+}
+
+// scrolledVTerm returns a VTerm with scrollback that has been scrolled up so
+// that IsScrolled() is true and GetScrollInfo() reports a non-zero offset.
+func scrolledVTerm(t *testing.T) *vterm.VTerm {
+	t.Helper()
+	vt := vterm.New(80, 24)
+	vt.AllowAltScreenScrollback = true
+	for i := 0; i < 100; i++ {
+		vt.Write([]byte(fmt.Sprintf("line %d\r\n", i)))
+	}
+	vt.ScrollView(10)
+	if !vt.IsScrolled() {
+		t.Fatal("setup: expected VTerm to be scrolled after ScrollView(10)")
+	}
+	return vt
+}
+
+func TestFormatScrollPos(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset int
+		total  int
+		want   string
+	}{
+		{name: "zero total short-circuits", offset: 0, total: 0, want: "0/0"},
+		{name: "zero total ignores offset", offset: 5, total: 0, want: "0/0"},
+		{name: "typical position", offset: 3, total: 42, want: "3/42 lines up"},
+		{name: "offset equals total", offset: 42, total: 42, want: "42/42 lines up"},
+		{name: "single line", offset: 1, total: 1, want: "1/1 lines up"},
+		{name: "negative offset is rendered verbatim", offset: -2, total: 10, want: "-2/10 lines up"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatScrollPos(tt.offset, tt.total); got != tt.want {
+				t.Fatalf("formatScrollPos(%d, %d) = %q, want %q", tt.offset, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderTabBarNoWorkspace(t *testing.T) {
+	m := NewTerminalModel() // no workspace set -> m.workspace == nil
+	got := m.renderTabBar()
+	if !strings.Contains(got, "No terminal") {
+		t.Fatalf("expected 'No terminal' message with no workspace, got %q", got)
+	}
+	if len(m.tabHits) != 0 {
+		t.Fatalf("expected no hit regions with no workspace, got %d", len(m.tabHits))
+	}
+}
+
+func TestRenderTabBarWorkspaceNoTabs(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	got := m.renderTabBar()
+	if !strings.Contains(got, "+ New") {
+		t.Fatalf("expected '+ New' button when workspace has no tabs, got %q", got)
+	}
+	// A single clickable plus region must be registered.
+	if len(m.tabHits) != 1 {
+		t.Fatalf("expected exactly one hit region (plus), got %d", len(m.tabHits))
+	}
+	hit := m.tabHits[0]
+	if hit.kind != terminalTabHitPlus {
+		t.Fatalf("expected plus hit kind, got %v", hit.kind)
+	}
+	if hit.index != -1 {
+		t.Fatalf("expected plus index -1, got %d", hit.index)
+	}
+	if hit.region.Width <= 0 || hit.region.Height != 1 {
+		t.Fatalf("expected positive-width single-row region, got %+v", hit.region)
+	}
+}
+
+func TestRenderTabBarSingleTab(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	got := m.renderTabBar()
+	if !strings.Contains(got, "Terminal 1") {
+		t.Fatalf("expected tab name in output, got %q", got)
+	}
+	if !strings.Contains(got, "+ New") {
+		t.Fatalf("expected trailing '+ New' button, got %q", got)
+	}
+
+	// Expect one tab hit, one close hit, and one plus hit.
+	var tabHits, closeHits, plusHits int
+	for _, h := range m.tabHits {
+		switch h.kind {
+		case terminalTabHitTab:
+			tabHits++
+		case terminalTabHitClose:
+			closeHits++
+		case terminalTabHitPlus:
+			plusHits++
+		}
+	}
+	if tabHits != 1 {
+		t.Fatalf("expected 1 tab hit, got %d", tabHits)
+	}
+	if closeHits != 1 {
+		t.Fatalf("expected 1 close hit, got %d", closeHits)
+	}
+	if plusHits != 1 {
+		t.Fatalf("expected 1 plus hit, got %d", plusHits)
+	}
+}
+
+func TestRenderTabBarMultipleTabsHitLayout(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m,
+		newWorkspaceTab(t, "Terminal 1"),
+		newWorkspaceTab(t, "Terminal 2"),
+		newWorkspaceTab(t, "Terminal 3"),
+	)
+	m.setActiveTabIdx(1)
+
+	got := m.renderTabBar()
+	for _, name := range []string{"Terminal 1", "Terminal 2", "Terminal 3"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("expected %q in tab bar, got %q", name, got)
+		}
+	}
+
+	// Collect tab hits in order; their X origins must be strictly increasing
+	// because each rendered tab is laid out left-to-right.
+	var tabXs []int
+	var plus int
+	for _, h := range m.tabHits {
+		switch h.kind {
+		case terminalTabHitTab:
+			tabXs = append(tabXs, h.region.X)
+		case terminalTabHitPlus:
+			plus++
+		}
+	}
+	if len(tabXs) != 3 {
+		t.Fatalf("expected 3 tab hits, got %d", len(tabXs))
+	}
+	for i := 1; i < len(tabXs); i++ {
+		if tabXs[i] <= tabXs[i-1] {
+			t.Fatalf("tab hit X origins not increasing: %v", tabXs)
+		}
+	}
+	if plus != 1 {
+		t.Fatalf("expected exactly 1 plus hit, got %d", plus)
+	}
+}
+
+func TestRenderTabBarFallbackNameForEmptyName(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	// Empty Name triggers the "Terminal %d" fallback (1-indexed).
+	seedTabs(t, m, newWorkspaceTab(t, ""))
+
+	got := m.renderTabBar()
+	if !strings.Contains(got, "Terminal 1") {
+		t.Fatalf("expected fallback name 'Terminal 1' for empty tab name, got %q", got)
+	}
+}
+
+func TestRenderTabBarResetsHitsBetweenCalls(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	m.renderTabBar()
+	firstCount := len(m.tabHits)
+	if firstCount == 0 {
+		t.Fatal("expected hit regions after first render")
+	}
+	// A second render must not accumulate stale regions.
+	m.renderTabBar()
+	if len(m.tabHits) != firstCount {
+		t.Fatalf("expected hit count to reset to %d on re-render, got %d", firstCount, len(m.tabHits))
+	}
+}
+
+func TestTerminalTabBarViewMatchesRenderTabBar(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	// TabBarView is a thin wrapper around renderTabBar; both should agree.
+	if got, want := m.TabBarView(), m.renderTabBar(); got != want {
+		t.Fatalf("TabBarView() = %q, want %q", got, want)
+	}
+}
+
+func TestTerminalLayerNilWhenNoTerminal(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	// No tabs -> getTerminal() is nil.
+	if layer := m.TerminalLayer(); layer != nil {
+		t.Fatalf("expected nil layer with no terminal, got %+v", layer)
+	}
+}
+
+func TestTerminalLayerNilWhenNilVTerm(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, &TerminalTab{ID: generateTerminalTabID(), Name: "T", State: &TerminalState{}})
+	if layer := m.TerminalLayer(); layer != nil {
+		t.Fatalf("expected nil layer with nil VTerm, got %+v", layer)
+	}
+}
+
+func TestTerminalLayerReturnsSnapshot(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	layer := m.TerminalLayer()
+	if layer == nil {
+		t.Fatal("expected non-nil layer for live VTerm")
+	}
+	if layer.Snap == nil {
+		t.Fatal("expected snapshot in returned layer")
+	}
+	// newWorkspaceTab uses vterm.New(10, 3).
+	if layer.Snap.Width != 10 || layer.Snap.Height != 3 {
+		t.Fatalf("snapshot size = %dx%d, want 10x3", layer.Snap.Width, layer.Snap.Height)
+	}
+}
+
+func TestTerminalLayerCursorVisibilityFollowsFocus(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	// Unfocused: cursor hidden in the snapshot.
+	unfocused := m.TerminalLayer()
+	if unfocused == nil || unfocused.Snap == nil {
+		t.Fatal("expected snapshot while unfocused")
+	}
+	if unfocused.Snap.ShowCursor {
+		t.Fatal("expected cursor hidden when model is unfocused")
+	}
+
+	// Focused: cursor shown.
+	m.Focus()
+	focused := m.TerminalLayer()
+	if focused == nil || focused.Snap == nil {
+		t.Fatal("expected snapshot while focused")
+	}
+	if !focused.Snap.ShowCursor {
+		t.Fatal("expected cursor shown when model is focused")
+	}
+}
+
+func TestTerminalLayerWithCursorOwnerFalseHidesCursor(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.Focus() // focused, but cursor ownership is denied below
+
+	layer := m.TerminalLayerWithCursorOwner(false)
+	if layer == nil || layer.Snap == nil {
+		t.Fatal("expected snapshot even when not cursor owner")
+	}
+	if layer.Snap.ShowCursor {
+		t.Fatal("expected cursor hidden when this pane does not own the cursor")
+	}
+}
+
+func TestTerminalLayerUsesCache(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+
+	first := m.TerminalLayer()
+	if first == nil {
+		t.Fatal("expected first layer")
+	}
+	ts := m.getTerminal()
+	ts.mu.Lock()
+	cached := ts.CachedSnap
+	ts.mu.Unlock()
+	if cached == nil {
+		t.Fatal("expected snapshot to be cached after first call")
+	}
+
+	// Second call at the same version/focus must reuse the cached snapshot.
+	second := m.TerminalLayer()
+	if second == nil {
+		t.Fatal("expected second layer")
+	}
+	if second.Snap != cached {
+		t.Fatal("expected cached snapshot to be reused on second call")
+	}
+}

--- a/internal/ui/sidebar/terminal_render_view_test.go
+++ b/internal/ui/sidebar/terminal_render_view_test.go
@@ -1,0 +1,309 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for StatusLine, HelpLines, View, TerminalOrigin and TerminalSize live
+// here (split from terminal_render_test.go to respect the 500-line file cap).
+// Shared helpers (newTerminalModelWithWorkspace, scrolledVTerm) and the tab-bar
+// and layer tests live in terminal_render_test.go in this same package.
+
+func TestStatusLineNoTerminal(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	if got := m.StatusLine(); got != "" {
+		t.Fatalf("expected empty status line with no terminal, got %q", got)
+	}
+}
+
+func TestStatusLineNilVTerm(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, &TerminalTab{ID: generateTerminalTabID(), Name: "T", State: &TerminalState{Running: true}})
+	if got := m.StatusLine(); got != "" {
+		t.Fatalf("expected empty status line with nil VTerm, got %q", got)
+	}
+}
+
+func TestStatusLineRunningHasNoStatus(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Running = true
+	seedTabs(t, m, tab)
+	if got := m.StatusLine(); got != "" {
+		t.Fatalf("expected empty status line for a running, non-scrolled terminal, got %q", got)
+	}
+}
+
+func TestStatusLineScrolled(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Running = true
+	tab.State.VTerm = scrolledVTerm(t)
+	seedTabs(t, m, tab)
+
+	got := m.StatusLine()
+	if !strings.Contains(got, "SCROLL:") {
+		t.Fatalf("expected SCROLL status when scrolled, got %q", got)
+	}
+	if !strings.Contains(got, "lines up") {
+		t.Fatalf("expected scroll position in status, got %q", got)
+	}
+}
+
+func TestStatusLineDetached(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Detached = true
+	tab.State.Running = true
+	seedTabs(t, m, tab)
+
+	if got := m.StatusLine(); !strings.Contains(got, "DETACHED") {
+		t.Fatalf("expected DETACHED status, got %q", got)
+	}
+}
+
+func TestStatusLineStopped(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Running = false
+	tab.State.Detached = false
+	seedTabs(t, m, tab)
+
+	if got := m.StatusLine(); !strings.Contains(got, "STOPPED") {
+		t.Fatalf("expected STOPPED status, got %q", got)
+	}
+}
+
+func TestStatusLineScrolledTakesPrecedenceOverDetached(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Detached = true
+	tab.State.VTerm = scrolledVTerm(t)
+	seedTabs(t, m, tab)
+
+	// Scroll state is checked before Detached, so SCROLL must win.
+	got := m.StatusLine()
+	if !strings.Contains(got, "SCROLL:") {
+		t.Fatalf("expected SCROLL to take precedence over DETACHED, got %q", got)
+	}
+	if strings.Contains(got, "DETACHED") {
+		t.Fatalf("did not expect DETACHED in scrolled status, got %q", got)
+	}
+}
+
+func TestHelpLinesHiddenWhenHintsOff(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	m.height = 40
+	// showKeymapHints defaults to false.
+	if lines := m.HelpLines(80); lines != nil {
+		t.Fatalf("expected nil help lines when hints disabled, got %v", lines)
+	}
+}
+
+func TestHelpLinesShownWhenHintsOn(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.height = 40
+	m.showKeymapHints = true
+
+	lines := m.HelpLines(80)
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty help lines when hints enabled")
+	}
+	joined := strings.Join(lines, " ")
+	if !strings.Contains(joined, "new term") {
+		t.Fatalf("expected 'new term' hint, got %q", joined)
+	}
+}
+
+func TestHelpLinesClampedToHeight(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.showKeymapHints = true
+	// Tiny width forces many wrapped help lines; tiny height clamps the count.
+	m.height = 3 // maxHelpHeight = height - tabBarHeight - statusLineReserve = 1
+	lines := m.HelpLines(1)
+	maxHelpHeight := m.height - tabBarHeight - statusLineReserve
+	if len(lines) > maxHelpHeight {
+		t.Fatalf("expected help lines clamped to %d, got %d", maxHelpHeight, len(lines))
+	}
+}
+
+func TestHelpLinesNegativeWidthIsClamped(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.showKeymapHints = true
+	m.height = 40
+	// width < 1 is clamped to 1 internally; must not panic and must return lines.
+	lines := m.HelpLines(-5)
+	if len(lines) == 0 {
+		t.Fatal("expected help lines even with negative width")
+	}
+}
+
+func TestHelpLinesIncludeMultiTabHints(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m,
+		newWorkspaceTab(t, "Terminal 1"),
+		newWorkspaceTab(t, "Terminal 2"),
+	)
+	m.showKeymapHints = true
+	m.height = 40
+
+	joined := strings.Join(m.HelpLines(200), " ")
+	for _, want := range []string{"next", "prev", "close"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected multi-tab hint %q, got %q", want, joined)
+		}
+	}
+}
+
+func TestHelpLinesSingleTabOmitsMultiTabHints(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.showKeymapHints = true
+	m.height = 40
+
+	joined := strings.Join(m.HelpLines(200), " ")
+	if strings.Contains(joined, ":next") {
+		t.Fatalf("did not expect 'next' multi-tab hint with a single tab, got %q", joined)
+	}
+}
+
+func TestTerminalOrigin(t *testing.T) {
+	tests := []struct {
+		name             string
+		offsetX, offsetY int
+		wantX, wantY     int
+	}{
+		{name: "zero origin offsets by tab bar", offsetX: 0, offsetY: 0, wantX: 0, wantY: 1},
+		{name: "non-zero origin", offsetX: 4, offsetY: 7, wantX: 4, wantY: 8},
+		{name: "negative offsets preserved", offsetX: -2, offsetY: -3, wantX: -2, wantY: -2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewTerminalModel()
+			m.offsetX = tt.offsetX
+			m.offsetY = tt.offsetY
+			gotX, gotY := m.TerminalOrigin()
+			if gotX != tt.wantX || gotY != tt.wantY {
+				t.Fatalf("TerminalOrigin() = (%d,%d), want (%d,%d)", gotX, gotY, tt.wantX, tt.wantY)
+			}
+		})
+	}
+}
+
+func TestTerminalSize(t *testing.T) {
+	tests := []struct {
+		name             string
+		width, height    int
+		hints            bool
+		wantW            int
+		wantHeightAtMost int
+	}{
+		// height - tabBarHeight(1) - statusLineReserve(1) - len(helpLines)
+		{name: "typical size", width: 80, height: 30, hints: false, wantW: 80, wantHeightAtMost: 28},
+		{name: "width clamped to 1", width: 0, height: 30, hints: false, wantW: 1, wantHeightAtMost: 28},
+		{name: "height floored to 1", width: 80, height: 1, hints: false, wantW: 80, wantHeightAtMost: 1},
+		{name: "negative height floored to 1", width: 80, height: -10, hints: false, wantW: 80, wantHeightAtMost: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewTerminalModel()
+			m.showKeymapHints = tt.hints
+			m.width = tt.width
+			m.height = tt.height
+			w, h := m.TerminalSize()
+			if w != tt.wantW {
+				t.Fatalf("TerminalSize() width = %d, want %d", w, tt.wantW)
+			}
+			if h < 1 {
+				t.Fatalf("TerminalSize() height = %d, want >= 1", h)
+			}
+			if h > tt.wantHeightAtMost {
+				t.Fatalf("TerminalSize() height = %d, want <= %d", h, tt.wantHeightAtMost)
+			}
+		})
+	}
+}
+
+func TestViewNoWorkspaceShowsNoTerminal(t *testing.T) {
+	m := NewTerminalModel() // nil workspace
+	m.width = 40
+	m.height = 10
+	out := m.View()
+	if !strings.Contains(out, "No terminal") {
+		t.Fatalf("expected 'No terminal' in view with no workspace, got %q", out)
+	}
+}
+
+func TestViewWorkspaceNoTabsShowsNewButton(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	m.width = 40
+	m.height = 10
+	out := m.View()
+	if !strings.Contains(out, "+ New") {
+		t.Fatalf("expected '+ New' button in view for empty workspace, got %q", out)
+	}
+}
+
+func TestViewRendersTabAndTerminal(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Running = true
+	seedTabs(t, m, tab)
+	m.width = 40
+	m.height = 10
+
+	out := m.View()
+	if !strings.Contains(out, "Terminal 1") {
+		t.Fatalf("expected tab name in view, got %q", out)
+	}
+	// View must never exceed m.height lines.
+	if got := len(strings.Split(out, "\n")); got > m.height {
+		t.Fatalf("view produced %d lines, exceeds height %d", got, m.height)
+	}
+}
+
+func TestViewRespectsHeightCap(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.width = 20
+	m.height = 5
+
+	out := m.View()
+	lines := strings.Split(out, "\n")
+	if len(lines) > m.height {
+		t.Fatalf("expected at most %d lines, got %d", m.height, len(lines))
+	}
+}
+
+func TestViewShowsScrollIndicator(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	tab := newWorkspaceTab(t, "Terminal 1")
+	tab.State.Running = true
+	tab.State.VTerm = scrolledVTerm(t)
+	seedTabs(t, m, tab)
+	m.width = 80
+	m.height = 30
+
+	out := m.View()
+	if !strings.Contains(out, "SCROLL:") {
+		t.Fatalf("expected SCROLL indicator in scrolled view, got %q", out)
+	}
+}
+
+func TestViewZeroHeightDoesNotPanic(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	seedTabs(t, m, newWorkspaceTab(t, "Terminal 1"))
+	m.width = 10
+	m.height = 0
+
+	out := m.View()
+	// With height 0 the cap loop is skipped; assert it still returns a string
+	// containing the tab bar rather than panicking.
+	if !strings.Contains(out, "Terminal 1") {
+		t.Fatalf("expected tab name even at zero height, got %q", out)
+	}
+}


### PR DESCRIPTION
Adds thorough table-driven unit tests for the previously untested rendering functions in `internal/ui/sidebar/terminal_render.go`: renderTabBar, TabBarView, TerminalLayer (+WithCursorOwner), StatusLine, HelpLines, View, TerminalOrigin, TerminalSize, and formatScrollPos.

What+why: these rendering helpers had no direct coverage; the tests assert real return values and behavior (tab-bar hit regions, cursor visibility in snapshots, SCROLL/DETACHED/STOPPED status precedence, help-line visibility and height clamping, view height cap, origin/size math, scroll-position formatting). Tests rely only on the package's existing in-memory VTerm fixtures (newWorkspaceTab/seedTabs) plus a small scrolledVTerm helper, so none exec tmux/git or require a live Bubble Tea program — no target function was skipped. No production code changed. Split across two test files to respect the 500-line file cap.

Part of the quality stacked diff. Stacked on improve/075-test-sidebar-project-tree. Ticket 076 (testability).