### PR TITLE
No injectable tmux runner — exit-code-1 / stderr-classification glue t

### DIFF
--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -14,7 +14,7 @@ func SessionNamesWithClients(opts Options) (map[string]bool, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "list-clients", "-F", "#{session_name}")
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))
@@ -74,7 +74,7 @@ func SessionCreatedAt(sessionName string, opts Options) (int64, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "list-sessions", "-F", "#{session_name}\t#{session_created}")
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/tmux/tags.go
+++ b/internal/tmux/tags.go
@@ -73,7 +73,7 @@ func listSessionsWithTags(tags map[string]string, opts Options) ([]sessionTagRow
 	}
 	cmd, cancel := tmuxCommand(opts, "list-sessions", "-F", format)
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			return nil, keys, nil
@@ -167,7 +167,7 @@ func SetSessionTagValues(sessionName string, tags []OptionValue, opts Options) e
 
 	cmd, cancel := tmuxCommand(opts, args...)
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -198,7 +198,7 @@ func tmuxCommand(opts Options, args ...string) (*exec.Cmd, context.CancelFunc) {
 func runTmux(opts Options, args ...string) error {
 	cmd, cancel := tmuxCommand(opts, args...)
 	defer cancel()
-	if err := cmd.Run(); err != nil {
+	if _, err := runTmuxCmd(cmd); err != nil {
 		if isExitCode1(err) {
 			return nil
 		}
@@ -215,7 +215,7 @@ func runTmux(opts Options, args ...string) error {
 func listTmux(opts Options, args ...string) ([]string, error) {
 	cmd, cancel := tmuxCommand(opts, args...)
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			return nil, nil
@@ -228,7 +228,7 @@ func listTmux(opts Options, args ...string) ([]string, error) {
 func hasSession(sessionName string, opts Options) (bool, error) {
 	cmd, cancel := tmuxCommand(opts, "has-session", "-t", sessionTarget(sessionName))
 	defer cancel()
-	if err := cmd.Run(); err != nil {
+	if _, err := runTmuxCmd(cmd); err != nil {
 		if isExitCode1(err) {
 			return false, nil
 		}
@@ -320,7 +320,7 @@ func SessionTagValue(sessionName, key string, opts Options) (string, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "show-options", "-t", exactSessionOptionTarget(sessionName), "-v", key)
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			return "", nil
@@ -345,7 +345,7 @@ func GlobalOptionValue(key string, opts Options) (string, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "show-options", "-g", "-v", key)
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			if isOptionMissingStderr(string(output)) {
@@ -375,7 +375,7 @@ func SetGlobalOptionValue(key, value string, opts Options) error {
 	}
 	cmd, cancel := tmuxCommand(opts, "set-option", "-g", key, value)
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))
@@ -424,7 +424,7 @@ func SetGlobalOptionValues(values []OptionValue, opts Options) error {
 	}
 	cmd, cancel := tmuxCommand(opts, args...)
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		if isExitCode1(err) {
 			stderr := strings.TrimSpace(string(output))

--- a/internal/tmux/tmux_global_options.go
+++ b/internal/tmux/tmux_global_options.go
@@ -32,7 +32,7 @@ func GlobalOptionValues(keys []string, opts Options) (map[string]string, error) 
 	format := strings.Join(formatParts, separator)
 	cmd, cancel := tmuxCommand(opts, "display-message", "-p", format)
 	defer cancel()
-	output, err := cmd.CombinedOutput()
+	output, err := runTmuxCmdCombined(cmd)
 	if err != nil {
 		// Unlike show-options -g -v, display-message does not provide a reliable
 		// "missing option" sentinel. Treat exit 1 as an operational error.

--- a/internal/tmux/tmux_runner.go
+++ b/internal/tmux/tmux_runner.go
@@ -1,0 +1,20 @@
+package tmux
+
+import "os/exec"
+
+// runTmuxCmd executes a tmux command and returns its stdout. It is the single
+// exec choke point for read paths that only need stdout (listTmux, runTmux,
+// SessionTagValue, SessionCreatedAt, listSessionsWithTags). It is a package var
+// so a test can swap it for a fake that returns canned ([]byte, error) — in
+// particular an *exec.ExitError with code 1 — and drive the
+// exit-1-means-empty / isExitCode1-but-other-error branches without a live tmux
+// server. Mirrors the enterSleep var-seam precedent in send.go.
+var runTmuxCmd = func(cmd *exec.Cmd) ([]byte, error) { return cmd.Output() }
+
+// runTmuxCmdCombined executes a tmux command and returns its combined
+// stdout+stderr. It is the choke point for sites that classify tmux stderr
+// (SessionNamesWithClients, SetSessionTagValues, the global-option setters):
+// stderr text decides whether an exit-code-1 failure is "treat as empty" or a
+// real error, so the combined output must be captured. Swappable in tests for
+// the same reason as runTmuxCmd.
+var runTmuxCmdCombined = func(cmd *exec.Cmd) ([]byte, error) { return cmd.CombinedOutput() }

--- a/internal/tmux/tmux_runner_seam_test.go
+++ b/internal/tmux/tmux_runner_seam_test.go
@@ -1,0 +1,238 @@
+package tmux
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// This file covers the error-classification *glue* — the wiring that decides,
+// for a given (output, error) from the exec choke point, whether to return an
+// empty result, swallow the error, or wrap/propagate it. Before the runTmuxCmd /
+// runTmuxCmdCombined var-seams (tmux_runner.go), these branches were reachable
+// only when a real tmux server produced the exact failure. Here we swap the
+// seam for a fake and drive every branch without a live tmux server.
+//
+// The pure classifiers (isExitCode1 / isSessionNotFoundStderr / isNoClientStderr
+// / isOptionMissingStderr) are tested in errors_test.go; this file pins how each
+// read/mutate site *reacts* to them.
+
+// exitCode1Err returns a genuine *exec.ExitError whose ExitCode() == 1 by
+// running a real subprocess that exits 1. tmux signals "not found" this way, and
+// isExitCode1 unwraps via errors.As(*exec.ExitError), so a fabricated error type
+// would not exercise the real classifier. Built once per test.
+func exitCode1Err(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 1").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("setup: expected exec.ExitError with code 1, got %v", err)
+	}
+	return err
+}
+
+// fakeRunTmuxCmd installs a runTmuxCmd seam returning the given output/err and
+// restores the original on cleanup.
+func fakeRunTmuxCmd(t *testing.T, output []byte, err error) {
+	t.Helper()
+	orig := runTmuxCmd
+	runTmuxCmd = func(*exec.Cmd) ([]byte, error) { return output, err }
+	t.Cleanup(func() { runTmuxCmd = orig })
+}
+
+// fakeRunTmuxCmdCombined installs a runTmuxCmdCombined seam.
+func fakeRunTmuxCmdCombined(t *testing.T, output []byte, err error) {
+	t.Helper()
+	orig := runTmuxCmdCombined
+	runTmuxCmdCombined = func(*exec.Cmd) ([]byte, error) { return output, err }
+	t.Cleanup(func() { runTmuxCmdCombined = orig })
+}
+
+// testOpts disables EnsureAvailable's dependence on a real tmux by pointing at a
+// throwaway server name; the seam short-circuits the actual exec, but
+// EnsureAvailable still needs tmux on PATH for the exported entry points.
+func testOpts() Options {
+	opts := DefaultOptions()
+	opts.ServerName = "amux-runner-seam-test"
+	return opts
+}
+
+// ---------------------------------------------------------------------------
+// listTmux: exit 1 -> empty, other error -> propagated, success -> parsed.
+// ---------------------------------------------------------------------------
+
+func TestListTmux_ExitCode1MeansEmpty(t *testing.T) {
+	fakeRunTmuxCmd(t, nil, exitCode1Err(t))
+	lines, err := listTmux(testOpts(), "list-panes")
+	if err != nil {
+		t.Fatalf("exit 1 should be swallowed as empty, got err: %v", err)
+	}
+	if lines != nil {
+		t.Fatalf("exit 1 should yield nil lines, got %#v", lines)
+	}
+}
+
+func TestListTmux_OtherErrorPropagates(t *testing.T) {
+	want := errors.New("no server running on /tmp/x")
+	fakeRunTmuxCmd(t, nil, want)
+	lines, err := listTmux(testOpts(), "list-panes")
+	if !errors.Is(err, want) {
+		t.Fatalf("non-exit-1 error must propagate, got lines=%#v err=%v", lines, err)
+	}
+}
+
+func TestListTmux_SuccessParsesLines(t *testing.T) {
+	fakeRunTmuxCmd(t, []byte("sess-a\t0\nsess-b\t1\n"), nil)
+	lines, err := listTmux(testOpts(), "list-panes")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := []string{"sess-a\t0", "sess-b\t1"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %#v, want %#v", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("line %d: got %q want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runTmux: exit 1 -> nil error (mutation against a missing target is fine),
+// other error -> propagated.
+// ---------------------------------------------------------------------------
+
+func TestRunTmux_ExitCode1IsNotAnError(t *testing.T) {
+	fakeRunTmuxCmd(t, nil, exitCode1Err(t))
+	if err := runTmux(testOpts(), "kill-session", "-t", "=gone"); err != nil {
+		t.Fatalf("exit 1 must be treated as success, got %v", err)
+	}
+}
+
+func TestRunTmux_OtherErrorPropagates(t *testing.T) {
+	want := errors.New("connection refused")
+	fakeRunTmuxCmd(t, nil, want)
+	if err := runTmux(testOpts(), "kill-session", "-t", "=x"); !errors.Is(err, want) {
+		t.Fatalf("non-exit-1 error must propagate, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SessionNamesWithClients (CombinedOutput): exit 1 + no-client/empty stderr ->
+// empty set, exit 1 + other stderr -> error, success -> parsed.
+// ---------------------------------------------------------------------------
+
+func TestSessionNamesWithClients_NoClientStderrIsEmpty(t *testing.T) {
+	skipIfNoTmux(t)
+	fakeRunTmuxCmdCombined(t, []byte("no client found"), exitCode1Err(t))
+	got, err := SessionNamesWithClients(testOpts())
+	if err != nil {
+		t.Fatalf("no-client stderr must be swallowed, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty attached set, got %#v", got)
+	}
+}
+
+func TestSessionNamesWithClients_EmptyStderrIsEmpty(t *testing.T) {
+	skipIfNoTmux(t)
+	fakeRunTmuxCmdCombined(t, nil, exitCode1Err(t))
+	got, err := SessionNamesWithClients(testOpts())
+	if err != nil {
+		t.Fatalf("exit 1 with empty stderr must be swallowed, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty attached set, got %#v", got)
+	}
+}
+
+func TestSessionNamesWithClients_OtherStderrIsError(t *testing.T) {
+	skipIfNoTmux(t)
+	exitErr := exitCode1Err(t)
+	fakeRunTmuxCmdCombined(t, []byte("lost server"), exitErr)
+	got, err := SessionNamesWithClients(testOpts())
+	if err == nil {
+		t.Fatalf("exit 1 with unrelated stderr must surface as error, got set=%#v", got)
+	}
+	if len(got) != 0 {
+		t.Fatalf("error path should not populate the set, got %#v", got)
+	}
+}
+
+func TestSessionNamesWithClients_SuccessParsesNames(t *testing.T) {
+	skipIfNoTmux(t)
+	fakeRunTmuxCmdCombined(t, []byte("amux-a\namux-b\n"), nil)
+	got, err := SessionNamesWithClients(testOpts())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !got["amux-a"] || !got["amux-b"] || len(got) != 2 {
+		t.Fatalf("expected {amux-a, amux-b}, got %#v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetSessionTagValues (CombinedOutput): the has-session pre-check runs through
+// runTmuxCmd, then the set-option runs through runTmuxCmdCombined. We drive both
+// seams to reach the session-not-found-stderr -> nil and other-stderr -> wrapped
+// branches without a live server.
+// ---------------------------------------------------------------------------
+
+// withExistingSession makes hasSession (which goes through runTmuxCmd) report
+// the session exists, so SetSessionTagValues proceeds to the set-option call.
+func withExistingSession(t *testing.T) {
+	t.Helper()
+	orig := runTmuxCmd
+	// has-session success: zero exit, no output needed.
+	runTmuxCmd = func(*exec.Cmd) ([]byte, error) { return nil, nil }
+	t.Cleanup(func() { runTmuxCmd = orig })
+}
+
+func TestSetSessionTagValues_SessionNotFoundStderrReturnsNil(t *testing.T) {
+	skipIfNoTmux(t)
+	withExistingSession(t)
+	fakeRunTmuxCmdCombined(t, []byte("no such session: amux-x"), exitCode1Err(t))
+	err := SetSessionTagValues("amux-x", []OptionValue{{Key: "@amux_k", Value: "v"}}, testOpts())
+	if err != nil {
+		t.Fatalf("session-gone stderr must be swallowed, got %v", err)
+	}
+}
+
+func TestSetSessionTagValues_OtherStderrIsWrappedError(t *testing.T) {
+	skipIfNoTmux(t)
+	withExistingSession(t)
+	fakeRunTmuxCmdCombined(t, []byte("server exited unexpectedly"), exitCode1Err(t))
+	err := SetSessionTagValues("amux-x", []OptionValue{{Key: "@amux_k", Value: "v"}}, testOpts())
+	if err == nil {
+		t.Fatalf("unrelated stderr on exit 1 must surface as error")
+	}
+	if !strings.Contains(err.Error(), "server exited unexpectedly") {
+		t.Fatalf("wrapped error should include the stderr, got %v", err)
+	}
+}
+
+func TestSetSessionTagValues_SuccessReturnsNil(t *testing.T) {
+	skipIfNoTmux(t)
+	withExistingSession(t)
+	fakeRunTmuxCmdCombined(t, nil, nil)
+	err := SetSessionTagValues("amux-x", []OptionValue{{Key: "@amux_k", Value: "v"}}, testOpts())
+	if err != nil {
+		t.Fatalf("successful set-option must return nil, got %v", err)
+	}
+}
+
+// TestRunTmuxCmdSeamsDefaultToRealImpl guards that the default seam wiring runs
+// the real cmd output methods (so production behavior is unchanged) by checking
+// the defaults actually execute a subprocess and surface its output.
+func TestRunTmuxCmdSeamsDefaultToRealImpl(t *testing.T) {
+	out, err := runTmuxCmd(exec.Command("sh", "-c", "printf hi"))
+	if err != nil || string(out) != "hi" {
+		t.Fatalf("default runTmuxCmd should run the real command, got out=%q err=%v", out, err)
+	}
+	combined, err := runTmuxCmdCombined(exec.Command("sh", "-c", "printf out; printf err 1>&2"))
+	if err != nil || !strings.Contains(string(combined), "out") || !strings.Contains(string(combined), "err") {
+		t.Fatalf("default runTmuxCmdCombined should capture stdout+stderr, got %q err=%v", combined, err)
+	}
+}


### PR DESCRIPTION
Adds a package-level runner seam (runTmuxCmd / runTmuxCmdCombined in a new tmux_runner.go) at the single exec choke point in internal/tmux, defaulting to the real cmd.Output/CombinedOutput. listTmux, runTmux, hasSession, SessionTagValue, SessionCreatedAt, SessionNamesWithClients, listSessionsWithTags, SetSessionTagValues and the global-option setters now route through it.

Why: tmuxCommand returned a concrete *exec.Cmd that every read/mutate site ran inline, so the glue mapping tmux's exit-code-1 and stderr text to 'treat as empty vs error' (the load-bearing 'exit code 1 means empty' convention that broke version-specifically in tmux 3.6a) was only covered when a real tmux produced that exact failure. New unit tests swap the seam for a fake returning canned output plus a genuine exit-code-1 *exec.ExitError, driving the exit-1-means-empty, isExitCode1-but-other-stderr->error, and no-client/session-gone-stderr->empty branches with no tmux server. Seam lives in tmux_runner.go so tmux.go stays under the 500-line cap. Mirrors the existing enterSleep var-seam in send.go.

Part of the quality stacked diff. Stacked on roadmap/18-updater-upgrade-orchestration-is-6-7-covered-n. Ticket 19 (testability).