### PR TITLE
test: share git-repo fixtures via testutil.InitRepo/RunGit

### DIFF
--- a/internal/app/app_operations_test.go
+++ b/internal/app/app_operations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 func TestGoHomeReleasesActiveWorkspaceFileWatch(t *testing.T) {
@@ -331,18 +332,9 @@ func skipIfNoGit(t *testing.T) {
 	}
 }
 
+// runGit delegates to the shared testutil fixture (git-env filtering + pinned
+// author identity); the package-level name is kept so existing call sites are
+// unchanged.
 func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=Test",
-		"GIT_AUTHOR_EMAIL=test@example.com",
-		"GIT_COMMITTER_NAME=Test",
-		"GIT_COMMITTER_EMAIL=test@example.com",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
-	}
+	testutil.RunGit(t, dir, args...)
 }

--- a/internal/app/workspace_service_init_test.go
+++ b/internal/app/workspace_service_init_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 // initTestRepo builds a minimal real git repository with a single commit on the
@@ -15,15 +16,7 @@ import (
 // DiscoverWorkspaces) are exercised against repositories like this one, mirroring
 // the convention used by service_git_test.go for methods that shell out.
 func initTestRepo(t *testing.T, branch string) string {
-	t.Helper()
-	repo := t.TempDir()
-	runGit(t, repo, "init", "-b", branch)
-	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
-		t.Fatalf("write README: %v", err)
-	}
-	runGit(t, repo, "add", "README.md")
-	runGit(t, repo, "commit", "-m", "init")
-	return repo
+	return testutil.InitRepoWithBranch(t, branch)
 }
 
 // TestDefaultGitOpsCreateWorkspace drives defaultGitOps.CreateWorkspace, the

--- a/internal/git/git_test_helpers_test.go
+++ b/internal/git/git_test_helpers_test.go
@@ -1,10 +1,10 @@
 package git
 
 import (
-	"os"
 	"os/exec"
-	"strings"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/testutil"
 )
 
 // skipIfNoGit skips the test if git is not installed
@@ -15,41 +15,13 @@ func skipIfNoGit(t *testing.T) {
 	}
 }
 
+// runGit and initRepo delegate to the shared testutil fixtures so the
+// git-env filtering, pinned author identity, and single-commit repo setup live
+// in one place (testutil.RunGit / testutil.InitRepo).
 func runGit(t *testing.T, dir string, args ...string) string {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-
-	// Filter out GIT_ environment variables that might be set by pre-push hooks
-	var env []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "GIT_DIR=") &&
-			!strings.HasPrefix(e, "GIT_WORK_TREE=") &&
-			!strings.HasPrefix(e, "GIT_INDEX_FILE=") {
-			env = append(env, e)
-		}
-	}
-
-	cmd.Env = append(
-		env,
-		"GIT_AUTHOR_NAME=Test",
-		"GIT_AUTHOR_EMAIL=test@example.com",
-		"GIT_COMMITTER_NAME=Test",
-		"GIT_COMMITTER_EMAIL=test@example.com",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))
-	}
-	return strings.TrimSpace(string(out))
+	return testutil.RunGit(t, dir, args...)
 }
 
 func initRepo(t *testing.T) string {
-	root := t.TempDir()
-	runGit(t, root, "init", "-b", "main")
-	if err := os.WriteFile(root+"/README.md", []byte("init"), 0o644); err != nil {
-		t.Fatalf("write file: %v", err)
-	}
-	runGit(t, root, "add", "README.md")
-	runGit(t, root, "commit", "-m", "init")
-	return root
+	return testutil.InitRepo(t)
 }

--- a/internal/testutil/gitrepo.go
+++ b/internal/testutil/gitrepo.go
@@ -1,0 +1,70 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// gitTB is the subset of *testing.T the git fixtures need. Following the fataler
+// pattern in wait.go, this lets the file avoid importing "testing" while still
+// accepting a real *testing.T.
+type gitTB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	TempDir() string
+}
+
+// RunGit runs `git args...` in dir and returns its trimmed combined output,
+// failing the test on error. It strips inherited GIT_DIR/GIT_WORK_TREE/
+// GIT_INDEX_FILE (which a surrounding pre-push hook or harness may set) so the
+// command always operates on dir, and pins a deterministic author/committer
+// identity so commits succeed without depending on the machine's global git
+// config.
+func RunGit(t gitTB, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+
+	env := make([]string, 0, len(os.Environ())+4)
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GIT_DIR=") ||
+			strings.HasPrefix(kv, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(kv, "GIT_INDEX_FILE=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = append(env,
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// InitRepo creates a throwaway git repository under t.TempDir() with a single
+// committed README on the default "main" branch and returns its path.
+func InitRepo(t gitTB) string {
+	return InitRepoWithBranch(t, "main")
+}
+
+// InitRepoWithBranch is InitRepo with a caller-chosen initial branch name.
+func InitRepoWithBranch(t gitTB, branch string) string {
+	t.Helper()
+	root := t.TempDir()
+	RunGit(t, root, "init", "-b", branch)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("init\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	RunGit(t, root, "add", "README.md")
+	RunGit(t, root, "commit", "-m", "init")
+	return root
+}

--- a/internal/testutil/gitrepo_test.go
+++ b/internal/testutil/gitrepo_test.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestInitRepoCreatesCommittedRepoOnBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	root := InitRepoWithBranch(t, "trunk")
+
+	// RunGit returns trimmed output, so the branch name is directly comparable.
+	if branch := RunGit(t, root, "rev-parse", "--abbrev-ref", "HEAD"); branch != "trunk" {
+		t.Fatalf("HEAD branch = %q, want trunk", branch)
+	}
+	// Exactly one commit, and README is tracked in it.
+	if count := RunGit(t, root, "rev-list", "--count", "HEAD"); count != "1" {
+		t.Fatalf("commit count = %q, want 1", count)
+	}
+	files := RunGit(t, root, "ls-files")
+	if !strings.Contains(files, "README.md") {
+		t.Fatalf("tracked files = %q, want README.md", files)
+	}
+	// The pinned identity is applied (no dependence on global git config).
+	if author := RunGit(t, root, "log", "-1", "--format=%an"); author != "Test" {
+		t.Fatalf("author = %q, want Test", author)
+	}
+}


### PR DESCRIPTION
The `TempDir → git init -b → write README → add → commit` repo setup and the git-env-filtering `runGit` wrapper were copy-pasted **three times** (`internal/git`, `internal/app`, `internal/e2e`), each drifted slightly (return type, `GIT_*` filtering, author identity).

### Change
- New `testutil.RunGit`, `testutil.InitRepo`, `testutil.InitRepoWithBranch` — the single source of truth. `RunGit` strips inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` and pins a deterministic `Test` author/committer identity (the union of what the copies did).
- The `git` and `app` package helpers now delegate to them; their **local names are kept**, so existing call sites are untouched.
- The `app` helper previously skipped `GIT_*` filtering — it now gets it (strict robustness improvement, same author identity → no test behavior change).

### Why it's safe
No test asserts README content (only that the file exists in the worktree, which the shared fixture still commits). The `e2e` helper uses a different author identity and is **intentionally left as-is** to avoid changing its behavior. Follows the `fataler` interface pattern in `wait.go` so the file needn't import `testing`.

### Verification
- `make devcheck` — green (vet, full tests incl. the real-git `git`/`app` suites that now run through the shared fixture, harness-golden, lint **0 issues**, file-length).
- Adds `TestInitRepoCreatesCommittedRepoOnBranch` exercising the fixture directly.

### Deferred
The audit also flagged injecting `now func() time.Time` into `workspaceService`/`WorkspaceStore` for deterministic timestamp tests — that's a production change, left for a separate PR.