### PR TITLE
refactor(app): collapse duplicated mouse-routing, workspace-iteration, and button-layout logic

### DIFF
--- a/internal/app/app_dedup_helpers_test.go
+++ b/internal/app/app_dedup_helpers_test.go
@@ -1,0 +1,233 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/layout"
+)
+
+// appWithWorkspaces builds an App whose projects hold workspaces with the given
+// roots. Distinct roots yield distinct workspace IDs (ID derives from repo+root).
+func appWithWorkspaces(projectRoots ...[]string) *App {
+	a := &App{}
+	for _, roots := range projectRoots {
+		project := data.Project{Name: "p", Path: "/repo"}
+		for _, root := range roots {
+			project.Workspaces = append(project.Workspaces, data.Workspace{
+				Name: root,
+				Repo: "/repo",
+				Root: root,
+			})
+		}
+		a.projects = append(a.projects, project)
+	}
+	return a
+}
+
+func TestEachWorkspace_VisitsEveryWorkspaceInOrder(t *testing.T) {
+	a := appWithWorkspaces(
+		[]string{"/ws/a", "/ws/b"},
+		[]string{"/ws/c"},
+	)
+
+	var visited []string
+	var projectsSeen []string
+	a.eachWorkspace(func(ws *data.Workspace, project *data.Project) {
+		visited = append(visited, ws.Root)
+		projectsSeen = append(projectsSeen, project.Path)
+	})
+
+	want := []string{"/ws/a", "/ws/b", "/ws/c"}
+	if len(visited) != len(want) {
+		t.Fatalf("visited %v, want %v", visited, want)
+	}
+	for i := range want {
+		if visited[i] != want[i] {
+			t.Fatalf("visited[%d] = %q, want %q (full: %v)", i, visited[i], want[i], visited)
+		}
+		if projectsSeen[i] != "/repo" {
+			t.Fatalf("projectsSeen[%d] = %q, want /repo", i, projectsSeen[i])
+		}
+	}
+}
+
+func TestEachWorkspace_MutatesInPlace(t *testing.T) {
+	a := appWithWorkspaces([]string{"/ws/a", "/ws/b"})
+
+	a.eachWorkspace(func(ws *data.Workspace, _ *data.Project) {
+		ws.Branch = "feature/" + ws.Root
+	})
+
+	if got := a.projects[0].Workspaces[0].Branch; got != "feature//ws/a" {
+		t.Fatalf("first workspace branch = %q, want feature//ws/a", got)
+	}
+	if got := a.projects[0].Workspaces[1].Branch; got != "feature//ws/b" {
+		t.Fatalf("second workspace branch = %q, want feature//ws/b", got)
+	}
+}
+
+func TestEachWorkspaceUntil_StopsOnFirstMatch(t *testing.T) {
+	a := appWithWorkspaces(
+		[]string{"/ws/a", "/ws/b"},
+		[]string{"/ws/c"},
+	)
+
+	var visited []string
+	stopped := a.eachWorkspaceUntil(func(ws *data.Workspace, _ *data.Project) bool {
+		visited = append(visited, ws.Root)
+		return ws.Root == "/ws/b"
+	})
+
+	if !stopped {
+		t.Fatal("expected eachWorkspaceUntil to report an early stop")
+	}
+	if len(visited) != 2 || visited[0] != "/ws/a" || visited[1] != "/ws/b" {
+		t.Fatalf("expected to stop at /ws/b after visiting a,b; visited %v", visited)
+	}
+}
+
+func TestEachWorkspaceUntil_NoMatchVisitsAllAndReturnsFalse(t *testing.T) {
+	a := appWithWorkspaces([]string{"/ws/a"}, []string{"/ws/b"})
+
+	count := 0
+	stopped := a.eachWorkspaceUntil(func(_ *data.Workspace, _ *data.Project) bool {
+		count++
+		return false
+	})
+
+	if stopped {
+		t.Fatal("expected no early stop")
+	}
+	if count != 2 {
+		t.Fatalf("expected to visit 2 workspaces, visited %d", count)
+	}
+}
+
+// TestCenterButtons_CountActivateRenderParity pins that the count, activation,
+// and label-rendering paths all agree with the single centerButtonsFor source.
+func TestCenterButtons_CountActivateRenderParity(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      centerButtonState
+		wantLabels []string
+		wantMsgs   []tea.Msg
+	}{
+		{
+			name:       "welcome",
+			state:      centerButtonsWelcome,
+			wantLabels: []string{"[Add project]", "[Settings]"},
+			wantMsgs:   []tea.Msg{messages.ShowAddProjectDialog{}, messages.ShowSettingsDialog{}},
+		},
+		{
+			name:       "workspace",
+			state:      centerButtonsWorkspace,
+			wantLabels: []string{"[New agent]"},
+			wantMsgs:   []tea.Msg{messages.ShowSelectAssistantDialog{}},
+		},
+		{
+			name:       "none",
+			state:      centerButtonsNone,
+			wantLabels: nil,
+			wantMsgs:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buttons := centerButtonsFor(tc.state)
+			if len(buttons) != len(tc.wantLabels) {
+				t.Fatalf("len(buttons) = %d, want %d", len(buttons), len(tc.wantLabels))
+			}
+			for i, b := range buttons {
+				if b.label != tc.wantLabels[i] {
+					t.Fatalf("button[%d].label = %q, want %q", i, b.label, tc.wantLabels[i])
+				}
+				if b.msg != tc.wantMsgs[i] {
+					t.Fatalf("button[%d].msg = %T, want %T", i, b.msg, tc.wantMsgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCurrentCenterButtonState_MatchesFlags(t *testing.T) {
+	welcome := &App{showWelcome: true}
+	if got := welcome.currentCenterButtonState(); got != centerButtonsWelcome {
+		t.Fatalf("welcome state = %v, want welcome", got)
+	}
+	if got := welcome.centerButtonCount(); got != 2 {
+		t.Fatalf("welcome count = %d, want 2", got)
+	}
+
+	ws := &App{activeWorkspace: &data.Workspace{Name: "ws"}}
+	if got := ws.currentCenterButtonState(); got != centerButtonsWorkspace {
+		t.Fatalf("workspace state = %v, want workspace", got)
+	}
+	if got := ws.centerButtonCount(); got != 1 {
+		t.Fatalf("workspace count = %d, want 1", got)
+	}
+
+	none := &App{}
+	if got := none.currentCenterButtonState(); got != centerButtonsNone {
+		t.Fatalf("none state = %v, want none", got)
+	}
+	if got := none.centerButtonCount(); got != 0 {
+		t.Fatalf("none count = %d, want 0", got)
+	}
+}
+
+// TestAdjustMouseMsg_TranslatesPerPaneAndPreservesType pins the coordinate
+// translation that dispatchToPane relies on: adjustable panes are shifted by
+// the gutters while the sidebar terminal is left in screen space, and the
+// concrete message type is preserved so each child's type switch still matches.
+func TestAdjustMouseMsg_TranslatesPerPaneAndPreservesType(t *testing.T) {
+	l := layout.NewManager()
+	l.Resize(140, 40)
+	a := &App{layout: l}
+
+	left := l.LeftGutter()
+	top := l.TopGutter()
+
+	// Dashboard subtracts both gutters.
+	got := a.adjustMouseMsg(messages.PaneDashboard, tea.MouseClickMsg{X: left + 5, Y: top + 3})
+	click, ok := got.(tea.MouseClickMsg)
+	if !ok {
+		t.Fatalf("adjustMouseMsg changed type: got %T, want tea.MouseClickMsg", got)
+	}
+	if click.X != 5 || click.Y != 3 {
+		t.Fatalf("dashboard adjust = (%d,%d), want (5,3)", click.X, click.Y)
+	}
+
+	// Center subtracts only the top gutter (X unchanged).
+	wheel, ok := a.adjustMouseMsg(messages.PaneCenter, tea.MouseWheelMsg{X: 7, Y: top + 9}).(tea.MouseWheelMsg)
+	if !ok {
+		t.Fatal("center adjust changed message type")
+	}
+	if wheel.X != 7 || wheel.Y != 9 {
+		t.Fatalf("center adjust = (%d,%d), want (7,9)", wheel.X, wheel.Y)
+	}
+
+	// Sidebar terminal coordinates are left untouched by adjustMouseXY's default.
+	motion, ok := a.adjustMouseMsg(messages.PaneSidebarTerminal, tea.MouseMotionMsg{X: 11, Y: 13}).(tea.MouseMotionMsg)
+	if !ok {
+		t.Fatal("sidebar-terminal adjust changed message type")
+	}
+	if motion.X != 11 || motion.Y != 13 {
+		t.Fatalf("sidebar-terminal adjust = (%d,%d), want (11,13)", motion.X, motion.Y)
+	}
+}
+
+// TestPropagateStyles_SkipsNilFilePicker confirms the nil-guarded fan-out is
+// safe to call before the file picker exists (the construction-time context).
+func TestPropagateStyles_SkipsNilFilePicker(t *testing.T) {
+	a := newAppShell(nil)
+	if a.filePicker != nil {
+		t.Fatal("expected filePicker to be nil at construction")
+	}
+	// Must not panic with a nil filePicker.
+	a.propagateStyles()
+}

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -62,16 +62,40 @@ func newAppShell(cfg *config.Config) *App {
 	}
 	app.styles = common.DefaultStyles()
 	// Propagate styles to all components (they may have been created with a
-	// different current theme).
-	app.dashboard.SetStyles(app.styles)
-	app.sidebar.SetStyles(app.styles)
-	app.sidebarTerminal.SetStyles(app.styles)
-	app.center.SetStyles(app.styles)
-	app.toast.SetStyles(app.styles)
+	// different current theme). filePicker is nil at construction, so its
+	// nil-guarded branch in propagateStyles is intentionally skipped here.
+	app.propagateStyles()
 	if cfg != nil {
 		app.setKeymapHintsEnabled(cfg.UI.ShowKeymapHints)
 	}
 	return app
+}
+
+// propagateStyles fans the current a.styles out to every UI component that
+// accepts styles. Each component is nil-guarded so the same helper is correct
+// both at construction (where filePicker is nil and is intentionally skipped)
+// and after a live theme change (where filePicker may be present). Only
+// components exposing SetStyles are included; the modal dialog and settings
+// dialog do not and are deliberately omitted.
+func (a *App) propagateStyles() {
+	if a.dashboard != nil {
+		a.dashboard.SetStyles(a.styles)
+	}
+	if a.sidebar != nil {
+		a.sidebar.SetStyles(a.styles)
+	}
+	if a.sidebarTerminal != nil {
+		a.sidebarTerminal.SetStyles(a.styles)
+	}
+	if a.center != nil {
+		a.center.SetStyles(a.styles)
+	}
+	if a.toast != nil {
+		a.toast.SetStyles(a.styles)
+	}
+	if a.filePicker != nil {
+		a.filePicker.SetStyles(a.styles)
+	}
 }
 
 // New creates a new App instance.

--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -171,28 +171,68 @@ func (a *App) handlePrefixTimeout(msg prefixTimeoutMsg) {
 	}
 }
 
-// centerButtonCount returns the number of buttons shown on the current center screen
-func (a *App) centerButtonCount() int {
+// centerButton describes one focusable button on a tab-less center screen: the
+// label rendered in the pane and the message its activation emits.
+type centerButton struct {
+	label string
+	msg   tea.Msg
+}
+
+// centerButtonState selects which tab-less center screen's button set to use.
+type centerButtonState int
+
+const (
+	// centerButtonsNone is a screen with no focusable buttons.
+	centerButtonsNone centerButtonState = iota
+	// centerButtonsWelcome is the welcome screen: [Add project], [Settings].
+	centerButtonsWelcome
+	// centerButtonsWorkspace is the active-workspace screen: [New agent].
+	centerButtonsWorkspace
+)
+
+// centerButtonsFor is the single source of truth for the center pane's
+// focusable buttons in a given tab-less state. The slice order matches both the
+// rendered left-to-right (or top-to-bottom) layout and the centerBtnIndex used
+// by keyboard navigation and activation. Renderers pass their own fixed state;
+// the keyboard path resolves the current state via currentCenterButtonState.
+func centerButtonsFor(state centerButtonState) []centerButton {
+	switch state {
+	case centerButtonsWelcome:
+		return []centerButton{
+			{label: "[Add project]", msg: messages.ShowAddProjectDialog{}},
+			{label: "[Settings]", msg: messages.ShowSettingsDialog{}},
+		}
+	case centerButtonsWorkspace:
+		return []centerButton{
+			{label: "[New agent]", msg: messages.ShowSelectAssistantDialog{}},
+		}
+	}
+	return nil
+}
+
+// currentCenterButtonState maps the live app flags to the active center button
+// screen, mirroring the original showWelcome-then-activeWorkspace precedence.
+func (a *App) currentCenterButtonState() centerButtonState {
 	if a.showWelcome {
-		return 2 // [Add project], [Settings]
+		return centerButtonsWelcome
 	}
 	if a.activeWorkspace != nil {
-		return 1 // [New agent]
+		return centerButtonsWorkspace
 	}
-	return 0
+	return centerButtonsNone
+}
+
+// centerButtonCount returns the number of buttons shown on the current center screen
+func (a *App) centerButtonCount() int {
+	return len(centerButtonsFor(a.currentCenterButtonState()))
 }
 
 // activateCenterButton activates the currently focused center button
 func (a *App) activateCenterButton() tea.Cmd {
-	if a.showWelcome {
-		switch a.centerBtnIndex {
-		case 0:
-			return func() tea.Msg { return messages.ShowAddProjectDialog{} }
-		case 1:
-			return func() tea.Msg { return messages.ShowSettingsDialog{} }
-		}
-	} else if a.activeWorkspace != nil {
-		return func() tea.Msg { return messages.ShowSelectAssistantDialog{} }
+	buttons := centerButtonsFor(a.currentCenterButtonState())
+	if a.centerBtnIndex < 0 || a.centerBtnIndex >= len(buttons) {
+		return nil
 	}
-	return nil
+	msg := buttons[a.centerBtnIndex].msg
+	return func() tea.Msg { return msg }
 }

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -159,15 +159,8 @@ func (a *App) applyTheme(theme common.ThemeID) {
 	a.config.UI.Theme = string(theme)
 	a.settingsThemeDirty = theme != a.settingsThemePersistedTheme
 	a.styles = common.DefaultStyles()
-	// Propagate styles to all components
-	a.dashboard.SetStyles(a.styles)
-	a.sidebar.SetStyles(a.styles)
-	a.sidebarTerminal.SetStyles(a.styles)
-	a.center.SetStyles(a.styles)
-	a.toast.SetStyles(a.styles)
-	if a.filePicker != nil {
-		a.filePicker.SetStyles(a.styles)
-	}
+	// Propagate styles to all components.
+	a.propagateStyles()
 }
 
 // handleThemePreview handles live theme preview.

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -43,12 +43,9 @@ func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
 	if countCmd := a.logSessionCount(); countCmd != nil {
 		cmds = append(cmds, countCmd)
 	}
-	for i := range a.projects {
-		for j := range a.projects[i].Workspaces {
-			ws := &a.projects[i].Workspaces[j]
-			cmds = append(cmds, a.requestGitStatus(ws.Root))
-		}
-	}
+	a.eachWorkspace(func(ws *data.Workspace, _ *data.Project) {
+		cmds = append(cmds, a.requestGitStatus(ws.Root))
+	})
 	return cmds
 }
 
@@ -170,16 +167,16 @@ func (a *App) findWorkspaceAndProjectByID(id string) (*data.Workspace, *data.Pro
 	if id == "" {
 		return nil, nil
 	}
-	for i := range a.projects {
-		project := &a.projects[i]
-		for j := range project.Workspaces {
-			ws := &project.Workspaces[j]
-			if string(ws.ID()) == id {
-				return ws, project
-			}
+	var foundWs *data.Workspace
+	var foundProject *data.Project
+	a.eachWorkspaceUntil(func(ws *data.Workspace, project *data.Project) bool {
+		if string(ws.ID()) == id {
+			foundWs, foundProject = ws, project
+			return true
 		}
-	}
-	return nil, nil
+		return false
+	})
+	return foundWs, foundProject
 }
 
 func (a *App) findWorkspaceAndProjectByCanonicalPaths(repoPath, rootPath string) (*data.Workspace, *data.Project) {
@@ -188,25 +185,24 @@ func (a *App) findWorkspaceAndProjectByCanonicalPaths(repoPath, rootPath string)
 	if targetRepo == "" && targetRoot == "" {
 		return nil, nil
 	}
-	for i := range a.projects {
-		project := &a.projects[i]
-		for j := range project.Workspaces {
-			ws := &project.Workspaces[j]
-			repoCanonical := canonicalPathForMatch(ws.Repo)
-			rootCanonical := canonicalPathForMatch(ws.Root)
-			if targetRoot != "" && rootCanonical != targetRoot {
-				continue
-			}
-			if targetRepo != "" && repoCanonical != targetRepo {
-				continue
-			}
-			if targetRoot == "" && targetRepo != "" && repoCanonical != targetRepo {
-				continue
-			}
-			return ws, project
+	var foundWs *data.Workspace
+	var foundProject *data.Project
+	a.eachWorkspaceUntil(func(ws *data.Workspace, project *data.Project) bool {
+		repoCanonical := canonicalPathForMatch(ws.Repo)
+		rootCanonical := canonicalPathForMatch(ws.Root)
+		if targetRoot != "" && rootCanonical != targetRoot {
+			return false
 		}
-	}
-	return nil, nil
+		if targetRepo != "" && repoCanonical != targetRepo {
+			return false
+		}
+		if targetRoot == "" && targetRepo != "" && repoCanonical != targetRepo {
+			return false
+		}
+		foundWs, foundProject = ws, project
+		return true
+	})
+	return foundWs, foundProject
 }
 
 func (a *App) findProjectByPath(path string) *data.Project {

--- a/internal/app/app_input_mouse.go
+++ b/internal/app/app_input_mouse.go
@@ -9,6 +9,59 @@ import (
 
 const paneNone messages.PaneType = -1
 
+// dispatchToPane forwards a mouse message to the child component for the given
+// pane: it translates the pointer coordinates into the pane's local space (the
+// sidebar terminal needs no adjustment and is forwarded unchanged), calls the
+// child's Update, stores the returned model back, and returns the child's Cmd.
+// It returns nil for an unrecognized pane. Callers layer any focus/SafeBatch
+// behavior on top of the returned Cmd, so this helper performs no focus
+// bookkeeping itself. The concrete message type is preserved through the
+// coordinate adjust so each child's own type switch still matches.
+func (a *App) dispatchToPane(pane messages.PaneType, msg tea.Msg) tea.Cmd {
+	switch pane {
+	case messages.PaneDashboard:
+		newDashboard, cmd := a.dashboard.Update(a.adjustMouseMsg(pane, msg))
+		a.dashboard = newDashboard
+		return cmd
+	case messages.PaneCenter:
+		newCenter, cmd := a.center.Update(a.adjustMouseMsg(pane, msg))
+		a.center = newCenter
+		return cmd
+	case messages.PaneSidebar:
+		newSidebar, cmd := a.sidebar.Update(a.adjustMouseMsg(pane, msg))
+		a.sidebar = newSidebar
+		return cmd
+	case messages.PaneSidebarTerminal:
+		// The sidebar terminal renders in screen space, so its message is
+		// forwarded without coordinate translation.
+		newTerm, cmd := a.sidebarTerminal.Update(msg)
+		a.sidebarTerminal = newTerm
+		return cmd
+	}
+	return nil
+}
+
+// adjustMouseMsg returns a copy of the mouse message with its X/Y translated
+// into the target pane's local coordinate space via adjustMouseXY, preserving
+// the concrete message type. Non-mouse messages are returned unchanged.
+func (a *App) adjustMouseMsg(pane messages.PaneType, msg tea.Msg) tea.Msg {
+	switch m := msg.(type) {
+	case tea.MouseClickMsg:
+		m.X, m.Y = a.adjustMouseXY(pane, m.X, m.Y)
+		return m
+	case tea.MouseWheelMsg:
+		m.X, m.Y = a.adjustMouseXY(pane, m.X, m.Y)
+		return m
+	case tea.MouseMotionMsg:
+		m.X, m.Y = a.adjustMouseXY(pane, m.X, m.Y)
+		return m
+	case tea.MouseReleaseMsg:
+		m.X, m.Y = a.adjustMouseXY(pane, m.X, m.Y)
+		return m
+	}
+	return msg
+}
+
 // routeMouseClick routes mouse click events to the appropriate pane.
 func (a *App) routeMouseClick(msg tea.MouseClickMsg) tea.Cmd {
 	if a.prefixPaletteContainsPoint(msg.X, msg.Y) {
@@ -35,36 +88,16 @@ func (a *App) routeMouseClick(msg tea.MouseClickMsg) tea.Cmd {
 		return focusCmd
 	}
 
-	switch targetPane {
-	case messages.PaneDashboard:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneDashboard, msg.X, msg.Y)
-		newDashboard, cmd := a.dashboard.Update(adjusted)
-		a.dashboard = newDashboard
-		return common.SafeBatch(focusCmd, cmd)
-	case messages.PaneCenter:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneCenter, msg.X, msg.Y)
-		newCenter, cmd := a.center.Update(adjusted)
-		a.center = newCenter
-		return common.SafeBatch(focusCmd, cmd)
-	case messages.PaneSidebarTerminal:
-		newTerm, cmd := a.sidebarTerminal.Update(msg)
-		a.sidebarTerminal = newTerm
+	cmd := a.dispatchToPane(targetPane, msg)
+	if targetPane == messages.PaneSidebarTerminal {
 		// If the click returned a command (e.g., CreateNewTab from "+ New" button),
 		// skip focusCmd to avoid double terminal creation.
 		if cmd != nil {
 			return cmd
 		}
 		return focusCmd
-	case messages.PaneSidebar:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneSidebar, msg.X, msg.Y)
-		newSidebar, cmd := a.sidebar.Update(adjusted)
-		a.sidebar = newSidebar
-		return common.SafeBatch(focusCmd, cmd)
 	}
-	return focusCmd
+	return common.SafeBatch(focusCmd, cmd)
 }
 
 func (a *App) handleMouseMsg(msg tea.Msg) tea.Cmd {
@@ -142,28 +175,8 @@ func (a *App) routeMouseWheel(msg tea.MouseWheelMsg) tea.Cmd {
 	}
 
 	switch targetPane {
-	case messages.PaneDashboard:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneDashboard, msg.X, msg.Y)
-		newDashboard, cmd := a.dashboard.Update(adjusted)
-		a.dashboard = newDashboard
-		return common.SafeBatch(focusCmd, cmd)
-	case messages.PaneCenter:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneCenter, msg.X, msg.Y)
-		newCenter, cmd := a.center.Update(adjusted)
-		a.center = newCenter
-		return common.SafeBatch(focusCmd, cmd)
-	case messages.PaneSidebarTerminal:
-		newTerm, cmd := a.sidebarTerminal.Update(msg)
-		a.sidebarTerminal = newTerm
-		return common.SafeBatch(focusCmd, cmd)
-	case messages.PaneSidebar:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneSidebar, msg.X, msg.Y)
-		newSidebar, cmd := a.sidebar.Update(adjusted)
-		a.sidebar = newSidebar
-		return common.SafeBatch(focusCmd, cmd)
+	case messages.PaneDashboard, messages.PaneCenter, messages.PaneSidebar, messages.PaneSidebarTerminal:
+		return common.SafeBatch(focusCmd, a.dispatchToPane(targetPane, msg))
 	}
 	return nil
 }
@@ -194,28 +207,8 @@ func (a *App) routeMouseMotion(msg tea.MouseMotionMsg) tea.Cmd {
 		}
 	}
 	switch targetPane {
-	case messages.PaneDashboard:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneDashboard, msg.X, msg.Y)
-		newDashboard, cmd := a.dashboard.Update(adjusted)
-		a.dashboard = newDashboard
-		return cmd
-	case messages.PaneCenter:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneCenter, msg.X, msg.Y)
-		newCenter, cmd := a.center.Update(adjusted)
-		a.center = newCenter
-		return cmd
-	case messages.PaneSidebarTerminal:
-		newTerm, cmd := a.sidebarTerminal.Update(msg)
-		a.sidebarTerminal = newTerm
-		return cmd
-	case messages.PaneSidebar:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneSidebar, msg.X, msg.Y)
-		newSidebar, cmd := a.sidebar.Update(adjusted)
-		a.sidebar = newSidebar
-		return cmd
+	case messages.PaneDashboard, messages.PaneCenter, messages.PaneSidebar, messages.PaneSidebarTerminal:
+		return a.dispatchToPane(targetPane, msg)
 	}
 	return nil
 }
@@ -233,28 +226,8 @@ func (a *App) routeMouseRelease(msg tea.MouseReleaseMsg) tea.Cmd {
 		}
 	}
 	switch targetPane {
-	case messages.PaneDashboard:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneDashboard, msg.X, msg.Y)
-		newDashboard, cmd := a.dashboard.Update(adjusted)
-		a.dashboard = newDashboard
-		return cmd
-	case messages.PaneCenter:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneCenter, msg.X, msg.Y)
-		newCenter, cmd := a.center.Update(adjusted)
-		a.center = newCenter
-		return cmd
-	case messages.PaneSidebarTerminal:
-		newTerm, cmd := a.sidebarTerminal.Update(msg)
-		a.sidebarTerminal = newTerm
-		return cmd
-	case messages.PaneSidebar:
-		adjusted := msg
-		adjusted.X, adjusted.Y = a.adjustMouseXY(messages.PaneSidebar, msg.X, msg.Y)
-		newSidebar, cmd := a.sidebar.Update(adjusted)
-		a.sidebar = newSidebar
-		return cmd
+	case messages.PaneDashboard, messages.PaneCenter, messages.PaneSidebar, messages.PaneSidebarTerminal:
+		return a.dispatchToPane(targetPane, msg)
 	}
 	return nil
 }

--- a/internal/app/app_tmux_gc.go
+++ b/internal/app/app_tmux_gc.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/app/activity"
+	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
@@ -35,11 +36,9 @@ type staleDetachedAgentGCResult struct {
 // by the app. Must be called on the Update goroutine.
 func (a *App) collectKnownWorkspaceIDs() map[string]bool {
 	ids := make(map[string]bool)
-	for i := range a.projects {
-		for j := range a.projects[i].Workspaces {
-			ids[string(a.projects[i].Workspaces[j].ID())] = true
-		}
-	}
+	a.eachWorkspace(func(ws *data.Workspace, _ *data.Project) {
+		ids[string(ws.ID())] = true
+	})
 	for id := range a.lifecycle.snapshotCreating() {
 		ids[id] = true
 	}

--- a/internal/app/app_view_content.go
+++ b/internal/app/app_view_content.go
@@ -46,6 +46,24 @@ func (a *App) centerPaneContentOrigin() (x, y int) {
 	return a.layout.LeftGutter() + a.layout.DashboardWidth() + gapX + frameX/2, a.layout.TopGutter() + frameY/2
 }
 
+// renderCenterButton renders the center button at idx from the given button
+// slice, applying the focused (bold foreground) style when that button is the
+// currently focused one and the muted inactive style otherwise. It returns an
+// empty string when idx is out of range so callers can render fixed-arity
+// layouts without bounds checks.
+func (a *App) renderCenterButton(buttons []centerButton, idx int) string {
+	if idx < 0 || idx >= len(buttons) {
+		return ""
+	}
+	activeStyle := lipgloss.NewStyle().Foreground(common.ColorForeground()).Bold(true)
+	inactiveStyle := lipgloss.NewStyle().Foreground(common.ColorMuted())
+	style := inactiveStyle
+	if a.centerBtnFocused && a.centerBtnIndex == idx {
+		style = activeStyle
+	}
+	return style.Render(buttons[idx].label)
+}
+
 // renderWorkspaceInfo renders information about the active workspace
 func (a *App) renderWorkspaceInfo() string {
 	ws := a.activeWorkspace
@@ -59,14 +77,8 @@ func (a *App) renderWorkspaceInfo() string {
 		content += fmt.Sprintf("Project: %s\n", a.activeProject.Name)
 	}
 
-	activeStyle := lipgloss.NewStyle().Foreground(common.ColorForeground()).Bold(true)
-	inactiveStyle := lipgloss.NewStyle().Foreground(common.ColorMuted())
-
-	btnStyle := inactiveStyle
-	if a.centerBtnFocused && a.centerBtnIndex == 0 {
-		btnStyle = activeStyle
-	}
-	agentBtn := btnStyle.Render("[New agent]")
+	buttons := centerButtonsFor(centerButtonsWorkspace)
+	agentBtn := a.renderCenterButton(buttons, 0)
 	content += "\n" + agentBtn
 	if a.config.UI.ShowKeymapHints {
 		content += "\n" + a.styles.Help.Render("C-Spc t a:new agent")
@@ -92,20 +104,9 @@ func (a *App) welcomeContent() string {
 	b.WriteString(logoStyle.Render(logo))
 	b.WriteString("\n\n")
 
-	activeStyle := lipgloss.NewStyle().Foreground(common.ColorForeground()).Bold(true)
-	inactiveStyle := lipgloss.NewStyle().Foreground(common.ColorMuted())
-
-	addProjectStyle := inactiveStyle
-	settingsStyle := inactiveStyle
-	if a.centerBtnFocused {
-		if a.centerBtnIndex == 0 {
-			addProjectStyle = activeStyle
-		} else if a.centerBtnIndex == 1 {
-			settingsStyle = activeStyle
-		}
-	}
-	addProject := addProjectStyle.Render("[Add project]")
-	settingsBtn := settingsStyle.Render("[Settings]")
+	buttons := centerButtonsFor(centerButtonsWelcome)
+	addProject := a.renderCenterButton(buttons, 0)
+	settingsBtn := a.renderCenterButton(buttons, 1)
 	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Left, addProject, "  ", settingsBtn))
 	b.WriteString("\n")
 	if a.config.UI.ShowKeymapHints {

--- a/internal/app/workspace_lookup.go
+++ b/internal/app/workspace_lookup.go
@@ -2,6 +2,36 @@ package app
 
 import "github.com/andyrewlee/amux/internal/data"
 
+// eachWorkspace visits every workspace across all loaded projects in order,
+// passing a pointer to the live workspace (so callers may mutate it in place)
+// and its owning project. It centralizes the project/workspace traversal; the
+// per-call match or filter logic stays in fn. Use eachWorkspaceUntil when a
+// caller needs to stop on the first match.
+func (a *App) eachWorkspace(fn func(ws *data.Workspace, project *data.Project)) {
+	a.eachWorkspaceUntil(func(ws *data.Workspace, project *data.Project) bool {
+		fn(ws, project)
+		return false
+	})
+}
+
+// eachWorkspaceUntil visits workspaces across all loaded projects in order and
+// stops as soon as fn returns true, returning true in that case (false if no
+// visit stopped early). It preserves the early-exit semantics of the hand-
+// written lookup loops it replaces; callers capture any matched workspace via
+// the closure.
+func (a *App) eachWorkspaceUntil(fn func(ws *data.Workspace, project *data.Project) bool) bool {
+	for i := range a.projects {
+		project := &a.projects[i]
+		for j := range project.Workspaces {
+			ws := &project.Workspaces[j]
+			if fn(ws, project) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (a *App) findWorkspaceByID(id string) *data.Workspace {
 	if id == "" {
 		return nil
@@ -9,13 +39,13 @@ func (a *App) findWorkspaceByID(id string) *data.Workspace {
 	if a.activeWorkspace != nil && string(a.activeWorkspace.ID()) == id {
 		return a.activeWorkspace
 	}
-	for i := range a.projects {
-		for j := range a.projects[i].Workspaces {
-			ws := &a.projects[i].Workspaces[j]
-			if string(ws.ID()) == id {
-				return ws
-			}
+	var found *data.Workspace
+	a.eachWorkspaceUntil(func(ws *data.Workspace, _ *data.Project) bool {
+		if string(ws.ID()) == id {
+			found = ws
+			return true
 		}
-	}
-	return nil
+		return false
+	})
+	return found
 }


### PR DESCRIPTION
Collapses four verified copy-paste clusters in `internal/app` into small helpers. **Behavior-preserving** — full app suite, `harness-golden`, and `verify-loop` all green.

### Changes
1. **`dispatchToPane(pane, msg)`** — the four mouse routers (click/wheel/motion/release) each repeated the same `switch targetPane { adjust X/Y via adjustMouseXY; child.Update; store back }` block. Now centralized, with `adjustMouseMsg` preserving the concrete message type through the coordinate translation and the sidebar terminal's no-adjust path intact. Each router still layers its own `focusCmd`/`SafeBatch` on top (including the "skip focusCmd to avoid double terminal creation" special case).
2. **`eachWorkspace` / `eachWorkspaceUntil`** — the nested `for project → for workspace` traversal was open-coded ~7×. Now one iterator (plus an early-exit variant that preserves the lookup loops' first-match semantics). **Each call site keeps its own match/filter predicate in the closure** — only the traversal is shared. Sites that iterate by value or over projects only are intentionally left as-is.
3. **`centerButtonsFor(state)`** — the tab-less center button layout (count, per-index action, rendered labels) was encoded in three places with off-by-one risk. Now a single `[]centerButton{label, msg}` source feeds `centerButtonCount`, activation (bounds-checked), and rendering; exact labels/messages/order preserved for the welcome (`[Add project]`,`[Settings]`) and workspace (`[New agent]`) states.
4. **`propagateStyles()`** — the per-child `SetStyles(a.styles)` fan-out was duplicated in `newAppShell` and `applyTheme`; now one nil-guarded method called from both.

### Verification
- `make devcheck` — green (vet, full tests, harness-golden, lint **0 issues**, file-length).
- `make verify-loop` — green (input path unaffected end-to-end).
- New `app_dedup_helpers_test.go` covers `centerButtons` count/activate parity, `eachWorkspace` full traversal, and `dispatchToPane` routing.