### PR TITLE
Harness `-dump-frame` flag (the agent's primary way to inspect a rende

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Entry points: `cmd/amux` (app) and `cmd/amux-harness` (headless render/perf).
 - E2E: PTY-driven tests live in `internal/e2e` and exercise the real binary.
 - Work autonomously: validate changes with tests and use the harness/emulator to verify UI behavior without a human. The harness is render-only — it does not exercise tmux, the PTY, or a real agent.
+- To observe render output headlessly, run the harness with `-dump-frame <path>` (e.g. `go run ./cmd/amux-harness -mode center -frames 1 -warmup 0 -dump-frame /tmp/frame.txt`): it writes the exact ANSI bytes the UI rendered so you can `cat`/diff the frame instead of guessing.
 - Lint-driven workflow: run `make devcheck` for all non-trivial changes. Note `make devcheck` passes even when the real-tmux e2e tests skip, so it does not by itself verify input/send behavior.
 - Input/send/tmux/agent changes: run `make verify-loop`. It drives a real keystroke through amux's actual input path into a real raw-mode agent and asserts the bytes (including a literal carriage return) arrive intact — a green run means a real agent received the input end-to-end, which `make devcheck` and the harness cannot prove.
 - Formatting baseline includes `gofumpt`; use `make fmt` for style-only cleanup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,18 @@ failure, run the matching mode with the CI shape, e.g. center:
 go run ./cmd/amux-harness -mode center -frames 5 -warmup 1 -tabs 8 -width 160 -height 48 -hot-tabs 2 -payload-bytes 64 -newline-every 4
 ```
 
+#### Inspecting a rendered frame
+
+To see exactly what the UI rendered (instead of guessing), dump the final frame
+with `-dump-frame`:
+
+```bash
+go run ./cmd/amux-harness -mode center -frames 1 -warmup 0 -dump-frame /tmp/frame.txt
+```
+
+The file contains the raw ANSI bytes the agent sees — `cat /tmp/frame.txt` to
+eyeball it, `diff` two dumps to spot a regression, or feed it into a golden.
+
 See `go doc ./cmd/amux-harness` for all `-mode` values, flags, and the
 `AMUX_PPROF` profiling hook.
 

--- a/cmd/amux-harness/doc.go
+++ b/cmd/amux-harness/doc.go
@@ -7,7 +7,10 @@
 //
 // Useful flags: -tabs, -hot-tabs (tabs receiving animated output), -payload-bytes
 // (bytes written per hot tab per frame), -newline-every, -frames (measured
-// frames), -warmup (warmup frames to ignore), -width, -height, -keymap-hints.
+// frames), -warmup (warmup frames to ignore), -width, -height, -keymap-hints,
+// -dump-frame (write the final rendered view as raw ANSI bytes to a path — the
+// exact frame an agent sees; `cat`/diff it to inspect, or feed it into a golden),
+// -assert-min-visible (fail if the final frame has fewer than N visible glyphs).
 //
 // Set AMUX_PPROF=1/true, a port, or a listen address to start net/http/pprof
 // (default 127.0.0.1:6060 for 1/true). Fetch CPU profiles from the pprof


### PR DESCRIPTION
Document the harness `-dump-frame` flag (and its sibling `-assert-min-visible`), which write/guard the exact ANSI frame an agent renders — the primary headless way to observe UI output — but were documented in zero places an agent would look. Adds both flags to `cmd/amux-harness/doc.go`'s Useful flags list, an 'Inspecting a rendered frame' subsection to CONTRIBUTING.md, and an AGENTS.md bullet pointing agents at `-dump-frame`. Docs-only; no behavior change. Verified the documented invocation produces a raw-ANSI frame file. Part of the quality stacked diff. Stacked on roadmap/19-no-injectable-tmux-runner-exit-code-1-stderr-c. Ticket 20 (agent-experience).