### PR TITLE
`make dev` requires `air` with zero install guidance anywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,14 @@ make devcheck
 
 `golangci-lint` is required locally. Install instructions: https://golangci-lint.run/welcome/install/
 
+For the hot-reload inner loop, `make dev` runs [`air`](https://github.com/air-verse/air) using the repo's `.air.toml`. Install it once with:
+
+```bash
+go install github.com/air-verse/air@latest
+```
+
+Ensure `$(go env GOPATH)/bin` is on your `PATH`; otherwise `make dev` prints this same install hint and exits.
+
 For style-only cleanup, run:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,13 @@ run: build
 	./$(BINARY_NAME)
 
 dev:
+	@command -v air >/dev/null 2>&1 || { \
+		echo "make dev: 'air' not found on PATH." >&2; \
+		echo "Install the hot-reload runner with:" >&2; \
+		echo "  go install github.com/air-verse/air@latest" >&2; \
+		echo "(then ensure \$$(go env GOPATH)/bin is on your PATH)." >&2; \
+		exit 1; \
+	}
 	air
 
 help:
@@ -225,7 +232,7 @@ help:
 	@echo "  vet        - Run go vet"
 	@echo "  clean      - Remove build artifacts"
 	@echo "  run        - Build and run"
-	@echo "  dev        - Run with hot reload (requires air)"
+	@echo "  dev        - Run with hot reload (requires air: go install github.com/air-verse/air@latest)"
 	@echo "  verify-loop - Drive a real keystroke through amux into a raw-mode agent (close-the-loop input gate; requires tmux)"
 	@echo "  tmux-skip-check - Warn (non-fatal) when real-tmux/e2e tests silently skip (no tmux server)"
 	@echo "  bench      - Run rendering benchmarks"


### PR DESCRIPTION
`make dev` shells out to `air` (a third-party binary not in go.mod tooling) with no install pointer anywhere, so a newcomer gets a bare `make: air: No such file or directory`. This adds a CONTRIBUTING note (`go install github.com/air-verse/air@latest`, matching `.air.toml`'s v1 config), surfaces the same hint in `make help`, and guards the `dev` target to print the install command instead of a cryptic error when `air` is missing. Mirrors how the project self-bootstraps golangci-lint. Part of the quality stacked diff. Stacked on roadmap/06-critical-external-message-interface-has-a-two. Ticket 07 (maintainability).