### PR TITLE
'agent-picker' dialog ID is a magic string duplicated across 5 sites, 

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -29,6 +29,10 @@ const (
 	DialogDeleteWorkspace = "delete_workspace"
 	DialogTrustScripts    = "trust_scripts"
 	DialogRemoveProject   = "remove_project"
+	// DialogSelectAssistant is the legacy ID for the assistant-selection flow.
+	// The dialog itself is built by common.NewAgentPicker and carries
+	// common.AgentPickerDialogID at runtime; handleDialogResult still matches
+	// DialogSelectAssistant alongside it so older callers keep routing.
 	DialogSelectAssistant = "select_assistant"
 	DialogQuit            = "quit"
 	DialogCleanupTmux     = "cleanup_tmux"

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -21,7 +21,7 @@ func (a *App) handleDialogResultMsg(msg tea.Msg) (bool, tea.Cmd) {
 	}
 	logging.Info("Received DialogResult: id=%s confirmed=%v", result.ID, result.Confirmed)
 	switch result.ID {
-	case DialogAddProject, DialogCreateWorkspace, DialogDeleteWorkspace, DialogTrustScripts, DialogRemoveProject, DialogSelectAssistant, "agent-picker", DialogQuit, DialogCleanupTmux:
+	case DialogAddProject, DialogCreateWorkspace, DialogDeleteWorkspace, DialogTrustScripts, DialogRemoveProject, DialogSelectAssistant, common.AgentPickerDialogID, DialogQuit, DialogCleanupTmux:
 		return true, common.SafeCmd(a.handleDialogResult(result))
 	}
 	// If not an App-level dialog, let it fall through to components.
@@ -107,7 +107,7 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 	logging.Debug("Dialog result: id=%s confirmed=%v value=%s", result.ID, result.Confirmed, result.Value)
 
 	if !result.Confirmed {
-		if result.ID == DialogSelectAssistant || result.ID == "agent-picker" {
+		if result.ID == DialogSelectAssistant || result.ID == common.AgentPickerDialogID {
 			a.pendingWorkspaceProject = nil
 			a.pendingWorkspaceName = ""
 			a.pendingWorkspaceBase = ""
@@ -174,7 +174,7 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 			}
 		}
 
-	case DialogSelectAssistant, "agent-picker":
+	case DialogSelectAssistant, common.AgentPickerDialogID:
 		assistant := result.Value
 		if err := validation.ValidateAssistant(assistant); err != nil {
 			return func() tea.Msg {

--- a/internal/ui/common/agent_picker.go
+++ b/internal/ui/common/agent_picker.go
@@ -7,6 +7,11 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
+// AgentPickerDialogID is the dialog ID assigned to the agent selection dialog
+// produced by NewAgentPicker. The app layer matches on it to route confirm
+// results, and dialog rendering branches on it for the picker's custom layout.
+const AgentPickerDialogID = "agent-picker"
+
 // NewAgentPicker creates a new agent selection dialog with fuzzy filtering
 func NewAgentPicker(options []string) *Dialog {
 	optionNames := normalizeAssistantOptions(options)
@@ -27,7 +32,7 @@ func NewAgentPicker(options []string) *Dialog {
 	fi.SetVirtualCursor(false)
 
 	return &Dialog{
-		id:              "agent-picker",
+		id:              AgentPickerDialogID,
 		dtype:           DialogSelect,
 		title:           "New Agent",
 		message:         "Select agent type:",

--- a/internal/ui/common/dialog_render.go
+++ b/internal/ui/common/dialog_render.go
@@ -174,7 +174,7 @@ func (d *Dialog) renderLines() []string {
 }
 
 func (d *Dialog) renderOptionsLines(baseLine int) []string {
-	if d.id == "agent-picker" {
+	if d.id == AgentPickerDialogID {
 		return d.renderAgentPickerOptions(baseLine)
 	}
 	return []string{d.renderHorizontalOptionsLine(baseLine)}


### PR DESCRIPTION
Hoist the bare "agent-picker" dialog ID into an exported `common.AgentPickerDialogID` constant owned by the package that builds `NewAgentPicker`, and reference it from all five former literal sites: the picker constructor (`common/agent_picker.go`), the render branch (`common/dialog_render.go`), and the three `handleDialogResult` routes (`app/app_input_dialogs.go`). A rename or typo in any of these previously broke confirm routing or rendering with no compile error; now there is a single source of truth. The legacy `DialogSelectAssistant` constant is kept (no dialog carries it at runtime, but it stays matched for older callers) with a doc comment explaining the dual identity. `go vet ./...`, `go test ./internal/app/...`, `./internal/ui/common/...`, and lint all pass. Part of the quality stacked diff. Stacked on roadmap/09-dialog-show-setup-boilerplate-setsize-setshowk. Ticket 10 (maintainability).