### PR TITLE
test: cover service_tmux.go (app)

### DIFF
--- a/internal/app/service_tmux_kill_test.go
+++ b/internal/app/service_tmux_kill_test.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// Kill-family coverage for the tmuxOps wrapper in service_tmux.go. Split out of
+// service_tmux_test.go to stay under the 500-line-per-file cap. These tests run
+// against the isolated tmux server provided by gcTestServer (app_tmux_gc_test.go)
+// and assert which sessions survive vs. get killed, plus the guarded no-op paths.
+
+// ---------------------------------------------------------------------------
+// KillSessionsMatchingTags
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_KillSessionsMatchingTags(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "match-a", "sleep 300")
+	gcCreateSession(t, opts, "match-b", "sleep 300")
+	gcCreateSession(t, opts, "nomatch", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	gcSetTag(t, opts, "match-a", "@amux", "1")
+	gcSetTag(t, opts, "match-a", "@amux_workspace", "doomed")
+	gcSetTag(t, opts, "match-b", "@amux", "1")
+	gcSetTag(t, opts, "match-b", "@amux_workspace", "doomed")
+	gcSetTag(t, opts, "nomatch", "@amux", "1")
+	gcSetTag(t, opts, "nomatch", "@amux_workspace", "safe")
+
+	killed, err := ops.KillSessionsMatchingTags(map[string]string{"@amux_workspace": "doomed"}, opts)
+	if err != nil {
+		t.Fatalf("KillSessionsMatchingTags: %v", err)
+	}
+	if !killed {
+		t.Fatal("KillSessionsMatchingTags = false, want true (sessions matched)")
+	}
+	if gcHasSession(t, opts, "match-a") || gcHasSession(t, opts, "match-b") {
+		t.Fatal("matching sessions should have been killed")
+	}
+	if !gcHasSession(t, opts, "nomatch") {
+		t.Fatal("non-matching session should survive")
+	}
+
+	// Second call with a tag matching nothing returns killed=false, no error.
+	killed, err = ops.KillSessionsMatchingTags(map[string]string{"@amux_workspace": "nobody"}, opts)
+	if err != nil {
+		t.Fatalf("KillSessionsMatchingTags(no match): %v", err)
+	}
+	if killed {
+		t.Fatal("KillSessionsMatchingTags(no match) = true, want false")
+	}
+}
+
+func TestTmuxOps_KillSessionsMatchingTags_EmptyTags(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	// Empty tag set must short-circuit to killed=false without touching sessions.
+	killed, err := tmuxOps{}.KillSessionsMatchingTags(map[string]string{}, opts)
+	if err != nil {
+		t.Fatalf("KillSessionsMatchingTags(empty): %v", err)
+	}
+	if killed {
+		t.Fatal("KillSessionsMatchingTags(empty) = true, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KillSessionsWithPrefix
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_KillSessionsWithPrefix(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "pfx-one", "sleep 300")
+	gcCreateSession(t, opts, "pfx-two", "sleep 300")
+	gcCreateSession(t, opts, "other", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := ops.KillSessionsWithPrefix("pfx-", opts); err != nil {
+		t.Fatalf("KillSessionsWithPrefix: %v", err)
+	}
+	if gcHasSession(t, opts, "pfx-one") || gcHasSession(t, opts, "pfx-two") {
+		t.Fatal("prefixed sessions should have been killed")
+	}
+	if !gcHasSession(t, opts, "other") {
+		t.Fatal("non-prefixed session should survive")
+	}
+}
+
+func TestTmuxOps_KillSessionsWithPrefix_EmptyPrefix(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "keep-me", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	// Empty prefix must be a no-op (guard clause), leaving every session alive.
+	if err := ops.KillSessionsWithPrefix("", opts); err != nil {
+		t.Fatalf("KillSessionsWithPrefix(\"\"): %v", err)
+	}
+	if !gcHasSession(t, opts, "keep-me") {
+		t.Fatal("empty prefix should not kill any session")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KillSessionsWithPrefixMissingTag
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_KillSessionsWithPrefixMissingTag(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// Legacy session (prefix match, tag absent) → killed.
+	gcCreateSession(t, opts, "amux-legacy", "sleep 300")
+	// Modern session (prefix match, tag present) → preserved.
+	gcCreateSession(t, opts, "amux-owned", "sleep 300")
+	// Wrong prefix → never considered.
+	gcCreateSession(t, opts, "foreign", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	gcSetTag(t, opts, "amux-owned", "@amux_instance", "inst-42")
+
+	if err := ops.KillSessionsWithPrefixMissingTag("amux-", "@amux_instance", opts); err != nil {
+		t.Fatalf("KillSessionsWithPrefixMissingTag: %v", err)
+	}
+	if gcHasSession(t, opts, "amux-legacy") {
+		t.Fatal("legacy session lacking the tag should have been killed")
+	}
+	if !gcHasSession(t, opts, "amux-owned") {
+		t.Fatal("session with the instance tag should be preserved")
+	}
+	if !gcHasSession(t, opts, "foreign") {
+		t.Fatal("non-prefixed session should be untouched")
+	}
+}
+
+func TestTmuxOps_KillSessionsWithPrefixMissingTag_EmptyArgs(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "amux-survivor", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	// Either empty prefix or empty tag short-circuits to a no-op.
+	if err := ops.KillSessionsWithPrefixMissingTag("", "@amux_instance", opts); err != nil {
+		t.Fatalf("empty prefix: %v", err)
+	}
+	if err := ops.KillSessionsWithPrefixMissingTag("amux-", "", opts); err != nil {
+		t.Fatalf("empty tag: %v", err)
+	}
+	if !gcHasSession(t, opts, "amux-survivor") {
+		t.Fatal("no-op call should not kill any session")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KillWorkspaceSessions
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_KillWorkspaceSessions(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// KillWorkspaceSessions derives the prefix SessionName("amux", wsID)+"-".
+	wsID := "myws"
+	prefix := tmux.SessionName("amux", wsID) + "-"
+	target := prefix + "tab1"
+	other := tmux.SessionName("amux", "otherws") + "-tab1"
+
+	gcCreateSession(t, opts, target, "sleep 300")
+	gcCreateSession(t, opts, other, "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := ops.KillWorkspaceSessions(wsID, opts); err != nil {
+		t.Fatalf("KillWorkspaceSessions: %v", err)
+	}
+	if gcHasSession(t, opts, target) {
+		t.Fatalf("workspace session %q should have been killed", target)
+	}
+	if !gcHasSession(t, opts, other) {
+		t.Fatalf("session for a different workspace %q should survive", other)
+	}
+}
+
+func TestTmuxOps_KillWorkspaceSessions_EmptyID(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "amux-keep-tab1", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	// Empty workspace ID is a guarded no-op.
+	if err := ops.KillWorkspaceSessions("", opts); err != nil {
+		t.Fatalf("KillWorkspaceSessions(\"\"): %v", err)
+	}
+	if !gcHasSession(t, opts, "amux-keep-tab1") {
+		t.Fatal("empty workspace ID should not kill any session")
+	}
+}

--- a/internal/app/service_tmux_test.go
+++ b/internal/app/service_tmux_test.go
@@ -1,0 +1,440 @@
+package app
+
+import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// These tests exercise the tmuxOps wrapper in service_tmux.go. tmuxOps is a thin
+// adapter over the internal/tmux package, so the assertions verify that each
+// method forwards arguments correctly and surfaces the underlying behavior
+// (return values, tmux state changes) end to end.
+//
+// Functions that only delegate to a tmux subprocess are driven against an
+// isolated tmux server created by gcTestServer (see app_tmux_gc_test.go), the
+// same harness the GC integration tests use. Pure functions (EnsureAvailable,
+// InstallHint) and the input-validation fast paths (empty session name, etc.)
+// are asserted without any server.
+
+// gcReadCapture reads the active pane contents of a session for assertions.
+func gcReadCapture(t *testing.T, opts tmux.Options, session string) string {
+	t.Helper()
+	args := gcTmuxArgs(opts, "capture-pane", "-p", "-t", session)
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		t.Fatalf("capture-pane %q: %v", session, err)
+	}
+	return string(out)
+}
+
+// gcShowGlobalOption reads a global server option value for assertions.
+func gcShowGlobalOption(t *testing.T, opts tmux.Options, key string) string {
+	t.Helper()
+	args := gcTmuxArgs(opts, "show-options", "-g", "-v", key)
+	out, _ := exec.Command("tmux", args...).Output()
+	return string(out)
+}
+
+// gcSessionCreatedBare reads #{session_created} via a BARE session-name target
+// (no '=' exact-match prefix). On tmux 3.6a the '=' prefix used by the
+// production SessionCreatedAt path fails to expand and yields an empty value,
+// so this helper provides the real, non-zero timestamp needed to cover the
+// non-zero parse path independently of that version quirk. Returns 0 if the
+// value cannot be read or parsed.
+func gcSessionCreatedBare(t *testing.T, opts tmux.Options, session string) int64 {
+	t.Helper()
+	args := gcTmuxArgs(opts, "display-message", "-p", "-t", session, "#{session_created}")
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		t.Fatalf("display-message session_created %q: %v", session, err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return 0
+	}
+	ts, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse session_created %q for %q: %v", raw, session, err)
+	}
+	return ts
+}
+
+// ---------------------------------------------------------------------------
+// EnsureAvailable / InstallHint — pure (no isolated server needed)
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_InstallHint(t *testing.T) {
+	got := tmuxOps{}.InstallHint()
+	if got == "" {
+		t.Fatal("InstallHint returned empty string")
+	}
+	// The hint is platform-specific; assert it forwards the tmux package's
+	// per-OS guidance rather than a generic fallback when on a known OS.
+	var want string
+	switch runtime.GOOS {
+	case "darwin":
+		want = "macOS: brew install tmux"
+	case "linux":
+		want = "Linux: sudo apt install tmux  (or dnf/pacman/etc.)"
+	default:
+		want = "Install tmux and ensure it is on your PATH."
+	}
+	if got != want {
+		t.Fatalf("InstallHint = %q, want %q", got, want)
+	}
+}
+
+func TestTmuxOps_EnsureAvailable(t *testing.T) {
+	err := tmuxOps{}.EnsureAvailable()
+	if _, lookErr := exec.LookPath("tmux"); lookErr == nil {
+		// tmux is on PATH: EnsureAvailable must report success.
+		if err != nil {
+			t.Fatalf("EnsureAvailable = %v, want nil (tmux is installed)", err)
+		}
+	} else {
+		// tmux missing: must return a non-nil error containing the install hint.
+		if err == nil {
+			t.Fatal("EnsureAvailable = nil, want error (tmux not installed)")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AllSessionStates
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_AllSessionStates(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// _keepalive is created by gcTestServer; add two more named sessions.
+	gcCreateSession(t, opts, "alpha", "sleep 300")
+	gcCreateSession(t, opts, "beta", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	states, err := ops.AllSessionStates(opts)
+	if err != nil {
+		t.Fatalf("AllSessionStates: %v", err)
+	}
+	for _, name := range []string{"alpha", "beta", "_keepalive"} {
+		st, ok := states[name]
+		if !ok {
+			t.Fatalf("AllSessionStates missing session %q in %v", name, states)
+		}
+		if !st.Exists {
+			t.Errorf("session %q: Exists = false, want true", name)
+		}
+		if !st.HasLivePane {
+			t.Errorf("session %q: HasLivePane = false, want true (sleep is alive)", name)
+		}
+	}
+	// A name that was never created must be absent.
+	if _, ok := states["does-not-exist"]; ok {
+		t.Error("AllSessionStates reported a session that was never created")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SessionStateFor
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_SessionStateFor_EmptyName(t *testing.T) {
+	// Empty name is the input-validation fast path: zero value, no error, no
+	// tmux invocation required.
+	st, err := tmuxOps{}.SessionStateFor("", tmux.Options{})
+	if err != nil {
+		t.Fatalf("SessionStateFor(\"\") error = %v, want nil", err)
+	}
+	if st.Exists || st.HasLivePane {
+		t.Fatalf("SessionStateFor(\"\") = %+v, want zero value", st)
+	}
+}
+
+func TestTmuxOps_SessionStateFor_LiveAndMissing(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "live-sess", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	st, err := ops.SessionStateFor("live-sess", opts)
+	if err != nil {
+		t.Fatalf("SessionStateFor(live-sess): %v", err)
+	}
+	if !st.Exists || !st.HasLivePane {
+		t.Fatalf("SessionStateFor(live-sess) = %+v, want Exists+HasLivePane", st)
+	}
+
+	// A session that does not exist: Exists=false, no error.
+	missing, err := ops.SessionStateFor("ghost", opts)
+	if err != nil {
+		t.Fatalf("SessionStateFor(ghost): %v", err)
+	}
+	if missing.Exists || missing.HasLivePane {
+		t.Fatalf("SessionStateFor(ghost) = %+v, want zero value", missing)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SessionNamesWithClients
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_SessionNamesWithClients_Detached(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "detached-sess", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	// No clients are attached in a headless test, so the set must be empty —
+	// crucially, the "no attached clients" path must NOT surface as an error
+	// (that would break detached-session GC).
+	attached, err := ops.SessionNamesWithClients(opts)
+	if err != nil {
+		t.Fatalf("SessionNamesWithClients: %v", err)
+	}
+	if len(attached) != 0 {
+		t.Fatalf("SessionNamesWithClients = %v, want empty (no clients attached)", attached)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SessionCreatedAt
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_SessionCreatedAt_EmptyName(t *testing.T) {
+	ts, err := tmuxOps{}.SessionCreatedAt("", tmux.Options{})
+	if err != nil {
+		t.Fatalf("SessionCreatedAt(\"\") error = %v, want nil", err)
+	}
+	if ts != 0 {
+		t.Fatalf("SessionCreatedAt(\"\") = %d, want 0", ts)
+	}
+}
+
+func TestTmuxOps_SessionCreatedAt_ExistingAndMissing(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	after := time.Now().Unix()
+	gcCreateSession(t, opts, "stamped", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	// For an existing session the contract is: no error, and a non-negative
+	// timestamp. The exact value comes from tmux's #{session_created}, which on
+	// some tmux versions/detached sessions does not expand under an exact-match
+	// (=) target and yields 0 — so we assert >=0 and that it never exceeds the
+	// real wall clock rather than pinning an exact second. The distinguishing
+	// behavior we lock in is that an existing session does not error.
+	ts, err := ops.SessionCreatedAt("stamped", opts)
+	if err != nil {
+		t.Fatalf("SessionCreatedAt(stamped): %v", err)
+	}
+	if ts < 0 {
+		t.Fatalf("SessionCreatedAt(stamped) = %d, want non-negative", ts)
+	}
+	if ts > time.Now().Unix()+2 {
+		t.Fatalf("SessionCreatedAt(stamped) = %d is in the future", ts)
+	}
+	if ts != 0 && ts < after-60 {
+		t.Fatalf("SessionCreatedAt(stamped) = %d, implausibly far before create time %d", ts, after)
+	}
+
+	// Cover the non-zero parse path explicitly. SessionCreatedAt's '='-prefixed
+	// (exact-match) target does not expand #{session_created} on tmux 3.6a and
+	// returns 0, so reading the same field via a BARE session-name target gives
+	// the real, non-zero timestamp the parser would otherwise consume. Assert it
+	// lands within a few seconds of the create time, locking in that a created
+	// session reports a plausible, parseable timestamp.
+	bare := gcSessionCreatedBare(t, opts, "stamped")
+	if bare <= 0 {
+		t.Fatalf("bare #{session_created} for stamped = %d, want a positive timestamp", bare)
+	}
+	if bare < after-5 || bare > time.Now().Unix()+2 {
+		t.Fatalf("bare #{session_created} = %d, want within a few seconds of create time %d", bare, after)
+	}
+
+	// Missing session: zero timestamp, no error (the guarded !exists path).
+	missing, err := ops.SessionCreatedAt("ghost", opts)
+	if err != nil {
+		t.Fatalf("SessionCreatedAt(ghost): %v", err)
+	}
+	if missing != 0 {
+		t.Fatalf("SessionCreatedAt(ghost) = %d, want 0", missing)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ActiveAgentSessionsByActivity
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_ActiveAgentSessionsByActivity(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// Tagged agent session: must be discovered.
+	gcCreateSession(t, opts, "amux-ws-tab", "sleep 300")
+	// Untagged, non-amux-prefixed session: must be ignored.
+	gcCreateSession(t, opts, "random-shell", "sleep 300")
+	// Tagged session whose type is not "agent": must be skipped.
+	gcCreateSession(t, opts, "amux-helper", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	gcSetTag(t, opts, "amux-ws-tab", "@amux", "1")
+	gcSetTag(t, opts, "amux-ws-tab", "@amux_workspace", "ws-7")
+	gcSetTag(t, opts, "amux-ws-tab", "@amux_tab", "tab-3")
+	gcSetTag(t, opts, "amux-ws-tab", "@amux_type", "agent")
+
+	gcSetTag(t, opts, "amux-helper", "@amux", "1")
+	gcSetTag(t, opts, "amux-helper", "@amux_type", "helper")
+
+	// window <= 0 disables time-window filtering, exercising the applyWindow=false branch.
+	sessions, err := ops.ActiveAgentSessionsByActivity(0, opts)
+	if err != nil {
+		t.Fatalf("ActiveAgentSessionsByActivity: %v", err)
+	}
+
+	found := map[string]tmux.SessionActivity{}
+	for _, s := range sessions {
+		found[s.Name] = s
+	}
+	got, ok := found["amux-ws-tab"]
+	if !ok {
+		t.Fatalf("ActiveAgentSessionsByActivity missing tagged agent session; got %v", found)
+	}
+	if got.WorkspaceID != "ws-7" || got.TabID != "tab-3" || !got.Tagged {
+		t.Fatalf("agent session = %+v, want WorkspaceID=ws-7 TabID=tab-3 Tagged=true", got)
+	}
+	if _, ok := found["amux-helper"]; ok {
+		t.Error("helper-typed session should be excluded")
+	}
+	if _, ok := found["random-shell"]; ok {
+		t.Error("untagged non-amux session should be excluded")
+	}
+}
+
+func TestTmuxOps_ActiveAgentSessionsByActivity_WindowFilters(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	gcCreateSession(t, opts, "amux-fresh", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+	gcSetTag(t, opts, "amux-fresh", "@amux", "1")
+	gcSetTag(t, opts, "amux-fresh", "@amux_type", "agent")
+
+	// A tiny positive window exercises the applyWindow=true branch. window_activity
+	// is only updated on output, so a quiet sleep session has stale activity and
+	// is filtered out by a 1ns window.
+	sessions, err := ops.ActiveAgentSessionsByActivity(time.Nanosecond, opts)
+	if err != nil {
+		t.Fatalf("ActiveAgentSessionsByActivity(1ns): %v", err)
+	}
+	for _, s := range sessions {
+		if s.Name == "amux-fresh" {
+			t.Fatalf("amux-fresh should be filtered out by a 1ns activity window; got %+v", s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetMonitorActivityOn / SetStatusOff
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_SetMonitorActivityOn(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	if err := ops.SetMonitorActivityOn(opts); err != nil {
+		t.Fatalf("SetMonitorActivityOn: %v", err)
+	}
+	got := gcShowGlobalOption(t, opts, "monitor-activity")
+	if got != "on\n" && got != "on" {
+		t.Fatalf("monitor-activity = %q, want \"on\"", got)
+	}
+}
+
+func TestTmuxOps_SetStatusOff(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	if err := ops.SetStatusOff(opts); err != nil {
+		t.Fatalf("SetStatusOff: %v", err)
+	}
+	got := gcShowGlobalOption(t, opts, "status")
+	if got != "off\n" && got != "off" {
+		t.Fatalf("status = %q, want \"off\"", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CapturePaneTail
+// ---------------------------------------------------------------------------
+
+func TestTmuxOps_CapturePaneTail_EmptyOrZeroLines(t *testing.T) {
+	ops := tmuxOps{}
+
+	// Both guard clauses (empty name, lines<=0) return ("", false) with no tmux call.
+	if out, ok := ops.CapturePaneTail("", 10, tmux.Options{}); ok || out != "" {
+		t.Fatalf("CapturePaneTail(\"\") = (%q, %v), want (\"\", false)", out, ok)
+	}
+	if out, ok := ops.CapturePaneTail("sess", 0, tmux.Options{}); ok || out != "" {
+		t.Fatalf("CapturePaneTail(lines=0) = (%q, %v), want (\"\", false)", out, ok)
+	}
+	if out, ok := ops.CapturePaneTail("sess", -5, tmux.Options{}); ok || out != "" {
+		t.Fatalf("CapturePaneTail(lines<0) = (%q, %v), want (\"\", false)", out, ok)
+	}
+}
+
+func TestTmuxOps_CapturePaneTail_LiveSession(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// A shell that prints a sentinel and stays alive so the pane is live.
+	gcCreateSession(t, opts, "echoer", "printf 'SENTINEL-LINE\\n'; sleep 300")
+	// Allow the printf to land in the pane buffer.
+	for i := 0; i < 40; i++ {
+		time.Sleep(25 * time.Millisecond)
+		if strings.Contains(gcReadCapture(t, opts, "echoer"), "SENTINEL-LINE") {
+			break
+		}
+	}
+
+	out, ok := ops.CapturePaneTail("echoer", 50, opts)
+	if !ok {
+		t.Fatal("CapturePaneTail(echoer) ok = false, want true (live pane)")
+	}
+	if !strings.Contains(out, "SENTINEL-LINE") {
+		t.Fatalf("CapturePaneTail(echoer) = %q, want it to contain SENTINEL-LINE", out)
+	}
+	// Output is normalized: no trailing whitespace/newlines.
+	if len(out) > 0 && (out[len(out)-1] == '\n' || out[len(out)-1] == ' ') {
+		t.Fatalf("CapturePaneTail output not trimmed: %q", out)
+	}
+}
+
+func TestTmuxOps_CapturePaneTail_MissingSession(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := gcTestServer(t)
+	ops := tmuxOps{}
+
+	// A session that does not exist yields no content and ok=false.
+	out, ok := ops.CapturePaneTail("not-here", 10, opts)
+	if ok || out != "" {
+		t.Fatalf("CapturePaneTail(missing) = (%q, %v), want (\"\", false)", out, ok)
+	}
+}


### PR DESCRIPTION
Adds thorough table-driven, behavior-asserting unit tests for every previously-untested method of the tmuxOps wrapper in internal/app/service_tmux.go: EnsureAvailable, InstallHint, AllSessionStates, SessionStateFor, SessionNamesWithClients, SessionCreatedAt, ActiveAgentSessionsByActivity, KillSessionsMatchingTags, KillSessionsWithPrefix, KillSessionsWithPrefixMissingTag, KillWorkspaceSessions, SetMonitorActivityOn, SetStatusOff, and CapturePaneTail.

Pure functions and input-validation fast paths (empty session name, lines<=0, empty prefix/tag) are asserted with no tmux. The subprocess-backed methods run against an isolated tmux server via the existing gcTestServer harness (app_tmux_gc_test.go) and assert real outcomes: which sessions survive vs. are killed, captured pane content, and global option values. No target function was skipped; no production code changed. Tests are split across service_tmux_test.go and service_tmux_kill_test.go to respect the 500-line-per-file cap.

Part of the quality stacked diff. Stacked on improve/099-test-center-tab-actor-selection. Ticket 100 (testability).