### PR TITLE
tmux pane cursor/size malformed-input error branches are untestable (e

### DIFF
--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -125,7 +125,15 @@ func paneCursorPosition(paneID string, opts Options) (int, int, bool, error) {
 	if err != nil {
 		return 0, 0, false, err
 	}
-	for _, line := range parseOutputLines(output) {
+	return parsePaneCursor(parseOutputLines(output), paneID)
+}
+
+// parsePaneCursor extracts the cursor position for paneID from tmux list-panes
+// output lines formatted as "#{pane_id}\t#{cursor_x}\t#{cursor_y}". Lines for
+// other panes (or malformed field counts) are skipped; non-numeric cursor
+// fields surface as an error. Returns ok=false when no line matches paneID.
+func parsePaneCursor(lines []string, paneID string) (int, int, bool, error) {
+	for _, line := range lines {
 		parts, err := parseTabFields(line, 3)
 		if err != nil || parts[0] != paneID {
 			continue
@@ -150,7 +158,16 @@ func paneSize(paneID string, opts Options) (int, int, bool, error) {
 	if err != nil {
 		return 0, 0, false, err
 	}
-	for _, line := range parseOutputLines(output) {
+	return parsePaneSize(parseOutputLines(output), paneID)
+}
+
+// parsePaneSize extracts the cell dimensions for paneID from tmux list-panes
+// output lines formatted as "#{pane_id}\t#{pane_width}\t#{pane_height}". Lines
+// for other panes (or malformed field counts) are skipped; non-numeric or
+// zero/negative dimensions surface as an error. Returns ok=false when no line
+// matches paneID.
+func parsePaneSize(lines []string, paneID string) (int, int, bool, error) {
+	for _, line := range lines {
 		parts, err := parseTabFields(line, 3)
 		if err != nil || parts[0] != paneID {
 			continue

--- a/internal/tmux/capture_parse_test.go
+++ b/internal/tmux/capture_parse_test.go
@@ -1,0 +1,188 @@
+package tmux
+
+import "testing"
+
+// These tests exercise the pure parsers split out of paneCursorPosition and
+// paneSize. The malformed/zero-or-negative error branches guard against tmux
+// emitting non-numeric or non-positive fields; a live tmux server never
+// produces such output, so before the split these branches were unreachable
+// from any integration test and silently uncovered. Driving the parsers with
+// crafted lines lets us pin the field-count, paneID-match, strconv and
+// validation behavior without a subprocess.
+
+func TestParsePaneCursor(t *testing.T) {
+	const paneID = "%3"
+	tests := []struct {
+		name    string
+		lines   []string
+		wantX   int
+		wantY   int
+		wantOK  bool
+		wantErr bool
+	}{
+		{
+			name:   "matching paneID returns cursor",
+			lines:  []string{"%3\t12\t7"},
+			wantX:  12,
+			wantY:  7,
+			wantOK: true,
+		},
+		{
+			name:   "non-matching paneID skipped then matched",
+			lines:  []string{"%2\t99\t99", "%3\t4\t5"},
+			wantX:  4,
+			wantY:  5,
+			wantOK: true,
+		},
+		{
+			name:   "only non-matching paneIDs -> ok=false",
+			lines:  []string{"%2\t99\t99"},
+			wantOK: false,
+		},
+		{
+			name:   "zero cursor is valid",
+			lines:  []string{"%3\t0\t0"},
+			wantX:  0,
+			wantY:  0,
+			wantOK: true,
+		},
+		{
+			name:    "non-numeric cursor_x -> error",
+			lines:   []string{"%3\tabc\t5"},
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric cursor_y -> error",
+			lines:   []string{"%3\t4\txyz"},
+			wantErr: true,
+		},
+		{
+			name:   "too few fields skipped -> ok=false",
+			lines:  []string{"%3\t4"},
+			wantOK: false,
+		},
+		{
+			name:   "empty output -> ok=false",
+			lines:  nil,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y, ok, err := parsePaneCursor(tt.lines, paneID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (x=%d y=%d ok=%v)", x, y, ok)
+				}
+				if ok {
+					t.Fatalf("expected ok=false on error, got ok=true")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && (x != tt.wantX || y != tt.wantY) {
+				t.Fatalf("got (%d,%d), want (%d,%d)", x, y, tt.wantX, tt.wantY)
+			}
+		})
+	}
+}
+
+func TestParsePaneSize(t *testing.T) {
+	const paneID = "%3"
+	tests := []struct {
+		name     string
+		lines    []string
+		wantCols int
+		wantRows int
+		wantOK   bool
+		wantErr  bool
+	}{
+		{
+			name:     "matching paneID returns size",
+			lines:    []string{"%3\t80\t24"},
+			wantCols: 80,
+			wantRows: 24,
+			wantOK:   true,
+		},
+		{
+			name:     "non-matching paneID skipped then matched",
+			lines:    []string{"%2\t1\t1", "%3\t100\t40"},
+			wantCols: 100,
+			wantRows: 40,
+			wantOK:   true,
+		},
+		{
+			name:   "only non-matching paneIDs -> ok=false",
+			lines:  []string{"%2\t80\t24"},
+			wantOK: false,
+		},
+		{
+			name:    "non-numeric width -> error",
+			lines:   []string{"%3\tabc\t24"},
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric height -> error",
+			lines:   []string{"%3\t80\txyz"},
+			wantErr: true,
+		},
+		{
+			name:    "zero width -> error",
+			lines:   []string{"%3\t0\t24"},
+			wantErr: true,
+		},
+		{
+			name:    "zero height -> error",
+			lines:   []string{"%3\t80\t0"},
+			wantErr: true,
+		},
+		{
+			name:    "negative width -> error",
+			lines:   []string{"%3\t-5\t24"},
+			wantErr: true,
+		},
+		{
+			name:    "negative height -> error",
+			lines:   []string{"%3\t80\t-1"},
+			wantErr: true,
+		},
+		{
+			name:   "too few fields skipped -> ok=false",
+			lines:  []string{"%3\t80"},
+			wantOK: false,
+		},
+		{
+			name:   "empty output -> ok=false",
+			lines:  nil,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cols, rows, ok, err := parsePaneSize(tt.lines, paneID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (cols=%d rows=%d ok=%v)", cols, rows, ok)
+				}
+				if ok {
+					t.Fatalf("expected ok=false on error, got ok=true")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && (cols != tt.wantCols || rows != tt.wantRows) {
+				t.Fatalf("got (%d,%d), want (%d,%d)", cols, rows, tt.wantCols, tt.wantRows)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Split paneCursorPosition and paneSize into thin exec wrappers (tmuxCommand + cmd.Output) plus pure parsePaneCursor/parsePaneSize helpers that own field-count, paneID-match, strconv and malformed/zero-or-negative validation, mirroring capture_snapshot.go. This makes the previously dead-to-coverage malformed-cursor and zero/negative-size error branches reachable from table-driven unit tests (matching/non-matching paneID, malformed and zero/negative fields, too-few-fields, empty output). No behavior change. Part of the quality stacked diff. Stacked on roadmap/14-tmux-parse-and-decide-loops-fused-with-exec-ex. Ticket 15 (testability).