### PR TITLE
applyTmuxEnvFromConfig force=true branch and setEnvOrUnset helper are 

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -80,7 +80,7 @@ func New(version, commit, date string) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	applyTmuxEnvFromConfig(cfg, false)
+	applyTmuxEnvFromConfig(cfg)
 	tmuxOpts := tmux.DefaultOptions()
 
 	// Ensure directories exist
@@ -307,15 +307,8 @@ func (a *App) tmuxSyncInterval() time.Duration {
 	return interval
 }
 
-func applyTmuxEnvFromConfig(cfg *config.Config, force bool) {
+func applyTmuxEnvFromConfig(cfg *config.Config) {
 	if cfg == nil {
-		return
-	}
-	if force {
-		setEnvOrUnset(config.WorkspacesRootEnvVar, cfg.Paths.WorkspacesRoot)
-		setEnvOrUnset("AMUX_TMUX_SERVER", cfg.UI.TmuxServer)
-		setEnvOrUnset("AMUX_TMUX_CONFIG", cfg.UI.TmuxConfigPath)
-		setEnvOrUnset("AMUX_TMUX_SYNC_INTERVAL", cfg.UI.TmuxSyncInterval)
 		return
 	}
 	setEnvIfNonEmpty(config.WorkspacesRootEnvVar, cfg.Paths.WorkspacesRoot)

--- a/internal/app/app_init_more_test.go
+++ b/internal/app/app_init_more_test.go
@@ -337,7 +337,7 @@ var tmuxEnvKeys = []string{
 
 // pinTmuxEnv registers cleanups that restore every managed env var to its
 // pre-test value, so mutations made by applyTmuxEnvFromConfig do not leak across
-// tests regardless of which branch ran.
+// tests.
 func pinTmuxEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range tmuxEnvKeys {
@@ -368,9 +368,8 @@ func TestApplyTmuxEnvFromConfig_NilConfigIsNoOp(t *testing.T) {
 	for _, key := range tmuxEnvKeys {
 		t.Setenv(key, "sentinel-"+key)
 	}
-	// A nil config must leave the environment untouched on both force settings.
-	applyTmuxEnvFromConfig(nil, false)
-	applyTmuxEnvFromConfig(nil, true)
+	// A nil config must leave the environment untouched.
+	applyTmuxEnvFromConfig(nil)
 	for _, key := range tmuxEnvKeys {
 		if got := os.Getenv(key); got != "sentinel-"+key {
 			t.Errorf("nil config mutated %s to %q", key, got)
@@ -378,7 +377,7 @@ func TestApplyTmuxEnvFromConfig_NilConfigIsNoOp(t *testing.T) {
 	}
 }
 
-func TestApplyTmuxEnvFromConfig_NonForce_OnlySetsNonEmpty(t *testing.T) {
+func TestApplyTmuxEnvFromConfig_OnlySetsNonEmpty(t *testing.T) {
 	pinTmuxEnv(t)
 	// Pre-seed values that should survive because the config leaves them empty.
 	t.Setenv("AMUX_TMUX_CONFIG", "preexisting-config")
@@ -391,7 +390,7 @@ func TestApplyTmuxEnvFromConfig_NonForce_OnlySetsNonEmpty(t *testing.T) {
 	}
 
 	cfg := cfgWithTmux("amux-server", "", "", "/tmp/ws-root")
-	applyTmuxEnvFromConfig(cfg, false)
+	applyTmuxEnvFromConfig(cfg)
 
 	// Non-empty config fields are applied.
 	if got := os.Getenv("AMUX_TMUX_SERVER"); got != "amux-server" {
@@ -400,7 +399,7 @@ func TestApplyTmuxEnvFromConfig_NonForce_OnlySetsNonEmpty(t *testing.T) {
 	if got := os.Getenv(config.WorkspacesRootEnvVar); got != "/tmp/ws-root" {
 		t.Errorf("%s = %q, want %q", config.WorkspacesRootEnvVar, got, "/tmp/ws-root")
 	}
-	// Empty config fields must NOT clobber preexisting values in non-force mode.
+	// Empty config fields must NOT clobber preexisting values.
 	if got := os.Getenv("AMUX_TMUX_CONFIG"); got != "preexisting-config" {
 		t.Errorf("AMUX_TMUX_CONFIG = %q, want preexisting value preserved", got)
 	}
@@ -409,31 +408,16 @@ func TestApplyTmuxEnvFromConfig_NonForce_OnlySetsNonEmpty(t *testing.T) {
 	}
 }
 
-func TestApplyTmuxEnvFromConfig_Force_UnsetsEmptyFields(t *testing.T) {
-	pinTmuxEnv(t)
-	// Pre-seed values that force mode must clear because the config is empty.
-	for _, key := range tmuxEnvKeys {
-		t.Setenv(key, "stale-"+key)
-	}
-
-	cfg := cfgWithTmux("", "", "", "")
-	applyTmuxEnvFromConfig(cfg, true)
-
-	for _, key := range tmuxEnvKeys {
-		if got, ok := os.LookupEnv(key); ok {
-			t.Errorf("force mode left %s set to %q, want unset", key, got)
-		}
-	}
-}
-
-func TestApplyTmuxEnvFromConfig_Force_SetsAndOverwritesNonEmptyFields(t *testing.T) {
+// TestApplyTmuxEnvFromConfig_OverwritesNonEmptyFields verifies that non-empty
+// config fields overwrite any preexisting env values.
+func TestApplyTmuxEnvFromConfig_OverwritesNonEmptyFields(t *testing.T) {
 	pinTmuxEnv(t)
 	for _, key := range tmuxEnvKeys {
 		t.Setenv(key, "stale-"+key)
 	}
 
 	cfg := cfgWithTmux("srv", "/etc/tmux.conf", "9s", "/var/ws")
-	applyTmuxEnvFromConfig(cfg, true)
+	applyTmuxEnvFromConfig(cfg)
 
 	want := map[string]string{
 		"AMUX_TMUX_SERVER":          "srv",
@@ -443,14 +427,14 @@ func TestApplyTmuxEnvFromConfig_Force_SetsAndOverwritesNonEmptyFields(t *testing
 	}
 	for key, exp := range want {
 		if got := os.Getenv(key); got != exp {
-			t.Errorf("force overwrite %s = %q, want %q", key, got, exp)
+			t.Errorf("overwrite %s = %q, want %q", key, got, exp)
 		}
 	}
 }
 
 // TestApplyTmuxEnvFromConfig_TrimsWhitespace verifies the trimming contract is
 // honored through the helpers: a whitespace-only field is treated as empty
-// (preserved in non-force mode) while a padded value is stored trimmed.
+// (the preexisting value is preserved) while a padded value is stored trimmed.
 func TestApplyTmuxEnvFromConfig_TrimsWhitespace(t *testing.T) {
 	pinTmuxEnv(t)
 	t.Setenv("AMUX_TMUX_SERVER", "keepme")
@@ -459,7 +443,7 @@ func TestApplyTmuxEnvFromConfig_TrimsWhitespace(t *testing.T) {
 	}
 
 	cfg := cfgWithTmux("   ", "  /padded/path  ", "", "")
-	applyTmuxEnvFromConfig(cfg, false)
+	applyTmuxEnvFromConfig(cfg)
 
 	// Whitespace-only server is treated as empty: the preexisting value survives.
 	if got := os.Getenv("AMUX_TMUX_SERVER"); got != "keepme" {

--- a/internal/app/env_helpers.go
+++ b/internal/app/env_helpers.go
@@ -5,15 +5,6 @@ import (
 	"strings"
 )
 
-func setEnvOrUnset(key, value string) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		_ = os.Unsetenv(key)
-		return
-	}
-	_ = os.Setenv(key, value)
-}
-
 func setEnvIfNonEmpty(key, value string) {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/internal/app/env_helpers_test.go
+++ b/internal/app/env_helpers_test.go
@@ -26,92 +26,6 @@ func withCleanEnv(t *testing.T) {
 	})
 }
 
-func TestSetEnvOrUnset(t *testing.T) {
-	tests := []struct {
-		name string
-		// seed is set before invoking the helper to exercise overwrite/clear
-		// behavior; seedSet controls whether the variable starts present.
-		seed    string
-		seedSet bool
-		value   string
-		wantVal string
-		wantSet bool
-	}{
-		{
-			name:    "non-empty sets value",
-			value:   "hello",
-			wantVal: "hello",
-			wantSet: true,
-		},
-		{
-			name:    "empty unsets when previously set",
-			seed:    "previous",
-			seedSet: true,
-			value:   "",
-			wantSet: false,
-		},
-		{
-			name:    "empty is no-op when previously unset",
-			value:   "",
-			wantSet: false,
-		},
-		{
-			name:    "whitespace-only treated as empty and unsets",
-			seed:    "previous",
-			seedSet: true,
-			value:   "   \t  ",
-			wantSet: false,
-		},
-		{
-			name:    "value is trimmed before storing",
-			value:   "  spaced  ",
-			wantVal: "spaced",
-			wantSet: true,
-		},
-		{
-			name:    "non-empty overwrites existing value",
-			seed:    "old",
-			seedSet: true,
-			value:   "new",
-			wantVal: "new",
-			wantSet: true,
-		},
-		{
-			name:    "internal whitespace preserved after trim",
-			value:   "  a b\tc  ",
-			wantVal: "a b\tc",
-			wantSet: true,
-		},
-		{
-			name:    "newline-only treated as empty",
-			seed:    "previous",
-			seedSet: true,
-			value:   "\n\n",
-			wantSet: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			withCleanEnv(t)
-			if tt.seedSet {
-				if err := os.Setenv(envKey, tt.seed); err != nil {
-					t.Fatalf("seed setenv: %v", err)
-				}
-			}
-
-			setEnvOrUnset(envKey, tt.value)
-
-			got, ok := os.LookupEnv(envKey)
-			if ok != tt.wantSet {
-				t.Fatalf("present = %v, want %v (value=%q)", ok, tt.wantSet, got)
-			}
-			if tt.wantSet && got != tt.wantVal {
-				t.Fatalf("value = %q, want %q", got, tt.wantVal)
-			}
-		})
-	}
-}
-
 func TestSetEnvIfNonEmpty(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -129,8 +43,8 @@ func TestSetEnvIfNonEmpty(t *testing.T) {
 		},
 		{
 			name: "empty is no-op when previously unset",
-			// Distinguishes setEnvIfNonEmpty from setEnvOrUnset: the variable
-			// stays absent rather than being explicitly unset.
+			// setEnvIfNonEmpty never unsets: an empty value leaves the
+			// variable absent rather than explicitly unsetting it.
 			value:   "",
 			wantSet: false,
 		},


### PR DESCRIPTION
Drop the dead `force bool` parameter and force=true branch from `applyTmuxEnvFromConfig`, and delete the now-orphaned `setEnvOrUnset` helper. Production calls the function exactly once (with force=false), so only the `setEnvIfNonEmpty` path was ever reachable; the force branch and its helper ran solely in tests. Updates the sole production caller and the affected tests. Behavior is unchanged. Part of the quality stacked diff. Stacked on roadmap/02-data-project-behavior-methods-addworkspace-fin. Ticket 03 (simplicity).