### PR TITLE
ARCHITECTURE.md package table has drifted: omits 4 real packages and c

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,10 +18,11 @@ boundaries and command discipline between the app pump and the panes, see
 Dependencies point downward. Most UI code reaches OS and process boundaries
 through the tmux/pty/git/data layers. UI packages may still own
 interaction-local adapters when the behavior is part of a widget boundary, such
-as clipboard writes and file-picker filesystem reads in `internal/ui/common`, PTY
-tracing in `internal/ui/center`, and shell plumbing in the sidebar terminal.
-Shared process, persistence, git, tmux, and PTY behavior belongs in the lower
-layers.
+as clipboard writes and file-picker filesystem reads in `internal/ui/common`,
+per-tab PTY tracing in `internal/ui/center`, and shell plumbing in the sidebar
+terminal. Shared process, persistence, git, tmux, and PTY behavior — including the
+shared PTY/tmux read-loop and session plumbing in `internal/ui/ptyio` — belongs in
+the lower layers.
 
 ```
             cmd/amux            cmd/amux-harness
@@ -32,7 +33,7 @@ layers.
                  |   `-- internal/ui/{dashboard, center, sidebar, diff}
                  |              |
                  |              v
-                 |       internal/ui/{compositor, layout, common}
+                 |       internal/ui/{compositor, layout, common, ptyio, theme}
                  v              |
    internal/{tmux, pty, git,    v
      data, update, config,  internal/vterm   (terminal emulator)
@@ -58,12 +59,15 @@ The table is hand-maintained; keep it in sync when adding or moving a package.
 | `internal/ui/diff` | Scrollable, syntax-aware git diff viewer (a center tab) | `model.go` |
 | `internal/ui/compositor` | Composes vterm snapshots + UI layers into a frame; delta ANSI | `canvas.go` |
 | `internal/ui/layout` | Pane geometry and layout modes | `manager.go` |
-| `internal/ui/common` | Shared theming, widgets, selection, PTY/tmux plumbing | `theme.go`, `pty_reader.go` |
+| `internal/ui/common` | Shared widgets (dialogs, file picker), selection, clipboard; re-exports theme | `dialog.go`, `theme_reexport.go` |
+| `internal/ui/ptyio` | Shared PTY/tmux plumbing: read loop, output filtering/trimming, flush/chunk tuning consts, session bootstrap/restore | `doc.go`, `pty_reader.go`, `tuning.go` |
+| `internal/ui/theme` | Color palette, theme registry, icons, and lipgloss styles | `colors.go`, `theme.go`, `icons.go` |
 | `internal/vterm` | Terminal emulator: ANSI/VT parsing → cell grid + scrollback → ANSI | `vterm.go` |
 | `internal/tmux` | tmux CLI wrapper: sessions, capture, resize, activity tags | `tmux.go` |
 | `internal/pty` | Pseudo-terminals backing hosted agents (Agent, Terminal) | `agent.go` |
 | `internal/git` | git worktree-per-workspace model: worktrees, branches, diff, watcher | `operations.go`, `workspace.go` |
 | `internal/data` | Workspace record persistence (atomic JSON via WorkspaceStore) | `workspace_store.go` |
+| `internal/fsatomic` | Crash-safe single-file writes: temp-write, fsync, atomic rename-over (with .bak restore on Windows) | `fsatomic.go` |
 | `internal/update` | Self-update: version check, download, verify, install | `updater.go` |
 | `internal/config` | Configuration: assistants, UI settings, resolved paths | `config.go` |
 | `internal/supervisor` | Named background workers with restart/backoff and error surfacing | `supervisor.go` |
@@ -73,4 +77,5 @@ The table is hand-maintained; keep it in sync when adding or moving a package.
 | `internal/logging` | File-based logger; the output channel for internal packages | `logger.go` |
 | `internal/messages` | Shared Bubble Tea message vocabulary between pump and panes | `messages.go` |
 | `internal/validation` | Input/path guards (assistant, base ref, project path, workspace) | `validation.go` |
+| `internal/testutil` | Shared test polling helpers (deadline/poll loops with consistent failure messaging) | `wait.go` |
 | `internal/e2e` | PTY-driven end-to-end tests exercising the real binary | (tests) |

--- a/internal/app/arch_table_test.go
+++ b/internal/app/arch_table_test.go
@@ -1,0 +1,71 @@
+package app_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestArchitectureTableHasEveryPackage guards against ARCHITECTURE.md's
+// hand-maintained Packages table silently drifting from the real tree: it walks
+// `go list ./internal/... ./cmd/...` and fails if any package directory is not
+// mentioned in ARCHITECTURE.md. Add a row when this fails (don't just delete
+// the package from your mental model).
+func TestArchitectureTableHasEveryPackage(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	doc, err := os.ReadFile(filepath.Join(root, "ARCHITECTURE.md"))
+	if err != nil {
+		t.Fatalf("read ARCHITECTURE.md: %v", err)
+	}
+	// Restrict the match to the Packages *table* so a package named only in the
+	// prose or the dependency diagram cannot satisfy the guard: deleting a real
+	// table row must fail even if the name still appears elsewhere in the doc. We
+	// keep only table-row lines (those beginning with "| `") from the "## Packages"
+	// section onward, and match the backtick-wrapped package path against them.
+	full := string(doc)
+	if i := strings.Index(full, "## Packages"); i >= 0 {
+		full = full[i:]
+	}
+	var rows []string
+	for _, line := range strings.Split(full, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "| `") {
+			rows = append(rows, line)
+		}
+	}
+	table := strings.Join(rows, "\n")
+
+	cmd := exec.Command("go", "list", "./internal/...", "./cmd/...")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list: %v", err)
+	}
+
+	for _, pkg := range strings.Fields(string(out)) {
+		// Trim the module prefix so we compare on the repo-relative dir
+		// (e.g. internal/ui/common) the table actually lists.
+		rel := pkg
+		if i := strings.Index(pkg, "/internal/"); i >= 0 {
+			rel = pkg[i+1:]
+		} else if i := strings.Index(pkg, "/cmd/"); i >= 0 {
+			rel = pkg[i+1:]
+		}
+		// A package counts as documented if its own dir or its parent dir
+		// (but not a bare "internal"/"cmd" segment) is in the table, so
+		// test-support subpackages such as internal/e2e/fakeagent roll up
+		// under their parent's row instead of needing their own.
+		documented := strings.Contains(table, "`"+rel+"`")
+		if parent := filepath.Dir(rel); !documented && strings.Contains(parent, "/") {
+			documented = strings.Contains(table, "`"+parent+"`")
+		}
+		if !documented {
+			t.Errorf("ARCHITECTURE.md Packages table omits %q (add a row; the table is hand-maintained)", rel)
+		}
+	}
+}


### PR DESCRIPTION
Re-syncs the hand-maintained ARCHITECTURE.md Packages table with the actual tree. It had rotted: missing rows for internal/fsatomic (atomic file-write primitive), internal/ui/ptyio (shared PTY-IO plumbing/tuning consts), internal/ui/theme (palette + icons), and internal/testutil (test wait helpers); and the internal/ui/common row cited a nonexistent pty_reader.go (that file actually lives in the new ptyio package, so the pointer is now correct). Also fixes the dependency-direction prose and diagram to attribute PTY plumbing to ptyio, and adds a 40-line internal/app/arch_table_test.go guard that walks 'go list ./internal/... ./cmd/...' and fails if a package dir is absent from the table, so it can't silently drift again. Docs/test-only; no behavior change. Part of the quality stacked diff. Stacked on roadmap/29-go-mod-pins-go-1-26-4-with-no-toolchain-direct. Ticket 30 (developer-experience).