### PR TITLE
Adding one dialog requires synchronized edits across 7 sites in 6 file

### DIFF
--- a/internal/app/app_dialogs_registry.go
+++ b/internal/app/app_dialogs_registry.go
@@ -1,0 +1,44 @@
+package app
+
+import "github.com/andyrewlee/amux/internal/ui/common"
+
+// appDialogIDList is the single source of truth for the dialog IDs that the App
+// itself owns (as opposed to dialogs owned by center/sidebar components). Adding
+// a new App-level dialog means adding its ID here and a behavioral case in
+// handleDialogResult; the routing allow-list in handleDialogResultMsg derives
+// from this list, so the two enumerations can no longer drift.
+//
+// Keep this list in sync with the Dialog* constants in app_core.go and the
+// switch in handleDialogResult. TestAppDialogIDsCoverConstants asserts every
+// Dialog* constant is present here.
+var appDialogIDList = []string{
+	DialogAddProject,
+	DialogCreateWorkspace,
+	DialogDeleteWorkspace,
+	DialogTrustScripts,
+	DialogRemoveProject,
+	DialogSelectAssistant,
+	// AgentPickerDialogID is the runtime ID emitted by common.NewAgentPicker;
+	// it shares handleDialogResult's assistant-selection case with
+	// DialogSelectAssistant, so it must route to the App, not a component.
+	common.AgentPickerDialogID,
+	DialogQuit,
+	DialogCleanupTmux,
+}
+
+// appDialogIDs is the set form of appDialogIDList, built once at init. Routing
+// (handleDialogResultMsg) tests membership against this set instead of an inline
+// case list so a newly added dialog cannot silently misroute to a component.
+var appDialogIDs = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(appDialogIDList))
+	for _, id := range appDialogIDList {
+		set[id] = struct{}{}
+	}
+	return set
+}()
+
+// isAppDialogID reports whether id names a dialog handled at the App level.
+func isAppDialogID(id string) bool {
+	_, ok := appDialogIDs[id]
+	return ok
+}

--- a/internal/app/app_dialogs_registry_test.go
+++ b/internal/app/app_dialogs_registry_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+// TestAppDialogIDsCoverConstants guards the single-source-of-truth contract:
+// every Dialog* constant declared in app_core.go (plus the agent-picker runtime
+// ID) must be a member of appDialogIDs. If a new dialog constant is added
+// without registering it here, its DialogResult would silently misroute to a
+// component instead of handleDialogResult — this test fails first.
+func TestAppDialogIDsCoverConstants(t *testing.T) {
+	constants := []string{
+		DialogAddProject,
+		DialogCreateWorkspace,
+		DialogDeleteWorkspace,
+		DialogTrustScripts,
+		DialogRemoveProject,
+		DialogSelectAssistant,
+		common.AgentPickerDialogID,
+		DialogQuit,
+		DialogCleanupTmux,
+	}
+	for _, id := range constants {
+		if !isAppDialogID(id) {
+			t.Errorf("dialog ID %q is not registered in appDialogIDs; "+
+				"its DialogResult would misroute to a component", id)
+		}
+	}
+}
+
+// TestAppDialogIDsNoDuplicates ensures the list form has no duplicate entries
+// (which would mask a missing distinct ID and inflate the set's apparent size).
+func TestAppDialogIDsNoDuplicates(t *testing.T) {
+	seen := make(map[string]struct{}, len(appDialogIDList))
+	for _, id := range appDialogIDList {
+		if _, dup := seen[id]; dup {
+			t.Errorf("duplicate dialog ID %q in appDialogIDList", id)
+		}
+		seen[id] = struct{}{}
+	}
+	if len(seen) != len(appDialogIDs) {
+		t.Errorf("appDialogIDList has %d unique IDs but appDialogIDs has %d",
+			len(seen), len(appDialogIDs))
+	}
+}
+
+// TestUnknownDialogIDIsNotAppLevel sanity-checks the negative case: an ID that
+// is not in the registry must route away from the App.
+func TestUnknownDialogIDIsNotAppLevel(t *testing.T) {
+	if isAppDialogID("definitely-not-a-real-dialog") {
+		t.Fatal("unexpected: unknown ID reported as an App-level dialog")
+	}
+}

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -20,8 +20,7 @@ func (a *App) handleDialogResultMsg(msg tea.Msg) (bool, tea.Cmd) {
 		return false, nil
 	}
 	logging.Info("Received DialogResult: id=%s confirmed=%v", result.ID, result.Confirmed)
-	switch result.ID {
-	case DialogAddProject, DialogCreateWorkspace, DialogDeleteWorkspace, DialogTrustScripts, DialogRemoveProject, DialogSelectAssistant, common.AgentPickerDialogID, DialogQuit, DialogCleanupTmux:
+	if isAppDialogID(result.ID) {
 		return true, common.SafeCmd(a.handleDialogResult(result))
 	}
 	// If not an App-level dialog, let it fall through to components.
@@ -105,6 +104,14 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 	a.dialogWorkspace = nil
 	a.dialogTrustScriptsHash = ""
 	logging.Debug("Dialog result: id=%s confirmed=%v value=%s", result.ID, result.Confirmed, result.Value)
+
+	// Defensive: handleDialogResult only knows how to act on IDs in the shared
+	// registry. Routing already gates on isAppDialogID, so an unknown ID here
+	// signals the behavioral switch below and the registry have drifted.
+	if !isAppDialogID(result.ID) {
+		logging.Warn("handleDialogResult called with non-App dialog ID: %s", result.ID)
+		return nil
+	}
 
 	if !result.Confirmed {
 		if result.ID == DialogSelectAssistant || result.ID == common.AgentPickerDialogID {


### PR DESCRIPTION
Collapse the parallel App-level dialog-ID enumerations into a single source of truth. Previously a new dialog whose ID was omitted from handleDialogResultMsg's hand-maintained allow-list would silently misroute its DialogResult to a component (no compile error, confirm button just did nothing).

New file internal/app/app_dialogs_registry.go holds appDialogIDList, a set built once from it, and isAppDialogID. Routing (handleDialogResultMsg) tests set membership instead of an inline case list; handleDialogResult guards on the same set so the two enumerations cannot diverge. TestAppDialogIDsCoverConstants asserts every Dialog* constant is registered.

Part of the quality stacked diff. Stacked on roadmap/11-vterm-parser-state-go-snapshotparserstate-rest. Ticket 12 (maintainability).