### PR TITLE
go.mod pins Go 1.26.4 with no `toolchain` directive while the README a

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ It builds the linter version pinned in `.golangci-version` into the gitignored
 version (v2.x) and fails confusingly against this repo's v1 config. See
 [LINTING.md](LINTING.md) for the full rationale.
 
+The minimum supported Go is **1.26** (the `go` directive in `go.mod`); any Go
+1.26.x patch release builds the repo, so no `GOTOOLCHAIN` override is needed.
+
 Run the local checks that mirror CI:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Or via the install script:
 curl -fsSL https://raw.githubusercontent.com/andyrewlee/amux/main/install.sh | sh
 ```
 
-Or with Go:
+Or with Go (requires Go 1.26 or newer):
 
 ```bash
 go install github.com/andyrewlee/amux/cmd/amux@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andyrewlee/amux
 
-go 1.26.4
+go 1.26
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
Relax the go.mod floor from the patch-pinned `go 1.26.4` to the true minor floor `go 1.26`, and document the exact minimum in the README and CONTRIBUTING.

**Why:** With no `toolchain` directive, `go 1.26.4` made contributors on Go 1.26.0-1.26.3 hit a hard `go.mod requires go >= 1.26.4` refusal on `make build`/`go install` instead of an auto-download — a silent first-build wall. Adding `toolchain go1.26.4` is not durable: it equals the `go` directive version, so `go mod tidy`/`go build` strip it on the next dependency bump. Go patch releases add no language or API features, so nothing here ever required 1.26.4 over 1.26.0. Relaxing to `go 1.26` builds clean, keeps `go mod tidy` a no-op, makes the existing `Go-1.26` README badge accurate, and removes the wall entirely. CI reads the version via `go-version-file: go.mod`, so it tracks the new floor automatically.

Part of the quality stacked diff. Stacked on roadmap/28-readme-and-contributing-give-two-divergent-fir. Ticket 29 (developer-experience).