### PR TITLE
fix(tmux): read session creation time from session list

### DIFF
--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -72,15 +72,22 @@ func SessionCreatedAt(sessionName string, opts Options) (int64, error) {
 	if !exists {
 		return 0, nil
 	}
-	cmd, cancel := tmuxCommand(opts, "display-message", "-p", "-t", sessionTarget(sessionName), "#{session_created}")
+	cmd, cancel := tmuxCommand(opts, "list-sessions", "-F", "#{session_name}\t#{session_created}")
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
 		return 0, err
 	}
-	raw := strings.TrimSpace(string(output))
-	if raw == "" {
-		return 0, nil
+	for _, line := range parseOutputLines(output) {
+		name, raw, ok := strings.Cut(line, "\t")
+		if !ok || name != sessionName {
+			continue
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return 0, nil
+		}
+		return strconv.ParseInt(raw, 10, 64)
 	}
-	return strconv.ParseInt(raw, 10, 64)
+	return 0, nil
 }


### PR DESCRIPTION
## Summary
- read tmux session creation timestamps from list-sessions output
- avoid display-message exact-target compatibility issues on older tmux

## Verification
- autoreview clean: no accepted/actionable findings reported
- go test ./internal/tmux ./internal/app -run 'SessionCreatedAt|TmuxOps_SessionCreatedAt' -count=1
- go test ./internal/tmux ./internal/app -count=1
- go test ./internal/e2e -run TestWorkspaceFirstActivation_DoesNotFlashTabActive -count=1 -v
- pre-push hook passed on retry