### PR TITLE
fix: route center Ctrl-C through the per-agent interrupt sequence

### DIFF
--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -256,13 +256,22 @@ func (m *AgentManager) SendInterrupt(agent *Agent) error {
 		return nil
 	}
 
-	// Send multiple interrupts if configured (e.g., for Claude)
-	for i := 0; i < agent.Config.InterruptCount; i++ {
+	// A single Ctrl-C is the floor: an unconfigured agent (e.g. a viewer with a
+	// zero-value AssistantConfig) must still receive one interrupt, otherwise the
+	// user's Ctrl-C would be silently swallowed.
+	count := agent.Config.InterruptCount
+	if count < 1 {
+		count = 1
+	}
+
+	// Send multiple interrupts if configured (e.g., for Claude, which needs two
+	// Ctrl-C presses within a short window to actually interrupt).
+	for i := 0; i < count; i++ {
 		if err := agent.Terminal.SendInterrupt(); err != nil {
 			return err
 		}
 		// Add delay between interrupts if configured
-		if i < agent.Config.InterruptCount-1 && agent.Config.InterruptDelayMs > 0 {
+		if i < count-1 && agent.Config.InterruptDelayMs > 0 {
 			time.Sleep(time.Duration(agent.Config.InterruptDelayMs) * time.Millisecond)
 		}
 	}

--- a/internal/pty/agent_test.go
+++ b/internal/pty/agent_test.go
@@ -392,10 +392,12 @@ func TestAgentManager_SendInterrupt_ZeroCount(t *testing.T) {
 		Type:     AgentType("claude"),
 		Terminal: term,
 		Config: config.AssistantConfig{
-			InterruptCount: 0, // zero means no interrupts sent
+			InterruptCount: 0, // unconfigured: floors to a single interrupt
 		},
 	}
 
+	// A zero/unset InterruptCount must still deliver one Ctrl-C so a user's
+	// interrupt is never silently swallowed (e.g. for viewer agents).
 	err = m.SendInterrupt(agent)
 	if err != nil {
 		t.Errorf("SendInterrupt with zero count should succeed, got %v", err)

--- a/internal/ui/center/model_input_keys.go
+++ b/internal/ui/center/model_input_keys.go
@@ -133,6 +133,13 @@ func (m *Model) forwardKeyToTerminal(msg tea.KeyPressMsg, tab *Tab) (*Model, tea
 
 func (m *Model) handleTerminalCtrlKey(msg tea.KeyPressMsg, tab *Tab) (*Model, tea.Cmd, bool) {
 	switch {
+	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
+		// Route Ctrl-C through the per-agent interrupt so agents that need more
+		// than one Ctrl-C (e.g. Claude: InterruptCount 2, 200ms apart) are
+		// actually interrupted. A plain key-forward only ever sends one 0x03.
+		// Preserve the raw-key path's snap-to-bottom side effect.
+		m.scrollToBottomOnType(tab)
+		return m, m.interruptActiveAgentCmd(tab), true
 	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+n"))):
 		before := m.getActiveTabIdx()
 		m.nextTab()
@@ -157,6 +164,28 @@ func (m *Model) handleTerminalCtrlKey(msg tea.KeyPressMsg, tab *Tab) (*Model, te
 		return m, common.SafeBatch(stamp, m.userInputActivityTagCmd(tab)), true
 	}
 	return m, nil, false
+}
+
+// interruptActiveAgentCmd sends the agent's configured interrupt sequence
+// (count + inter-press delay) off the Bubble Tea update loop, since the delay
+// between presses must not block rendering. It also re-tags user-input activity
+// so the working indicator updates promptly.
+func (m *Model) interruptActiveAgentCmd(tab *Tab) tea.Cmd {
+	agent := tab.Agent
+	if agent == nil || m.agentManager == nil {
+		return nil
+	}
+	interrupt := func() tea.Msg {
+		_ = m.agentManager.SendInterrupt(agent)
+		return nil
+	}
+	// Mirror the raw-key path's bookkeeping for the 0x03 it would have sent:
+	// record the local-input echo window and re-tag user-input activity.
+	return common.SafeBatch(
+		interrupt,
+		m.noteLocalInput(tab, m.workspaceID(), "\x03", time.Now()),
+		m.userInputActivityTagCmd(tab),
+	)
 }
 
 func (m *Model) handleScrollbackKey(msg tea.KeyPressMsg, tab *Tab) (*Model, tea.Cmd, bool) {

--- a/internal/ui/center/model_interrupt_test.go
+++ b/internal/ui/center/model_interrupt_test.go
@@ -1,0 +1,49 @@
+package center
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/config"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+)
+
+// TestCenterCtrlCRoutesToAgentInterrupt locks in the fix for AGT-07: a live
+// Ctrl-C in the center pane must be intercepted by the ctrl-key handler and
+// routed through the per-agent interrupt (which honors InterruptCount /
+// InterruptDelayMs), NOT forwarded as a single raw 0x03 byte.
+//
+// Regression guard: previously ctrl+c fell through to the raw key-forward path,
+// so an agent that needs more than one Ctrl-C within a short window (e.g. Claude:
+// InterruptCount 2, 200ms apart) could not be interrupted with one keystroke.
+func TestCenterCtrlCRoutesToAgentInterrupt(t *testing.T) {
+	m := newTestModel()
+	term, err := appPty.New("cat", t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("new terminal: %v", err)
+	}
+	defer func() { _ = term.Close() }()
+
+	tab := &Tab{Agent: &appPty.Agent{
+		Terminal: term,
+		Config:   config.AssistantConfig{InterruptCount: 2, InterruptDelayMs: 1},
+	}}
+
+	_, cmd, handled := m.handleTerminalCtrlKey(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}, tab)
+	if !handled {
+		t.Fatal("ctrl+c must be intercepted by the ctrl-key handler, not forwarded as a raw byte")
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+c must produce an interrupt command for an agent tab")
+	}
+}
+
+// TestInterruptActiveAgentCmdNilSafe guards the helper against tabs without a
+// live agent (detached/placeholder) and a model without an agent manager.
+func TestInterruptActiveAgentCmdNilSafe(t *testing.T) {
+	m := newTestModel()
+	if cmd := m.interruptActiveAgentCmd(&Tab{Agent: nil}); cmd != nil {
+		t.Fatal("interrupt on a tab with no agent must be a no-op (nil cmd)")
+	}
+}


### PR DESCRIPTION
## Problem
A live Ctrl-C in the **center** pane fell through to the raw key-forward path, which only sends a single `0x03`. Agents that need more than one Ctrl-C within a short window (e.g. Claude: `InterruptCount` 2, 200 ms apart) could **not** be interrupted with a single keystroke. (Implements **AGT-07** from the feature audit.)

## Fix
- `center.handleTerminalCtrlKey` now routes `ctrl+c` through `AgentManager.SendInterrupt`, which honors `InterruptCount` / `InterruptDelayMs`. The interrupt runs off the Bubble Tea update loop so the inter-press delay can't block rendering.
- The new `interruptActiveAgentCmd` helper preserves the raw path's side effects: snap-to-bottom, the local-input echo window (`noteLocalInput`), and the user-input activity re-tag.
- `pty.AgentManager.SendInterrupt` floors `InterruptCount` to 1, so an unconfigured agent (zero-value `AssistantConfig`, e.g. a viewer) still receives **one** interrupt instead of silently swallowing the user's Ctrl-C.

## Why it's safe
`handleTerminalCtrlKey` is only reachable after `forwardKeyToActiveTab` guards `tab.Agent == nil` and routes diff-viewer tabs elsewhere, so this can't swallow Ctrl-C on agent-less tabs. Bypassing the actor is required — the `InterruptCount`-with-delay sequence can't go through the single-byte actor path, and a Ctrl-C arriving promptly is the desired semantics.

## Verification
- `make devcheck` — green (vet, all unit tests, harness-golden, lint 0 issues, file-length).
- `make verify-loop` — green (real keystroke delivered end-to-end to a raw-mode agent).
- New regression tests: `TestCenterCtrlCRoutesToAgentInterrupt`, `TestInterruptActiveAgentCmdNilSafe`, and updated `TestAgentManager_SendInterrupt_ZeroCount`.