### PR TITLE
refactor(vterm): unify duplicated selection, resize, and render-rule logic

### DIFF
--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -139,28 +139,9 @@ func inSelection(sel SelectionRegion, x, y int) bool {
 	if !sel.Active {
 		return false
 	}
-
-	startX, startY := sel.StartX, sel.StartY
-	endX, endY := sel.EndX, sel.EndY
-
-	if startY > endY || (startY == endY && startX > endX) {
-		startX, endX = endX, startX
-		startY, endY = endY, startY
-	}
-
-	if y < startY || y > endY {
-		return false
-	}
-	if y == startY && y == endY {
-		return x >= startX && x <= endX
-	}
-	if y == startY {
-		return x >= startX
-	}
-	if y == endY {
-		return x <= endX
-	}
-	return true
+	startX, startY, endX, endY := vterm.NormalizeSelectionRange(
+		sel.StartX, sel.StartY, sel.EndX, sel.EndY)
+	return vterm.SelectionContains(startX, startY, endX, endY, x, y)
 }
 
 // Render converts the canvas to an ANSI string.
@@ -181,11 +162,8 @@ func (c *Canvas) Render() string {
 			if cell.Width == 0 {
 				continue
 			}
-			style := cell.Style
 			// Prevent underline-on-spaces from rendering as scanlines.
-			if style.Underline && (cell.Rune == 0 || cell.Rune == ' ') {
-				style.Underline = false
-			}
+			style := vterm.SuppressBlankUnderline(cell.Rune, cell.Style)
 			if style != lastStyle {
 				// Use full style for first cell (after reset), delta for subsequent
 				if firstCell {
@@ -196,11 +174,7 @@ func (c *Canvas) Render() string {
 				lastStyle = style
 			}
 			firstCell = false
-			r := cell.Rune
-			if r == 0 {
-				r = ' '
-			}
-			b.WriteRune(r)
+			b.WriteRune(vterm.RenderableRune(cell.Rune))
 		}
 		if y < c.Height-1 {
 			b.WriteRune('\n')

--- a/internal/ui/compositor/vtermlayer.go
+++ b/internal/ui/compositor/vtermlayer.go
@@ -129,14 +129,9 @@ func cellToUVSnapshot(uvCell *uv.Cell, cell vterm.Cell, snap *VTermSnapshot, x, 
 	}
 
 	// Suppress underline on blank cells (prevents visual scanlines)
-	if style.Underline && (cell.Rune == 0 || cell.Rune == ' ') {
-		style.Underline = false
-	}
+	style = vterm.SuppressBlankUnderline(cell.Rune, style)
 
-	r := cell.Rune
-	if r == 0 {
-		r = ' '
-	}
+	r := vterm.RenderableRune(cell.Rune)
 
 	*uvCell = uv.Cell{
 		Content: runeToString(r),
@@ -150,28 +145,9 @@ func inSelectionSnapshot(snap *VTermSnapshot, x, y int) bool {
 	if snap == nil || !snap.SelActive {
 		return false
 	}
-
-	startX, startY := snap.SelStartX, snap.SelStartY
-	endX, endY := snap.SelEndX, snap.SelEndY
-
-	if startY > endY || (startY == endY && startX > endX) {
-		startX, endX = endX, startX
-		startY, endY = endY, startY
-	}
-
-	if y < startY || y > endY {
-		return false
-	}
-	if y == startY && y == endY {
-		return x >= startX && x <= endX
-	}
-	if y == startY {
-		return x >= startX
-	}
-	if y == endY {
-		return x <= endX
-	}
-	return true
+	startX, startY, endX, endY := vterm.NormalizeSelectionRange(
+		snap.SelStartX, snap.SelStartY, snap.SelEndX, snap.SelEndY)
+	return vterm.SelectionContains(startX, startY, endX, endY, x, y)
 }
 
 // vtermStyleToUV converts a vterm.Style to ultraviolet's Style.

--- a/internal/ui/compositor/vtermlayer_snapshot.go
+++ b/internal/ui/compositor/vtermlayer_snapshot.go
@@ -159,10 +159,7 @@ func NewVTermSnapshotWithCache(term *vterm.VTerm, showCursor bool, prev *VTermSn
 		endX := term.SelEndX()
 
 		// Normalize so start is before end.
-		if startLine > endLine || (startLine == endLine && startX > endX) {
-			startLine, endLine = endLine, startLine
-			startX, endX = endX, startX
-		}
+		startX, startLine, endX, endLine = vterm.NormalizeSelectionRange(startX, startLine, endX, endLine)
 
 		visibleStartLine := term.ScreenYToAbsoluteLine(0)
 		visibleEndLine := term.ScreenYToAbsoluteLine(height - 1)

--- a/internal/vterm/dedup_helpers_test.go
+++ b/internal/vterm/dedup_helpers_test.go
@@ -1,0 +1,224 @@
+package vterm
+
+import (
+	"testing"
+)
+
+func TestSelectionContains(t *testing.T) {
+	// Bounds are assumed already normalized (start precedes end).
+	tests := []struct {
+		name                       string
+		startX, startY, endX, endY int
+		x, y                       int
+		want                       bool
+	}{
+		// Single-row selection: inclusive on both column bounds.
+		{"single row inside", 2, 1, 5, 1, 3, 1, true},
+		{"single row left edge", 2, 1, 5, 1, 2, 1, true},
+		{"single row right edge", 2, 1, 5, 1, 5, 1, true},
+		{"single row before start", 2, 1, 5, 1, 1, 1, false},
+		{"single row after end", 2, 1, 5, 1, 6, 1, false},
+		{"single row wrong row above", 2, 1, 5, 1, 3, 0, false},
+		{"single row wrong row below", 2, 1, 5, 1, 3, 2, false},
+
+		// First row of multi-row selection: x must be >= startX.
+		{"first row at start", 3, 1, 4, 3, 3, 1, true},
+		{"first row right of start", 3, 1, 4, 3, 9, 1, true},
+		{"first row left of start", 3, 1, 4, 3, 2, 1, false},
+
+		// Middle rows: fully selected regardless of x.
+		{"middle row col 0", 3, 1, 4, 3, 0, 2, true},
+		{"middle row high col", 3, 1, 4, 3, 99, 2, true},
+
+		// Last row: x must be <= endX.
+		{"last row at end", 3, 1, 4, 3, 4, 3, true},
+		{"last row left of end", 3, 1, 4, 3, 0, 3, true},
+		{"last row right of end", 3, 1, 4, 3, 5, 3, false},
+
+		// Outside the row range entirely.
+		{"above range", 3, 1, 4, 3, 3, 0, false},
+		{"below range", 3, 1, 4, 3, 3, 4, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SelectionContains(tc.startX, tc.startY, tc.endX, tc.endY, tc.x, tc.y)
+			if got != tc.want {
+				t.Errorf("SelectionContains(%d,%d,%d,%d, %d,%d) = %v, want %v",
+					tc.startX, tc.startY, tc.endX, tc.endY, tc.x, tc.y, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSelectionRange(t *testing.T) {
+	tests := []struct {
+		name                           string
+		startX, startY, endX, endY     int
+		wantSX, wantSY, wantEX, wantEY int
+	}{
+		{"already ordered", 1, 0, 4, 2, 1, 0, 4, 2},
+		{"reversed rows", 4, 2, 1, 0, 1, 0, 4, 2},
+		{"same row reversed cols", 7, 3, 2, 3, 2, 3, 7, 3},
+		{"same row ordered cols", 2, 3, 7, 3, 2, 3, 7, 3},
+		{"same point", 5, 5, 5, 5, 5, 5, 5, 5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sx, sy, ex, ey := NormalizeSelectionRange(tc.startX, tc.startY, tc.endX, tc.endY)
+			if sx != tc.wantSX || sy != tc.wantSY || ex != tc.wantEX || ey != tc.wantEY {
+				t.Errorf("NormalizeSelectionRange(%d,%d,%d,%d) = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
+					tc.startX, tc.startY, tc.endX, tc.endY,
+					sx, sy, ex, ey, tc.wantSX, tc.wantSY, tc.wantEX, tc.wantEY)
+			}
+		})
+	}
+}
+
+func TestSuppressBlankUnderline(t *testing.T) {
+	underlined := Style{Underline: true}
+	plain := Style{}
+
+	tests := []struct {
+		name          string
+		r             rune
+		in            Style
+		wantUnderline bool
+	}{
+		{"underline on glyph kept", 'a', underlined, true},
+		{"underline on space dropped", ' ', underlined, false},
+		{"underline on NUL dropped", 0, underlined, false},
+		{"no underline glyph", 'a', plain, false},
+		{"no underline space", ' ', plain, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SuppressBlankUnderline(tc.r, tc.in)
+			if got.Underline != tc.wantUnderline {
+				t.Errorf("SuppressBlankUnderline(%q, %+v).Underline = %v, want %v",
+					tc.r, tc.in, got.Underline, tc.wantUnderline)
+			}
+		})
+	}
+
+	// Only the Underline field may change; everything else must pass through.
+	in := Style{Underline: true, Bold: true, Fg: Color{Type: ColorIndexed, Value: 3}}
+	got := SuppressBlankUnderline(' ', in)
+	want := in
+	want.Underline = false
+	if got != want {
+		t.Errorf("SuppressBlankUnderline mutated more than Underline: got %+v, want %+v", got, want)
+	}
+}
+
+func TestRenderableRune(t *testing.T) {
+	if got := RenderableRune(0); got != ' ' {
+		t.Errorf("RenderableRune(0) = %q, want space", got)
+	}
+	if got := RenderableRune(' '); got != ' ' {
+		t.Errorf("RenderableRune(space) = %q, want space", got)
+	}
+	if got := RenderableRune('x'); got != 'x' {
+		t.Errorf("RenderableRune('x') = %q, want 'x'", got)
+	}
+}
+
+func TestResizeRows(t *testing.T) {
+	// Build a buffer where each row is filled with a distinct rune so we can
+	// tell preserved content from blank fill.
+	mkRow := func(width int, r rune) []Cell {
+		row := make([]Cell, width)
+		for i := range row {
+			row[i] = Cell{Rune: r, Width: 1}
+		}
+		return row
+	}
+	isBlank := func(row []Cell) bool {
+		blank := DefaultCell()
+		for _, c := range row {
+			if c != blank {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("grow height blank-fills new rows", func(t *testing.T) {
+		old := [][]Cell{mkRow(4, 'a'), mkRow(4, 'b')}
+		got := resizeRows(old, 4, 4)
+		if len(got) != 4 {
+			t.Fatalf("len = %d, want 4", len(got))
+		}
+		if got[0][0].Rune != 'a' || got[1][0].Rune != 'b' {
+			t.Errorf("existing rows not preserved: %q %q", got[0][0].Rune, got[1][0].Rune)
+		}
+		if !isBlank(got[2]) || !isBlank(got[3]) {
+			t.Errorf("new rows should be blank")
+		}
+	})
+
+	t.Run("shrink height drops trailing rows", func(t *testing.T) {
+		old := [][]Cell{mkRow(4, 'a'), mkRow(4, 'b'), mkRow(4, 'c')}
+		got := resizeRows(old, 4, 2)
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		if got[0][0].Rune != 'a' || got[1][0].Rune != 'b' {
+			t.Errorf("rows not preserved on shrink")
+		}
+	})
+
+	t.Run("row wider than width is reused as-is", func(t *testing.T) {
+		wide := mkRow(8, 'a')
+		old := [][]Cell{wide}
+		got := resizeRows(old, 4, 1)
+		if len(got[0]) != 8 {
+			t.Errorf("wide row should be reused unchanged, got width %d", len(got[0]))
+		}
+		// Must be the same backing slice (reuse, not copy).
+		if &got[0][0] != &wide[0] {
+			t.Errorf("wide row should be reused (same slice), not copied")
+		}
+	})
+
+	t.Run("row equal to width is reused as-is", func(t *testing.T) {
+		exact := mkRow(4, 'a')
+		old := [][]Cell{exact}
+		got := resizeRows(old, 4, 1)
+		if &got[0][0] != &exact[0] {
+			t.Errorf("exact-width row should be reused (same slice)")
+		}
+	})
+
+	t.Run("narrow row is expanded to width", func(t *testing.T) {
+		narrow := mkRow(2, 'a')
+		old := [][]Cell{narrow}
+		got := resizeRows(old, 5, 1)
+		if len(got[0]) != 5 {
+			t.Fatalf("expanded row width = %d, want 5", len(got[0]))
+		}
+		if got[0][0].Rune != 'a' || got[0][1].Rune != 'a' {
+			t.Errorf("original content not copied into expanded row")
+		}
+		blank := DefaultCell()
+		for i := 2; i < 5; i++ {
+			if got[0][i] != blank {
+				t.Errorf("expanded tail cell %d not blank: %+v", i, got[0][i])
+			}
+		}
+		// A fresh slice must have been allocated (not the narrow one).
+		if &got[0][0] == &narrow[0] {
+			t.Errorf("expanded row should be a fresh slice")
+		}
+	})
+
+	t.Run("empty source row is blank-filled", func(t *testing.T) {
+		old := [][]Cell{{}} // present but zero-length row
+		got := resizeRows(old, 3, 1)
+		if len(got[0]) != 3 || !isBlank(got[0]) {
+			t.Errorf("empty source row should be blank-filled to width")
+		}
+	})
+}

--- a/internal/vterm/render.go
+++ b/internal/vterm/render.go
@@ -365,13 +365,30 @@ func (v *VTerm) renderWithScrollbackFrom(screen [][]Cell, scrollbackLen int) str
 }
 
 func suppressBlankUnderline(cell Cell, style Style) Style {
-	// Some TUIs leave underline enabled while clearing rows; underline on spaces
-	// renders as scanlines, so drop it for blank cells at render time.
+	return SuppressBlankUnderline(cell.Rune, style)
+}
+
+// SuppressBlankUnderline drops the underline attribute when rune r is blank
+// (NUL or space). Some TUIs leave underline enabled while clearing rows;
+// underline on spaces renders as scanlines, so it is removed for blank cells at
+// render time. The rule is shared by the live renderer and both compositor
+// render paths so they stay pixel-identical.
+func SuppressBlankUnderline(r rune, style Style) Style {
 	if !style.Underline {
 		return style
 	}
-	if cell.Rune == 0 || cell.Rune == ' ' {
+	if r == 0 || r == ' ' {
 		style.Underline = false
 	}
 	return style
+}
+
+// RenderableRune substitutes a NUL rune (an unwritten cell) with a space so it
+// renders as blank rather than a control character. Other runes pass through
+// unchanged. Shared by the live renderer and the compositor render paths.
+func RenderableRune(r rune) rune {
+	if r == 0 {
+		return ' '
+	}
+	return r
 }

--- a/internal/vterm/selection.go
+++ b/internal/vterm/selection.go
@@ -7,6 +7,39 @@ func (v *VTerm) HasSelection() bool {
 	return v.selActive
 }
 
+// NormalizeSelectionRange orders the two endpoints so that (startX, startY)
+// comes before (endX, endY) in reading order (top-to-bottom, left-to-right on
+// the same row) and returns them. Coordinates may be in any consistent space
+// (screen-relative or absolute lines) as long as both endpoints use the same.
+func NormalizeSelectionRange(startX, startY, endX, endY int) (int, int, int, int) {
+	if startY > endY || (startY == endY && startX > endX) {
+		return endX, endY, startX, startY
+	}
+	return startX, startY, endX, endY
+}
+
+// SelectionContains reports whether cell (x, y) falls inside the linear
+// selection bounded by (startX, startY)..(endX, endY). The bounds MUST already
+// be normalized (see NormalizeSelectionRange) so start precedes end. The first
+// row of the range starts at startX, the last row ends at endX, and any rows in
+// between are fully selected. This is the rectangular-selection-free contains
+// test shared by the live renderer and the compositor snapshot paths.
+func SelectionContains(startX, startY, endX, endY, x, y int) bool {
+	if y < startY || y > endY {
+		return false
+	}
+	if y == startY && y == endY {
+		return x >= startX && x <= endX
+	}
+	if y == startY {
+		return x >= startX
+	}
+	if y == endY {
+		return x <= endX
+	}
+	return true
+}
+
 // IsInSelection checks if coordinate (x, screenY) is within the selection.
 // screenY is a screen-relative coordinate (0 to Height-1).
 func (v *VTerm) IsInSelection(x, screenY int) bool {
@@ -18,18 +51,14 @@ func (v *VTerm) IsInSelection(x, screenY int) bool {
 	absLine := v.ScreenYToAbsoluteLine(screenY)
 
 	// Normalize selection so start is before end.
-	startX, startLine := v.selStartX, v.selStartLine
-	endX, endLine := v.selEndX, v.selEndLine
-	if startLine > endLine || (startLine == endLine && startX > endX) {
-		startX, endX = endX, startX
-		startLine, endLine = endLine, startLine
-	}
+	startX, startLine, endX, endLine := NormalizeSelectionRange(
+		v.selStartX, v.selStartLine, v.selEndX, v.selEndLine)
 
-	// Check if (x, absLine) is in selection range
-	if absLine < startLine || absLine > endLine {
-		return false
-	}
 	if v.selRect {
+		// Rectangular selection: every row in range shares the same column span.
+		if absLine < startLine || absLine > endLine {
+			return false
+		}
 		minX := startX
 		maxX := endX
 		if minX > maxX {
@@ -37,21 +66,7 @@ func (v *VTerm) IsInSelection(x, screenY int) bool {
 		}
 		return x >= minX && x <= maxX
 	}
-	if startLine == endLine {
-		minX := startX
-		maxX := endX
-		if minX > maxX {
-			minX, maxX = maxX, minX
-		}
-		return x >= minX && x <= maxX
-	}
-	if absLine == startLine {
-		return x >= startX
-	}
-	if absLine == endLine {
-		return x <= endX
-	}
-	return true
+	return SelectionContains(startX, startLine, endX, endLine, x, absLine)
 }
 
 // SetSelection stores selection coordinates for rendering with highlight.
@@ -153,10 +168,7 @@ func (v *VTerm) GetTextRange(startX, startLine, endX, endLine int) string {
 	}
 
 	// Normalize selection so start is before end.
-	if startLine > endLine || (startLine == endLine && startX > endX) {
-		startX, endX = endX, startX
-		startLine, endLine = endLine, startLine
-	}
+	startX, startLine, endX, endLine = NormalizeSelectionRange(startX, startLine, endX, endLine)
 
 	if startLine < 0 {
 		startLine = 0

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -157,6 +157,32 @@ func (v *VTerm) makeScreen(width, height int) [][]Cell {
 	return screen
 }
 
+// resizeRows builds a new buffer of the given height from old, preserving each
+// existing row's content. A row already at least width wide is reused as-is
+// (it may stay wider than width, so resizing back up can restore content); a
+// narrower row is expanded into a fresh blank line of the new width; rows with
+// no source content are blank-filled. Used to resize the screen, alt screen,
+// and synchronized-output snapshot identically.
+func resizeRows(old [][]Cell, width, height int) [][]Cell {
+	rows := make([][]Cell, height)
+	for y := 0; y < height; y++ {
+		if y < len(old) && len(old[y]) > 0 {
+			// Preserve the original row content (may be wider than new width)
+			// but ensure it's at least as wide as new width.
+			if len(old[y]) >= width {
+				rows[y] = old[y]
+			} else {
+				// Expand row to new width.
+				rows[y] = MakeBlankLine(width)
+				copy(rows[y], old[y])
+			}
+		} else {
+			rows[y] = MakeBlankLine(width)
+		}
+	}
+	return rows
+}
+
 // Resize handles terminal resize.
 func (v *VTerm) Resize(width, height int) {
 	v.resize(width, height, true)
@@ -232,23 +258,7 @@ func (v *VTerm) resize(width, height int, revealHistoryOnGrow bool) {
 
 	// Resize screen buffer - preserve full row content to allow restoring
 	// on resize back to larger width
-	newScreen := make([][]Cell, height)
-	for y := 0; y < height; y++ {
-		if y < len(v.Screen) && len(v.Screen[y]) > 0 {
-			// Preserve the original row content (may be wider than new width)
-			// but ensure it's at least as wide as new width
-			if len(v.Screen[y]) >= width {
-				newScreen[y] = v.Screen[y]
-			} else {
-				// Expand row to new width
-				newScreen[y] = MakeBlankLine(width)
-				copy(newScreen[y], v.Screen[y])
-			}
-		} else {
-			newScreen[y] = MakeBlankLine(width)
-		}
-	}
-	v.Screen = newScreen
+	v.Screen = resizeRows(v.Screen, width, height)
 
 	// Update dimensions
 	v.Width = width
@@ -273,39 +283,13 @@ func (v *VTerm) resize(width, height int, revealHistoryOnGrow bool) {
 
 	// Also resize alt screen if it exists - preserve full row content
 	if v.altScreenBuf != nil {
-		newAlt := make([][]Cell, height)
-		for y := 0; y < height; y++ {
-			if y < len(v.altScreenBuf) && len(v.altScreenBuf[y]) > 0 {
-				if len(v.altScreenBuf[y]) >= width {
-					newAlt[y] = v.altScreenBuf[y]
-				} else {
-					newAlt[y] = MakeBlankLine(width)
-					copy(newAlt[y], v.altScreenBuf[y])
-				}
-			} else {
-				newAlt[y] = MakeBlankLine(width)
-			}
-		}
-		v.altScreenBuf = newAlt
+		v.altScreenBuf = resizeRows(v.altScreenBuf, width, height)
 	}
 	v.clampAltSavedCursor()
 
 	// Keep synchronized output snapshot aligned with new size - preserve full row content
 	if v.syncScreen != nil {
-		newSync := make([][]Cell, height)
-		for y := 0; y < height; y++ {
-			if y < len(v.syncScreen) && len(v.syncScreen[y]) > 0 {
-				if len(v.syncScreen[y]) >= width {
-					newSync[y] = v.syncScreen[y]
-				} else {
-					newSync[y] = MakeBlankLine(width)
-					copy(newSync[y], v.syncScreen[y])
-				}
-			} else {
-				newSync[y] = MakeBlankLine(width)
-			}
-		}
-		v.syncScreen = newSync
+		v.syncScreen = resizeRows(v.syncScreen, width, height)
 	}
 	if hadPendingRestoredAltScreen {
 		if v.AltScreen {


### PR DESCRIPTION
Removes three verified copy-paste clusters in the terminal renderer. **Behavior-preserving** — `make harness-golden` (pixel-exact render parity) stays green.

### Changes
1. **Selection containment (5 copies → 1).** Adds `vterm.NormalizeSelectionRange` and `vterm.SelectionContains` (the "first row from startX, last row to endX, middle rows full" linear test). `VTerm.IsInSelection` / `GetTextRange` and the compositor's `inSelection` (canvas.go) and snapshot `inSelection` (vtermlayer.go / vtermlayer_snapshot.go) — three of which were byte-identical — now call the shared helpers. The rectangular-selection branch in `IsInSelection` is preserved separately.
2. **Resize row-preserve loop (3 copies → 1).** Adds `resizeRows(old, width, height)` and calls it from the screen, alt-screen, and synchronized-snapshot resize paths, preserving the exact reuse-wide-row / expand-narrow-row / blank-fill semantics.
3. **Blank-cell render rule (3 paths → shared).** Exports `vterm.SuppressBlankUnderline` (drop underline on NUL/space cells) and `vterm.RenderableRune` (NUL→space) from the live renderer and reuses them in the two compositor render paths, which had inlined the same rule.

**Out of scope (deliberately not touched):** the three SGR/attribute mapping tables (too risky to merge on the hottest path), the `writeColorToBuilder` color-emitter near-dup, and the parser state machine.

### Verification
- `make devcheck` — green (vet, full tests, **harness-golden**, lint **0 issues**, file-length).
- New table tests in `vterm/dedup_helpers_test.go` cover `SelectionContains` boundary cases and `resizeRows` shrink/grow/width-expand.