### PR TITLE
fix(config): write config.json atomically via fsatomic

### DIFF
--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/andyrewlee/amux/internal/fsatomic"
 )
 
 // UISettings stores user-facing display preferences.
@@ -80,7 +82,9 @@ func saveUISettings(path string, settings UISettings) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	// Crash-safe write (temp + fsync + atomic rename) so a crash mid-save can't
+	// leave a torn config.json, matching the rest of amux's persistence.
+	return fsatomic.WriteFile(path, data, 0o644)
 }
 
 // SaveUISettings persists UI settings to the config file.


### PR DESCRIPTION
## What
`saveUISettings` wrote `config.json` with plain `os.WriteFile`, so a crash mid-save could leave a torn config file. This switches to `internal/fsatomic.WriteFile` (temp + fsync + atomic rename), matching the rest of amux's persistence (workspace.json, trusted-scripts.json).

## Why
Consistency + crash-safety. `os.MkdirAll` still runs first, so the temp file lands on the same filesystem as the target (no cross-device rename). No behavior change on the success path.

## Validation
- `go build ./...`, `go vet ./internal/config/`, `go test ./internal/config/` — green
- pinned golangci-lint (v2.12.2) on `./internal/config/...` — 0 issues
- Independently adversarially re-verified (drop-in correctness, perms note: fsatomic keeps temp-file private perms by design).

## Context
Found during the amux feature audit (story **OPS-05**). The other audit finding (AGT-07, Ctrl-C interrupt) already landed via #537.