### PR TITLE
README and CONTRIBUTING give two divergent first-run flows; README's o

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ AMUX requires `tmux` and is supported on Linux/macOS. Windows is not supported.
 ```bash
 git clone https://github.com/andyrewlee/amux.git
 cd amux
-make lint-tools   # one-time: builds the pinned golangci-lint into ./.cache/bin
+./scripts/install-hooks.sh   # one-time: enables the pre-commit + pre-push git hooks
+make lint-tools              # one-time: builds the pinned golangci-lint into ./.cache/bin
 make run
 ```
+
+Run `./scripts/install-hooks.sh` once after cloning. It points `core.hooksPath`
+at `.githooks`, enabling the pre-commit fmt/lint/file-length checks and the
+pre-push lint-parity gate the project relies on for quality.
 
 Run `make lint-tools` once before your first `make devcheck` or `git commit`.
 It builds the linter pinned in `.golangci-version` into the gitignored


### PR DESCRIPTION
The README Development block omitted `./scripts/install-hooks.sh`, so contributors onboarding from the README (the most-read doc) never installed the git hooks and got none of the pre-commit fmt/lint/file-length protection or pre-push lint-parity the project relies on. This aligns the README first-run flow with CONTRIBUTING.md by adding the hooks-install step, so both canonical onboarding paths agree (clone -> cd -> install-hooks -> lint-tools -> run).

Part of the quality stacked diff. Stacked on roadmap/27-pre-push-silently-passes-the-e2e-step-when-tmu. Ticket 28 (developer-experience).