### PR TITLE
test: cover center/model_tabs_session.go (center)

### DIFF
--- a/internal/ui/center/model_tabs_session_add_test.go
+++ b/internal/ui/center/model_tabs_session_add_test.go
@@ -1,0 +1,272 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// These tests exercise AddTabsFromWorkspace from model_tabs_session.go, which
+// merges newly-discovered tabs into an existing workspace without resetting UI
+// state. The returned tea.Cmd batches async reattach commands; those commands
+// touch tmux only when invoked, so the tests assert on tab construction and on
+// whether a (non-)nil command is produced, never invoking the returned cmd.
+
+func TestAddTabsFromWorkspace_NilWorkspaceReturnsNil(t *testing.T) {
+	m := newTestModel()
+	if cmd := m.AddTabsFromWorkspace(nil, []data.TabInfo{{Assistant: "claude"}}); cmd != nil {
+		t.Fatalf("expected nil cmd for nil workspace, got %T", cmd())
+	}
+}
+
+func TestAddTabsFromWorkspace_EmptyTabsReturnsNil(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+
+	if cmd := m.AddTabsFromWorkspace(ws, nil); cmd != nil {
+		t.Fatalf("expected nil cmd for nil tabs, got %T", cmd())
+	}
+	if cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{}); cmd != nil {
+		t.Fatalf("expected nil cmd for empty tabs, got %T", cmd())
+	}
+}
+
+func TestAddTabsFromWorkspace_NilConfigReturnsNil(t *testing.T) {
+	m := newTestModel()
+	m.config = nil
+	ws := newTestWorkspace("ws", "/repo/ws")
+
+	if cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{{Assistant: "claude", Status: "detached"}}); cmd != nil {
+		t.Fatalf("expected nil cmd for nil config, got %T", cmd())
+	}
+	if got := len(m.tabs.ByWorkspace[string(ws.ID())]); got != 0 {
+		t.Fatalf("expected no tabs added with nil config, got %d", got)
+	}
+}
+
+func TestAddTabsFromWorkspace_NilAssistantsMapReturnsNil(t *testing.T) {
+	m := newTestModel()
+	m.config = &config.Config{Assistants: nil}
+	ws := newTestWorkspace("ws", "/repo/ws")
+
+	if cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{{Assistant: "claude", Status: "detached"}}); cmd != nil {
+		t.Fatalf("expected nil cmd when Assistants map is nil, got %T", cmd())
+	}
+}
+
+func TestAddTabsFromWorkspace_SkipsFilteredTabs(t *testing.T) {
+	tests := []struct {
+		name string
+		info data.TabInfo
+	}{
+		{name: "empty assistant", info: data.TabInfo{Assistant: "", Status: "detached", SessionName: "s1"}},
+		{name: "unknown assistant", info: data.TabInfo{Assistant: "ghostwriter", Status: "detached", SessionName: "s2"}},
+		{name: "stopped status", info: data.TabInfo{Assistant: "claude", Status: "stopped", SessionName: "s3"}},
+		{name: "stopped status mixed case", info: data.TabInfo{Assistant: "claude", Status: "Stopped", SessionName: "s4"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel()
+			ws := newTestWorkspace("ws", "/repo/ws")
+			wsID := string(ws.ID())
+
+			cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{tc.info})
+			if cmd != nil {
+				t.Fatalf("expected nil cmd when the only tab is filtered, got %T", cmd())
+			}
+			if got := len(m.tabs.ByWorkspace[wsID]); got != 0 {
+				t.Fatalf("expected no tabs added, got %d", got)
+			}
+		})
+	}
+}
+
+func TestAddTabsFromWorkspace_AddsDetachedTabWithoutCommand(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Name: "Claude", Status: "detached", SessionName: "sess-detached"},
+	})
+	// A detached tab is materialized synchronously and needs no reattach cmd.
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for a detached-only batch, got %T", cmd())
+	}
+
+	tabs := m.tabs.ByWorkspace[wsID]
+	if len(tabs) != 1 {
+		t.Fatalf("expected 1 tab, got %d", len(tabs))
+	}
+	tab := tabs[0]
+	if !tab.Detached {
+		t.Fatal("expected the added tab to be detached")
+	}
+	if tab.Running {
+		t.Fatal("expected the detached tab not to be running")
+	}
+	if tab.SessionName != "sess-detached" {
+		t.Fatalf("session name = %q, want sess-detached", tab.SessionName)
+	}
+	if tab.reattachInFlight {
+		t.Fatal("expected detached tab not to be flagged reattachInFlight")
+	}
+}
+
+func TestAddTabsFromWorkspace_AddsRunningPlaceholderWithCommand(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Name: "Claude", Status: "running", SessionName: "sess-running"},
+	})
+	// A running tab is added as a placeholder and queued for async reattach.
+	if cmd == nil {
+		t.Fatal("expected a reattach cmd for a running tab")
+	}
+
+	tabs := m.tabs.ByWorkspace[wsID]
+	if len(tabs) != 1 {
+		t.Fatalf("expected 1 tab, got %d", len(tabs))
+	}
+	tab := tabs[0]
+	if !tab.Detached {
+		t.Fatal("expected the placeholder to start detached before reattach")
+	}
+	if !tab.reattachInFlight {
+		t.Fatal("expected the running placeholder to be flagged reattachInFlight")
+	}
+	if tab.SessionName != "sess-running" {
+		t.Fatalf("session name = %q, want sess-running", tab.SessionName)
+	}
+}
+
+func TestAddTabsFromWorkspace_SkipsSessionAlreadyOpen(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	// An existing live tab already owns "sess-1".
+	m.tabs.ByWorkspace[wsID] = []*Tab{
+		{ID: TabID("existing"), Assistant: "claude", Workspace: ws, SessionName: "sess-1", Running: true},
+	}
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Status: "detached", SessionName: "sess-1"},
+	})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when the session is already open, got %T", cmd())
+	}
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 1 {
+		t.Fatalf("expected the duplicate session not to add a tab, got %d tabs", got)
+	}
+}
+
+func TestAddTabsFromWorkspace_DedupesSessionWithinBatch(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Status: "detached", SessionName: "dup"},
+		{Assistant: "claude", Status: "detached", SessionName: "dup"},
+	})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for detached-only batch, got %T", cmd())
+	}
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 1 {
+		t.Fatalf("expected duplicate session within batch to be added once, got %d tabs", got)
+	}
+}
+
+func TestAddTabsFromWorkspace_MatchesExistingTabAgentSession(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	// Existing tab carries its session on the Agent rather than SessionName, so
+	// dedupe must fall back to the agent's Session field.
+	agentTab := &Tab{
+		ID:        TabID("existing"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		Agent:     &appPty.Agent{Workspace: ws, Session: "agent-sess"},
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{agentTab}
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Status: "detached", SessionName: "agent-sess"},
+	})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when session matches an existing tab's agent session, got %T", cmd())
+	}
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 1 {
+		t.Fatalf("expected no new tab when agent session matches, got %d tabs", got)
+	}
+}
+
+func TestAddTabsFromWorkspace_EmptySessionAddsEachTab(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	// Tabs with no session name are never deduped against one another.
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Status: "detached"},
+		{Assistant: "claude", Status: "detached"},
+	})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for detached-only batch, got %T", cmd())
+	}
+	if got := len(m.tabs.ByWorkspace[wsID]); got != 2 {
+		t.Fatalf("expected both session-less detached tabs to be added, got %d", got)
+	}
+}
+
+func TestAddTabsFromWorkspace_MixedBatchAddsAllAndBatchesRunning(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	cmd := m.AddTabsFromWorkspace(ws, []data.TabInfo{
+		{Assistant: "claude", Status: "detached", SessionName: "d1"},
+		{Assistant: "claude", Status: "running", SessionName: "r1"},
+		{Assistant: "codex", Status: "running", SessionName: "r2"},
+		{Assistant: "unknown", Status: "running", SessionName: "x1"}, // filtered
+		{Assistant: "claude", Status: "stopped", SessionName: "s1"},  // filtered
+	})
+	if cmd == nil {
+		t.Fatal("expected a batched cmd because the batch contains running tabs")
+	}
+
+	tabs := m.tabs.ByWorkspace[wsID]
+	if len(tabs) != 3 {
+		t.Fatalf("expected 3 tabs (1 detached + 2 running), got %d", len(tabs))
+	}
+
+	bySession := make(map[string]*Tab, len(tabs))
+	for _, tab := range tabs {
+		bySession[tab.SessionName] = tab
+	}
+	if d1, ok := bySession["d1"]; !ok || !d1.Detached || d1.reattachInFlight {
+		t.Fatalf("d1 should be a plain detached tab, got %+v", d1)
+	}
+	for _, sess := range []string{"r1", "r2"} {
+		tab, ok := bySession[sess]
+		if !ok {
+			t.Fatalf("expected running session %q to produce a placeholder tab", sess)
+		}
+		if !tab.reattachInFlight {
+			t.Fatalf("expected running placeholder %q to be reattachInFlight", sess)
+		}
+	}
+	if _, ok := bySession["x1"]; ok {
+		t.Fatal("expected unknown-assistant tab to be filtered out")
+	}
+	if _, ok := bySession["s1"]; ok {
+		t.Fatal("expected stopped tab to be filtered out")
+	}
+}

--- a/internal/ui/center/model_tabs_session_dispatch_test.go
+++ b/internal/ui/center/model_tabs_session_dispatch_test.go
@@ -1,0 +1,258 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// detachTabAt, DetachTabByID and DetachActiveTab are thin dispatchers in
+// model_tabs_session.go that resolve a tab from an index / id / active
+// selection and then delegate to detachTab. The tests below exercise the
+// resolution and boundary logic of those dispatchers directly; detachTab's
+// own state transitions are covered in model_tabs_session_detach_test.go.
+
+// setCurrentWorkspace wires a workspace as the model's current one so that
+// getTabs / getActiveTabIdx (which key off m.workspaceID()) resolve to it.
+func setCurrentWorkspace(m *Model, ws *data.Workspace) string {
+	m.workspace = ws
+	return string(ws.ID())
+}
+
+func TestDetachTabAt_OutOfRangeReturnsNil(t *testing.T) {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	chatTab := func() *Tab {
+		return &Tab{ID: TabID("tab-1"), Assistant: "claude", Workspace: ws, Running: true}
+	}
+
+	tests := []struct {
+		name  string
+		tabs  []*Tab
+		index int
+	}{
+		{name: "empty tabs", tabs: nil, index: 0},
+		{name: "negative index", tabs: []*Tab{chatTab()}, index: -1},
+		{name: "index equals length", tabs: []*Tab{chatTab()}, index: 1},
+		{name: "index beyond length", tabs: []*Tab{chatTab()}, index: 5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel()
+			wsID := setCurrentWorkspace(m, ws)
+			m.tabs.ByWorkspace[wsID] = tc.tabs
+
+			if cmd := m.detachTabAt(tc.index); cmd != nil {
+				t.Fatalf("expected nil cmd for %s, got %T", tc.name, cmd())
+			}
+		})
+	}
+}
+
+func TestDetachTabAt_ValidIndexDetachesSelectedTab(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := setCurrentWorkspace(m, ws)
+	keep := &Tab{ID: TabID("keep"), Assistant: "claude", Workspace: ws, Running: true}
+	target := &Tab{ID: TabID("target"), Assistant: "claude", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{keep, target}
+
+	cmd := m.detachTabAt(1)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for in-range index")
+	}
+	msg, ok := cmd().(messages.TabDetached)
+	if !ok {
+		t.Fatalf("expected messages.TabDetached, got %T", cmd())
+	}
+	if msg.Index != 1 {
+		t.Fatalf("detached index = %d, want 1", msg.Index)
+	}
+	if msg.WorkspaceID != wsID {
+		t.Fatalf("workspaceID = %q, want %q", msg.WorkspaceID, wsID)
+	}
+
+	target.mu.Lock()
+	targetDetached := target.Detached
+	target.mu.Unlock()
+	if !targetDetached {
+		t.Fatal("expected the selected tab to be detached")
+	}
+
+	keep.mu.Lock()
+	keepDetached := keep.Detached
+	keep.mu.Unlock()
+	if keepDetached {
+		t.Fatal("expected the non-selected tab to be untouched")
+	}
+}
+
+func TestDetachTabAt_NonChatTabReturnsToast(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := setCurrentWorkspace(m, ws)
+	// "vim" is not in the configured assistant roster, so it is not a chat tab.
+	nonChat := &Tab{ID: TabID("term"), Assistant: "vim", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{nonChat}
+
+	cmd := m.detachTabAt(0)
+	if cmd == nil {
+		t.Fatal("expected toast cmd for non-chat tab")
+	}
+	toast, ok := cmd().(messages.Toast)
+	if !ok {
+		t.Fatalf("expected messages.Toast, got %T", cmd())
+	}
+	if toast.Message != "Only assistant tabs can be detached" {
+		t.Fatalf("toast message = %q", toast.Message)
+	}
+
+	nonChat.mu.Lock()
+	detached := nonChat.Detached
+	nonChat.mu.Unlock()
+	if detached {
+		t.Fatal("expected non-chat tab not to be detached")
+	}
+}
+
+func TestDetachTabByID_EmptyWorkspaceReturnsNil(t *testing.T) {
+	m := newTestModel()
+	if cmd := m.DetachTabByID("", TabID("anything")); cmd != nil {
+		t.Fatalf("expected nil cmd for empty workspace id, got %T", cmd())
+	}
+}
+
+func TestDetachTabByID_UnknownIDReturnsNil(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	m.tabs.ByWorkspace[wsID] = []*Tab{
+		{ID: TabID("a"), Assistant: "claude", Workspace: ws, Running: true},
+		{ID: TabID("b"), Assistant: "claude", Workspace: ws, Running: true},
+	}
+
+	if cmd := m.DetachTabByID(wsID, TabID("missing")); cmd != nil {
+		t.Fatalf("expected nil cmd for unknown tab id, got %T", cmd())
+	}
+}
+
+func TestDetachTabByID_SkipsNilAndClosedTabs(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	closed := &Tab{ID: TabID("dup"), Assistant: "claude", Workspace: ws, Running: true}
+	closed.markClosing()
+	live := &Tab{ID: TabID("dup"), Assistant: "claude", Workspace: ws, Running: true}
+	// Both a nil entry and a closed tab share the target id; only the live tab
+	// at a later position should be detached.
+	m.tabs.ByWorkspace[wsID] = []*Tab{nil, closed, live}
+
+	cmd := m.DetachTabByID(wsID, TabID("dup"))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd when a live matching tab exists")
+	}
+	if _, ok := cmd().(messages.TabDetached); !ok {
+		t.Fatalf("expected messages.TabDetached, got %T", cmd())
+	}
+
+	live.mu.Lock()
+	liveDetached := live.Detached
+	live.mu.Unlock()
+	if !liveDetached {
+		t.Fatal("expected the live matching tab to be detached")
+	}
+
+	closed.mu.Lock()
+	closedDetached := closed.Detached
+	closed.mu.Unlock()
+	if closedDetached {
+		t.Fatal("expected the closed tab to be skipped, not detached")
+	}
+}
+
+func TestDetachTabByID_DetachesByIndexNotPosition(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	first := &Tab{ID: TabID("first"), Assistant: "claude", Workspace: ws, Running: true}
+	second := &Tab{ID: TabID("second"), Assistant: "claude", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{first, second}
+
+	cmd := m.DetachTabByID(wsID, TabID("second"))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg, ok := cmd().(messages.TabDetached)
+	if !ok {
+		t.Fatalf("expected messages.TabDetached, got %T", cmd())
+	}
+	if msg.Index != 1 {
+		t.Fatalf("detached index = %d, want 1 (slice position of the match)", msg.Index)
+	}
+	if msg.WorkspaceID != wsID {
+		t.Fatalf("workspaceID = %q, want %q", msg.WorkspaceID, wsID)
+	}
+}
+
+func TestDetachActiveTab_NoTabsReturnsNil(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := setCurrentWorkspace(m, ws)
+	m.tabs.ByWorkspace[wsID] = nil
+
+	if cmd := m.DetachActiveTab(); cmd != nil {
+		t.Fatalf("expected nil cmd with no tabs, got %T", cmd())
+	}
+}
+
+func TestDetachActiveTab_ActiveIndexOutOfRangeReturnsNil(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := setCurrentWorkspace(m, ws)
+	m.tabs.ByWorkspace[wsID] = []*Tab{
+		{ID: TabID("only"), Assistant: "claude", Workspace: ws, Running: true},
+	}
+	// Active index points past the end of the slice.
+	m.tabs.ActiveByWorkspace[wsID] = 3
+
+	if cmd := m.DetachActiveTab(); cmd != nil {
+		t.Fatalf("expected nil cmd for stale active index, got %T", cmd())
+	}
+}
+
+func TestDetachActiveTab_DetachesActiveSelection(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := setCurrentWorkspace(m, ws)
+	first := &Tab{ID: TabID("first"), Assistant: "claude", Workspace: ws, Running: true}
+	active := &Tab{ID: TabID("active"), Assistant: "claude", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{first, active}
+	m.tabs.ActiveByWorkspace[wsID] = 1
+
+	cmd := m.DetachActiveTab()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for valid active tab")
+	}
+	msg, ok := cmd().(messages.TabDetached)
+	if !ok {
+		t.Fatalf("expected messages.TabDetached, got %T", cmd())
+	}
+	if msg.Index != 1 {
+		t.Fatalf("detached active index = %d, want 1", msg.Index)
+	}
+
+	active.mu.Lock()
+	activeDetached := active.Detached
+	active.mu.Unlock()
+	if !activeDetached {
+		t.Fatal("expected the active tab to be detached")
+	}
+
+	first.mu.Lock()
+	firstDetached := first.Detached
+	first.mu.Unlock()
+	if firstDetached {
+		t.Fatal("expected the inactive tab to be untouched")
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for the previously-untested dispatch and merge functions in internal/ui/center/model_tabs_session.go: detachTabAt, DetachTabByID, DetachActiveTab and AddTabsFromWorkspace.

What is covered (real behavior assertions, no coverage theater):
- detachTabAt: out-of-range/negative/empty-index nil paths, valid-index detaches the selected tab only, non-chat tab returns the info toast without detaching.
- DetachTabByID: empty workspace and unknown id return nil, nil/closed tabs are skipped, detached index reflects slice position.
- DetachActiveTab: no-tabs and stale active-index nil paths, active selection is detached.
- AddTabsFromWorkspace: nil ws / empty tabs / nil config / nil Assistants map nil paths; filtering of empty/unknown assistant and stopped status; detached-tab construction (no cmd) vs running placeholder (reattachInFlight + batched cmd); session dedupe within a batch, against an existing tab's SessionName, and against an agent-held Session; session-less tabs added independently; mixed batch.

The async reattach commands that AddTabsFromWorkspace batches touch tmux only when invoked; the tests assert on (non-)nil command and tab state and never invoke those closures, so no live tmux/PTY harness is required. No production code changed (no test seam needed).

Part of the quality stacked diff. Stacked on improve/094-test-center-model-tab. Ticket 095 (testability).