### PR TITLE
testutil.Eventually/Consistently fail paths can't be tested — t.Fatalf

### DIFF
--- a/internal/testutil/wait.go
+++ b/internal/testutil/wait.go
@@ -5,54 +5,84 @@ package testutil
 
 import (
 	"cmp"
-	"testing"
 	"time"
 )
 
+// fataler is the minimal subset of *testing.T the polling helpers need.
+// Splitting it out (instead of taking a concrete *testing.T) lets the
+// timeout/failure branches be exercised by a fake recorder in tests without
+// failing the real harness. *testing.T satisfies this interface.
+type fataler interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+// clock makes the polling loops deterministic under test: real callers get the
+// wall clock and time.Sleep, while wait_test.go injects a fake clock so the
+// failure paths run instantly and without flakiness.
+type clock struct {
+	now   func() time.Time
+	sleep func(time.Duration)
+}
+
+func realClock() clock {
+	return clock{now: time.Now, sleep: time.Sleep}
+}
+
 // Eventually polls cond until it returns true or timeout elapses, failing the
 // test (via t.Fatalf with the formatted message) on timeout.
-func Eventually(t *testing.T, timeout, interval time.Duration, cond func() bool, msgf string, args ...any) {
+func Eventually(t fataler, timeout, interval time.Duration, cond func() bool, msgf string, args ...any) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	if !eventually(realClock(), timeout, interval, cond) {
+		t.Fatalf(msgf, args...)
+	}
+}
+
+// eventually is the pure polling loop behind Eventually. It returns true if
+// cond became true before the deadline and false on timeout, so the public
+// wrapper decides how to fail.
+func eventually(c clock, timeout, interval time.Duration, cond func() bool) (ok bool) {
+	deadline := c.now().Add(timeout)
 	for {
 		if cond() {
-			return
+			return true
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf(msgf, args...)
-			return
+		if c.now().After(deadline) {
+			return false
 		}
-		time.Sleep(interval)
+		c.sleep(interval)
 	}
 }
 
 // Consistently polls check for the full duration at the given interval,
 // failing the test the first time check returns a non-empty failure message.
 // It is the inverse of Eventually: the condition must hold the whole time.
-func Consistently(t *testing.T, duration, interval time.Duration, check func() string) {
+func Consistently(t fataler, duration, interval time.Duration, check func() string) {
 	t.Helper()
-	deadline := time.Now().Add(duration)
-	for time.Now().Before(deadline) {
-		if msg := check(); msg != "" {
-			t.Fatalf("%s", msg)
-		}
-		time.Sleep(interval)
+	if msg := consistently(realClock(), duration, interval, check); msg != "" {
+		t.Fatalf("%s", msg)
 	}
+}
+
+// consistently is the pure polling loop behind Consistently. It returns the
+// first non-empty failure message check produces, or "" if check held for the
+// whole duration.
+func consistently(c clock, duration, interval time.Duration, check func() string) string {
+	deadline := c.now().Add(duration)
+	for c.now().Before(deadline) {
+		if msg := check(); msg != "" {
+			return msg
+		}
+		c.sleep(interval)
+	}
+	return ""
 }
 
 // WaitForAtomic polls load until it reports a value >= want or timeout elapses,
 // failing the test on timeout. load typically reads an atomic counter.
-func WaitForAtomic[T cmp.Ordered](t *testing.T, load func() T, want T, timeout time.Duration) {
+func WaitForAtomic[T cmp.Ordered](t fataler, load func() T, want T, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for {
-		if load() >= want {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out after %s waiting for value >= %v (got %v)", timeout, want, load())
-			return
-		}
-		time.Sleep(time.Millisecond)
+	if !eventually(realClock(), timeout, time.Millisecond, func() bool { return load() >= want }) {
+		t.Fatalf("timed out after %s waiting for value >= %v (got %v)", timeout, want, load())
 	}
 }

--- a/internal/testutil/wait_test.go
+++ b/internal/testutil/wait_test.go
@@ -1,0 +1,163 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fakeFataler records Fatalf calls instead of failing a real *testing.T, so the
+// timeout/failure branches of the polling helpers can be asserted without
+// failing the harness running this test.
+type fakeFataler struct {
+	helperCalls int
+	fatalCalls  int
+	lastMsg     string
+}
+
+func (f *fakeFataler) Helper() { f.helperCalls++ }
+
+func (f *fakeFataler) Fatalf(format string, args ...any) {
+	f.fatalCalls++
+	f.lastMsg = fmt.Sprintf(format, args...)
+}
+
+// fakeClock advances by `step` on each now() call and never actually sleeps, so
+// the failure paths complete instantly and deterministically.
+type fakeClock struct {
+	cur    time.Time
+	step   time.Duration
+	sleeps int
+}
+
+func (fc *fakeClock) toClock() clock {
+	return clock{
+		now: func() time.Time {
+			t := fc.cur
+			fc.cur = fc.cur.Add(fc.step)
+			return t
+		},
+		sleep: func(time.Duration) { fc.sleeps++ },
+	}
+}
+
+func TestEventuallyTrueImmediately(t *testing.T) {
+	f := &fakeFataler{}
+	calls := 0
+	Eventually(f, time.Second, time.Millisecond, func() bool {
+		calls++
+		return true
+	}, "should not fail")
+
+	if f.fatalCalls != 0 {
+		t.Fatalf("expected no Fatalf when cond is true immediately, got %d (msg=%q)", f.fatalCalls, f.lastMsg)
+	}
+	if calls != 1 {
+		t.Fatalf("expected cond evaluated exactly once, got %d", calls)
+	}
+	if f.helperCalls != 1 {
+		t.Fatalf("expected Helper called once, got %d", f.helperCalls)
+	}
+}
+
+func TestEventuallyNeverTrueFailsOnceWithMessage(t *testing.T) {
+	f := &fakeFataler{}
+	// Short deadline keeps this near-instant: the public Eventually uses the real
+	// clock, and the condition never becomes true, so the call sleeps until the
+	// timeout. A few ms is enough to exercise the formatted-message timeout path.
+	Eventually(f, 5*time.Millisecond, time.Millisecond, func() bool { return false }, "timed out waiting for %s", "thing")
+
+	if f.fatalCalls != 1 {
+		t.Fatalf("expected exactly one Fatalf on timeout, got %d", f.fatalCalls)
+	}
+	if want := "timed out waiting for thing"; f.lastMsg != want {
+		t.Fatalf("expected formatted message %q, got %q", want, f.lastMsg)
+	}
+}
+
+func TestEventuallyPureTimesOut(t *testing.T) {
+	// now() advances 10ms per call against a 25ms timeout, so the loop must
+	// give up rather than spin forever; the fake clock guarantees termination.
+	fc := &fakeClock{cur: time.Unix(0, 0), step: 10 * time.Millisecond}
+	ok := eventually(fc.toClock(), 25*time.Millisecond, time.Millisecond, func() bool { return false })
+	if ok {
+		t.Fatal("expected eventually to report timeout (false) when cond never holds")
+	}
+	if fc.sleeps == 0 {
+		t.Fatal("expected the loop to sleep between polls before timing out")
+	}
+}
+
+func TestEventuallyPureSucceedsBeforeDeadline(t *testing.T) {
+	fc := &fakeClock{cur: time.Unix(0, 0), step: time.Millisecond}
+	hit := 0
+	ok := eventually(fc.toClock(), time.Second, time.Millisecond, func() bool {
+		hit++
+		return hit >= 3
+	})
+	if !ok {
+		t.Fatal("expected eventually to report success when cond becomes true before deadline")
+	}
+}
+
+func TestConsistentlyFailsOnFirstNonEmptyCheck(t *testing.T) {
+	f := &fakeFataler{}
+	checks := 0
+	Consistently(f, time.Second, time.Millisecond, func() string {
+		checks++
+		return "broke immediately"
+	})
+
+	if f.fatalCalls != 1 {
+		t.Fatalf("expected exactly one Fatalf on first non-empty check, got %d", f.fatalCalls)
+	}
+	if f.lastMsg != "broke immediately" {
+		t.Fatalf("expected message %q, got %q", "broke immediately", f.lastMsg)
+	}
+	if checks != 1 {
+		t.Fatalf("expected check evaluated exactly once before failing, got %d", checks)
+	}
+}
+
+func TestConsistentlyHoldsForWholeDuration(t *testing.T) {
+	f := &fakeFataler{}
+	Consistently(f, 5*time.Millisecond, time.Millisecond, func() string { return "" })
+	if f.fatalCalls != 0 {
+		t.Fatalf("expected no Fatalf when check stays empty, got %d (msg=%q)", f.fatalCalls, f.lastMsg)
+	}
+}
+
+func TestConsistentlyPureReturnsFirstFailure(t *testing.T) {
+	fc := &fakeClock{cur: time.Unix(0, 0), step: time.Millisecond}
+	calls := 0
+	msg := consistently(fc.toClock(), time.Second, time.Millisecond, func() string {
+		calls++
+		if calls == 2 {
+			return "failed on second check"
+		}
+		return ""
+	})
+	if msg != "failed on second check" {
+		t.Fatalf("expected first non-empty failure message, got %q", msg)
+	}
+}
+
+func TestWaitForAtomicReachesWant(t *testing.T) {
+	f := &fakeFataler{}
+	v := int64(0)
+	WaitForAtomic(f, func() int64 { v++; return v }, 3, time.Second)
+	if f.fatalCalls != 0 {
+		t.Fatalf("expected no Fatalf once load reaches want, got %d (msg=%q)", f.fatalCalls, f.lastMsg)
+	}
+}
+
+func TestWaitForAtomicTimesOut(t *testing.T) {
+	f := &fakeFataler{}
+	WaitForAtomic(f, func() int64 { return 0 }, 3, time.Millisecond)
+	if f.fatalCalls != 1 {
+		t.Fatalf("expected exactly one Fatalf on timeout, got %d", f.fatalCalls)
+	}
+	if f.lastMsg == "" {
+		t.Fatal("expected a non-empty timeout message")
+	}
+}


### PR DESCRIPTION
Replaces the concrete `*testing.T` argument in the shared polling helpers (`Eventually`/`Consistently`/`WaitForAtomic`) with a minimal `fataler` interface (`Helper`/`Fatalf`), and splits each loop into a pure, clock-injected core (`eventually`/`consistently`). This makes the previously-untestable timeout/failure branches assertable: a fake recorder captures the `Fatalf` call and a fake clock makes the test instant and non-flaky. `*testing.T` still satisfies `fataler`, so every caller compiles unchanged and behavior is identical. Adds `wait_test.go` covering: cond true immediately (no Fatalf), cond never true (exactly one Fatalf with the formatted message), Consistently failing on first non-empty check, plus pure-loop timeout/success cases.

Why: `internal/testutil/wait.go` is what essentially every e2e and real-tmux test relies on for timing stability, and it had no test coverage. An inverted `After`/`Before` comparison or a success-on-timeout regression would silently make every dependent test stop actually waiting/asserting.

Part of the quality stacked diff. Stacked on roadmap/16-fakeagent-verify-loop-s-stand-in-agent-has-all. Ticket 17 (testability).