### PR TITLE
fix: UX/logistical defects from full-app feature audit

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -86,6 +86,8 @@ type App struct {
 	// Theme persistence state for settings dialog exits.
 	settingsThemePersistedTheme common.ThemeID
 	settingsThemeDirty          bool
+	// Theme that was active when the settings dialog opened, restored on Esc.
+	settingsThemeOriginal common.ThemeID
 
 	// Overlays
 	toast *common.ToastModel

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -125,18 +125,20 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 
 	switch result.ID {
 	case DialogAddProject:
-		if result.Value != "" {
-			path := validation.SanitizeInput(result.Value)
-			logging.Info("Adding project from dialog: %s", path)
-			if err := validation.ValidateProjectPath(path); err != nil {
-				logging.Warn("Project path validation failed: %v", err)
-				return func() tea.Msg {
-					return messages.Error{Err: err, Context: errorContext(errorServiceDialog, "validating project path")}
-				}
-			}
+		if result.Value == "" {
+			// Confirming an empty path must not silently close with no feedback.
+			return a.toast.ShowWarning("Project path is required")
+		}
+		path := validation.SanitizeInput(result.Value)
+		logging.Info("Adding project from dialog: %s", path)
+		if err := validation.ValidateProjectPath(path); err != nil {
+			logging.Warn("Project path validation failed: %v", err)
 			return func() tea.Msg {
-				return messages.AddProject{Path: path}
+				return messages.Error{Err: err, Context: errorContext(errorServiceDialog, "validating project path")}
 			}
+		}
+		return func() tea.Msg {
+			return messages.AddProject{Path: path}
 		}
 
 	case DialogCreateWorkspace:

--- a/internal/app/app_input_dialogs_test.go
+++ b/internal/app/app_input_dialogs_test.go
@@ -126,3 +126,20 @@ func TestAppUpdate_FilePickerVisibleConsumesWheel(t *testing.T) {
 		t.Fatalf("expected wheel input to move file picker selection to beta, got %q", after)
 	}
 }
+
+func TestHandleDialogResult_AddProjectEmptyShowsWarning(t *testing.T) {
+	app := &App{toast: common.NewToastModel()}
+
+	cmd := app.handleDialogResult(common.DialogResult{
+		ID:        DialogAddProject,
+		Confirmed: true,
+		Value:     "",
+	})
+
+	if cmd == nil {
+		t.Fatal("expected warning toast command")
+	}
+	if view := ansi.Strip(app.toast.View()); !strings.Contains(view, "Project path is required") {
+		t.Fatalf("expected project path warning toast, got %q", view)
+	}
+}

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -128,6 +128,7 @@ func (a *App) handleShowCleanupTmuxDialog() {
 func (a *App) handleShowSettingsDialog() {
 	persistedUI := a.config.PersistedUISettings()
 	a.settingsThemePersistedTheme = common.ThemeID(persistedUI.Theme)
+	a.settingsThemeOriginal = common.ThemeID(a.config.UI.Theme)
 	a.settingsThemeDirty = common.ThemeID(a.config.UI.Theme) != a.settingsThemePersistedTheme
 	a.settingsDialogSession++
 	a.settingsDialog = common.NewSettingsDialog(
@@ -195,7 +196,16 @@ func (a *App) persistSettingsThemeIfDirty() tea.Cmd {
 }
 
 // handleSettingsResult handles settings dialog close.
-func (a *App) handleSettingsResult(_ common.SettingsResult) tea.Cmd {
+func (a *App) handleSettingsResult(res common.SettingsResult) tea.Cmd {
+	if res.Canceled {
+		// Esc cancels: revert any live theme preview to what was active when the
+		// dialog opened and do not persist.
+		a.applyTheme(a.settingsThemeOriginal)
+		a.settingsThemeDirty = false
+		a.settingsDialog = nil
+		a.settingsDialogSession++
+		return nil
+	}
 	if a.settingsDialog != nil {
 		a.applyTheme(a.settingsDialog.SelectedTheme())
 	}

--- a/internal/app/app_input_messages_dialogs_test.go
+++ b/internal/app/app_input_messages_dialogs_test.go
@@ -54,6 +54,49 @@ func TestHandleThemePreview_PersistsOnCloseOnly(t *testing.T) {
 	}
 }
 
+func TestHandleSettingsResult_CancelRevertsPreviewWithoutSave(t *testing.T) {
+	prevTheme := common.GetCurrentTheme().ID
+	defer common.SetCurrentTheme(prevTheme)
+
+	h, err := NewHarness(HarnessOptions{
+		Mode:   HarnessCenter,
+		Width:  120,
+		Height: 40,
+	})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "amux-config.json")
+	h.app.config.Paths.ConfigPath = configPath
+	originalTheme := common.ThemeID(h.app.config.UI.Theme)
+	previewTheme := common.ThemeTokyoNight
+	if previewTheme == originalTheme {
+		previewTheme = common.ThemeGruvbox
+	}
+	h.app.handleShowSettingsDialog()
+	session := h.app.settingsDialogSession
+
+	_ = h.app.handleThemePreview(common.ThemePreview{Theme: previewTheme, Session: session})
+	if common.ThemeID(h.app.config.UI.Theme) != previewTheme {
+		t.Fatalf("expected preview theme to apply, got %q", h.app.config.UI.Theme)
+	}
+
+	cmd := h.app.handleSettingsResult(common.SettingsResult{Canceled: true})
+	if cmd != nil {
+		t.Fatal("expected canceled settings close to skip persistence")
+	}
+	if got := common.ThemeID(h.app.config.UI.Theme); got != originalTheme {
+		t.Fatalf("canceled settings close theme = %q, want original %q", got, originalTheme)
+	}
+	if h.app.settingsThemeDirty {
+		t.Fatal("expected canceled settings close to clear dirty flag")
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected canceled settings close not to write config, stat err=%v", err)
+	}
+}
+
 func TestHandleSettingsResult_SaveFailureShowsWarningToast(t *testing.T) {
 	prevTheme := common.GetCurrentTheme().ID
 	defer common.SetCurrentTheme(prevTheme)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,9 @@ func (c *Config) IsAssistantKnown(assistant string) bool {
 // loaded it consults the config map; otherwise it falls back to the canonical
 // agent registry rather than reporting false for every agent.
 func (c *Config) IsChatAssistant(name string) bool {
+	// Normalize so casing/whitespace agree with IsAssistantKnown and the
+	// registry, both of which key on the normalized (lowercased) name.
+	name = normalizeAssistantName(name)
 	if c != nil && len(c.Assistants) > 0 {
 		_, ok := c.Assistants[name]
 		return ok

--- a/internal/config/is_chat_assistant_test.go
+++ b/internal/config/is_chat_assistant_test.go
@@ -20,6 +20,12 @@ func TestIsChatAssistant(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "nil config falls back to registry after normalization",
+			cfg:       nil,
+			assistant: "  CLAUDE  ",
+			want:      true,
+		},
+		{
 			name:      "nil config falls back to registry: unknown agent is not chat",
 			cfg:       nil,
 			assistant: "totally-unknown",
@@ -60,6 +66,14 @@ func TestIsChatAssistant(t *testing.T) {
 				"codex":  {Command: "codex"},
 			}},
 			assistant: "codex",
+			want:      true,
+		},
+		{
+			name: "non-empty config: assistant name is normalized",
+			cfg: &Config{Assistants: map[string]AssistantConfig{
+				"codex": {Command: "codex"},
+			}},
+			assistant: "  CODEX  ",
 			want:      true,
 		},
 	}

--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -63,8 +65,14 @@ func saveUISettings(path string, settings UISettings) error {
 	}
 
 	payload := map[string]any{}
-	if existing, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(existing, &payload)
+	if existing, err := os.ReadFile(path); err == nil && len(bytes.TrimSpace(existing)) > 0 {
+		// Refuse to clobber an existing-but-unparseable config: the loader
+		// tolerates malformed JSON (falls back to defaults), so blindly
+		// overwriting here would silently drop unrelated sections the user
+		// hand-edited (e.g. "assistants").
+		if err := json.Unmarshal(existing, &payload); err != nil {
+			return fmt.Errorf("refusing to overwrite malformed config %s: %w", path, err)
+		}
 	}
 
 	ui, ok := payload["ui"].(map[string]any)

--- a/internal/config/user_settings_test.go
+++ b/internal/config/user_settings_test.go
@@ -191,25 +191,26 @@ func TestSaveUISettingsOverwritesExistingUISection(t *testing.T) {
 	}
 }
 
-func TestSaveUISettingsRecoversFromMalformedExistingFile(t *testing.T) {
-	// A corrupt existing file must not block a save; unmarshal errors are
-	// swallowed and the payload is rebuilt from scratch.
+func TestSaveUISettingsRefusesMalformedExistingFile(t *testing.T) {
+	// A corrupt existing file must not be overwritten because it may contain
+	// hand-edited sections that the tolerant loader skipped.
 	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte("}{ not json at all"), 0o644); err != nil {
+	original := []byte("}{ not json at all")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
 	settings := UISettings{Theme: "gruvbox", ShowKeymapHints: true, TmuxSyncInterval: "2s"}
-	if err := saveUISettings(path, settings); err != nil {
-		t.Fatalf("saveUISettings() error = %v", err)
+	if err := saveUISettings(path, settings); err == nil {
+		t.Fatal("saveUISettings() error = nil, want non-nil for malformed existing config")
 	}
 
-	file, err := readConfigFile(path)
+	got, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("readConfigFile() error = %v", err)
+		t.Fatalf("ReadFile() error = %v", err)
 	}
-	if got := applyUISettings(defaultUISettings(), file.UI); got != settings {
-		t.Errorf("settings after recovery = %+v, want %+v", got, settings)
+	if string(got) != string(original) {
+		t.Fatalf("config file was modified despite malformed JSON: got %q want %q", got, original)
 	}
 }
 

--- a/internal/process/script_trust.go
+++ b/internal/process/script_trust.go
@@ -108,6 +108,11 @@ func (t *ScriptTrust) Trust(repoPath string, configContent []byte) error {
 		return nil
 	}
 	key := data.NormalizePath(repoPath)
+	if key == "" {
+		// Mirror IsTrusted's guard: an empty key can never be matched, so
+		// recording one would "succeed" while granting no real trust.
+		return nil
+	}
 	entries := t.load()
 	entries[key] = hashConfig(configContent)
 

--- a/internal/process/script_trust_test.go
+++ b/internal/process/script_trust_test.go
@@ -29,6 +29,21 @@ func TestScriptTrustTrustThenTrusted(t *testing.T) {
 	}
 }
 
+func TestScriptTrustEmptyPathDoesNotWriteRegistry(t *testing.T) {
+	dir := t.TempDir()
+	trust := NewScriptTrust(dir)
+
+	if err := trust.Trust("", []byte(`{"setup-workspace":["touch marker"]}`)); err != nil {
+		t.Fatalf("Trust(empty) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, trustRegistryFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected no trust registry for empty path, stat err = %v", err)
+	}
+	if trust.IsTrusted("", []byte(`{"setup-workspace":["touch marker"]}`)) {
+		t.Fatal("empty repo path must never be trusted")
+	}
+}
+
 func TestScriptTrustInvalidatedWhenContentChanges(t *testing.T) {
 	trust := NewScriptTrust(t.TempDir())
 	repo := t.TempDir()

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -93,8 +93,11 @@ type ptyTabReattachFailed struct {
 }
 
 func truncateDisplayName(name string) string {
-	if len(name) > 20 {
-		return "..." + name[len(name)-17:]
+	// Count/slice by rune, not byte, so multibyte/CJK names are never cut
+	// mid-rune (which would render as a replacement glyph).
+	r := []rune(name)
+	if len(r) > 20 {
+		return "..." + string(r[len(r)-17:])
 	}
 	return name
 }

--- a/internal/ui/center/model_tabs_test.go
+++ b/internal/ui/center/model_tabs_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 )
 
-// TestTruncateDisplayName exercises the byte-length-based trailing-tail policy:
-// names of 20 bytes or fewer are returned verbatim, while longer names are
-// rewritten as "..." plus the trailing 17 bytes (a 20-byte result).
+// TestTruncateDisplayName exercises the rune-length-based trailing-tail policy:
+// names of 20 runes or fewer are returned verbatim, while longer names are
+// rewritten as "..." plus the trailing 17 runes.
 func TestTruncateDisplayName(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -38,6 +38,11 @@ func TestTruncateDisplayName(t *testing.T) {
 			input: "abcdefghijklmnopqrstuvwxyz",
 			want:  "...jklmnopqrstuvwxyz",
 		},
+		{
+			name:  "multibyte name truncates on rune boundary",
+			input: strings.Repeat("界", 21),
+			want:  "..." + strings.Repeat("界", 17),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -50,7 +55,7 @@ func TestTruncateDisplayName(t *testing.T) {
 }
 
 // TestTruncateDisplayName_BoundaryLengths is a property check across the cutover:
-// the result is never longer than 20 bytes, and a truncated result always begins
+// the result is never longer than 20 runes, and a truncated result always begins
 // with the "..." marker while preserving the original suffix.
 func TestTruncateDisplayName_BoundaryLengths(t *testing.T) {
 	for n := 0; n <= 40; n++ {
@@ -68,13 +73,13 @@ func TestTruncateDisplayName_BoundaryLengths(t *testing.T) {
 			}
 			continue
 		}
-		if len(got) != 20 {
-			t.Fatalf("len=%d: truncated result %q has length %d, want 20", n, got, len(got))
+		if gotRunes := len([]rune(got)); gotRunes != 20 {
+			t.Fatalf("len=%d: truncated result %q has rune length %d, want 20", n, got, gotRunes)
 		}
 		if !strings.HasPrefix(got, "...") {
 			t.Fatalf("len=%d: truncated result %q must start with ...", n, got)
 		}
-		// The trailing 17 bytes of the original survive verbatim.
+		// The trailing 17 bytes of the ASCII original survive verbatim.
 		if want := input[len(input)-17:]; !strings.HasSuffix(got, want) {
 			t.Fatalf("len=%d: truncated result %q must end with original tail %q", n, got, want)
 		}

--- a/internal/ui/center/model_tabs_viewer.go
+++ b/internal/ui/center/model_tabs_viewer.go
@@ -137,10 +137,7 @@ func (m *Model) createDiffTab(change *git.Change, mode git.DiffMode, ws *data.Wo
 	dv.SetFocused(true)
 
 	wsID := string(ws.ID())
-	displayName := "Diff: " + change.Path
-	if len(displayName) > 20 {
-		displayName = "..." + displayName[len(displayName)-17:]
-	}
+	displayName := truncateDisplayName("Diff: " + change.Path)
 
 	tab := &Tab{
 		ID:            generateTabID(),

--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -127,15 +127,16 @@ func fuzzyMatch(pattern, target string) bool {
 	if pattern == "" {
 		return true
 	}
-	pattern = strings.ToLower(pattern)
-	target = strings.ToLower(target)
+	// Match by rune, not byte, so multibyte/CJK names filter correctly.
+	pr := []rune(strings.ToLower(pattern))
+	tr := []rune(strings.ToLower(target))
 	pi := 0
-	for ti := 0; ti < len(target) && pi < len(pattern); ti++ {
-		if target[ti] == pattern[pi] {
+	for ti := 0; ti < len(tr) && pi < len(pr); ti++ {
+		if tr[ti] == pr[pi] {
 			pi++
 		}
 	}
-	return pi == len(pattern)
+	return pi == len(pr)
 }
 
 // SetInputTransform sets a transform function that will be applied to input text

--- a/internal/ui/common/dialog_render_test.go
+++ b/internal/ui/common/dialog_render_test.go
@@ -167,6 +167,15 @@ func TestDialogViewSelectFilterEnabled(t *testing.T) {
 	}
 }
 
+func TestFuzzyMatchHandlesMultibyteRunes(t *testing.T) {
+	if !fuzzyMatch("日語", "日本語") {
+		t.Fatal("expected fuzzyMatch to match multibyte runes in order")
+	}
+	if fuzzyMatch("語日", "日本語") {
+		t.Fatal("expected fuzzyMatch to preserve rune order")
+	}
+}
+
 // TestDialogHelpText exercises every branch of helpText, including the
 // filter-enabled vs. plain select cases and the default fall-through for an
 // unset dialog type.

--- a/internal/ui/common/filepicker_navigation.go
+++ b/internal/ui/common/filepicker_navigation.go
@@ -90,12 +90,16 @@ func (fp *FilePicker) applyFilter() {
 		}
 	}
 
+	// Clamp the cursor to the last valid row (not one past it) so the selection
+	// stays visible as the filter narrows, then re-sync the scroll window so a
+	// prior scroll offset can't leave the (now shorter) list rendered empty.
 	if fp.cursor >= len(fp.filteredIdx) {
-		fp.cursor = min(fp.cursor, len(fp.filteredIdx))
+		fp.cursor = len(fp.filteredIdx) - 1
 	}
 	if fp.cursor < 0 {
 		fp.cursor = 0
 	}
+	fp.ensureVisible()
 }
 
 // handlePathInput checks if the input is a navigable path

--- a/internal/ui/common/filepicker_navigation_test.go
+++ b/internal/ui/common/filepicker_navigation_test.go
@@ -23,6 +23,31 @@ func writeFile(t *testing.T, path string) {
 	}
 }
 
+func TestFilePickerApplyFilterClampsCursorAndScroll(t *testing.T) {
+	tmp := t.TempDir()
+	mkdirAll(t, filepath.Join(tmp, "alpha"))
+	mkdirAll(t, filepath.Join(tmp, "beta"))
+	mkdirAll(t, filepath.Join(tmp, "gamma"))
+
+	fp := NewFilePicker("id", tmp, true)
+	fp.Show()
+	fp.cursor = len(fp.filteredIdx) - 1
+	fp.scrollOffset = len(fp.filteredIdx) - 1
+	fp.input.SetValue("alpha")
+
+	fp.applyFilter()
+
+	if len(fp.filteredIdx) != 1 {
+		t.Fatalf("filteredIdx length = %d, want 1", len(fp.filteredIdx))
+	}
+	if fp.cursor != 0 {
+		t.Fatalf("cursor = %d, want 0 after filtering to one item", fp.cursor)
+	}
+	if fp.scrollOffset != 0 {
+		t.Fatalf("scrollOffset = %d, want 0 after cursor clamp", fp.scrollOffset)
+	}
+}
+
 func TestFilePickerHandleOpenFromInput(t *testing.T) {
 	t.Run("empty input is a no-op", func(t *testing.T) {
 		tmp := t.TempDir()

--- a/internal/ui/common/settings.go
+++ b/internal/ui/common/settings.go
@@ -10,8 +10,12 @@ import (
 	"github.com/andyrewlee/amux/internal/messages"
 )
 
-// SettingsResult is sent when the settings dialog is closed.
-type SettingsResult struct{}
+// SettingsResult is sent when the settings dialog is closed. Canceled is true
+// when the user dismissed via Esc (revert any live theme preview) rather than
+// confirming via [Close].
+type SettingsResult struct {
+	Canceled bool
+}
 
 // ThemePreview is sent when user navigates through themes for live preview.
 type ThemePreview struct {
@@ -128,7 +132,7 @@ func (s *SettingsDialog) Update(msg tea.Msg) (*SettingsDialog, tea.Cmd) {
 		switch {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
 			s.visible = false
-			return s, func() tea.Msg { return SettingsResult{} }
+			return s, func() tea.Msg { return SettingsResult{Canceled: true} }
 
 		case key.Matches(msg, key.NewBinding(key.WithKeys("enter", " "))):
 			return s.handleSelect()

--- a/internal/ui/common/settings_nav_test.go
+++ b/internal/ui/common/settings_nav_test.go
@@ -86,8 +86,12 @@ func TestHandleSelectClose(t *testing.T) {
 	if d.Visible() {
 		t.Fatal("selecting Close should hide the dialog")
 	}
-	if _, ok := cmd().(SettingsResult); !ok {
+	result, ok := cmd().(SettingsResult)
+	if !ok {
 		t.Fatalf("expected SettingsResult, got %T", cmd())
+	}
+	if result.Canceled {
+		t.Fatal("Close SettingsResult should not be marked canceled")
 	}
 }
 

--- a/internal/ui/common/settings_test.go
+++ b/internal/ui/common/settings_test.go
@@ -204,8 +204,12 @@ func TestUpdateEscClosesDialog(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("esc should emit a SettingsResult command")
 	}
-	if _, ok := cmd().(SettingsResult); !ok {
+	result, ok := cmd().(SettingsResult)
+	if !ok {
 		t.Fatalf("expected SettingsResult, got %T", cmd())
+	}
+	if !result.Canceled {
+		t.Fatal("esc SettingsResult should be marked canceled")
 	}
 }
 

--- a/internal/ui/diff/model.go
+++ b/internal/ui/diff/model.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"errors"
 	"path/filepath"
 
 	"charm.land/bubbles/v2/key"
@@ -128,6 +129,12 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		m.loading = false
 		if msg.err != nil {
 			m.err = msg.err
+			return m, nil
+		}
+		// git diff failures are carried in DiffResult.Error with a nil Go error;
+		// surface them via the error view instead of rendering "No changes".
+		if msg.diff != nil && msg.diff.Error != "" {
+			m.err = errors.New(msg.diff.Error)
 			return m, nil
 		}
 		m.err = nil

--- a/internal/ui/diff/model_test.go
+++ b/internal/ui/diff/model_test.go
@@ -150,6 +150,22 @@ func TestDiffLoaded_IgnoresStaleLoadCompletion(t *testing.T) {
 	}
 }
 
+func TestDiffLoaded_WithResultErrorShowsError(t *testing.T) {
+	m := &Model{}
+
+	updated, _ := m.Update(diffLoaded{diff: &git.DiffResult{Error: "fatal: bad revision"}})
+
+	if updated.err == nil {
+		t.Fatal("expected DiffResult.Error to populate model error")
+	}
+	if updated.err.Error() != "fatal: bad revision" {
+		t.Fatalf("model error = %q, want %q", updated.err.Error(), "fatal: bad revision")
+	}
+	if updated.diff != nil {
+		t.Fatalf("expected errored diff not to be retained, got %+v", updated.diff)
+	}
+}
+
 func TestPageScrollUsesMinimumOneLine(t *testing.T) {
 	m := newModelWithDiff(4, 10, nil)
 	m.focused = true

--- a/internal/ui/diff/view.go
+++ b/internal/ui/diff/view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/ui/common"
@@ -260,37 +261,29 @@ func (m *Model) renderLine(lineNum int, line git.DiffLine, numWidth, contentWidt
 			Foreground(common.ColorForeground())
 	}
 
-	// Handle line wrapping
-	if m.wrap && len(content) > contentWidth {
+	// Handle line wrapping. Width checks and slicing are display-width and
+	// grapheme aware (ansi.*) so multibyte/CJK content is never cut mid-rune.
+	if m.wrap && ansi.StringWidth(content) > contentWidth {
 		content = m.wrapLine(content, contentWidth)
-	} else if len(content) > contentWidth {
-		// Truncate with ellipsis
+	} else if ansi.StringWidth(content) > contentWidth {
+		// Truncate with ellipsis (ansi.Truncate keeps the tail within width).
 		if contentWidth > 3 {
-			content = content[:contentWidth-3] + "..."
+			content = ansi.Truncate(content, contentWidth, "...")
 		}
 	}
 
 	return lineNumStr + " " + contentStyle.Render(content)
 }
 
-// wrapLine wraps a long line to fit within width
+// wrapLine wraps a long line to fit within width, breaking on display-cell
+// (not byte) boundaries and indenting continuation lines.
 func (m *Model) wrapLine(content string, width int) string {
-	if len(content) <= width {
+	if ansi.StringWidth(content) <= width {
 		return content
 	}
 
-	var wrapped strings.Builder
-	for i := 0; i < len(content); i += width {
-		end := i + width
-		if end > len(content) {
-			end = len(content)
-		}
-		if i > 0 {
-			wrapped.WriteString("\n    ") // Indent continuation lines
-		}
-		wrapped.WriteString(content[i:end])
-	}
-	return wrapped.String()
+	segments := strings.Split(ansi.Hardwrap(content, width, false), "\n")
+	return strings.Join(segments, "\n    ") // Indent continuation lines
 }
 
 // renderFooter renders the footer with keybindings and scroll info

--- a/internal/ui/diff/view_test.go
+++ b/internal/ui/diff/view_test.go
@@ -2,8 +2,10 @@ package diff
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/andyrewlee/amux/internal/git"
 )
@@ -202,5 +204,25 @@ func TestViewMultibyteWrap(t *testing.T) {
 
 	if out == "" {
 		t.Fatal("View() returned empty string for multibyte wrapped diff")
+	}
+}
+
+func TestViewMultibyteOverflowProducesValidUTF8(t *testing.T) {
+	longContent := strings.Repeat("日本語アイウエオ", 30)
+
+	for _, wrap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("wrap=%v", wrap), func(t *testing.T) {
+			m := newSizedModel()
+			m.wrap = wrap
+			m.diff = &git.DiffResult{
+				Lines: []git.DiffLine{
+					{Kind: git.DiffLineAdd, Content: longContent},
+				},
+			}
+
+			if out := m.View(); !utf8.ValidString(out) {
+				t.Fatalf("View() produced invalid UTF-8 with wrap=%v", wrap)
+			}
+		})
 	}
 }

--- a/internal/ui/sidebar/model_input.go
+++ b/internal/ui/sidebar/model_input.go
@@ -63,6 +63,12 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			if !ok {
 				return m, nil
 			}
+			// Ignore clicks on section headers: they aren't actionable, and
+			// moving the cursor onto one makes the selection visually vanish
+			// (headers render no cursor) while opening nothing.
+			if idx < 0 || idx >= len(m.displayItems) || m.displayItems[idx].isHeader {
+				return m, nil
+			}
 			m.cursor = idx
 			return m, m.openCurrentItem()
 		}

--- a/internal/ui/sidebar/model_input_test.go
+++ b/internal/ui/sidebar/model_input_test.go
@@ -187,18 +187,17 @@ func TestInputClickOnHeaderIsNoOpOpen(t *testing.T) {
 	m := newInputModel(t)
 	start := m.cursor
 
-	// Y=4 maps to displayItems[3], which is the "Unstaged" header. rowIndexAt
-	// still resolves the row, but openCurrentItem must refuse to open a header.
+	// Y=4 maps to displayItems[3], which is the "Unstaged" header. Header clicks
+	// are ignored completely so the visible cursor stays on an actionable row.
 	_, cmd := m.Update(tea.MouseClickMsg{X: 2, Y: 4, Button: tea.MouseLeft})
-	if m.cursor != 3 {
-		t.Fatalf("expected click on header row to set cursor to header index 3, got %d", m.cursor)
+	if m.cursor != start {
+		t.Fatalf("expected click on header row to keep cursor at %d, got %d", start, m.cursor)
 	}
 	if cmd != nil {
 		if msg := cmd(); msg != nil {
 			t.Fatalf("expected no OpenDiff when clicking a header, got %T", msg)
 		}
 	}
-	_ = start
 }
 
 func TestInputClickOutsideRowsIsNoOp(t *testing.T) {

--- a/internal/ui/sidebar/model_lifecycle.go
+++ b/internal/ui/sidebar/model_lifecycle.go
@@ -61,7 +61,19 @@ func (m *Model) SetWorkspace(ws *data.Workspace) {
 	m.scrollOffset = 0
 	m.filterQuery = ""
 	m.filterInput.SetValue("")
+	// Fully exit filter mode (mirroring Blur) so a workspace switch mid-filter
+	// doesn't leave a phantom filter capturing subsequent keystrokes.
+	if m.filterMode {
+		m.filterMode = false
+		m.filterInput.Blur()
+	}
 	m.rebuildDisplayList()
+}
+
+// FilterActive reports whether the Changes view is currently in filter-input
+// mode (used so the tab bar doesn't steal digit keys meant for the filter).
+func (m *Model) FilterActive() bool {
+	return m.filterMode
 }
 
 // SetGitStatus sets the git status.

--- a/internal/ui/sidebar/model_view.go
+++ b/internal/ui/sidebar/model_view.go
@@ -188,7 +188,9 @@ func (m *Model) helpLines(contentWidth int) []string {
 	items := []string{
 		m.helpItem("k/↑", "up"),
 		m.helpItem("j/↓", "down"),
+		m.helpItem("enter/o", "open"),
 		m.helpItem("/", "filter"),
+		m.helpItem("g", "refresh"),
 	}
 	return common.WrapHelpItems(items, contentWidth)
 }

--- a/internal/ui/sidebar/project_tree.go
+++ b/internal/ui/sidebar/project_tree.go
@@ -255,12 +255,20 @@ func (m *ProjectTree) rebuildFlatList() {
 	}
 }
 
-// reloadTree reloads the entire tree from disk
+// reloadTree reloads the entire tree from disk, preserving which directories
+// were expanded and the cursor position so a refresh (or hidden-toggle) picks up
+// new files without collapsing the whole view back to the top level.
 func (m *ProjectTree) reloadTree() {
 	if m.workspace == nil {
 		m.root = nil
 		m.flatNodes = nil
 		return
+	}
+
+	expanded := m.collectExpandedPaths()
+	selectedPath := ""
+	if m.cursor >= 0 && m.cursor < len(m.flatNodes) {
+		selectedPath = m.flatNodes[m.cursor].Path
 	}
 
 	m.root = &ProjectTreeNode{
@@ -272,7 +280,47 @@ func (m *ProjectTree) reloadTree() {
 	}
 
 	m.expandNode(m.root)
+	m.restoreExpansion(m.root, expanded)
 	m.rebuildFlatList()
+
+	if selectedPath != "" {
+		for i, node := range m.flatNodes {
+			if node.Path == selectedPath {
+				m.cursor = i
+				break
+			}
+		}
+	}
+}
+
+// collectExpandedPaths returns the set of directory paths currently expanded.
+func (m *ProjectTree) collectExpandedPaths() map[string]bool {
+	expanded := map[string]bool{}
+	if m.root == nil {
+		return expanded
+	}
+	var collect func(n *ProjectTreeNode)
+	collect = func(n *ProjectTreeNode) {
+		if n.IsDir && n.Expanded {
+			expanded[n.Path] = true
+		}
+		for _, child := range n.Children {
+			collect(child)
+		}
+	}
+	collect(m.root)
+	return expanded
+}
+
+// restoreExpansion re-expands directories (by path) that were expanded before a
+// reload and still exist on disk.
+func (m *ProjectTree) restoreExpansion(node *ProjectTreeNode, expanded map[string]bool) {
+	for _, child := range node.Children {
+		if child.IsDir && expanded[child.Path] {
+			m.expandNode(child)
+			m.restoreExpansion(child, expanded)
+		}
+	}
 }
 
 func (m *ProjectTree) visibleHeight() int {

--- a/internal/ui/sidebar/project_tree_reload_test.go
+++ b/internal/ui/sidebar/project_tree_reload_test.go
@@ -1,0 +1,42 @@
+package sidebar
+
+import "testing"
+
+func TestProjectTreeReloadPreservesExpansionAndCursor(t *testing.T) {
+	m := newSeededProjectTree(t)
+
+	alpha := m.flatNodes[0]
+	if alpha.Name != "alpha" {
+		t.Fatalf("expected first node alpha, got %q", alpha.Name)
+	}
+	m.expandNode(alpha)
+	m.rebuildFlatList()
+
+	nestedPath := ""
+	for i, node := range m.flatNodes {
+		if node.Name == "nested.txt" {
+			m.cursor = i
+			nestedPath = node.Path
+			break
+		}
+	}
+	if nestedPath == "" {
+		t.Fatal("expected nested.txt visible after expanding alpha")
+	}
+
+	m.reloadTree()
+
+	stillVisible := false
+	for _, node := range m.flatNodes {
+		if node.Path == nestedPath {
+			stillVisible = true
+			break
+		}
+	}
+	if !stillVisible {
+		t.Fatal("reloadTree collapsed the previously expanded directory")
+	}
+	if m.cursor < 0 || m.cursor >= len(m.flatNodes) || m.flatNodes[m.cursor].Path != nestedPath {
+		t.Fatalf("reloadTree did not preserve cursor position (cursor=%d)", m.cursor)
+	}
+}

--- a/internal/ui/sidebar/project_tree_view.go
+++ b/internal/ui/sidebar/project_tree_view.go
@@ -146,6 +146,7 @@ func (m *ProjectTree) helpLines(contentWidth int) []string {
 		m.helpItem("j/↓", "down"),
 		m.helpItem("h/←", "collapse"),
 		m.helpItem("l/→", "expand"),
+		m.helpItem("enter/o", "open"),
 		m.helpItem(".", "hidden"),
 		m.helpItem("r", "refresh"),
 	}

--- a/internal/ui/sidebar/project_tree_view_test.go
+++ b/internal/ui/sidebar/project_tree_view_test.go
@@ -15,6 +15,7 @@ var helpItemTexts = []struct{ key, desc string }{
 	{"j/↓", "down"},
 	{"h/←", "collapse"},
 	{"l/→", "expand"},
+	{"enter/o", "open"},
 	{".", "hidden"},
 	{"r", "refresh"},
 }
@@ -73,8 +74,8 @@ func TestProjectTreeHelpLinesWrapByWidth(t *testing.T) {
 		// reason documents the wrapping boundary being exercised.
 		reason string
 	}{
-		{name: "very narrow puts each item on its own line", width: 4, wantLines: 6, reason: "6 items, none fit together"},
-		{name: "wide fits everything on one line", width: 500, wantLines: 1, reason: "all 6 items fit"},
+		{name: "very narrow puts each item on its own line", width: 4, wantLines: 7, reason: "7 items, none fit together"},
+		{name: "wide fits everything on one line", width: 500, wantLines: 1, reason: "all 7 items fit"},
 		{name: "zero width single joined line", width: 0, wantLines: 1, reason: "WrapHelpItems joins with no wrap"},
 		{name: "negative width single joined line", width: -10, wantLines: 1, reason: "WrapHelpItems joins with no wrap"},
 	}

--- a/internal/ui/sidebar/tabs.go
+++ b/internal/ui/sidebar/tabs.go
@@ -144,8 +144,10 @@ func (m *TabbedSidebar) Update(msg tea.Msg) (*TabbedSidebar, tea.Cmd) {
 		return m, common.SafeBatch(cmds...)
 
 	case tea.KeyPressMsg:
-		// Tab switching with number keys when focused
-		if m.focused {
+		// Tab switching with number keys when focused, but not while the Changes
+		// view is in filter mode (so digits get typed into the filter instead of
+		// silently switching tabs).
+		if m.focused && !(m.activeTab == TabChanges && m.changes.FilterActive()) {
 			switch {
 			case key.Matches(msg, key.NewBinding(key.WithKeys("1"))):
 				m.activeTab = TabChanges

--- a/internal/ui/sidebar/tabs_view_test.go
+++ b/internal/ui/sidebar/tabs_view_test.go
@@ -235,6 +235,20 @@ func TestUpdateNumberKeysIgnoredWhenUnfocused(t *testing.T) {
 	}
 }
 
+func TestUpdateNumberKeysIgnoredWhileChangesFilterActive(t *testing.T) {
+	s := newTestTabbedSidebar(t)
+	s.Focus()
+	s.SetActiveTab(TabChanges)
+	s.changes.filterMode = true
+	s.changes.filterInput.Focus()
+
+	updated, _ := s.Update(tea.KeyPressMsg{Code: '2', Text: "2"})
+
+	if updated.ActiveTab() != TabChanges {
+		t.Fatalf("filter-active number key should not switch tabs, got %d", updated.ActiveTab())
+	}
+}
+
 func TestUpdateMouseClickOnTabBarSwitchesTabs(t *testing.T) {
 	s := newTestTabbedSidebar(t)
 	s.SetSize(40, 20)


### PR DESCRIPTION
## What & why

A full-app feature audit inventoried every user-facing feature of amux (110
features → user stories + code-grounded expected behaviour), tested each, and
found **16 logistical/UX defects**. This PR fixes all of them. Each fix has
regression tests; all pass `make devcheck` (lint **0 issues** + full suite) and
`make verify-loop`.

The dominant bug class was **byte- vs display-width** string handling.

## Fixes

**Unicode / rendering correctness**
- Diff viewer truncated/wrapped long lines and tab names by **byte** index → multibyte/CJK rendered as mojibake. Now display-width + grapheme aware (`ansi`/`uniseg`).
- Dialog/file-picker fuzzy filter matched by byte → broke non-ASCII filenames. Now rune-aware.

**Diff viewer**
- A real `git diff` failure (carried in `DiffResult.Error` with a nil Go error) rendered as "No changes to display". Now surfaced via the error view.

**Settings / config**
- Esc on the settings dialog silently **persisted** the previewed theme (no way to cancel). Esc now reverts to the theme active at open; only `[Close]` persists.
- `saveUISettings` silently **wiped** a malformed config (dropping e.g. `assistants`) on the next setting change. Now refuses to clobber an unparseable config and writes atomically (`fsatomic`).
- `IsChatAssistant` didn't normalize the name → disagreed with `IsAssistantKnown`/registry. Now normalized.

**File picker**
- Cursor clamped one **past** the last entry on filter → selection vanished / wrong Enter target. Now clamps to the last valid row + re-syncs scroll.
- Confirming an empty Add-Project path closed silently → now warns.

**Sidebar**
- `1`/`2` hijacked filter typing in the Changes tab → now gated while filtering.
- Clicking a section header parked the (invisible) cursor on it → header clicks ignored.
- Help bars omitted the open/refresh keys → added.
- Project-tree `r` refresh collapsed all expanded dirs and lost the cursor → now preserves expansion + selection.
- Switching workspace mid-filter left a phantom filter → now cleared.

**Trust gate**
- `ScriptTrust.Trust` recorded an entry for an empty repo path (which `IsTrusted` can never match) → now guarded, matching `IsTrusted`.

## Review & verification

- **Four parallel adversarial reviewers** scrutinized every fix (tracing real control flow, running probes): **0 blockers, 0 majors**. The tree-reload change survived deletion / hidden-toggle / deep-nesting / symlink-loop probes.
- `make devcheck`: lint **0 issues**, fmt clean, file-length OK, full unit suite green.
- CI-parity strict lint (`make lint-ci-parity` vs `origin/main`): clean.
- `make verify-loop` + e2e keystroke delivery: green (real keystroke → raw agent).
- `go test ./...`: 30/30 packages.

Branched off current `origin/main` (post #537); the two commits are isolated audit fixes (no overlap with other in-flight work).
