### PR TITLE
git operations.go: family of GOOS-defaulting wrapper shims called only

### DIFF
--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -168,10 +168,6 @@ func RunGitRawCtx(ctx context.Context, dir string, args ...string) ([]byte, erro
 	return stdout.Bytes(), nil
 }
 
-func gitCommandContextError(ctx context.Context, runErr error, args []string) error {
-	return gitCommandContextErrorWithKillForGOOS(ctx, runtime.GOOS, runErr, args, false)
-}
-
 func gitCommandContextErrorWithKill(ctx context.Context, runErr error, args []string, killedByContext bool) error {
 	return gitCommandContextErrorWithKillForGOOS(ctx, runtime.GOOS, runErr, args, killedByContext)
 }
@@ -193,16 +189,6 @@ func gitAllowFailureCommandContextErrorWithKill(
 	)
 }
 
-func gitAllowFailureCommandContextErrorForGOOS(
-	ctx context.Context,
-	goos string,
-	runErr error,
-	args []string,
-	stdoutLen int,
-) error {
-	return gitAllowFailureCommandContextErrorWithKillForGOOS(ctx, goos, runErr, args, stdoutLen, false)
-}
-
 func gitAllowFailureCommandContextErrorWithKillForGOOS(
 	ctx context.Context,
 	goos string,
@@ -215,10 +201,6 @@ func gitAllowFailureCommandContextErrorWithKillForGOOS(
 		return nil
 	}
 	return gitCommandContextErrorWithKillForGOOS(ctx, goos, runErr, args, killedByContext)
-}
-
-func gitCommandContextErrorForGOOS(ctx context.Context, goos string, runErr error, args []string) error {
-	return gitCommandContextErrorWithKillForGOOS(ctx, goos, runErr, args, false)
 }
 
 func gitCommandContextErrorWithKillForGOOS(
@@ -239,7 +221,7 @@ func gitCommandContextErrorWithKillForGOOS(
 		return nil
 	}
 	if err := ctx.Err(); err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
-		if killedByContext || isCommandContextTerminationExitCodeForGOOS(goos, exitErr.ExitCode()) {
+		if killedByContext || isCommandContextTerminationExitCode(exitErr.ExitCode()) {
 			return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 		}
 	}
@@ -247,10 +229,6 @@ func gitCommandContextErrorWithKillForGOOS(
 }
 
 func isCommandContextTerminationExitCode(exitCode int) bool {
-	return isCommandContextTerminationExitCodeForGOOS(runtime.GOOS, exitCode)
-}
-
-func isCommandContextTerminationExitCodeForGOOS(_ string, exitCode int) bool {
 	return exitCode == -1
 }
 

--- a/internal/git/operations_test.go
+++ b/internal/git/operations_test.go
@@ -269,7 +269,7 @@ func TestGitCommandContextErrorDoesNotMaskExitErrorAfterLateCancel(t *testing.T)
 
 	cancel()
 
-	if ctxErr := gitCommandContextError(ctx, err, []string{"status"}); ctxErr != nil {
+	if ctxErr := gitCommandContextErrorWithKill(ctx, err, []string{"status"}, false); ctxErr != nil {
 		t.Fatalf("expected late cancellation to preserve original exit error, got %v", ctxErr)
 	}
 }
@@ -296,12 +296,13 @@ func TestGitAllowFailureCommandContextErrorForWindowsPreservesOutputExitOne(t *t
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if ctxErr := gitAllowFailureCommandContextErrorForGOOS(
+	if ctxErr := gitAllowFailureCommandContextErrorWithKillForGOOS(
 		ctx,
 		"windows",
 		err,
 		[]string{"diff", "--no-index", "--no-color", "--", left, right},
 		1,
+		false,
 	); ctxErr != nil {
 		t.Fatalf("expected allow-failure output to suppress ambiguous windows timeout mapping, got %v", ctxErr)
 	}
@@ -329,12 +330,13 @@ func TestGitAllowFailureCommandContextErrorForWindowsWithoutKillDoesNotMapTimeou
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	ctxErr := gitAllowFailureCommandContextErrorForGOOS(
+	ctxErr := gitAllowFailureCommandContextErrorWithKillForGOOS(
 		ctx,
 		"windows",
 		err,
 		[]string{"diff", "--no-index", "--no-color", "--", left, right},
 		0,
+		false,
 	)
 	if ctxErr != nil {
 		t.Fatalf("expected ordinary exit error to remain unmapped without kill evidence, got %v", ctxErr)
@@ -436,11 +438,12 @@ func TestGitCommandContextErrorForWindowsWithoutKillDoesNotMapTimeout(t *testing
 	defer cancel()
 	time.Sleep(2 * time.Millisecond)
 
-	ctxErr := gitCommandContextErrorForGOOS(
+	ctxErr := gitCommandContextErrorWithKillForGOOS(
 		ctx,
 		"windows",
 		err,
 		[]string{"diff", "--no-index", "--no-color", "--", left, right},
+		false,
 	)
 	if ctxErr != nil {
 		t.Fatalf("expected ordinary exit error to remain unmapped without kill evidence, got %v", ctxErr)


### PR DESCRIPTION
Deletes four test-only convenience wrappers in internal/git/operations.go (gitCommandContextError, gitAllowFailureCommandContextErrorForGOOS, gitCommandContextErrorForGOOS, isCommandContextTerminationExitCodeForGOOS) that had zero production callers — production only uses the *WithKill / *WithKillForGOOS variants. Tests now call the live functions directly with explicit killedByContext=false. Also collapses the ignored `_ string` goos param out of isCommandContextTerminationExitCodeForGOOS (merged into isCommandContextTerminationExitCode), since the GOOS dimension was fictional generality. Behavior is identical; make devcheck-equivalent checks (gofmt, go build/vet ./..., go test ./..., pinned golangci-lint on internal/git, check-file-length) all pass. Part of the quality stacked diff. Stacked on roadmap/04-data-workspacestore-update-appendopentab-are-d. Ticket 05 (simplicity).