### PR TITLE
tabActor single-write-path invariant — the subtlest concurrency rule i

### DIFF
--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -1,3 +1,23 @@
+// Tab-actor concurrency invariants. The tab actor (RunTabActor) serializes all
+// mutations to a tab's Terminal so that PTY-reader goroutines, the Bubble Tea
+// update loop, and selection/scroll handlers never touch the same terminal
+// concurrently. When editing this package, preserve these rules:
+//
+//  1. Single write path. Every tab terminal write goes through RunTabActor via a
+//     tabEvent (sendTabEvent -> handleTabEvent), or — only when the actor channel
+//     cannot accept the event — through the synchronous fallback in
+//     recoverFailedActorSend. Never call tab.WriteToTerminal or other terminal
+//     mutators directly from Update; that bypasses the actor and races the reader.
+//
+//  2. Backpressure contract. shouldDropTabEvent sheds load only for the
+//     selection/scroll class of events (selection-update, selection-scroll-tick,
+//     scroll-by, scroll-page) once tabEvents is >=75% full; those are coalescible
+//     UI gestures. tabEventWriteOutput is NEVER dropped — losing output corrupts
+//     the terminal — and the closed-tab guard in sendTabEvent returns true (treat
+//     as delivered) for write events so callers do not re-buffer them.
+//
+// See internal/app/MESSAGE_FLOW.md and internal/app/ARCHITECTURE.md (Invariants)
+// for the broader External-message rules these constraints fit inside.
 package center
 
 import (


### PR DESCRIPTION
Documents the tab-actor concurrency invariants in-place. Adds a leading doc comment to internal/ui/center/tab_actor.go stating (1) all tab terminal writes funnel through RunTabActor or the synchronous fallback — never call tab.WriteToTerminal directly from Update; (2) the tabEvents backpressure contract — shouldDropTabEvent sheds only selection/scroll-class events at >=75% capacity while tabEventWriteOutput is never dropped and the closed-tab guard returns delivered for write events; (3) a cross-link to internal/app/MESSAGE_FLOW.md and ARCHITECTURE.md. The rule previously lived only in ARCHITECTURE.md, far from the code it constrains, so an agent editing center had no local statement of the model. Part of the quality stacked diff. Stacked on roadmap/20-harness-dump-frame-flag-the-agent-s-primary-wa. Ticket 21 (agent-experience).