### PR TITLE
Git hooks bypass the pinned golangci-lint, reintroducing the exact con

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,18 @@ if ! make fmt-check; then
 fi
 
 echo "amux pre-commit: running golangci-lint..."
-golangci-lint run
+# Route lint through `make lint` so it resolves the pinned ./.cache/bin
+# golangci-lint matched to .golangci-version (via the Makefile GOLANGCI probe)
+# and runs check-golangci-version first. A bare `golangci-lint run` from PATH is
+# frequently the wrong version and fails confusingly (a v2.x binary cannot read
+# this repo's v1 .golangci.yml: "unsupported version of the configuration"); the
+# make path prefers the pinned binary when present and surfaces the actionable
+# "run make lint-tools" guidance before that confusing config error, rather than
+# leaving it as the last word. See LINTING.md.
+#
+# NOTE: `make lint` also runs check-file-length on the whole tree, which is
+# harmless and complements the staged-only guard below.
+make lint
 
 echo "amux pre-commit: checking file lengths (max 500 lines)..."
 staged_go_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')


### PR DESCRIPTION
The pre-commit hook called a bare `golangci-lint run` from PATH, bypassing the pinned `./.cache/bin/golangci-lint` that `make lint` resolves (via the Makefile GOLANGCI probe matched to `.golangci-version`). A contributor who follows the documented install path (golangci-lint.run, which installs latest v2.x) hit a confusing `unsupported version of the configuration` error on their very first `git commit`, with no guidance — defeating the pinned-linter mechanism LINTING.md describes.

This routes the pre-commit lint through `make lint`, so it runs `check-golangci-version` first and uses the pinned binary when present. With an absent/stale pinned binary or wrong PATH version, the hook now emits the actionable `run make lint-tools` hint instead of a raw config error. Mirrors the pre-push hook, which already routes lint through `make lint-ci-parity`. The staged-file length guard is unchanged.

Verified: with the pinned binary present the hook resolves `./.cache/bin/golangci-lint` and passes; with it absent (and none on PATH) the hook prints the lint-tools install hint; with a wrong-version (v2.x-style) binary on PATH it warns 'run make lint-tools' before any config error.

Part of the quality stacked diff. Stacked on roadmap/24-amux-pty-trace-captures-only-agent-amux-output. Ticket 25 (developer-experience).