### PR TITLE
Three divergent implementations of 'is this assistant a chat agent?' w

### DIFF
--- a/internal/app/app_tmux_activity_hysteresis.go
+++ b/internal/app/app_tmux_activity_hysteresis.go
@@ -13,12 +13,6 @@ import (
 // Concurrency safety: built synchronously in the Update loop.
 func (a *App) tabSessionInfoByName() map[string]activity.SessionInfo {
 	infoBySession := make(map[string]activity.SessionInfo)
-	assistants := map[string]struct{}{}
-	if a.config != nil {
-		for name := range a.config.Assistants {
-			assistants[name] = struct{}{}
-		}
-	}
 	for _, project := range a.projects {
 		for i := range project.Workspaces {
 			ws := &project.Workspaces[i]
@@ -32,7 +26,10 @@ func (a *App) tabSessionInfoByName() map[string]activity.SessionInfo {
 					status = "running"
 				}
 				assistant := strings.TrimSpace(tab.Assistant)
-				_, isChat := assistants[assistant]
+				// Single source of truth for chat-classification so activity
+				// detection and the center renderer agree, including when no
+				// config is loaded (empty-config falls back to the registry).
+				isChat := a.config.IsChatAssistant(assistant)
 				infoBySession[name] = activity.SessionInfo{
 					Status:      status,
 					WorkspaceID: string(ws.ID()),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,19 @@ func (c *Config) IsAssistantKnown(assistant string) bool {
 	return ok
 }
 
+// IsChatAssistant reports whether name should be treated as a chat agent. It is
+// the single source of truth for this predicate so activity detection and the
+// center renderer agree even on the empty-config path: when assistants are
+// loaded it consults the config map; otherwise it falls back to the canonical
+// agent registry rather than reporting false for every agent.
+func (c *Config) IsChatAssistant(name string) bool {
+	if c != nil && len(c.Assistants) > 0 {
+		_, ok := c.Assistants[name]
+		return ok
+	}
+	return IsRegisteredAgent(name)
+}
+
 // ResolvedDefaultAssistant returns a valid default assistant name.
 func (c *Config) ResolvedDefaultAssistant() string {
 	if c == nil {

--- a/internal/config/is_chat_assistant_test.go
+++ b/internal/config/is_chat_assistant_test.go
@@ -1,0 +1,74 @@
+package config
+
+import "testing"
+
+// TestIsChatAssistant pins the agreed chat-classification fallback so activity
+// detection (app.tabSessionInfoByName) and center rendering (center.assistantIsChat)
+// stay in lockstep. The empty-config and registered-but-not-in-config cases are
+// exactly where the previous three divergent implementations disagreed.
+func TestIsChatAssistant(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *Config
+		assistant string
+		want      bool
+	}{
+		{
+			name:      "nil config falls back to registry: registered agent is chat",
+			cfg:       nil,
+			assistant: "claude",
+			want:      true,
+		},
+		{
+			name:      "nil config falls back to registry: unknown agent is not chat",
+			cfg:       nil,
+			assistant: "totally-unknown",
+			want:      false,
+		},
+		{
+			name:      "empty config falls back to registry: registered agent is chat",
+			cfg:       &Config{Assistants: map[string]AssistantConfig{}},
+			assistant: "codex",
+			want:      true,
+		},
+		{
+			name:      "empty config falls back to registry: unknown agent is not chat",
+			cfg:       &Config{Assistants: map[string]AssistantConfig{}},
+			assistant: "totally-unknown",
+			want:      false,
+		},
+		{
+			name: "non-empty config: present assistant is chat even if unregistered",
+			cfg: &Config{Assistants: map[string]AssistantConfig{
+				"custom-bot": {Command: "custom"},
+			}},
+			assistant: "custom-bot",
+			want:      true,
+		},
+		{
+			name: "non-empty config: registered agent absent from config is not chat",
+			cfg: &Config{Assistants: map[string]AssistantConfig{
+				"custom-bot": {Command: "custom"},
+			}},
+			assistant: "claude",
+			want:      false,
+		},
+		{
+			name: "non-empty config: assistant present alongside others is chat",
+			cfg: &Config{Assistants: map[string]AssistantConfig{
+				"claude": {Command: "claude"},
+				"codex":  {Command: "codex"},
+			}},
+			assistant: "codex",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.IsChatAssistant(tt.assistant); got != tt.want {
+				t.Fatalf("IsChatAssistant(%q) = %v, want %v", tt.assistant, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/center/model_chat_tab.go
+++ b/internal/ui/center/model_chat_tab.go
@@ -1,15 +1,13 @@
 package center
 
-import "github.com/andyrewlee/amux/internal/config"
-
 func (m *Model) assistantIsChat(assistant string) bool {
-	if m != nil && m.config != nil && len(m.config.Assistants) > 0 {
-		_, ok := m.config.Assistants[assistant]
-		return ok
+	if m == nil {
+		return false
 	}
-	// Fallback when no config is loaded: consult the canonical agent registry
-	// so the supported roster stays in lockstep with config/theme.
-	return config.IsRegisteredAgent(assistant)
+	// Delegate to the single source of truth so activity detection and center
+	// rendering classify chat agents identically, including the empty-config
+	// path where it falls back to the canonical agent registry.
+	return m.config.IsChatAssistant(assistant)
 }
 
 func tabHasDiffViewerLocked(tab *Tab) bool {


### PR DESCRIPTION
Adds `Config.IsChatAssistant` as the single source of truth for chat-agent classification (present in `c.Assistants` -> true; else `config.IsRegisteredAgent`) and routes both `app.tabSessionInfoByName` and `center.assistantIsChat` through it. Previously these two call sites disagreed on the empty-config path — activity detection reported every agent as non-chat while center rendering fell back to the canonical registry — so the two subsystems could classify the same tab differently. A new table test pins the empty-config and registered-but-not-in-config cases. Part of the quality stacked diff. Stacked on roadmap/12-adding-one-dialog-requires-synchronized-edits. Ticket 13 (maintainability).