### PR TITLE
refactor(ui): dedup pane drag-selection/scroll glue and tab-bar height

### DIFF
--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -131,8 +131,8 @@ func (m *Model) terminalMetrics() TerminalMetrics {
 		borderLeft   = 1
 		paddingLeft  = 1
 		borderTop    = 1
-		tabBarHeight = 1 // compact tabs (no borders, single line)
-		baseOverhead = 4 // borders (2) + tab bar (1) + status line reserve (1)
+		tabBarHeight = common.TabBarHeight // compact tabs (no borders, single line)
+		baseOverhead = 4                   // borders (2) + tab bar (1) + status line reserve (1)
 	)
 
 	width := m.contentWidth()

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -119,30 +119,19 @@ func (m *Model) updateMouseMotion(msg tea.MouseMotionMsg) (*Model, tea.Cmd) {
 	}
 	tab.mu.Lock()
 	if tab.Selection.Active && tab.Terminal != nil {
-		termWidth := tab.Terminal.Width
-		termHeight := tab.Terminal.Height
-		if termX < 0 {
-			termX = 0
-		}
-		if termX >= termWidth {
-			termX = termWidth - 1
-		}
-
-		// Set scroll direction from unclamped Y before clamping
-		tab.selectionScroll.SetDirection(termY, termHeight)
-
-		if termY < 0 {
-			m.scrollTerminalViewLocked(tab, 1)
-			termY = 0
-		} else if termY >= termHeight {
-			m.scrollTerminalViewLocked(tab, -1)
-			termY = termHeight - 1
-		}
-		absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
-		common.ExtendSelection(tab.Terminal, &tab.Selection, termX, absLine)
-
-		tab.selectionLastTermX = termX
-		if needTick, gen := tab.selectionScroll.NeedsTick(); needTick {
+		needTick, gen := common.DragSelect(
+			tab.Terminal,
+			&tab.Selection,
+			&tab.selectionScroll,
+			termX, termY, tab.Terminal.Width, tab.Terminal.Height,
+			&tab.selectionLastTermX,
+			func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
+			func(screenY int) int {
+				absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
+				return absLine
+			},
+		)
+		if needTick {
 			wsID := m.workspaceID()
 			tabID := tab.ID
 			cmds = append(cmds, common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
@@ -384,21 +373,23 @@ func (m *Model) updateSelectionScrollTick(msg selectionScrollTick) tea.Cmd {
 		tab.mu.Unlock()
 		return nil
 	}
-	m.scrollTerminalViewLocked(tab, tab.selectionScroll.ScrollDir)
-
-	// Update selection endpoint to viewport edge
-	edgeY := 0
-	if tab.selectionScroll.ScrollDir < 0 {
-		edgeY = tab.Terminal.Height - 1
-	}
-	absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
-	endX := tab.selectionLastTermX
-	common.ExtendSelection(tab.Terminal, &tab.Selection, endX, absLine)
+	common.SelectionScrollTickStep(
+		tab.Terminal,
+		&tab.Selection,
+		&tab.selectionScroll,
+		tab.Terminal.Height,
+		tab.selectionLastTermX,
+		func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
+		func(screenY int) int {
+			absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
+			return absLine
+		},
+	)
 
 	tab.mu.Unlock()
 	tabID := msg.TabID
 	wtID := msg.WorkspaceID
-	cmds = append(cmds, common.SafeTick(100*time.Millisecond, func(time.Time) tea.Msg {
+	cmds = append(cmds, common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
 		return selectionScrollTick{WorkspaceID: wtID, TabID: tabID, Gen: msg.Gen}
 	}))
 	return common.SafeBatch(cmds...)

--- a/internal/ui/center/model_wheel.go
+++ b/internal/ui/center/model_wheel.go
@@ -1,5 +1,7 @@
 package center
 
+import "github.com/andyrewlee/amux/internal/vterm"
+
 // CanConsumeWheel reports whether the active center tab can meaningfully handle
 // mouse-wheel input. Detached chat tabs count so wheel-driven focus can trigger
 // reattach; otherwise a tab must have scrollable diff or terminal content.
@@ -31,7 +33,7 @@ func (m *Model) CanConsumeWheel() bool {
 		return tab.DiffViewer.CanConsumeWheel()
 	}
 	if tab.Terminal != nil {
-		return tab.Terminal.MouseReportingEnabled() || tab.Terminal.MaxViewOffset() > 0
+		return tab.Terminal.MouseReportingEnabled() || vterm.VTermHasScrollback(tab.Terminal)
 	}
 	return false
 }

--- a/internal/ui/center/tab_actor_selection.go
+++ b/internal/ui/center/tab_actor_selection.go
@@ -85,34 +85,21 @@ func (m *Model) handleSelectionUpdate(ev tabEvent) {
 	if !tab.Selection.Active || tab.Terminal == nil {
 		return
 	}
-	termWidth := tab.Terminal.Width
-	termHeight := tab.Terminal.Height
-	termX := ev.termX
-	termY := ev.termY
 
-	if termX < 0 {
-		termX = 0
-	}
-	if termX >= termWidth {
-		termX = termWidth - 1
-	}
+	needTick, gen := common.DragSelect(
+		tab.Terminal,
+		&tab.Selection,
+		&tab.selectionScroll,
+		ev.termX, ev.termY, tab.Terminal.Width, tab.Terminal.Height,
+		&tab.selectionLastTermX,
+		func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
+		func(screenY int) int {
+			absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
+			return absLine
+		},
+	)
 
-	// Set scroll direction from unclamped Y before clamping
-	tab.selectionScroll.SetDirection(termY, termHeight)
-
-	if termY < 0 {
-		m.scrollTerminalViewLocked(tab, 1)
-		termY = 0
-	} else if termY >= termHeight {
-		m.scrollTerminalViewLocked(tab, -1)
-		termY = termHeight - 1
-	}
-
-	absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
-	common.ExtendSelection(tab.Terminal, &tab.Selection, termX, absLine)
-
-	tab.selectionLastTermX = termX
-	if needTick, gen := tab.selectionScroll.NeedsTick(); needTick && m.msgSink != nil {
+	if needTick && m.msgSink != nil {
 		m.msgSink(selectionTickRequest{
 			workspaceID: ev.workspaceID,
 			tabID:       ev.tabID,
@@ -149,16 +136,18 @@ func (m *Model) handleSelectionScrollTick(ev tabEvent) {
 		tab.mu.Unlock()
 		return
 	}
-	m.scrollTerminalViewLocked(tab, tab.selectionScroll.ScrollDir)
-
-	// Update selection endpoint to viewport edge
-	edgeY := 0
-	if tab.selectionScroll.ScrollDir < 0 {
-		edgeY = tab.Terminal.Height - 1
-	}
-	absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, edgeY)
-	endX := tab.selectionLastTermX
-	common.ExtendSelection(tab.Terminal, &tab.Selection, endX, absLine)
+	common.SelectionScrollTickStep(
+		tab.Terminal,
+		&tab.Selection,
+		&tab.selectionScroll,
+		tab.Terminal.Height,
+		tab.selectionLastTermX,
+		func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
+		func(screenY int) int {
+			absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
+			return absLine
+		},
+	)
 
 	tab.mu.Unlock()
 	if m.msgSink != nil {

--- a/internal/ui/common/hit.go
+++ b/internal/ui/common/hit.go
@@ -1,5 +1,11 @@
 package common
 
+// TabBarHeight is the height, in rows, of the compact pane tab strip. Both the
+// center and sidebar terminal panes render their tab strip as a single
+// borderless line, and both use this when converting between screen and
+// content coordinates.
+const TabBarHeight = 1
+
 // HitRegion represents a rectangular hit target in view-local coordinates.
 type HitRegion struct {
 	ID     string

--- a/internal/ui/common/selection.go
+++ b/internal/ui/common/selection.go
@@ -11,6 +11,89 @@ type SelectionState struct {
 	EndLine   int  // End row (absolute line number)
 }
 
+// DragSelect advances an in-progress drag selection toward the pointer at
+// (termX, termY) and reports whether an auto-scroll tick loop should be
+// (re)started. The caller must hold the owning tab/terminal mutex and must have
+// already confirmed sel.Active and a non-nil v.
+//
+// termX is clamped to [0, termWidth); the unclamped termY drives the scroll
+// direction (scrollState.SetDirection) before being clamped to the viewport.
+// When the pointer is above or below the viewport, scroll is invoked with +1
+// (up into history) or -1 (down toward live) and termY is pinned to the
+// matching edge. The clamped termY is mapped to an absolute line via
+// screenYToAbs and the selection endpoint is extended there. The clamped termX
+// is written to *lastTermX so tick-driven edge extension can reuse it.
+//
+// The two closures absorb the only per-pane divergence: scroll performs the
+// pane's viewport move (center's chat-history-aware scroll vs the sidebar's raw
+// ScrollView+note), and screenYToAbs maps a screen row to an absolute line.
+// The returned (needTick, gen) come straight from scrollState.NeedsTick(); the
+// caller owns scheduling the actual tick command.
+func DragSelect(
+	v *vterm.VTerm,
+	sel *SelectionState,
+	scrollState *SelectionScrollState,
+	termX, termY, termWidth, termHeight int,
+	lastTermX *int,
+	scroll func(delta int),
+	screenYToAbs func(screenY int) int,
+) (needTick bool, gen uint64) {
+	if termX < 0 {
+		termX = 0
+	}
+	if termX >= termWidth {
+		termX = termWidth - 1
+	}
+
+	// Set scroll direction from the unclamped Y before clamping.
+	scrollState.SetDirection(termY, termHeight)
+
+	if termY < 0 {
+		scroll(1)
+		termY = 0
+	} else if termY >= termHeight {
+		scroll(-1)
+		termY = termHeight - 1
+	}
+
+	absLine := screenYToAbs(termY)
+	ExtendSelection(v, sel, termX, absLine)
+
+	*lastTermX = termX
+	return scrollState.NeedsTick()
+}
+
+// SelectionScrollTickStep performs one auto-scroll tick of a drag selection:
+// it scrolls the viewport one line in scrollState.ScrollDir and extends the
+// selection endpoint to the now-exposed viewport edge. The caller must hold the
+// owning tab/terminal mutex and must have already validated the tick via
+// scrollState.HandleTick (which confirms the generation, direction, and active
+// state) plus sel.Active and a non-nil v.
+//
+// The edge row is the top of the viewport when scrolling up into history and
+// the bottom (termHeight-1) when scrolling down toward live; screenYToAbs maps
+// it to an absolute line. lastTermX supplies the horizontal endpoint. scroll
+// and screenYToAbs carry the same per-pane meaning as in DragSelect. The caller
+// owns scheduling the next tick command.
+func SelectionScrollTickStep(
+	v *vterm.VTerm,
+	sel *SelectionState,
+	scrollState *SelectionScrollState,
+	termHeight int,
+	lastTermX int,
+	scroll func(delta int),
+	screenYToAbs func(screenY int) int,
+) {
+	scroll(scrollState.ScrollDir)
+
+	edgeY := 0
+	if scrollState.ScrollDir < 0 {
+		edgeY = termHeight - 1
+	}
+	absLine := screenYToAbs(edgeY)
+	ExtendSelection(v, sel, lastTermX, absLine)
+}
+
 // ExtendSelection moves the far endpoint of an in-progress selection to
 // (endX, endAbsLine). The anchor is read from the live vterm selection, falling
 // back to sel's stored start when the vterm has no selection yet, then written

--- a/internal/ui/common/selection_drag_test.go
+++ b/internal/ui/common/selection_drag_test.go
@@ -1,0 +1,206 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// seedSelection returns a VTerm with an active one-point selection at
+// (startX, startLine) so ExtendSelection has a valid anchor to extend from.
+func seedSelection(startX, startLine int) (*vterm.VTerm, *SelectionState) {
+	v := vterm.New(80, 24)
+	v.SetSelection(startX, startLine, startX, startLine, true, false)
+	sel := &SelectionState{
+		Active:    true,
+		StartX:    startX,
+		StartLine: startLine,
+		EndX:      startX,
+		EndLine:   startLine,
+	}
+	return v, sel
+}
+
+func TestDragSelect(t *testing.T) {
+	t.Parallel()
+
+	const termWidth, termHeight = 80, 24
+
+	tests := []struct {
+		name string
+		// Drag pointer position, in terminal coordinates.
+		termX, termY int
+		// Scroll direction state going in.
+		startDir    int
+		startActive bool
+		// Expectations.
+		wantScrollDelta int  // 0 means scroll closure not invoked
+		wantAbsScreenY  int  // screen row passed to screenYToAbs
+		wantLastTermX   int  // value written to *lastTermX
+		wantDir         int  // scrollScroll.ScrollDir after the call
+		wantNeedTick    bool // returned needTick
+	}{
+		{
+			name:  "in-bounds drag does not scroll",
+			termX: 10, termY: 5,
+			wantScrollDelta: 0,
+			wantAbsScreenY:  5,
+			wantLastTermX:   10,
+			wantDir:         0,
+			wantNeedTick:    false,
+		},
+		{
+			name:  "clamps negative X to zero",
+			termX: -7, termY: 5,
+			wantScrollDelta: 0,
+			wantAbsScreenY:  5,
+			wantLastTermX:   0,
+			wantDir:         0,
+			wantNeedTick:    false,
+		},
+		{
+			name:  "clamps X past width to width-1",
+			termX: 999, termY: 5,
+			wantScrollDelta: 0,
+			wantAbsScreenY:  5,
+			wantLastTermX:   termWidth - 1,
+			wantDir:         0,
+			wantNeedTick:    false,
+		},
+		{
+			name:  "above viewport scrolls up and pins Y to top, needs tick",
+			termX: 10, termY: -3,
+			wantScrollDelta: 1,
+			wantAbsScreenY:  0,
+			wantLastTermX:   10,
+			wantDir:         1,
+			wantNeedTick:    true,
+		},
+		{
+			name:  "below viewport scrolls down and pins Y to bottom, needs tick",
+			termX: 10, termY: termHeight + 4,
+			wantScrollDelta: -1,
+			wantAbsScreenY:  termHeight - 1,
+			wantLastTermX:   10,
+			wantDir:         -1,
+			wantNeedTick:    true,
+		},
+		{
+			name:  "already-active tick loop does not request another",
+			termX: 10, termY: -3,
+			startDir: 1, startActive: true,
+			wantScrollDelta: 1,
+			wantAbsScreenY:  0,
+			wantLastTermX:   10,
+			wantDir:         1,
+			wantNeedTick:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v, sel := seedSelection(3, 3)
+			scrollState := &SelectionScrollState{ScrollDir: tt.startDir, Active: tt.startActive}
+
+			var gotScrollDelta int
+			var gotScreenY int
+			lastTermX := -999
+
+			needTick, gen := DragSelect(
+				v, sel, scrollState,
+				tt.termX, tt.termY, termWidth, termHeight,
+				&lastTermX,
+				func(delta int) { gotScrollDelta += delta },
+				func(screenY int) int { gotScreenY = screenY; return screenY * 100 },
+			)
+
+			if gotScrollDelta != tt.wantScrollDelta {
+				t.Errorf("scroll delta = %d, want %d", gotScrollDelta, tt.wantScrollDelta)
+			}
+			if gotScreenY != tt.wantAbsScreenY {
+				t.Errorf("screenYToAbs got screenY %d, want %d", gotScreenY, tt.wantAbsScreenY)
+			}
+			if lastTermX != tt.wantLastTermX {
+				t.Errorf("*lastTermX = %d, want %d", lastTermX, tt.wantLastTermX)
+			}
+			if scrollState.ScrollDir != tt.wantDir {
+				t.Errorf("ScrollDir = %d, want %d", scrollState.ScrollDir, tt.wantDir)
+			}
+			if needTick != tt.wantNeedTick {
+				t.Errorf("needTick = %v, want %v", needTick, tt.wantNeedTick)
+			}
+			// The selection endpoint X must track the clamped termX, and its
+			// end line must be the absLine the closure returned (screenY*100).
+			if sel.EndX != tt.wantLastTermX {
+				t.Errorf("sel.EndX = %d, want %d", sel.EndX, tt.wantLastTermX)
+			}
+			if sel.EndLine != tt.wantAbsScreenY*100 {
+				t.Errorf("sel.EndLine = %d, want %d", sel.EndLine, tt.wantAbsScreenY*100)
+			}
+			if needTick && gen == 0 {
+				t.Error("needTick true but gen is zero")
+			}
+		})
+	}
+}
+
+func TestSelectionScrollTickStep(t *testing.T) {
+	t.Parallel()
+
+	const termHeight = 24
+
+	tests := []struct {
+		name            string
+		scrollDir       int
+		lastTermX       int
+		wantScrollDelta int
+		wantScreenY     int // edge row mapped to abs line
+	}{
+		{
+			name:            "scrolling up extends to top edge",
+			scrollDir:       1,
+			lastTermX:       12,
+			wantScrollDelta: 1,
+			wantScreenY:     0,
+		},
+		{
+			name:            "scrolling down extends to bottom edge",
+			scrollDir:       -1,
+			lastTermX:       7,
+			wantScrollDelta: -1,
+			wantScreenY:     termHeight - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v, sel := seedSelection(3, 3)
+			scrollState := &SelectionScrollState{ScrollDir: tt.scrollDir, Active: true}
+
+			var gotScrollDelta int
+			var gotScreenY int
+
+			SelectionScrollTickStep(
+				v, sel, scrollState,
+				termHeight, tt.lastTermX,
+				func(delta int) { gotScrollDelta += delta },
+				func(screenY int) int { gotScreenY = screenY; return screenY * 100 },
+			)
+
+			if gotScrollDelta != tt.wantScrollDelta {
+				t.Errorf("scroll delta = %d, want %d", gotScrollDelta, tt.wantScrollDelta)
+			}
+			if gotScreenY != tt.wantScreenY {
+				t.Errorf("screenYToAbs got screenY %d, want %d", gotScreenY, tt.wantScreenY)
+			}
+			if sel.EndX != tt.lastTermX {
+				t.Errorf("sel.EndX = %d, want %d (lastTermX)", sel.EndX, tt.lastTermX)
+			}
+			if sel.EndLine != tt.wantScreenY*100 {
+				t.Errorf("sel.EndLine = %d, want %d", sel.EndLine, tt.wantScreenY*100)
+			}
+		})
+	}
+}

--- a/internal/ui/sidebar/terminal_render.go
+++ b/internal/ui/sidebar/terminal_render.go
@@ -262,8 +262,10 @@ func (m *TerminalModel) helpLines(contentWidth int) []string {
 	return common.WrapHelpItems(items, contentWidth)
 }
 
-// tabBarHeight is the height of the terminal tab bar (single line, no borders)
-const tabBarHeight = 1
+// tabBarHeight is the height of the terminal tab bar (single line, no borders).
+// It aliases the shared common.TabBarHeight so the center and sidebar panes
+// stay in lockstep.
+const tabBarHeight = common.TabBarHeight
 
 // statusLineReserve keeps space for the status line even when hidden.
 const statusLineReserve = 1

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -165,42 +165,18 @@ func (m *TerminalModel) handleMouseMotion(msg tea.MouseMotionMsg) (*TerminalMode
 
 	ts.mu.Lock()
 	if ts.Selection.Active && ts.VTerm != nil {
-		termWidth := ts.VTerm.Width
-		termHeight := ts.VTerm.Height
-
-		// Clamp X to terminal bounds
-		if termX < 0 {
-			termX = 0
-		}
-		if termX >= termWidth {
-			termX = termWidth - 1
-		}
-
-		// Set scroll direction from unclamped Y before clamping
-		ts.selectionScroll.SetDirection(termY, termHeight)
-
-		// Auto-scroll when dragging at edges
-		if termY < 0 {
-			// Dragging above viewport - scroll up into history
-			ts.VTerm.ScrollView(1)
-			ts.VTerm.NoteSyncViewportInteraction()
-			termY = 0
-		} else if termY >= termHeight {
-			// Dragging below viewport - scroll down toward live
-			ts.VTerm.ScrollView(-1)
-			ts.VTerm.NoteSyncViewportInteraction()
-			termY = termHeight - 1
-		}
-
-		// Convert to absolute line and update selection
-		absLine := ts.VTerm.ScreenYToAbsoluteLine(termY)
-		common.ExtendSelection(ts.VTerm, &ts.Selection, termX, absLine)
-
-		// Store last X for tick-based endpoint updates
-		ts.selectionLastTermX = termX
+		needTick, gen := common.DragSelect(
+			ts.VTerm,
+			&ts.Selection,
+			&ts.selectionScroll,
+			termX, termY, ts.VTerm.Width, ts.VTerm.Height,
+			&ts.selectionLastTermX,
+			ts.VTerm.ScrollViewAndNote,
+			ts.VTerm.ScreenYToAbsoluteLine,
+		)
 
 		// Start tick loop for continuous scrolling if needed
-		if needTick, gen := ts.selectionScroll.NeedsTick(); needTick {
+		if needTick {
 			activeTab := m.getActiveTab()
 			if activeTab != nil {
 				wsID := m.workspaceID()
@@ -269,17 +245,15 @@ func (m *TerminalModel) handleSelectionScrollTick(msg SidebarSelectionScrollTick
 		ts.mu.Unlock()
 		return nil
 	}
-	ts.VTerm.ScrollView(ts.selectionScroll.ScrollDir)
-	ts.VTerm.NoteSyncViewportInteraction()
-
-	// Update selection endpoint to viewport edge
-	edgeY := 0
-	if ts.selectionScroll.ScrollDir < 0 {
-		edgeY = ts.VTerm.Height - 1
-	}
-	absLine := ts.VTerm.ScreenYToAbsoluteLine(edgeY)
-	endX := ts.selectionLastTermX
-	common.ExtendSelection(ts.VTerm, &ts.Selection, endX, absLine)
+	common.SelectionScrollTickStep(
+		ts.VTerm,
+		&ts.Selection,
+		&ts.selectionScroll,
+		ts.VTerm.Height,
+		ts.selectionLastTermX,
+		ts.VTerm.ScrollViewAndNote,
+		ts.VTerm.ScreenYToAbsoluteLine,
+	)
 
 	ts.mu.Unlock()
 

--- a/internal/ui/sidebar/terminal_update.go
+++ b/internal/ui/sidebar/terminal_update.go
@@ -114,11 +114,9 @@ func (m *TerminalModel) handleMouseWheel(msg tea.MouseWheelMsg) (*TerminalModel,
 	ts.mu.Lock()
 	delta := common.ScrollDeltaForHeight(ts.VTerm.Height, 8) // ~12.5% of viewport
 	if msg.Button == tea.MouseWheelUp {
-		ts.VTerm.ScrollView(delta)
-		ts.VTerm.NoteSyncViewportInteraction()
+		ts.VTerm.ScrollViewAndNote(delta)
 	} else if msg.Button == tea.MouseWheelDown {
-		ts.VTerm.ScrollView(-delta)
-		ts.VTerm.NoteSyncViewportInteraction()
+		ts.VTerm.ScrollViewAndNote(-delta)
 	}
 	ts.mu.Unlock()
 	return m, nil
@@ -179,8 +177,7 @@ func (m *TerminalModel) handleKeyPress(msg tea.KeyPressMsg) (*TerminalModel, tea
 	case tea.KeyPgUp:
 		ts.mu.Lock()
 		if ts.VTerm != nil {
-			ts.VTerm.ScrollView(common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
-			ts.VTerm.NoteSyncViewportInteraction()
+			ts.VTerm.ScrollViewAndNote(common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
 		}
 		ts.mu.Unlock()
 		return m, nil
@@ -188,8 +185,7 @@ func (m *TerminalModel) handleKeyPress(msg tea.KeyPressMsg) (*TerminalModel, tea
 	case tea.KeyPgDown:
 		ts.mu.Lock()
 		if ts.VTerm != nil {
-			ts.VTerm.ScrollView(-common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
-			ts.VTerm.NoteSyncViewportInteraction()
+			ts.VTerm.ScrollViewAndNote(-common.ScrollDeltaForHeight(ts.VTerm.Height, 2))
 		}
 		ts.mu.Unlock()
 		return m, nil

--- a/internal/ui/sidebar/wheel.go
+++ b/internal/ui/sidebar/wheel.go
@@ -1,5 +1,7 @@
 package sidebar
 
+import "github.com/andyrewlee/amux/internal/vterm"
+
 // CanConsumeWheel reports whether the active sidebar tab has meaningful wheel
 // scroll content. This avoids hover-wheel focus steals from empty panes.
 func (m *TabbedSidebar) CanConsumeWheel() bool {
@@ -32,7 +34,7 @@ func (m *TerminalModel) CanConsumeWheel() bool {
 	}
 	tab.State.mu.Lock()
 	defer tab.State.mu.Unlock()
-	return tab.State.VTerm != nil && tab.State.VTerm.MaxViewOffset() > 0
+	return vterm.VTermHasScrollback(tab.State.VTerm)
 }
 
 func (m *Model) canConsumeWheel() bool {

--- a/internal/vterm/vterm_scroll_test.go
+++ b/internal/vterm/vterm_scroll_test.go
@@ -263,3 +263,76 @@ func TestMaxViewOffsetUsesFrozenSyncSnapshot(t *testing.T) {
 		t.Fatalf("MaxViewOffset() during sync = %d, want 3 (frozen scrollback)", got)
 	}
 }
+
+func TestVTermHasScrollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		vt         *VTerm
+		scrollback int
+		want       bool
+	}{
+		{name: "nil receiver", vt: nil, want: false},
+		{name: "no scrollback", vt: New(5, 3), want: false},
+		{name: "one scrollback row", vt: New(5, 3), scrollback: 1, want: true},
+		{name: "many scrollback rows", vt: New(5, 3), scrollback: 42, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.vt != nil && tt.scrollback > 0 {
+				addScrollbackLines(tt.vt, tt.scrollback)
+			}
+			if got := VTermHasScrollback(tt.vt); got != tt.want {
+				t.Fatalf("VTermHasScrollback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScrollViewAndNote verifies the helper moves the viewport exactly like
+// ScrollView and records the interaction like NoteSyncViewportInteraction, so
+// the two paired calls stay equivalent to the inlined pair.
+func TestScrollViewAndNote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("moves viewport like ScrollView", func(t *testing.T) {
+		t.Parallel()
+		vt := New(80, 24)
+		addScrollbackLines(vt, 100)
+
+		vt.ScrollViewAndNote(30)
+		if vt.ViewOffset != 30 {
+			t.Fatalf("ViewOffset = %d, want 30", vt.ViewOffset)
+		}
+		vt.ScrollViewAndNote(-10)
+		if vt.ViewOffset != 20 {
+			t.Fatalf("ViewOffset = %d after scroll back, want 20", vt.ViewOffset)
+		}
+	})
+
+	t.Run("clamps like ScrollView", func(t *testing.T) {
+		t.Parallel()
+		vt := New(80, 24)
+		addScrollbackLines(vt, 5)
+
+		vt.ScrollViewAndNote(9999)
+		if vt.ViewOffset != 5 {
+			t.Fatalf("ViewOffset = %d, want clamp to max 5", vt.ViewOffset)
+		}
+	})
+
+	t.Run("notes interaction during sync while scrolled", func(t *testing.T) {
+		t.Parallel()
+		vt := New(80, 24)
+		addScrollbackLines(vt, 100)
+		vt.setSynchronizedOutput(true)
+
+		vt.ScrollViewAndNote(10)
+		if !vt.syncPreserveViewport {
+			t.Error("expected syncPreserveViewport set after scrolling into history during sync")
+		}
+	})
+}

--- a/internal/vterm/vterm_view_helpers.go
+++ b/internal/vterm/vterm_view_helpers.go
@@ -1,0 +1,20 @@
+package vterm
+
+// ScrollViewAndNote scrolls the view by delta lines and then records the
+// resulting viewport interaction, exactly as if the caller had written
+// ScrollView followed by NoteSyncViewportInteraction. UI scroll paths that
+// move the viewport in response to user input (mousewheel, drag-select edge
+// scroll, PgUp/PgDown) pair these two calls; this helper keeps that pairing
+// in one place so the anchor bookkeeping cannot drift between call sites.
+func (v *VTerm) ScrollViewAndNote(delta int) {
+	v.ScrollView(delta)
+	v.NoteSyncViewportInteraction()
+}
+
+// VTermHasScrollback reports whether v is non-nil and currently has scrollback
+// the viewport can move into. It is the shared leaf used by the per-pane
+// CanConsumeWheel checks to avoid hover-wheel focus steals from panes with no
+// scrollable history.
+func VTermHasScrollback(v *VTerm) bool {
+	return v != nil && v.MaxViewOffset() > 0
+}


### PR DESCRIPTION
Removes the remaining per-pane copy-paste between the center and sidebar terminals (their PTY plumbing, tab storage, and selection-scroll *state* are already shared via `ptyio`/`common.TabSet`/`common.SelectionScrollState`; this targets only the thin glue left over). **Behavior-preserving** — full suite, `harness-golden`, and `verify-loop` all green.

### Tier A — consistency fixes
- **A1 — latent bug:** center's selection auto-scroll used a magic `100*time.Millisecond` while everything else uses `common.SelectionScrollTickInterval` (verified `= 100ms`). Now uses the constant, so retuning it can't silently skip the center pane.
- **A2:** the doubled `tabBarHeight = 1` (center + sidebar) is hoisted to one documented `common.TabBarHeight`.
- **A3:** the `ScrollView` + `NoteSyncViewportInteraction` pairing, open-coded ~8× in the sidebar, becomes `(*vterm.VTerm).ScrollViewAndNote(delta)` so the anchor bookkeeping can't be half-applied.
- **A4:** the `!= nil && MaxViewOffset() > 0` scrollback check reimplemented in each pane's `CanConsumeWheel` becomes the shared leaf `vterm.VTermHasScrollback`.

### Tier B — extraction
- **B1 — DONE:** the ~30-line drag-extend handler and its auto-scroll-tick twin (copied between `center/model_input_mouse.go` and `sidebar/terminal_selection.go`) become `common.DragSelect` + `common.SelectionScrollTickStep`. The only per-pane divergence — center's chat-history-aware scroll vs the sidebar's raw `ScrollView` — is passed as two closures (`scroll(delta)`, `screenYToAbs(y)`). Verified the clamp/`SetDirection`/edge-scroll `±1` sign/`ExtendSelection` sequence is byte-identical to both originals.
- **B2 — SKIPPED:** the dynamic tab-bar render/hit-test geometry extraction was intentionally left out — it's render code with off-by-one-prone close-button geometry and a poorer risk/reward; deferred rather than risk a render regression.

### Verification
- `make devcheck` — green (vet, full tests, harness-golden, lint **0 issues**, file-length).
- `make verify-loop` — green (selection/wheel input path intact end-to-end).
- New `common/selection_drag_test.go` and `vterm/vterm_scroll_test.go` cover `DragSelect`/`SelectionScrollTickStep` math (with fake closures) and `ScrollViewAndNote`/`VTermHasScrollback`.