### PR TITLE
test: cover center/model_pty_status.go (center)

### DIFF
--- a/internal/ui/center/model_pty_status_agents_test.go
+++ b/internal/ui/center/model_pty_status_agents_test.go
@@ -1,0 +1,399 @@
+package center
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+// These tests cover the workspace-level agent-status helpers in
+// model_pty_status.go: HasRunningAgents, HasActiveAgents,
+// GetActiveWorkspaceRoots, GetRunningWorkspaceRoots.
+
+func TestHasRunningAgents(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		build func(m *Model)
+		want  bool
+	}{
+		{
+			name:  "no workspaces",
+			build: func(*Model) {},
+			want:  false,
+		},
+		{
+			name: "running chat tab",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{Assistant: "claude", Workspace: ws, Running: true},
+				}
+			},
+			want: true,
+		},
+		{
+			name: "chat tab not running",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{Assistant: "claude", Workspace: ws, Running: false},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "running non-chat tab ignored",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{Assistant: "vim", Workspace: ws, Running: true},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "running but closed tab ignored",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				closed := &Tab{Assistant: "claude", Workspace: ws, Running: true}
+				closed.markClosed()
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{closed}
+			},
+			want: false,
+		},
+		{
+			name: "second tab running across workspaces",
+			build: func(m *Model) {
+				ws1 := newTestWorkspace("ws1", "/repo/ws1")
+				ws2 := newTestWorkspace("ws2", "/repo/ws2")
+				m.tabs.ByWorkspace[string(ws1.ID())] = []*Tab{
+					{Assistant: "claude", Workspace: ws1, Running: false},
+				}
+				m.tabs.ByWorkspace[string(ws2.ID())] = []*Tab{
+					{Assistant: "vim", Workspace: ws2, Running: true},
+					{Assistant: "codex", Workspace: ws2, Running: true},
+				}
+			},
+			want: true,
+		},
+		{
+			name: "active output does not imply running",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{
+						Assistant: "claude",
+						Workspace: ws,
+						Running:   false,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-1 * time.Second),
+						},
+					},
+				}
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModel()
+			tt.build(m)
+			if got := m.HasRunningAgents(); got != tt.want {
+				t.Fatalf("HasRunningAgents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasActiveAgents(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		build func(m *Model)
+		want  bool
+	}{
+		{
+			name:  "no workspaces",
+			build: func(*Model) {},
+			want:  false,
+		},
+		{
+			name: "chat tab with recent visible output",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{
+						Assistant: "claude",
+						Workspace: ws,
+						Running:   true,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-1 * time.Second),
+						},
+					},
+				}
+			},
+			want: true,
+		},
+		{
+			name: "running chat tab without recent output is inactive",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{Assistant: "claude", Workspace: ws, Running: true},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "stale visible output past the activity window is inactive",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{
+						Assistant: "claude",
+						Workspace: ws,
+						Running:   true,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-(tabActiveWindow + time.Second)),
+						},
+					},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "detached chat tab with recent output is inactive",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{
+						Assistant: "claude",
+						Workspace: ws,
+						Running:   true,
+						Detached:  true,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-1 * time.Second),
+						},
+					},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "non-chat tab with recent output is inactive",
+			build: func(m *Model) {
+				ws := newTestWorkspace("ws", "/repo/ws")
+				m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+					{
+						Assistant: "vim",
+						Workspace: ws,
+						Running:   true,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-1 * time.Second),
+						},
+					},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "active tab in a second workspace is detected",
+			build: func(m *Model) {
+				ws1 := newTestWorkspace("ws1", "/repo/ws1")
+				ws2 := newTestWorkspace("ws2", "/repo/ws2")
+				m.tabs.ByWorkspace[string(ws1.ID())] = []*Tab{
+					{Assistant: "claude", Workspace: ws1, Running: true},
+				}
+				m.tabs.ByWorkspace[string(ws2.ID())] = []*Tab{
+					{
+						Assistant: "codex",
+						Workspace: ws2,
+						Running:   true,
+						tabActivityState: tabActivityState{
+							lastVisibleOutput: now.Add(-1 * time.Second),
+						},
+					},
+				}
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModel()
+			tt.build(m)
+			if got := m.HasActiveAgents(); got != tt.want {
+				t.Fatalf("HasActiveAgents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetActiveWorkspaceRoots(t *testing.T) {
+	now := time.Now()
+
+	t.Run("empty model returns no roots", func(t *testing.T) {
+		m := newTestModel()
+		if roots := m.GetActiveWorkspaceRoots(); len(roots) != 0 {
+			t.Fatalf("expected no roots, got %v", roots)
+		}
+	})
+
+	t.Run("only active workspaces contribute their root", func(t *testing.T) {
+		m := newTestModel()
+		activeWS := newTestWorkspace("active", "/repo/active")
+		idleWS := newTestWorkspace("idle", "/repo/idle")
+
+		m.tabs.ByWorkspace[string(activeWS.ID())] = []*Tab{
+			{
+				Assistant: "claude",
+				Workspace: activeWS,
+				Running:   true,
+				tabActivityState: tabActivityState{
+					lastVisibleOutput: now.Add(-1 * time.Second),
+				},
+			},
+		}
+		m.tabs.ByWorkspace[string(idleWS.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: idleWS, Running: true},
+		}
+
+		roots := m.GetActiveWorkspaceRoots()
+		if len(roots) != 1 || roots[0] != "/repo/active" {
+			t.Fatalf("expected [/repo/active], got %v", roots)
+		}
+	})
+
+	t.Run("root taken from first tab carrying a workspace", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: nil},
+			{
+				Assistant: "claude",
+				Workspace: ws,
+				Running:   true,
+				tabActivityState: tabActivityState{
+					lastVisibleOutput: now.Add(-1 * time.Second),
+				},
+			},
+		}
+		roots := m.GetActiveWorkspaceRoots()
+		if len(roots) != 1 || roots[0] != "/repo/ws" {
+			t.Fatalf("expected [/repo/ws], got %v", roots)
+		}
+	})
+
+	t.Run("multiple active workspaces each reported once", func(t *testing.T) {
+		m := newTestModel()
+		ws1 := newTestWorkspace("ws1", "/repo/ws1")
+		ws2 := newTestWorkspace("ws2", "/repo/ws2")
+		for _, ws := range []*data.Workspace{ws1, ws2} {
+			m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+				{
+					Assistant: "claude",
+					Workspace: ws,
+					Running:   true,
+					tabActivityState: tabActivityState{
+						lastVisibleOutput: now.Add(-1 * time.Second),
+					},
+				},
+			}
+		}
+		roots := m.GetActiveWorkspaceRoots()
+		sort.Strings(roots)
+		if len(roots) != 2 || roots[0] != "/repo/ws1" || roots[1] != "/repo/ws2" {
+			t.Fatalf("expected both roots, got %v", roots)
+		}
+	})
+}
+
+func TestGetRunningWorkspaceRoots(t *testing.T) {
+	t.Run("empty model returns no roots", func(t *testing.T) {
+		m := newTestModel()
+		if roots := m.GetRunningWorkspaceRoots(); len(roots) != 0 {
+			t.Fatalf("expected no roots, got %v", roots)
+		}
+	})
+
+	t.Run("idle but running tab still reported", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			// Running with no recent output: active=false but running=true.
+			{Assistant: "claude", Workspace: ws, Running: true},
+		}
+		roots := m.GetRunningWorkspaceRoots()
+		if len(roots) != 1 || roots[0] != "/repo/ws" {
+			t.Fatalf("expected [/repo/ws], got %v", roots)
+		}
+	})
+
+	t.Run("non-running tab excluded", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: ws, Running: false},
+		}
+		if roots := m.GetRunningWorkspaceRoots(); len(roots) != 0 {
+			t.Fatalf("expected no roots, got %v", roots)
+		}
+	})
+
+	t.Run("non-chat tab excluded even when running", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			{Assistant: "vim", Workspace: ws, Running: true},
+		}
+		if roots := m.GetRunningWorkspaceRoots(); len(roots) != 0 {
+			t.Fatalf("expected no roots, got %v", roots)
+		}
+	})
+
+	t.Run("running tab without workspace contributes no root", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: nil, Running: true},
+		}
+		if roots := m.GetRunningWorkspaceRoots(); len(roots) != 0 {
+			t.Fatalf("expected no roots when running tab lacks a workspace, got %v", roots)
+		}
+	})
+
+	t.Run("only one root per workspace despite multiple running tabs", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: ws, Running: true},
+			{Assistant: "codex", Workspace: ws, Running: true},
+		}
+		roots := m.GetRunningWorkspaceRoots()
+		if len(roots) != 1 || roots[0] != "/repo/ws" {
+			t.Fatalf("expected exactly one root for the workspace, got %v", roots)
+		}
+	})
+
+	t.Run("multiple workspaces each contribute a root", func(t *testing.T) {
+		m := newTestModel()
+		ws1 := newTestWorkspace("ws1", "/repo/ws1")
+		ws2 := newTestWorkspace("ws2", "/repo/ws2")
+		m.tabs.ByWorkspace[string(ws1.ID())] = []*Tab{
+			{Assistant: "claude", Workspace: ws1, Running: true},
+		}
+		m.tabs.ByWorkspace[string(ws2.ID())] = []*Tab{
+			{Assistant: "codex", Workspace: ws2, Running: true},
+		}
+		roots := m.GetRunningWorkspaceRoots()
+		sort.Strings(roots)
+		if len(roots) != 2 || roots[0] != "/repo/ws1" || roots[1] != "/repo/ws2" {
+			t.Fatalf("expected both running roots, got %v", roots)
+		}
+	})
+}

--- a/internal/ui/center/model_pty_status_readers_test.go
+++ b/internal/ui/center/model_pty_status_readers_test.go
@@ -1,0 +1,125 @@
+package center
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// StartPTYReaders only spawns a real PTY read goroutine when a tab is both
+// Running and backed by a live *appPty.Agent terminal; with Running=false or no
+// Agent it short-circuits in startPTYReader, so the iteration, stall-detection
+// and skip guards are exercised here without execing tmux or requiring a live
+// Bubble Tea program.
+func TestStartPTYReaders(t *testing.T) {
+	t.Run("no workspaces is a no-op returning nil cmd", func(t *testing.T) {
+		m := newTestModel()
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd for empty model, got non-nil")
+		}
+	})
+
+	t.Run("nil and closed tabs are skipped without starting a reader", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		closed := &Tab{ID: TabID("closed"), Assistant: "claude", Workspace: ws, Running: true}
+		closed.markClosed()
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{nil, closed}
+
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd")
+		}
+		// A closed tab must never have had its reader marked active.
+		closed.mu.Lock()
+		active := closed.ReaderActive
+		closed.mu.Unlock()
+		if active {
+			t.Fatal("expected closed tab reader to stay inactive")
+		}
+	})
+
+	t.Run("non-running tab does not spawn a reader", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		tab := &Tab{ID: TabID("idle"), Assistant: "claude", Workspace: ws, Running: false}
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd")
+		}
+		tab.mu.Lock()
+		active := tab.ReaderActive
+		tab.mu.Unlock()
+		if active {
+			t.Fatal("expected non-running tab to have no active reader")
+		}
+	})
+
+	t.Run("stalled active reader is stopped before restart", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		// ReaderActive with a heartbeat older than the stall timeout triggers the
+		// stall branch, which calls stopPTYReader (clearing ReaderActive and
+		// zeroing the heartbeat). Running stays false so no new goroutine spawns.
+		stale := time.Now().Add(-(ptyReaderStallTimeout + time.Second)).UnixNano()
+		tab := &Tab{ID: TabID("stalled"), Assistant: "claude", Workspace: ws}
+		tab.ReaderActive = true
+		atomic.StoreInt64(&tab.Heartbeat, stale)
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd")
+		}
+		tab.mu.Lock()
+		active := tab.ReaderActive
+		tab.mu.Unlock()
+		if active {
+			t.Fatal("expected stalled reader to be stopped")
+		}
+		if hb := atomic.LoadInt64(&tab.Heartbeat); hb != 0 {
+			t.Fatalf("expected heartbeat reset to 0 after stop, got %d", hb)
+		}
+	})
+
+	t.Run("fresh active reader is left running", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		fresh := time.Now().UnixNano()
+		tab := &Tab{ID: TabID("fresh"), Assistant: "claude", Workspace: ws}
+		tab.ReaderActive = true
+		atomic.StoreInt64(&tab.Heartbeat, fresh)
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd")
+		}
+		tab.mu.Lock()
+		active := tab.ReaderActive
+		tab.mu.Unlock()
+		if !active {
+			t.Fatal("expected a freshly-beating reader to be left active")
+		}
+		if hb := atomic.LoadInt64(&tab.Heartbeat); hb != fresh {
+			t.Fatalf("expected heartbeat untouched, got %d want %d", hb, fresh)
+		}
+	})
+
+	t.Run("active reader with zero heartbeat is not treated as stalled", func(t *testing.T) {
+		m := newTestModel()
+		ws := newTestWorkspace("ws", "/repo/ws")
+		tab := &Tab{ID: TabID("nobeat"), Assistant: "claude", Workspace: ws}
+		tab.ReaderActive = true
+		atomic.StoreInt64(&tab.Heartbeat, 0)
+		m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+		if cmd := m.StartPTYReaders(); cmd != nil {
+			t.Fatalf("expected nil cmd")
+		}
+		tab.mu.Lock()
+		active := tab.ReaderActive
+		tab.mu.Unlock()
+		if !active {
+			t.Fatal("expected reader with zero heartbeat to be left untouched (lastBeat > 0 guard)")
+		}
+	})
+}


### PR DESCRIPTION
Adds thorough table-driven unit tests for the previously-untested agent-status helpers in internal/ui/center/model_pty_status.go: HasRunningAgents, HasActiveAgents, GetActiveWorkspaceRoots, GetRunningWorkspaceRoots, and StartPTYReaders.

Tests assert on real return values and cover empty/nil inputs, closed/detached/non-chat tabs, the tabActiveWindow boundary, multi-workspace fan-out, and the PTY-reader stall/restart guard (stale vs fresh vs zero heartbeat). StartPTYReaders is exercised with non-running / no-Agent tabs so startPTYReader short-circuits without spawning a goroutine or execing tmux (the cursor/TerminalLayer paths already have sibling coverage). Split into model_pty_status_agents_test.go and model_pty_status_readers_test.go to stay under the 500-line file cap. No production code changed.

Part of the quality stacked diff. Stacked on improve/091-test-center-model-input-lifecycle. Ticket 092 (testability).