### PR TITLE
AMUX_PTY_TRACE captures only agent→amux output, leaving the amux→agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ make run
 - Perf profiling: set `AMUX_PROFILE=1` to emit periodic timing/counter snapshots; adjust cadence with `AMUX_PROFILE_INTERVAL_MS` (default 5000).
 - pprof: set `AMUX_PPROF=1` (or a port like `6061`) to expose `net/http/pprof` on `127.0.0.1`.
 - Debug signals: set `AMUX_DEBUG_SIGNALS=1` and send `SIGUSR1` to dump goroutines into the log.
-- PTY tracing: set `AMUX_PTY_TRACE=1` or a comma-separated assistant list; traces write to the log dir (or OS temp dir if logging is disabled).
+- PTY tracing: set `AMUX_PTY_TRACE=1` or a comma-separated assistant list; traces write to the log dir (or OS temp dir if logging is disabled). The trace captures both directions of the pipeline — agent→amux output is tagged `RECV` and amux→agent input (keystrokes, pastes, the delayed Enter/CR) is tagged `SEND` — so send-path issues like a dropped Enter can be debugged at the byte level.

--- a/internal/ui/center/model_input.go
+++ b/internal/ui/center/model_input.go
@@ -17,6 +17,7 @@ func (m *Model) directSendToTerminal(tab *Tab, data, label string) (*Model, bool
 	if tab.Agent == nil || tab.Agent.Terminal == nil {
 		return m, false, nil
 	}
+	m.tracePTYInput(tab, []byte(data))
 	if err := tab.Agent.Terminal.SendString(data); err != nil {
 		logging.Warn("%s failed for tab %s: %v", label, tab.ID, err)
 		tab.mu.Lock()

--- a/internal/ui/center/model_pty_trace.go
+++ b/internal/ui/center/model_pty_trace.go
@@ -69,8 +69,29 @@ func ptyTraceFileName(assistant, tabID, ts string) string {
 	return fmt.Sprintf("amux-pty-%s-%s-%s.log", token, tabID, ts)
 }
 
+// tracePTYOutput records bytes flowing FROM the agent TO amux (PTY output) into
+// the per-tab trace file. The chunk line is tagged "RECV" so the direction is
+// distinguishable from input (see tracePTYInput).
 func (m *Model) tracePTYOutput(tab *Tab, data []byte) {
-	if tab == nil || !ptyTraceAllowed(tab.Assistant) {
+	m.tracePTY(tab, "RECV", data)
+}
+
+// tracePTYInput records bytes flowing FROM amux TO the agent (keystrokes,
+// pastes, and the 50ms-delayed Enter / hex 0D carriage return) into the same
+// per-tab trace file as the output direction. The chunk line is tagged "SEND"
+// so a 'my Enter didn't register' / keystroke-forwarding bug can be debugged at
+// the byte level. Both directions share ptyTraceAllowed, ptyTraceDir, and the
+// ptyTraceLimit budget so the trace stays bounded.
+func (m *Model) tracePTYInput(tab *Tab, data []byte) {
+	m.tracePTY(tab, "SEND", data)
+}
+
+// tracePTY is the shared, direction-tagged writer behind tracePTYOutput and
+// tracePTYInput. direction is a short marker ("RECV"/"SEND") that prefixes the
+// chunk header so both dimensions of the PTY pipeline interleave in one trace
+// file while remaining distinguishable.
+func (m *Model) tracePTY(tab *Tab, direction string, data []byte) {
+	if tab == nil || len(data) == 0 || !ptyTraceAllowed(tab.Assistant) {
 		return
 	}
 
@@ -85,9 +106,15 @@ func (m *Model) tracePTYOutput(tab *Tab, data []byte) {
 		dir := ptyTraceDir()
 		name := ptyTraceFileName(tab.Assistant, string(tab.ID), time.Now().Format("20060102-150405"))
 		path := filepath.Join(dir, name)
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			logging.Warn("PTY trace open failed: %v", err)
+			tab.ptyTraceClosed = true
+			return
+		}
+		if err := file.Chmod(0o600); err != nil {
+			_ = file.Close()
+			logging.Warn("PTY trace chmod failed: %v", err)
 			tab.ptyTraceClosed = true
 			return
 		}
@@ -117,7 +144,7 @@ func (m *Model) tracePTYOutput(tab *Tab, data []byte) {
 		data = data[:remaining]
 	}
 
-	_, _ = tab.ptyTraceFile.Write([]byte(fmt.Sprintf("chunk offset=%d bytes=%d\n", tab.ptyTraceBytes, len(data))))
+	_, _ = tab.ptyTraceFile.Write([]byte(fmt.Sprintf("%s chunk offset=%d bytes=%d\n", direction, tab.ptyTraceBytes, len(data))))
 	_, _ = tab.ptyTraceFile.Write([]byte(hex.Dump(data)))
 	tab.ptyTraceBytes += len(data)
 

--- a/internal/ui/center/model_pty_trace_test.go
+++ b/internal/ui/center/model_pty_trace_test.go
@@ -1,8 +1,12 @@
 package center
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/logging"
 )
 
 func TestPtyTraceFileName(t *testing.T) {
@@ -26,5 +30,84 @@ func TestPtyTraceFileName(t *testing.T) {
 		if !strings.HasSuffix(got, "-tab-1-20060102-150405.log") {
 			t.Errorf("ptyTraceFileName(%q): unexpected suffix in %q", c.assistant, got)
 		}
+	}
+}
+
+// TestTracePTYBothDirections proves the trace records both the agent→amux
+// (RECV) and amux→agent (SEND) directions in the same per-tab file, tagged so
+// they are distinguishable.
+func TestTracePTYBothDirections(t *testing.T) {
+	t.Setenv("AMUX_PTY_TRACE", "1")
+	// Pin the trace directory (ptyTraceDir resolves to the log dir) to a live
+	// temp dir so the lazily-opened trace file lands somewhere we control and is
+	// readable regardless of stale log paths left by sibling tests.
+	dir := t.TempDir()
+	if err := logging.Initialize(dir, logging.LevelDebug); err != nil {
+		t.Fatalf("logging init: %v", err)
+	}
+	defer logging.Close()
+
+	m := newTestModel()
+	tab := &Tab{ID: TabID("trace-both"), Assistant: "claude"}
+	t.Cleanup(func() {
+		if tab.ptyTraceFile != nil {
+			_ = tab.ptyTraceFile.Close()
+		}
+	})
+
+	m.tracePTYInput(tab, []byte("hi\r"))
+	m.tracePTYOutput(tab, []byte("ok"))
+
+	if tab.ptyTraceFile == nil {
+		t.Fatal("trace file was not opened")
+	}
+	path := tab.ptyTraceFile.Name()
+	if filepath.Dir(path) != filepath.Clean(dir) {
+		t.Fatalf("trace file %q not under expected dir %q", path, dir)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat trace: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("trace file permissions = %o, want 600", perm)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "SEND chunk ") {
+		t.Errorf("trace missing SEND marker:\n%s", got)
+	}
+	if !strings.Contains(got, "RECV chunk ") {
+		t.Errorf("trace missing RECV marker:\n%s", got)
+	}
+	// The 0D carriage return (the historically bug-prone Enter byte) must be
+	// visible in the SEND hex dump so a dropped-Enter bug is debuggable.
+	if !strings.Contains(got, "hi.") || !strings.Contains(got, "0d") {
+		t.Errorf("SEND hex dump missing CR byte:\n%s", got)
+	}
+}
+
+// TestTracePTYInputGated confirms the send-direction trace respects the
+// AMUX_PTY_TRACE gate and the empty-data short-circuit.
+func TestTracePTYInputGated(t *testing.T) {
+	t.Setenv("AMUX_PTY_TRACE", "")
+
+	m := newTestModel()
+	tab := &Tab{ID: TabID("trace-gated"), Assistant: "claude"}
+	m.tracePTYInput(tab, []byte("hi"))
+
+	if tab.ptyTraceFile != nil {
+		t.Fatal("trace file opened while AMUX_PTY_TRACE was disabled")
+	}
+
+	// Even when enabled, empty data must not open a file.
+	t.Setenv("AMUX_PTY_TRACE", "1")
+	m.tracePTYInput(tab, nil)
+	if tab.ptyTraceFile != nil {
+		t.Fatal("trace file opened for empty input data")
 	}
 }

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -305,6 +305,7 @@ func (m *Model) sendMouseToTerminal(tab *Tab, data string, tabID TabID, workspac
 	if closed || agent == nil || agent.Terminal == nil {
 		return
 	}
+	m.tracePTYInput(tab, []byte(data))
 	if err := agent.Terminal.SendString(data); err != nil {
 		logging.Warn("Mouse input failed for tab %s: %v", tab.ID, err)
 		tab.mu.Lock()
@@ -327,6 +328,7 @@ func (m *Model) sendToTerminal(tab *Tab, data string, tabID TabID, workspaceID, 
 	if closed || agent == nil || agent.Terminal == nil {
 		return
 	}
+	m.tracePTYInput(tab, []byte(data))
 	if err := agent.Terminal.SendString(data); err != nil {
 		logging.Warn("%s failed for tab %s: %v", label, tab.ID, err)
 		tab.mu.Lock()


### PR DESCRIPTION
AMUX_PTY_TRACE only traced PTY output (agent→amux), so a dropped-Enter / keystroke-forwarding bug — the most common send-path failure and the historically most bug-prone area (tmux send/Enter/CR) — could not be confirmed at the byte level; the trace only showed the agent's reply.

This adds a symmetric send-direction trace under the same gate. `tracePTYInput` shares `tracePTYOutput`'s per-tab file, `hex.Dump`, and `ptyTraceLimit` budget (both now route through a shared `tracePTY` writer) but tags the chunk header `SEND` vs the existing `RECV`, so both dimensions interleave in one file while staying distinguishable. It is wired at the keystroke/paste/mouse PTY-write sites: `sendToTerminal`, `sendMouseToTerminal` (tab actor) and the synchronous `directSendToTerminal` fallback. README documents that the trace now covers both directions. Adds tests covering both directions, the CR byte in the SEND dump, and the gate/empty-data short-circuit.

Part of the quality stacked diff. Stacked on roadmap/23-harness-has-no-input-overlay-injection-dialogs. Ticket 24 (agent-experience).