### PR TITLE
test: cover center/model_input_lifecycle.go (center)

### DIFF
--- a/internal/ui/center/model_input_lifecycle_handlers_misc_test.go
+++ b/internal/ui/center/model_input_lifecycle_handlers_misc_test.go
@@ -1,0 +1,253 @@
+package center
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// ---------------------------------------------------------------------------
+// updateOpenDiff
+// ---------------------------------------------------------------------------
+
+func TestUpdateOpenDiff_NilChangeIsNoOp(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+
+	got, cmd := m.updateOpenDiff(messages.OpenDiff{Change: nil, Workspace: ws})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected nil command for a nil diff change")
+	}
+	if got := len(m.tabs.ByWorkspace[string(ws.ID())]); got != 0 {
+		t.Fatalf("expected no diff tab created for nil change, got %d", got)
+	}
+}
+
+func TestUpdateOpenDiff_NilWorkspaceReturnsError(t *testing.T) {
+	m := newTestModel()
+
+	got, cmd := m.updateOpenDiff(messages.OpenDiff{
+		Change:    &git.Change{Path: "main.go", Kind: git.ChangeModified},
+		Mode:      git.DiffModeUnstaged,
+		Workspace: nil,
+	})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd == nil {
+		t.Fatal("expected an error command for a nil workspace")
+	}
+	errMsg, ok := cmd().(messages.Error)
+	if !ok {
+		t.Fatalf("expected messages.Error, got %T", cmd())
+	}
+	if errMsg.Context != "creating diff viewer" {
+		t.Fatalf("unexpected error context: %q", errMsg.Context)
+	}
+}
+
+func TestUpdateOpenDiff_CreatesDiffTab(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	m.SetWorkspace(ws)
+
+	// A brand-new diff path builds a diff.Model viewer in-process (no git CLI is
+	// invoked until the returned command runs, which we intentionally do not do).
+	got, cmd := m.updateOpenDiff(messages.OpenDiff{
+		Change:    &git.Change{Path: "pkg/foo.go", Kind: git.ChangeModified},
+		Mode:      git.DiffModeUnstaged,
+		Workspace: ws,
+	})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command for a freshly created diff tab")
+	}
+
+	tabs := m.tabs.ByWorkspace[wsID]
+	if len(tabs) != 1 {
+		t.Fatalf("expected exactly one diff tab created, got %d", len(tabs))
+	}
+	tab := tabs[0]
+	if tab.Assistant != "diff" {
+		t.Fatalf("expected diff assistant, got %q", tab.Assistant)
+	}
+	if tab.DiffViewer == nil {
+		t.Fatal("expected the created tab to carry a diff viewer")
+	}
+	if m.tabs.ActiveByWorkspace[wsID] != 0 {
+		t.Fatalf("expected the new diff tab to become active, got %d", m.tabs.ActiveByWorkspace[wsID])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateWorkspaceDeleted
+// ---------------------------------------------------------------------------
+
+func TestUpdateWorkspaceDeleted_NilWorkspaceIsNoOp(t *testing.T) {
+	m := newTestModel()
+	other := newTestWorkspace("keep", "/repo/keep")
+	otherID := string(other.ID())
+	m.tabs.ByWorkspace[otherID] = []*Tab{{ID: TabID("keep"), Workspace: other, Running: true}}
+
+	got, cmd := m.updateWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: nil})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected nil command for a nil workspace")
+	}
+	if got := len(m.tabs.ByWorkspace[otherID]); got != 1 {
+		t.Fatalf("expected unrelated workspace tabs untouched, got %d", got)
+	}
+}
+
+func TestUpdateWorkspaceDeleted_CleansUpTabs(t *testing.T) {
+	m := newTestModel()
+	target := newTestWorkspace("gone", "/repo/gone")
+	keep := newTestWorkspace("keep", "/repo/keep")
+	targetID := string(target.ID())
+	keepID := string(keep.ID())
+
+	doomed := &Tab{
+		ID:        TabID("doomed"),
+		Workspace: target,
+		Running:   true,
+		Terminal:  vterm.New(80, 24),
+	}
+	survivor := &Tab{ID: TabID("survivor"), Workspace: keep, Running: true}
+	m.tabs.ByWorkspace[targetID] = []*Tab{doomed}
+	m.tabs.ByWorkspace[keepID] = []*Tab{survivor}
+
+	got, cmd := m.updateWorkspaceDeleted(messages.WorkspaceDeleted{Workspace: target})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected nil command from workspace deletion")
+	}
+
+	if _, ok := m.tabs.ByWorkspace[targetID]; ok {
+		t.Fatal("expected deleted workspace to be removed from the tab set")
+	}
+	if got := len(m.tabs.ByWorkspace[keepID]); got != 1 {
+		t.Fatalf("expected the other workspace's tabs untouched, got %d", got)
+	}
+	// Cleanup tears down the tab: it is marked closed and its terminal released.
+	if !doomed.isClosed() {
+		t.Fatal("expected the deleted workspace's tab to be marked closed")
+	}
+	if doomed.Running {
+		t.Fatal("expected the deleted workspace's tab to stop running")
+	}
+	doomed.mu.Lock()
+	term := doomed.Terminal
+	doomed.mu.Unlock()
+	if term != nil {
+		t.Fatal("expected the deleted tab's terminal to be released")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateTabSelectionResult
+// ---------------------------------------------------------------------------
+
+func TestUpdateTabSelectionResult_EmptyClipboardIsNoOp(t *testing.T) {
+	m := newTestModel()
+
+	// An empty clipboard is a documented no-op in CopyToClipboardWithLog, so this
+	// path never shells out to pbcopy and is safe to assert in a unit test.
+	got, cmd := m.updateTabSelectionResult(tabSelectionResult{
+		workspaceID: "ws",
+		tabID:       TabID("tab"),
+		clipboard:   "",
+	})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected nil command from a selection result")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateSelectionTickRequest
+// ---------------------------------------------------------------------------
+
+func TestUpdateSelectionTickRequest_SchedulesScrollTick(t *testing.T) {
+	m := newTestModel()
+
+	got, cmd := m.updateSelectionTickRequest(selectionTickRequest{
+		workspaceID: "ws-7",
+		tabID:       TabID("tab-7"),
+		gen:         42,
+	})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd == nil {
+		t.Fatal("expected a tick command to be scheduled")
+	}
+
+	// Running the tick command yields the scroll tick carrying the same identity
+	// and generation so a stale tab/generation can be filtered downstream.
+	msg := cmd()
+	tick, ok := msg.(selectionScrollTick)
+	if !ok {
+		t.Fatalf("expected selectionScrollTick, got %T", msg)
+	}
+	if tick.WorkspaceID != "ws-7" {
+		t.Fatalf("expected workspace id carried through, got %q", tick.WorkspaceID)
+	}
+	if tick.TabID != TabID("tab-7") {
+		t.Fatalf("expected tab id carried through, got %q", tick.TabID)
+	}
+	if tick.Gen != 42 {
+		t.Fatalf("expected generation carried through, got %d", tick.Gen)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateTabDiffCmd
+// ---------------------------------------------------------------------------
+
+func TestUpdateTabDiffCmd_ForwardsInnerCommand(t *testing.T) {
+	m := newTestModel()
+	sentinel := messages.Toast{Message: "diff-forwarded", Level: messages.ToastInfo}
+
+	got, cmd := m.updateTabDiffCmd(tabDiffCmd{cmd: func() tea.Msg { return sentinel }})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd == nil {
+		t.Fatal("expected the wrapped command to be forwarded")
+	}
+	out, ok := cmd().(messages.Toast)
+	if !ok {
+		t.Fatalf("expected the forwarded command to produce the inner message, got %T", cmd())
+	}
+	if out.Message != "diff-forwarded" {
+		t.Fatalf("expected forwarded message payload, got %q", out.Message)
+	}
+}
+
+func TestUpdateTabDiffCmd_NilInnerCommandIsForwardedAsNil(t *testing.T) {
+	m := newTestModel()
+
+	got, cmd := m.updateTabDiffCmd(tabDiffCmd{cmd: nil})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected a nil inner command to forward as nil")
+	}
+}

--- a/internal/ui/center/model_input_lifecycle_handlers_test.go
+++ b/internal/ui/center/model_input_lifecycle_handlers_test.go
@@ -1,0 +1,268 @@
+package center
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// findMsg returns the first message of type T in msgs, reporting whether one was
+// found. It keeps the batch assertions below focused on the payload that matters
+// rather than the (unspecified) ordering of the batched commands.
+func findMsg[T any](msgs []tea.Msg) (T, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(T); ok {
+			return typed, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+// ---------------------------------------------------------------------------
+// updateLaunchAgent
+// ---------------------------------------------------------------------------
+
+func TestUpdateLaunchAgent_NilWorkspaceReturnsError(t *testing.T) {
+	m := newTestModel()
+
+	got, cmd := m.updateLaunchAgent(messages.LaunchAgent{Assistant: "claude", Workspace: nil})
+	if got != m {
+		t.Fatal("expected the same model pointer to be returned")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command even when workspace is nil")
+	}
+	// createAgentTab with a nil workspace yields a pure error message (no tmux),
+	// so running the command here does not touch any external process.
+	errMsg, ok := cmd().(messages.Error)
+	if !ok {
+		t.Fatalf("expected messages.Error for nil workspace, got %T", cmd())
+	}
+	if errMsg.Context != "creating agent" {
+		t.Fatalf("unexpected error context: %q", errMsg.Context)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateOpenFileInVim
+// ---------------------------------------------------------------------------
+
+func TestUpdateOpenFileInVim_NilWorkspaceReturnsError(t *testing.T) {
+	m := newTestModel()
+
+	got, cmd := m.updateOpenFileInVim(messages.OpenFileInVim{Path: "main.go", Workspace: nil})
+	if got != m {
+		t.Fatal("expected the same model pointer to be returned")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command even when workspace is nil")
+	}
+	// createVimTab with a nil workspace yields a pure error message (no tmux).
+	errMsg, ok := cmd().(messages.Error)
+	if !ok {
+		t.Fatalf("expected messages.Error for nil workspace, got %T", cmd())
+	}
+	if errMsg.Context != "creating vim viewer" {
+		t.Fatalf("unexpected error context: %q", errMsg.Context)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updatePtyTabCreateResult
+// ---------------------------------------------------------------------------
+
+func TestUpdatePtyTabCreateResult_InvalidInputsReturnError(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	agent := &appPty.Agent{Session: "amux-sess"}
+
+	cases := []struct {
+		name string
+		msg  ptyTabCreateResult
+	}{
+		{
+			name: "nil workspace",
+			msg:  ptyTabCreateResult{Workspace: nil, Agent: agent, TabID: TabID("tab-1")},
+		},
+		{
+			name: "nil agent",
+			msg:  ptyTabCreateResult{Workspace: ws, Agent: nil, TabID: TabID("tab-1")},
+		},
+		{
+			name: "missing tab id",
+			msg:  ptyTabCreateResult{Workspace: ws, Agent: agent, TabID: TabID("")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel()
+			got, cmd := m.updatePtyTabCreateResult(tc.msg)
+			if got != m {
+				t.Fatal("expected the same model pointer to be returned")
+			}
+			if cmd == nil {
+				t.Fatal("expected an error command for invalid create result")
+			}
+			if _, ok := cmd().(messages.Error); !ok {
+				t.Fatalf("expected messages.Error, got %T", cmd())
+			}
+			// No tab should have been registered on a rejected create result.
+			if got := len(m.tabs.ByWorkspace[string(ws.ID())]); got != 0 {
+				t.Fatalf("expected no tabs created on rejection, got %d", got)
+			}
+		})
+	}
+}
+
+func TestUpdatePtyTabCreateResult_CreatesNewTab(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	// An Agent with a nil Terminal exercises the create path without a live PTY
+	// (mirrors model_tabs_identity_test.go), so resizePTY/response-writer are
+	// skipped while the tab is still registered and activated.
+	got, cmd := m.updatePtyTabCreateResult(ptyTabCreateResult{
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "amux-create-sess"},
+		TabID:     TabID("tab-created"),
+		Rows:      24,
+		Cols:      80,
+		Activate:  true,
+	})
+	if got != m {
+		t.Fatal("expected the same model pointer to be returned")
+	}
+
+	tabs := m.tabs.ByWorkspace[wsID]
+	if len(tabs) != 1 {
+		t.Fatalf("expected exactly one tab created, got %d", len(tabs))
+	}
+	tab := tabs[0]
+	if tab.ID != TabID("tab-created") {
+		t.Fatalf("expected new tab id preserved, got %q", tab.ID)
+	}
+	if tab.Assistant != "codex" {
+		t.Fatalf("expected assistant codex, got %q", tab.Assistant)
+	}
+	if tab.SessionName != "amux-create-sess" {
+		t.Fatalf("expected session name carried onto tab, got %q", tab.SessionName)
+	}
+	if !tab.Running {
+		t.Fatal("expected freshly created tab to be Running")
+	}
+	if m.tabs.ActiveByWorkspace[wsID] != 0 {
+		t.Fatalf("expected new tab to become active, got index %d", m.tabs.ActiveByWorkspace[wsID])
+	}
+
+	// The handler reports the new tab via messages.TabCreated.
+	created, ok := cmd().(messages.TabCreated)
+	if !ok {
+		t.Fatalf("expected messages.TabCreated, got %T", cmd())
+	}
+	if created.Index != 0 {
+		t.Fatalf("expected TabCreated index 0, got %d", created.Index)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updatePtyTabReattachFailed
+// ---------------------------------------------------------------------------
+
+func TestUpdatePtyTabReattachFailed_UnknownTabIsNoOp(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	m.tabs.ByWorkspace[wsID] = []*Tab{}
+
+	got, cmd := m.updatePtyTabReattachFailed(ptyTabReattachFailed{
+		WorkspaceID: wsID,
+		TabID:       TabID("missing-tab"),
+		Err:         errors.New("boom"),
+	})
+	if got != m {
+		t.Fatal("expected same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected nil command when the target tab is unknown")
+	}
+}
+
+func TestUpdatePtyTabReattachFailed_MarksTabAndToasts(t *testing.T) {
+	cases := []struct {
+		name        string
+		action      string
+		stopped     bool
+		wantLabel   string
+		wantDetach  bool // expected Detached value after the failure
+		startDetach bool
+	}{
+		{name: "default action reattach", action: "", stopped: false, wantLabel: "Reattach", startDetach: true, wantDetach: true},
+		{name: "explicit reattach", action: "reattach", stopped: false, wantLabel: "Reattach", startDetach: true, wantDetach: true},
+		{name: "restart action", action: "restart", stopped: false, wantLabel: "Restart", startDetach: true, wantDetach: true},
+		{name: "stopped clears detached", action: "reattach", stopped: true, wantLabel: "Reattach", startDetach: true, wantDetach: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel()
+			ws := newTestWorkspace("ws", "/repo/ws")
+			wsID := string(ws.ID())
+			tab := &Tab{
+				ID:               TabID("tab-reattach"),
+				Assistant:        "claude",
+				Workspace:        ws,
+				Running:          true,
+				Detached:         tc.startDetach,
+				reattachInFlight: true,
+			}
+			m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+
+			got, cmd := m.updatePtyTabReattachFailed(ptyTabReattachFailed{
+				WorkspaceID: wsID,
+				TabID:       tab.ID,
+				Err:         errors.New("connection refused"),
+				Stopped:     tc.stopped,
+				Action:      tc.action,
+			})
+			if got != m {
+				t.Fatal("expected same model pointer")
+			}
+
+			tab.mu.Lock()
+			running, inFlight, detached := tab.Running, tab.reattachInFlight, tab.Detached
+			tab.mu.Unlock()
+			if running {
+				t.Fatal("expected Running=false after reattach failure")
+			}
+			if inFlight {
+				t.Fatal("expected reattachInFlight cleared after reattach failure")
+			}
+			if detached != tc.wantDetach {
+				t.Fatalf("expected Detached=%v after failure, got %v", tc.wantDetach, detached)
+			}
+
+			msgs := drainBatch(cmd)
+			if _, ok := findMsg[messages.TabStateChanged](msgs); !ok {
+				t.Fatalf("expected a TabStateChanged message, got %+v", msgs)
+			}
+			toast, ok := findMsg[messages.Toast](msgs)
+			if !ok {
+				t.Fatalf("expected a Toast message, got %+v", msgs)
+			}
+			if toast.Level != messages.ToastWarning {
+				t.Fatalf("expected warning toast, got %q", toast.Level)
+			}
+			wantPrefix := tc.wantLabel + " failed:"
+			if len(toast.Message) < len(wantPrefix) || toast.Message[:len(wantPrefix)] != wantPrefix {
+				t.Fatalf("expected toast prefixed %q, got %q", wantPrefix, toast.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for the previously-untested message handlers in `internal/ui/center/model_input_lifecycle.go`: updateLaunchAgent, updateOpenFileInVim, updatePtyTabCreateResult, updatePtyTabReattachFailed, updateOpenDiff, updateWorkspaceDeleted, updateTabSelectionResult, updateSelectionTickRequest, updateTabDiffCmd.

Tests make real assertions on behavior and return values: returned-model identity, error contexts (nil workspace/agent, missing tab id), tab creation/activation, workspace-delete teardown (tab closed + terminal released), reattach-failure state transitions and per-action toast labels (Reattach/Restart, stopped clears Detached), scroll-tick payload propagation, and command forwarding. Edge cases covered: nil/empty inputs, unknown tab, nil inner command.

No production code changed. Happy paths use a nil-Terminal Agent (the existing convention in model_tabs_identity_test.go) so no live tmux/PTY/git CLI is exec'd; the clipboard and fresh-diff paths are asserted via their documented no-op / in-process branches without shelling out. Split across two files to respect the 500-line-per-file cap. All local gates pass (gofmt, build, vet, go test, golangci-lint v1.64.8, check-file-length).

Part of the quality stacked diff. Stacked on improve/090-test-center-tab-actor. Ticket 091 (testability).