### PR TITLE
Critical external-message interface has a two-tier hierarchy whose low

### DIFF
--- a/internal/app/app_msgpump.go
+++ b/internal/app/app_msgpump.go
@@ -55,28 +55,14 @@ func (a *App) tryEnqueueExternalMsg(msg tea.Msg) bool {
 		return false
 	}
 	if isCriticalExternalMsg(msg) {
-		_, nonEvicting := msg.(common.NonEvictingCriticalExternalMsg)
+		// Critical messages are non-evicting: if the critical queue is full they
+		// drop themselves rather than evicting a queued non-critical message.
 		select {
 		case a.externalCritical <- msg:
 			return true
 		default:
-			if nonEvicting {
-				perf.Count("external_msg_drop_critical", 1)
-				return false
-			}
-			// Critical channel full - try to drop a non-critical message to make room
-			select {
-			case <-a.externalMsgs:
-				perf.Count("external_msg_drop_noncritical", 1)
-			default:
-			}
-			select {
-			case a.externalCritical <- msg:
-				return true
-			default:
-				perf.Count("external_msg_drop_critical", 1)
-				return false
-			}
+			perf.Count("external_msg_drop_critical", 1)
+			return false
 		}
 	}
 	select {

--- a/internal/app/app_msgpump_test.go
+++ b/internal/app/app_msgpump_test.go
@@ -17,16 +17,6 @@ func (criticalTestMsg) MarkCriticalExternalMsg() {}
 
 var _ common.CriticalExternalMsg = criticalTestMsg{}
 
-type nonEvictingCriticalTestMsg struct{}
-
-func (nonEvictingCriticalTestMsg) MarkCriticalExternalMsg()            {}
-func (nonEvictingCriticalTestMsg) MarkNonEvictingCriticalExternalMsg() {}
-
-var (
-	_ common.CriticalExternalMsg            = nonEvictingCriticalTestMsg{}
-	_ common.NonEvictingCriticalExternalMsg = nonEvictingCriticalTestMsg{}
-)
-
 func TestEnqueueExternalMsgDropsWhenFull(t *testing.T) {
 	a := &App{externalMsgs: make(chan tea.Msg, 1)}
 
@@ -88,17 +78,7 @@ func TestEnqueueExternalMsgRoutesCriticalInterfaceToCriticalQueue(t *testing.T) 
 	}
 }
 
-func TestNonEvictingCriticalInterfaceImpliesCriticalRouting(t *testing.T) {
-	var msg any = nonEvictingCriticalTestMsg{}
-	if _, ok := msg.(common.NonEvictingCriticalExternalMsg); !ok {
-		t.Fatal("expected test message to implement NonEvictingCriticalExternalMsg")
-	}
-	if _, ok := msg.(common.CriticalExternalMsg); !ok {
-		t.Fatal("expected NonEvictingCriticalExternalMsg to imply CriticalExternalMsg")
-	}
-}
-
-func TestEnqueueExternalMsg_NonEvictingCriticalDoesNotDropNormalQueue(t *testing.T) {
+func TestEnqueueExternalMsg_FullCriticalQueueDoesNotDropNormalQueue(t *testing.T) {
 	a := &App{
 		externalMsgs:     make(chan tea.Msg, 1),
 		externalCritical: make(chan tea.Msg, 1),
@@ -107,7 +87,11 @@ func TestEnqueueExternalMsg_NonEvictingCriticalDoesNotDropNormalQueue(t *testing
 	a.externalMsgs <- testMsg("normal")
 	a.externalCritical <- criticalTestMsg{}
 
-	a.enqueueExternalMsg(nonEvictingCriticalTestMsg{})
+	// Critical messages are non-evicting: enqueuing one while the critical queue
+	// is full must drop the new message rather than evict the normal queue.
+	if a.tryEnqueueExternalMsg(criticalTestMsg{}) {
+		t.Fatal("expected enqueue to fail when critical queue is full")
+	}
 
 	if got := len(a.externalMsgs); got != 1 {
 		t.Fatalf("expected normal queue length to remain 1, got %d", got)

--- a/internal/app/soak_test.go
+++ b/internal/app/soak_test.go
@@ -131,7 +131,7 @@ func logSoakPerf(t *testing.T, stats []perf.StatSnapshot, counters []perf.Counte
 	}
 	for _, c := range counters {
 		switch c.Name {
-		case "external_msg_drop", "external_msg_drop_noncritical", "external_msg_drop_critical":
+		case "external_msg_drop", "external_msg_drop_critical":
 			t.Logf("soak counter %s=%d", c.Name, c.Value)
 		}
 	}

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -68,8 +68,7 @@ type selectionTickRequest struct {
 
 type tabActorRedraw struct{}
 
-func (tabActorRedraw) MarkCriticalExternalMsg()            {}
-func (tabActorRedraw) MarkNonEvictingCriticalExternalMsg() {}
+func (tabActorRedraw) MarkCriticalExternalMsg() {}
 
 type tabDiffCmd struct{ cmd tea.Cmd }
 

--- a/internal/ui/center/tab_actor_handlers_test.go
+++ b/internal/ui/center/tab_actor_handlers_test.go
@@ -16,17 +16,15 @@ import (
 // tabActorRedraw marker methods
 // ---------------------------------------------------------------------------
 
-// TestTabActorRedraw_MarkerMethods exercises the two marker methods directly.
-// They are intentionally no-ops, but the compiler-level guarantee that they
-// implement the critical-external-msg contract is the load-bearing behavior:
-// the actor relies on these markers so its redraw nudge survives msg eviction.
+// TestTabActorRedraw_MarkerMethods exercises the marker method directly. It is
+// intentionally a no-op, but the compiler-level guarantee that it implements the
+// critical-external-msg contract is the load-bearing behavior: the actor relies
+// on this marker so its redraw nudge is routed through the critical queue.
 func TestTabActorRedraw_MarkerMethods(t *testing.T) {
 	r := tabActorRedraw{}
-	// Direct calls must not panic and must remain no-ops (nothing to observe).
-	// Interface satisfaction is covered by
-	// TestTabActorRedraw_IsNonEvictingCriticalExternalMsg.
+	// Direct call must not panic and must remain a no-op (nothing to observe).
+	// Interface satisfaction is covered by TestTabActorRedraw_IsCriticalExternalMsg.
 	r.MarkCriticalExternalMsg()
-	r.MarkNonEvictingCriticalExternalMsg()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ui/center/tab_actor_input_test.go
+++ b/internal/ui/center/tab_actor_input_test.go
@@ -250,13 +250,10 @@ func TestShouldPostTabActorRedraw(t *testing.T) {
 	}
 }
 
-func TestTabActorRedraw_IsNonEvictingCriticalExternalMsg(t *testing.T) {
+func TestTabActorRedraw_IsCriticalExternalMsg(t *testing.T) {
 	var msg any = tabActorRedraw{}
 	if _, ok := msg.(common.CriticalExternalMsg); !ok {
 		t.Fatal("expected tabActorRedraw to implement CriticalExternalMsg")
-	}
-	if _, ok := msg.(common.NonEvictingCriticalExternalMsg); !ok {
-		t.Fatal("expected tabActorRedraw to implement NonEvictingCriticalExternalMsg")
 	}
 }
 

--- a/internal/ui/common/external_msg.go
+++ b/internal/ui/common/external_msg.go
@@ -2,14 +2,11 @@ package common
 
 // CriticalExternalMsg marks messages that must bypass the normal lossy external
 // message queue and go through the critical path instead.
+//
+// Critical messages are non-evicting: when the critical queue is full they drop
+// themselves rather than evicting a queued non-critical message. (An evicting
+// tier used to exist, but no real message ever needed it, so the distinction was
+// removed.)
 type CriticalExternalMsg interface {
 	MarkCriticalExternalMsg()
-}
-
-// NonEvictingCriticalExternalMsg marks critical messages that should drop
-// themselves when the critical queue is full instead of evicting normal
-// external messages.
-type NonEvictingCriticalExternalMsg interface {
-	CriticalExternalMsg
-	MarkNonEvictingCriticalExternalMsg()
 }


### PR DESCRIPTION
Collapse the two-tier CriticalExternalMsg / NonEvictingCriticalExternalMsg hierarchy into a single non-evicting CriticalExternalMsg marker.

The only production critical message (tabActorRedraw) implemented both interfaces, so it was always non-evicting and the make-room-by-dropping-noncritical eviction branch in tryEnqueueExternalMsg was unreachable except via a synthetic test type. This removes that dead capability: delete NonEvictingCriticalExternalMsg, make CriticalExternalMsg mean non-evicting, drop the eviction branch, and prune the synthetic test types plus the now-dead external_msg_drop_noncritical counter. Behavior is identical to production today. make devcheck passes.

Part of the quality stacked diff. Stacked on roadmap/05-git-operations-go-family-of-goos-defaulting-wr. Ticket 06 (simplicity).