### PR TITLE
refactor(fsatomic): add WriteJSON helper; make delete tombstone crash-safe

### DIFF
--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -86,13 +86,9 @@ func saveUISettings(path string, settings UISettings) error {
 	ui["tmux_sync_interval"] = settings.TmuxSyncInterval
 	payload["ui"] = ui
 
-	data, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		return err
-	}
 	// Crash-safe write (temp + fsync + atomic rename) so a crash mid-save can't
 	// leave a torn config.json, matching the rest of amux's persistence.
-	return fsatomic.WriteFile(path, data, 0o644)
+	return fsatomic.WriteJSON(path, payload)
 }
 
 // SaveUISettings persists UI settings to the config file.

--- a/internal/data/registry.go
+++ b/internal/data/registry.go
@@ -122,12 +122,7 @@ func (r *Registry) saveUnlocked(paths []string) error {
 		}
 	}
 
-	data, err := json.MarshalIndent(registry, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	return fsatomic.WriteFile(r.path, data, 0o644)
+	return fsatomic.WriteJSON(r.path, registry)
 }
 
 // AddProject adds a project path to the registry

--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -193,14 +193,9 @@ func (s *WorkspaceStore) Save(ws *Workspace) error {
 		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 
-	data, err := json.MarshalIndent(ws, "", "  ")
-	if err != nil {
-		return fmt.Errorf("save workspace %s: %w", id, err)
-	}
-
 	// Atomic replace (temp + fsync + rename) so a crash mid-save can never
 	// leave a truncated workspace.json behind.
-	if err := fsatomic.WriteFile(path, data, 0o644); err != nil {
+	if err := fsatomic.WriteJSON(path, ws); err != nil {
 		return fmt.Errorf("save workspace %s: %w", id, err)
 	}
 	if oldID != "" {
@@ -228,14 +223,10 @@ func (s *WorkspaceStore) saveWorkspaceLocked(id WorkspaceID, ws *Workspace) erro
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(ws, "", "  ")
-	if err != nil {
-		return err
-	}
 	// Atomic replace (temp + fsync + rename, with backup recovery on platforms
 	// that need it), matching Save. The caller already holds the workspace lock.
 	// A crash mid-save can never leave a truncated workspace.json behind.
-	if err := fsatomic.WriteFile(path, data, 0o644); err != nil {
+	if err := fsatomic.WriteJSON(path, ws); err != nil {
 		return err
 	}
 	return nil

--- a/internal/data/workspace_store_tombstone.go
+++ b/internal/data/workspace_store_tombstone.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/andyrewlee/amux/internal/fsatomic"
 )
 
 // deletingMarkerName is the per-workspace delete tombstone. It lives inside the
@@ -18,7 +20,9 @@ func (s *WorkspaceStore) deletingMarkerPath(id WorkspaceID) string {
 }
 
 // MarkDeleting writes a durable tombstone for id before destructive delete steps
-// begin. The marker is written atomically (temp file + rename).
+// begin. The marker is written crash-safely (temp + fsync + atomic rename) via
+// fsatomic, so an interrupted delete can never leave a torn marker that startup
+// recovery would reject.
 func (s *WorkspaceStore) MarkDeleting(id WorkspaceID) error {
 	if err := validateWorkspaceID(id); err != nil {
 		return err
@@ -27,16 +31,7 @@ func (s *WorkspaceStore) MarkDeleting(id WorkspaceID) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	marker := s.deletingMarkerPath(id)
-	tmp := marker + ".tmp"
-	if err := os.WriteFile(tmp, []byte("1"), 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, marker); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
+	return fsatomic.WriteFile(s.deletingMarkerPath(id), []byte("1"), 0o644)
 }
 
 // IsDeleting reports whether a delete tombstone exists for id.

--- a/internal/fsatomic/fsatomic.go
+++ b/internal/fsatomic/fsatomic.go
@@ -7,6 +7,8 @@
 package fsatomic
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,6 +24,18 @@ var renameFile = os.Rename
 // with os.WriteFile but is never used to widen access beyond the process umask.
 func WriteFile(path string, data []byte, perm os.FileMode) error {
 	return writeFileForGOOS(runtime.GOOS, path, data, perm)
+}
+
+// WriteJSON marshals v as two-space-indented JSON and atomically writes it to
+// path via WriteFile (temp + fsync + atomic rename). The indent matches the
+// on-disk format amux uses for every metadata file, so callers no longer repeat
+// the marshal-then-WriteFile dance.
+func WriteJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("fsatomic: marshal %s: %w", path, err)
+	}
+	return WriteFile(path, data, 0o644)
 }
 
 func writeFileForGOOS(goos, path string, data []byte, perm os.FileMode) error {

--- a/internal/fsatomic/fsatomic_test.go
+++ b/internal/fsatomic/fsatomic_test.go
@@ -7,6 +7,50 @@ import (
 	"testing"
 )
 
+func TestWriteJSONMarshalsIndentedAndReplacesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	if err := WriteJSON(path, payload{Name: "amux", Count: 2}); err != nil {
+		t.Fatalf("WriteJSON error = %v", err)
+	}
+
+	// Byte-for-byte parity with json.MarshalIndent(v, "", "  ") and no trailing
+	// newline, so existing on-disk files are unchanged.
+	want := "{\n  \"name\": \"amux\",\n  \"count\": 2\n}"
+	if got, _ := os.ReadFile(path); string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+
+	// Overwrite leaves no temp files behind (atomic replace).
+	if err := WriteJSON(path, payload{Name: "x", Count: 9}); err != nil {
+		t.Fatalf("WriteJSON overwrite error = %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected only the target file, found %d entries", len(entries))
+	}
+}
+
+func TestWriteJSONReturnsMarshalError(t *testing.T) {
+	// A channel cannot be marshaled; WriteJSON must surface the error and never
+	// create the target file.
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := WriteJSON(path, make(chan int)); err == nil {
+		t.Fatal("expected marshal error, got nil")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target should not exist after marshal failure, stat err = %v", err)
+	}
+}
+
 func TestWriteFileReplacesAtomically(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "state.json")

--- a/internal/process/script_trust.go
+++ b/internal/process/script_trust.go
@@ -116,12 +116,8 @@ func (t *ScriptTrust) Trust(repoPath string, configContent []byte) error {
 	entries := t.load()
 	entries[key] = hashConfig(configContent)
 
-	out, err := json.MarshalIndent(entries, "", "  ")
-	if err != nil {
-		return err
-	}
 	if err := os.MkdirAll(filepath.Dir(t.path), 0o755); err != nil {
 		return err
 	}
-	return fsatomic.WriteFile(t.path, out, 0o644)
+	return fsatomic.WriteJSON(t.path, entries)
 }


### PR DESCRIPTION
Consolidates the repeated `json.MarshalIndent(v, "", "  ")` + `fsatomic.WriteFile` dance behind one helper, and closes a real crash-safety gap in the delete tombstone.

### Changes
- **`fsatomic.WriteJSON(path, v)`** — marshals `v` as two-space-indented JSON (byte-for-byte identical to the current on-disk format, no trailing newline) then atomically replaces `path` via `WriteFile` (temp + fsync + atomic rename). Routed through it: `data.Registry.saveUnlocked`, `data.WorkspaceStore.Save` / `saveWorkspaceLocked`, `process.ScriptTrust.Trust`, and `config.saveUISettings`.
- **`WorkspaceStore.MarkDeleting` crash-safety fix** — it hand-rolled `os.WriteFile(tmp) + os.Rename` **without an fsync**, so an interrupted delete could leave a torn tombstone that startup recovery then rejects (`empty/invalid` marker → manual cleanup). It now uses `fsatomic.WriteFile` (fsync + atomic rename + Windows backup shuffle). The one-byte internal marker drops from `0o644` to `fsatomic`'s private perms — fine for a recovery marker.

### Why it's safe
No on-disk format change — `WriteJSON` produces identical bytes (covered by a parity unit test). `WriteFile` already deliberately ignores the `perm` arg (private temp-file perms by design), so the previously-passed `0o644` was already a no-op at every JSON site.

### Verification
- `make devcheck` — vet, full tests, harness-golden, lint **0 issues**, file-length all green.
- New tests: `TestWriteJSONMarshalsIndentedAndReplacesAtomically` (indent parity + no-temp-leftover) and `TestWriteJSONReturnsMarshalError` (marshal failure leaves no target file).

### Deliberately not included
Routing `internal/git`'s duplicate atomic-writer (`workspace_cleanup_marker_atomic.go`) through `fsatomic` is left for a separate change — it explicitly `Chmod`s markers to `0o600`, which conflicts with `fsatomic`'s deliberate "never widen perms / keep private temp perms" design, so merging them is a design decision, not a mechanical dedup.