### PR TITLE
refactor(tmux): route capture exec through the runTmuxCmd seam

### DIFF
--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -63,7 +63,7 @@ func sessionPaneID(sessionName string, opts Options) (string, error) {
 	// empty pane_id for detached sessions on some tmux versions.
 	cmd, cancel := tmuxCommand(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_id}\t#{pane_active}\t#{pane_dead}")
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +93,7 @@ func sessionPaneID(sessionName string, opts Options) (string, error) {
 func sessionActivePaneLive(sessionName string, opts Options) bool {
 	cmd, cancel := tmuxCommand(opts, "display-message", "-p", "-t", sessionTarget(sessionName), "#{pane_dead}")
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return false
 	}
@@ -121,7 +121,7 @@ func paneSize(paneID string, opts Options) (int, int, bool, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "list-panes", "-t", paneID, "-F", "#{pane_id}\t#{pane_width}\t#{pane_height}")
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return 0, 0, false, err
 	}
@@ -261,7 +261,7 @@ func paneCoversVisibleWindow(paneID string, opts Options) (bool, error) {
 	}
 	cmd, cancel := tmuxCommand(opts, "list-panes", "-t", paneID, "-F", "#{pane_id}")
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return false, err
 	}
@@ -326,7 +326,7 @@ func CapturePane(sessionName string, opts Options) ([]byte, error) {
 	// -t: target pane by globally unique pane ID
 	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-e", "-N", "-S", "-", "-E", "-1", "-t", paneID)
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 	// to sessionPaneID so we preserve the old first-live-pane behavior.
 	if sessionActivePaneLive(sessionName, opts) {
 		cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-t", sessionTarget(sessionName), "-S", strconv.Itoa(startLine))
-		output, err := cmd.Output()
+		output, err := runTmuxCmd(cmd)
 		cancel()
 		if err == nil {
 			// Normalize: trim trailing whitespace and trailing empty lines.
@@ -395,7 +395,7 @@ func CapturePaneTail(sessionName string, lines int, opts Options) (string, bool)
 	}
 	cmd2, cancel2 := tmuxCommand(opts, "capture-pane", "-p", "-t", paneID, "-S", strconv.Itoa(startLine))
 	defer cancel2()
-	out2, err2 := cmd2.Output()
+	out2, err2 := runTmuxCmd(cmd2)
 	if err2 != nil {
 		return "", false
 	}

--- a/internal/tmux/capture_seam_test.go
+++ b/internal/tmux/capture_seam_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPaneSizeParsesViaSeam exercises paneSize end-to-end through the runTmuxCmd
+// seam. Before capture.go routed its exec through runTmuxCmd, paneSize's
+// build-exec-parse path could not be unit-tested at all (only the parsePaneSize
+// helper in isolation); now canned list-panes output drives the whole function
+// with no live tmux server.
+func TestPaneSizeParsesViaSeam(t *testing.T) {
+	fakeRunTmuxCmd(t, []byte("%5\t80\t24\n"), nil)
+
+	cols, rows, ok, err := paneSize("%5", testOpts())
+	if err != nil {
+		t.Fatalf("paneSize error = %v", err)
+	}
+	if !ok || cols != 80 || rows != 24 {
+		t.Fatalf("paneSize = (%d, %d, %v), want (80, 24, true)", cols, rows, ok)
+	}
+}
+
+// TestPaneSizePropagatesTmuxError confirms an exec failure surfaced by the seam
+// reaches the caller rather than being silently treated as an empty pane.
+func TestPaneSizePropagatesTmuxError(t *testing.T) {
+	wantErr := errors.New("boom")
+	fakeRunTmuxCmd(t, nil, wantErr)
+
+	if _, _, _, err := paneSize("%5", testOpts()); !errors.Is(err, wantErr) {
+		t.Fatalf("paneSize err = %v, want %v", err, wantErr)
+	}
+}
+
+// TestCapturePaneSnapshotDataViaSeam confirms the unexported snapshot capture
+// helper now returns exactly what the seam yields, proving the capture path is
+// reachable in tests without spawning tmux.
+func TestCapturePaneSnapshotDataViaSeam(t *testing.T) {
+	want := []byte("line one\x1b[0m\nline two\n")
+	fakeRunTmuxCmd(t, want, nil)
+
+	got, err := capturePaneSnapshotData("%9", testOpts())
+	if err != nil {
+		t.Fatalf("capturePaneSnapshotData error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("capturePaneSnapshotData = %q, want %q", got, want)
+	}
+}

--- a/internal/tmux/capture_snapshot.go
+++ b/internal/tmux/capture_snapshot.go
@@ -12,7 +12,7 @@ func capturePaneSnapshotData(paneID string, opts Options) ([]byte, error) {
 	// -t: target pane by globally unique pane ID
 	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-e", "-N", "-S", "-", "-t", paneID)
 	defer cancel()
-	return cmd.Output()
+	return runTmuxCmd(cmd)
 }
 
 func paneSnapshotInfoForPane(
@@ -102,7 +102,7 @@ func paneSnapshotMetadataForPane(paneID string, opts Options) (paneSnapshotMetad
 		"#{pane_id}\t#{pane_width}\t#{pane_height}\t#{cursor_x}\t#{cursor_y}\t#{alternate_on}\t#{alternate_saved_x}\t#{alternate_saved_y}\t#{cursor_flag}\t#{origin_flag}\t#{scroll_region_upper}\t#{scroll_region_lower}",
 	)
 	defer cancel()
-	output, err := cmd.Output()
+	output, err := runTmuxCmd(cmd)
 	if err != nil {
 		return paneSnapshotMetadata{}, err
 	}


### PR DESCRIPTION
`capture.go` and `capture_snapshot.go` called `cmd.Output()` directly at **9 sites**, while the rest of the `tmux` package routes reads through the `runTmuxCmd` var-seam (`listTmux`, `SessionTagValue`, `SessionCreatedAt`, …). That left the entire capture / pane-metadata path — `sessionPaneID`, `paneSize`, `CapturePane`, `CapturePaneTail`, `capturePaneSnapshotData` — impossible to unit-test with canned tmux output, even though the seam already existed for exactly this purpose.

### Change
Replace the 9 `cmd.Output()` calls with `runTmuxCmd(cmd)`. `runTmuxCmd` is literally defined as `cmd.Output()`, so behavior is **byte-for-byte identical** — the only difference is that tests can now swap the seam (via the existing `fakeRunTmuxCmd` helper).

### Tests added (all run with no live tmux)
- `TestPaneSizeParsesViaSeam` — `paneSize` parses canned `list-panes` output end-to-end (previously only the `parsePaneSize` helper was reachable).
- `TestPaneSizePropagatesTmuxError` — an exec error surfaced by the seam reaches the caller instead of being treated as an empty pane.
- `TestCapturePaneSnapshotDataViaSeam` — the snapshot capture helper returns exactly the seam output.

### Verification
- `make devcheck` — green (vet, full tests, harness-golden, lint **0 issues**, file-length).
- `make verify-loop` — green (real keystroke delivered end-to-end; no regression in the tmux path).