### PR TITLE
fakeagent (verify-loop's stand-in agent) has all logic in func main() 

### DIFF
--- a/internal/e2e/fakeagent/main.go
+++ b/internal/e2e/fakeagent/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -32,6 +33,48 @@ import (
 // readyBanner is emitted once the agent is in raw mode and ready for input.
 // Tests wait for it before typing so input is never sent prematurely.
 const readyBanner = "FAKEAGENT READY"
+
+// syncer is the subset of *os.File the recorder needs to flush after each read.
+// Extracting it lets recordStream accept an in-memory writer in tests while the
+// real run passes the log file, whose Sync makes the appended bytes pollable.
+type syncer interface {
+	io.Writer
+	Sync() error
+}
+
+// readyBannerBytes returns the exact bytes the agent emits once raw mode is
+// active. \r\n (not \n) because the terminal is raw, so the kernel performs no
+// NL->CRNL output translation and the banner must carry its own carriage return.
+func readyBannerBytes() []byte {
+	return []byte(readyBanner + "\r\n")
+}
+
+// recordStream is the load-bearing recorder: it copies every byte read from in
+// to log, flushing (Sync) after each non-empty read so a polling test observes
+// bytes deterministically, and returns when the reader reports an error.
+//
+// It must preserve bytes verbatim — in particular an embedded carriage return
+// (0x0D) — because that is exactly what proves a real keystroke (hex 0D, not the
+// named Enter key) reached a raw-mode agent. io.EOF is treated as a clean end of
+// stream and reported as nil; any other read error is returned. A read that
+// yields n>0 before signaling an error still records that partial buffer.
+func recordStream(in io.Reader, log syncer) error {
+	buf := make([]byte, 256)
+	for {
+		n, readErr := in.Read(buf)
+		if n > 0 {
+			if _, werr := log.Write(buf[:n]); werr == nil {
+				_ = log.Sync() // flush per read so tests can poll deterministically
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return nil
+			}
+			return readErr
+		}
+	}
+}
 
 func main() {
 	var startupDelay time.Duration
@@ -72,19 +115,7 @@ func main() {
 	// Match full-screen terminal apps that ask their host to deliver wheel
 	// events to stdin instead of using outer scrollback.
 	fmt.Fprint(os.Stdout, "\x1b[?1000h\x1b[?1006h")
-	// \r\n because the terminal is now raw (no NL->CRNL output translation).
-	fmt.Fprint(os.Stdout, readyBanner+"\r\n")
+	os.Stdout.Write(readyBannerBytes())
 
-	buf := make([]byte, 256)
-	for {
-		n, readErr := os.Stdin.Read(buf)
-		if n > 0 {
-			if _, werr := log.Write(buf[:n]); werr == nil {
-				_ = log.Sync() // flush per read so tests can poll deterministically
-			}
-		}
-		if readErr != nil {
-			return
-		}
-	}
+	_ = recordStream(os.Stdin, log)
 }

--- a/internal/e2e/fakeagent/main_test.go
+++ b/internal/e2e/fakeagent/main_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+// syncWriter is an in-memory syncer: it records every Write and counts Syncs so
+// tests can assert recordStream flushes after each non-empty read.
+type syncWriter struct {
+	bytes.Buffer
+	syncs int
+}
+
+func (w *syncWriter) Sync() error {
+	w.syncs++
+	return nil
+}
+
+func TestReadyBannerBytesEndsWithCRLF(t *testing.T) {
+	got := readyBannerBytes()
+	want := []byte("FAKEAGENT READY\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("readyBannerBytes() = %q, want %q", got, want)
+	}
+	// The trailing \r is the load-bearing part: a raw terminal performs no
+	// NL->CRNL translation, so the banner must carry its own carriage return.
+	if got[len(got)-2] != '\r' || got[len(got)-1] != '\n' {
+		t.Fatalf("banner must end with CRLF, got %q", got)
+	}
+}
+
+// TestRecordStreamPreservesEmbeddedCR is the bug-#2 regression sentinel: a
+// payload carrying a literal carriage return (0x0D) must be recorded byte-for-
+// byte. A regression to the named "Enter" key would never deliver 0x0D, so this
+// guards the close-the-loop guarantee.
+func TestRecordStreamPreservesEmbeddedCR(t *testing.T) {
+	payload := []byte("hello\rworld\r")
+	if !bytes.Contains(payload, []byte{0x0D}) {
+		t.Fatal("test payload must contain an embedded CR")
+	}
+
+	var log syncWriter
+	if err := recordStream(bytes.NewReader(payload), &log); err != nil {
+		t.Fatalf("recordStream returned error: %v", err)
+	}
+
+	if !bytes.Equal(log.Bytes(), payload) {
+		t.Fatalf("recorded %q, want exact bytes %q", log.Bytes(), payload)
+	}
+	if bytes.Count(log.Bytes(), []byte{0x0D}) != 2 {
+		t.Fatalf("expected 2 carriage returns preserved, got %q", log.Bytes())
+	}
+	if log.syncs == 0 {
+		t.Fatal("recordStream never Synced; a polling test would race")
+	}
+}
+
+// partialThenEOFReader yields a non-empty buffer and io.EOF in the SAME Read
+// call, exercising the n>0-with-error path. recordStream must still record the
+// partial buffer before returning.
+type partialThenEOFReader struct {
+	data []byte
+	done bool
+}
+
+func (r *partialThenEOFReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	n := copy(p, r.data)
+	return n, io.EOF
+}
+
+func TestRecordStreamRecordsPartialBufferOnEOF(t *testing.T) {
+	payload := []byte("mid\rstream")
+	var log syncWriter
+	if err := recordStream(&partialThenEOFReader{data: payload}, &log); err != nil {
+		t.Fatalf("recordStream returned error: %v", err)
+	}
+	if !bytes.Equal(log.Bytes(), payload) {
+		t.Fatalf("partial buffer not recorded: got %q, want %q", log.Bytes(), payload)
+	}
+}
+
+// errReader returns data then a non-EOF error; recordStream must surface that
+// error (not swallow it like EOF) yet still record the bytes read with it.
+type errReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	r.done = true
+	n := copy(p, r.data)
+	return n, r.err
+}
+
+func TestRecordStreamSurfacesNonEOFError(t *testing.T) {
+	sentinel := errors.New("boom")
+	payload := []byte("data\r")
+	var log syncWriter
+	err := recordStream(&errReader{data: payload, err: sentinel}, &log)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("recordStream err = %v, want %v", err, sentinel)
+	}
+	if !bytes.Equal(log.Bytes(), payload) {
+		t.Fatalf("bytes read alongside error not recorded: got %q", log.Bytes())
+	}
+}
+
+// chunkedReader yields each chunk in its own Read call, then io.EOF, so a test
+// can exercise multiple non-empty reads in a single recordStream run.
+type chunkedReader struct {
+	chunks [][]byte
+	i      int
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.i])
+	r.i++
+	return n, nil
+}
+
+// TestRecordStreamSyncsPerNonEmptyRead pins the flush PLACEMENT: recordStream
+// must Sync after every non-empty read, not once at end-of-stream. A regression
+// that flushed a single time at EOF would still satisfy the weaker syncs>0 check
+// in TestRecordStreamPreservesEmbeddedCR yet reintroduce the polling race this
+// recorder exists to prevent, so assert one Sync per non-empty read.
+func TestRecordStreamSyncsPerNonEmptyRead(t *testing.T) {
+	chunks := [][]byte{[]byte("ab"), []byte("c\r")}
+	var log syncWriter
+	if err := recordStream(&chunkedReader{chunks: chunks}, &log); err != nil {
+		t.Fatalf("recordStream returned error: %v", err)
+	}
+	if log.syncs != len(chunks) {
+		t.Fatalf("expected one Sync per non-empty read (%d), got %d", len(chunks), log.syncs)
+	}
+	if got := log.String(); got != "abc\r" {
+		t.Fatalf("recorded %q, want %q", got, "abc\r")
+	}
+}


### PR DESCRIPTION
Extracts the load-bearing byte-recording loop and the CRLF readiness banner out of fakeagent's func main() into pure functions: recordStream(in io.Reader, log syncer) error and readyBannerBytes() []byte. main() now only parses flags/env, toggles raw mode, and calls recordStream(os.Stdin, log) — behavior identical.

Why: fakeagent is verify-loop's stand-in raw-mode agent; recordStream is the only thing that proves a real keystroke (literal 0x0D CR, not the named Enter key) reaches a raw-mode agent. It had zero tests and structurally could not get one. New main_test.go covers the bug-#2 embedded-CR sentinel (exact byte preservation incl. CR), partial-buffer-then-EOF recording, per-read Sync (so polling tests don't race), and non-EOF error surfacing — all without a PTY.

Part of the quality stacked diff. Stacked on roadmap/15-tmux-pane-cursor-size-malformed-input-error-br. Ticket 16 (testability).