### PR TITLE
test: cover center/model_tabs_actions.go (center)

### DIFF
--- a/internal/ui/center/model_tabs_actions_terminal_test.go
+++ b/internal/ui/center/model_tabs_actions_terminal_test.go
@@ -1,0 +1,221 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// ----- SendToTerminal -----
+
+func TestSendToTerminal_EmptyListIsNoOp(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	m.SendToTerminal("hello") // must not panic with no tabs
+}
+
+func TestSendToTerminal_OutOfRangeActiveIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, wsID := newActionsModel(t, tab)
+	m.tabs.ActiveByWorkspace[wsID] = 9
+
+	m.SendToTerminal("hello") // out-of-range active index, no panic
+}
+
+func TestSendToTerminal_ClosedTabIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	tab.markClosed()
+	m, _, _ := newActionsModel(t, tab)
+
+	m.SendToTerminal("hello") // closed tab, no panic
+}
+
+func TestSendToTerminal_NilAgentIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0") // Agent stays nil
+	m, _, _ := newActionsModel(t, tab)
+
+	m.SendToTerminal("hello")
+	if tab.Detached {
+		t.Fatalf("nil agent should not mark the tab detached")
+	}
+}
+
+func TestSendToTerminal_WritesToLiveTerminal(t *testing.T) {
+	dir := t.TempDir()
+	term, err := appPty.NewWithSize("cat >/dev/null", dir, nil, 24, 80)
+	if err != nil {
+		t.Fatalf("expected test PTY terminal: %v", err)
+	}
+	defer func() { _ = term.Close() }()
+
+	ws := newTestWorkspace("ws", dir)
+	tab := chatTab(ws, "tab-0")
+	tab.Agent = &appPty.Agent{Terminal: term}
+	m, _, _ := newActionsModel(t, tab)
+
+	m.SendToTerminal("hello")
+	if tab.Detached {
+		t.Fatalf("successful send should not detach the tab")
+	}
+}
+
+func TestSendToTerminal_FailureMarksDetached(t *testing.T) {
+	dir := t.TempDir()
+	term, err := appPty.NewWithSize("cat >/dev/null", dir, nil, 24, 80)
+	if err != nil {
+		t.Fatalf("expected test PTY terminal: %v", err)
+	}
+	// Close the terminal so SendString fails with io.ErrClosedPipe, exercising
+	// the detach-on-error branch.
+	_ = term.Close()
+
+	ws := newTestWorkspace("ws", dir)
+	tab := chatTab(ws, "tab-0")
+	tab.Agent = &appPty.Agent{Terminal: term}
+	m, _, _ := newActionsModel(t, tab)
+
+	m.SendToTerminal("hello")
+
+	tab.mu.Lock()
+	detached := tab.Detached
+	running := tab.Running
+	tab.mu.Unlock()
+	if !detached {
+		t.Fatalf("send failure should mark the tab detached")
+	}
+	if running {
+		t.Fatalf("send failure should clear the running flag")
+	}
+}
+
+// ----- ScrollActiveTerminalPage -----
+
+func TestScrollActiveTerminalPage_ZeroDirectionIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, _ := newActionsModel(t, tab)
+
+	m.ScrollActiveTerminalPage(0) // must not panic and must do nothing
+}
+
+func TestScrollActiveTerminalPage_EmptyListIsNoOp(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	m.ScrollActiveTerminalPage(1)
+}
+
+func TestScrollActiveTerminalPage_OutOfRangeActiveIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, wsID := newActionsModel(t, tab)
+	m.tabs.ActiveByWorkspace[wsID] = 7
+
+	m.ScrollActiveTerminalPage(1)
+}
+
+func TestScrollActiveTerminalPage_NilTerminalIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0") // no Terminal allocated
+	m, _, _ := newActionsModel(t, tab)
+
+	// Active tab has no terminal viewport; scroll should be a safe no-op.
+	m.ScrollActiveTerminalPage(1)
+	m.ScrollActiveTerminalPage(-1)
+}
+
+// ----- GetTabsInfo -----
+
+func TestGetTabsInfo_MapsStatusAndActiveIndex(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	running := &Tab{
+		ID: "t-run", Name: "run", Assistant: "claude", Workspace: ws,
+		Running: true, SessionName: "amux-run",
+	}
+	detached := &Tab{
+		ID: "t-det", Name: "det", Assistant: "codex", Workspace: ws,
+		Running: true, Detached: true, SessionName: "amux-det",
+	}
+	stopped := &Tab{
+		ID: "t-stop", Name: "stop", Assistant: "claude", Workspace: ws,
+	}
+	m, _, wsID := newActionsModel(t, running, detached, stopped)
+	m.tabs.ActiveByWorkspace[wsID] = 2
+
+	infos, active := m.GetTabsInfo()
+	if active != 2 {
+		t.Fatalf("active index = %d, want 2", active)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("expected 3 tab infos, got %d", len(infos))
+	}
+
+	want := []data.TabInfo{
+		{Assistant: "claude", Name: "run", SessionName: "amux-run", Status: "running"},
+		{Assistant: "codex", Name: "det", SessionName: "amux-det", Status: "detached"},
+		{Assistant: "claude", Name: "stop", SessionName: "", Status: "stopped"},
+	}
+	for i, w := range want {
+		got := infos[i]
+		if got.Assistant != w.Assistant || got.Name != w.Name ||
+			got.SessionName != w.SessionName || got.Status != w.Status {
+			t.Fatalf("info[%d] = %+v, want %+v", i, got, w)
+		}
+	}
+}
+
+func TestGetTabsInfo_DetachedTakesPrecedenceOverRunning(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{
+		ID: "t", Name: "n", Assistant: "claude", Workspace: ws,
+		Running: true, Detached: true,
+	}
+	m, _, _ := newActionsModel(t, tab)
+
+	infos, _ := m.GetTabsInfo()
+	if infos[0].Status != "detached" {
+		t.Fatalf("detached must win over running, got %q", infos[0].Status)
+	}
+}
+
+func TestGetTabsInfo_FallsBackToAgentSession(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{
+		ID: "t", Name: "n", Assistant: "claude", Workspace: ws,
+		Running: true,
+		Agent:   &appPty.Agent{Session: "agent-session"},
+	}
+	m, _, _ := newActionsModel(t, tab)
+
+	infos, _ := m.GetTabsInfo()
+	if infos[0].SessionName != "agent-session" {
+		t.Fatalf("expected session fallback to agent session, got %q", infos[0].SessionName)
+	}
+}
+
+func TestGetTabsInfo_SkipsNilTabs(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "t")
+	m, _, wsID := newActionsModel(t, nil, tab, nil)
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	infos, active := m.GetTabsInfo()
+	if len(infos) != 1 {
+		t.Fatalf("expected nil tabs to be skipped, got %d infos", len(infos))
+	}
+	if active != 1 {
+		t.Fatalf("active index should be preserved, got %d", active)
+	}
+}
+
+func TestGetTabsInfo_EmptyReturnsNilSlice(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	infos, active := m.GetTabsInfo()
+	if len(infos) != 0 {
+		t.Fatalf("expected no tab infos, got %d", len(infos))
+	}
+	if active != 0 {
+		t.Fatalf("expected active index 0, got %d", active)
+	}
+}

--- a/internal/ui/center/model_tabs_actions_test.go
+++ b/internal/ui/center/model_tabs_actions_test.go
@@ -1,0 +1,394 @@
+package center
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// newActionsModel wires a model to an active workspace with the supplied tabs so
+// the workspace-scoped helpers (getTabs/getActiveTabIdx/...) resolve correctly.
+// workspaceID() returns "" until m.workspace is set, which would silently route
+// every lookup to the empty-string bucket, so always go through this helper.
+func newActionsModel(t *testing.T, tabs ...*Tab) (*Model, *data.Workspace, string) {
+	t.Helper()
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	m.tabs.ByWorkspace[wsID] = tabs
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+	return m, ws, wsID
+}
+
+func chatTab(ws *data.Workspace, id string) *Tab {
+	return &Tab{
+		ID:        TabID(id),
+		Name:      id,
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+	}
+}
+
+// drainBatch runs a (possibly batched) command and returns every concrete
+// message it produces, flattening one level of tea.BatchMsg.
+func drainBatch(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, sub := range batch {
+			if sub == nil {
+				continue
+			}
+			out = append(out, sub())
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+// ----- closeCurrentTab / closeTabAt -----
+
+func TestCloseTabAt_OutOfRangeIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, wsID := newActionsModel(t, tab)
+
+	for _, idx := range []int{-1, 1, 99} {
+		if cmd := m.closeTabAt(idx); cmd != nil {
+			t.Fatalf("closeTabAt(%d) on single tab expected nil cmd, got non-nil", idx)
+		}
+	}
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 1 {
+		t.Fatalf("expected tab list untouched, got %d tabs", got)
+	}
+	if tab.isClosed() {
+		t.Fatalf("expected out-of-range close to leave tab open")
+	}
+}
+
+func TestCloseTabAt_EmptyListIsNoOp(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	if cmd := m.closeTabAt(0); cmd != nil {
+		t.Fatalf("closeTabAt on empty list expected nil cmd")
+	}
+}
+
+func TestCloseTabAt_RemovesTabAndReportsIndex(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	first := chatTab(ws, "tab-0")
+	second := chatTab(ws, "tab-1")
+	m, _, wsID := newActionsModel(t, first, second)
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	cmd := m.closeTabAt(0)
+	if cmd == nil {
+		t.Fatalf("expected close cmd")
+	}
+
+	remaining := m.tabs.ByWorkspace[wsID]
+	if len(remaining) != 1 || remaining[0].ID != "tab-1" {
+		t.Fatalf("expected only tab-1 to remain, got %+v", remaining)
+	}
+	if !first.isClosed() {
+		t.Fatalf("expected closed tab to be marked closed")
+	}
+	// Removing a tab before the active index shifts the active index left.
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 0 {
+		t.Fatalf("active index should shift to 0 after removing index 0, got %d", got)
+	}
+
+	msgs := drainBatch(cmd)
+	var gotClosed bool
+	for _, msg := range msgs {
+		if closed, ok := msg.(messages.TabClosed); ok {
+			gotClosed = true
+			if closed.Index != 0 {
+				t.Fatalf("TabClosed.Index = %d, want 0", closed.Index)
+			}
+		}
+	}
+	if !gotClosed {
+		t.Fatalf("expected messages.TabClosed in command output")
+	}
+}
+
+func TestCloseTabAt_ClosingActiveLastTabClampsIndex(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	first := chatTab(ws, "tab-0")
+	second := chatTab(ws, "tab-1")
+	m, _, wsID := newActionsModel(t, first, second)
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	if cmd := m.closeTabAt(1); cmd == nil {
+		t.Fatalf("expected close cmd")
+	}
+	// Active was the last tab; closing it should clamp the active index down.
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 0 {
+		t.Fatalf("active index should clamp to 0, got %d", got)
+	}
+	if len(m.tabs.ByWorkspace[wsID]) != 1 {
+		t.Fatalf("expected one remaining tab")
+	}
+}
+
+func TestCloseTabAt_BatchesKillWhenSessionPresent(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	tab.SessionName = "amux-some-session"
+	m, _, _ := newActionsModel(t, tab)
+
+	cmd := m.closeTabAt(0)
+	if cmd == nil {
+		t.Fatalf("expected close cmd")
+	}
+	// With a session name the result is a Batch (close notification + async kill).
+	if _, ok := cmd().(tea.BatchMsg); !ok {
+		t.Fatalf("expected tea.BatchMsg when a tmux session must be killed")
+	}
+}
+
+func TestCloseCurrentTab_DelegatesToActiveIndex(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	first := chatTab(ws, "tab-0")
+	second := chatTab(ws, "tab-1")
+	m, _, wsID := newActionsModel(t, first, second)
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	cmd := m.closeCurrentTab()
+	if cmd == nil {
+		t.Fatalf("expected close cmd for active tab")
+	}
+	remaining := m.tabs.ByWorkspace[wsID]
+	if len(remaining) != 1 || remaining[0].ID != "tab-0" {
+		t.Fatalf("expected active tab-1 to be closed, got %+v", remaining)
+	}
+}
+
+func TestCloseCurrentTab_EmptyListIsNoOp(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	if cmd := m.closeCurrentTab(); cmd != nil {
+		t.Fatalf("closeCurrentTab on empty list expected nil cmd")
+	}
+}
+
+func TestCloseCurrentTab_OutOfRangeActiveIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, wsID := newActionsModel(t, tab)
+	m.tabs.ActiveByWorkspace[wsID] = 5 // beyond range
+
+	if cmd := m.closeCurrentTab(); cmd != nil {
+		t.Fatalf("closeCurrentTab with out-of-range active index expected nil cmd")
+	}
+	if len(m.tabs.ByWorkspace[wsID]) != 1 {
+		t.Fatalf("expected tab list untouched")
+	}
+}
+
+// CloseActiveTab is a thin public wrapper over closeCurrentTab.
+func TestCloseActiveTab_PublicWrapper(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	m, _, wsID := newActionsModel(t, tab)
+
+	if cmd := m.CloseActiveTab(); cmd == nil {
+		t.Fatalf("expected CloseActiveTab cmd")
+	}
+	if len(m.tabs.ByWorkspace[wsID]) != 0 {
+		t.Fatalf("expected the only tab to be removed")
+	}
+}
+
+// ----- nextTab / prevTab / NextTab / PrevTab -----
+
+func TestNextPrevTab_CycleCircularly(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t,
+		chatTab(ws, "a"), chatTab(ws, "b"), chatTab(ws, "c"))
+
+	m.nextTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 1 {
+		t.Fatalf("nextTab from 0 -> %d, want 1", got)
+	}
+	m.nextTab()
+	m.nextTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 0 {
+		t.Fatalf("nextTab should wrap to 0, got %d", got)
+	}
+	m.prevTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 2 {
+		t.Fatalf("prevTab from 0 should wrap to 2, got %d", got)
+	}
+}
+
+func TestNextPrevTab_EmptyListLeavesIndexUnchanged(t *testing.T) {
+	m, _, wsID := newActionsModel(t)
+	m.tabs.ActiveByWorkspace[wsID] = 0
+
+	m.nextTab()
+	m.prevTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 0 {
+		t.Fatalf("expected index to stay 0 with no tabs, got %d", got)
+	}
+}
+
+func TestNextTab_PublicWrapperMovesAndReturnsSelectionCmd(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t, chatTab(ws, "a"), chatTab(ws, "b"))
+
+	cmd := m.NextTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 1 {
+		t.Fatalf("NextTab should advance active index to 1, got %d", got)
+	}
+	assertSelectionChanged(t, cmd, wsID, 1)
+}
+
+func TestPrevTab_PublicWrapperMovesAndReturnsSelectionCmd(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t, chatTab(ws, "a"), chatTab(ws, "b"))
+
+	cmd := m.PrevTab()
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 1 {
+		t.Fatalf("PrevTab from 0 should wrap to 1, got %d", got)
+	}
+	assertSelectionChanged(t, cmd, wsID, 1)
+}
+
+// ----- SelectTab -----
+
+func TestSelectTab_ValidIndexSelectsAndEmitsCmd(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t, chatTab(ws, "a"), chatTab(ws, "b"), chatTab(ws, "c"))
+
+	cmd := m.SelectTab(2)
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 2 {
+		t.Fatalf("SelectTab(2) active index = %d, want 2", got)
+	}
+	assertSelectionChanged(t, cmd, wsID, 2)
+}
+
+func TestSelectTab_OutOfRangeIsNoOp(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t, chatTab(ws, "a"), chatTab(ws, "b"))
+
+	for _, idx := range []int{-1, 2, 50} {
+		if cmd := m.SelectTab(idx); cmd != nil {
+			t.Fatalf("SelectTab(%d) out of range expected nil cmd", idx)
+		}
+	}
+	if got := m.tabs.ActiveByWorkspace[wsID]; got != 0 {
+		t.Fatalf("expected active index unchanged at 0, got %d", got)
+	}
+}
+
+func TestSelectTab_EmptyListIsNoOp(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	if cmd := m.SelectTab(0); cmd != nil {
+		t.Fatalf("SelectTab on empty list expected nil cmd")
+	}
+}
+
+// ----- tabSelectionCommand -----
+
+func TestTabSelectionCommand_NilWhenNoWorkspace(t *testing.T) {
+	m := newTestModel() // no workspace set -> workspaceID() == ""
+	if cmd := m.tabSelectionCommand(); cmd != nil {
+		t.Fatalf("expected nil selection cmd without an active workspace")
+	}
+}
+
+func TestTabSelectionCommand_EmitsSelectionChanged(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m, _, wsID := newActionsModel(t, chatTab(ws, "a"), chatTab(ws, "b"))
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	assertSelectionChanged(t, m.tabSelectionCommand(), wsID, 1)
+}
+
+func assertSelectionChanged(t *testing.T, cmd tea.Cmd, wsID string, wantIdx int) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected non-nil selection cmd")
+	}
+	var found bool
+	for _, msg := range drainBatch(cmd) {
+		if sel, ok := msg.(messages.TabSelectionChanged); ok {
+			found = true
+			if sel.WorkspaceID != wsID || sel.ActiveIndex != wantIdx {
+				t.Fatalf("TabSelectionChanged = %+v, want ws=%q idx=%d", sel, wsID, wantIdx)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected messages.TabSelectionChanged in command output")
+	}
+}
+
+// ----- reattachActiveTabIfDetached / ReattachActiveTabIfDetached -----
+
+func TestReattachActiveTabIfDetached_NoTabsIsNil(t *testing.T) {
+	m, _, _ := newActionsModel(t)
+	if cmd := m.reattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil with no tabs")
+	}
+	if cmd := m.ReattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil from public wrapper with no tabs")
+	}
+}
+
+func TestReattachActiveTabIfDetached_NotDetachedIsNil(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0") // attached chat tab
+	m, _, _ := newActionsModel(t, tab)
+
+	if cmd := m.reattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil reattach cmd for attached tab")
+	}
+}
+
+func TestReattachActiveTabIfDetached_ClosedTabIsNil(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	tab.Detached = true
+	tab.markClosed()
+	m, _, _ := newActionsModel(t, tab)
+
+	if cmd := m.reattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil reattach cmd for closed tab")
+	}
+}
+
+func TestReattachActiveTabIfDetached_ReattachInFlightIsNil(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := chatTab(ws, "tab-0")
+	tab.Detached = true
+	tab.reattachInFlight = true
+	m, _, _ := newActionsModel(t, tab)
+
+	if cmd := m.reattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil reattach cmd while a reattach is already in flight")
+	}
+}
+
+func TestReattachActiveTabIfDetached_NonChatTabIsNil(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{
+		ID:        TabID("tab-0"),
+		Assistant: "vim", // not a registered chat assistant
+		Workspace: ws,
+		Detached:  true,
+	}
+	m, _, _ := newActionsModel(t, tab)
+
+	if cmd := m.reattachActiveTabIfDetached(); cmd != nil {
+		t.Fatalf("expected nil reattach cmd for a detached non-chat tab")
+	}
+}


### PR DESCRIPTION
Adds thorough table-driven unit tests for the previously-untested tab action helpers in internal/ui/center/model_tabs_actions.go: closeCurrentTab, closeTabAt, nextTab, prevTab, reattachActiveTabIfDetached, ReattachActiveTabIfDetached, tabSelectionCommand, NextTab, PrevTab, CloseActiveTab, SelectTab, SendToTerminal, ScrollActiveTerminalPage, GetTabsInfo.

Tests assert real behavior and return values: tab removal + active-index clamping, circular next/prev math, batched tmux-kill command emission when a session is present, TabSelectionChanged/TabClosed message payloads, reattach nil-guards (no-tabs/attached/closed/in-flight/non-chat), GetTabsInfo status mapping (running/detached/stopped, detached-wins, agent-session fallback, nil-tab skipping), and SendToTerminal success vs failure-detach paths exercised against a real PTY (cat) via appPty.NewWithSize (the package's existing pattern). No production code changed; split across two files to respect the 500-line-per-file cap.

Part of the quality stacked diff. Stacked on improve/087-test-sidebar-wheel. Ticket 088 (testability).