### PR TITLE
refactor(data): inject a clock into WorkspaceStore for deterministic Created

### DIFF
--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/andyrewlee/amux/internal/fsatomic"
 
@@ -20,6 +21,10 @@ const workspaceFilename = "workspace.json"
 type WorkspaceStore struct {
 	root             string // ~/.amux/workspaces-metadata
 	defaultAssistant string
+	// now supplies the current time when stamping Created on freshly discovered
+	// workspaces. It defaults to time.Now and is overridable in tests so
+	// discovery timestamps can be asserted deterministically.
+	now func() time.Time
 }
 
 // NewWorkspaceStore creates a new workspace store
@@ -27,7 +32,17 @@ func NewWorkspaceStore(root string) *WorkspaceStore {
 	return &WorkspaceStore{
 		root:             root,
 		defaultAssistant: DefaultAssistant,
+		now:              time.Now,
 	}
+}
+
+// clock returns the store's current time, falling back to time.Now when the
+// store was built without the constructor (e.g. a zero-value literal).
+func (s *WorkspaceStore) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 // SetDefaultAssistant updates the assistant used when applying defaults while loading metadata.

--- a/internal/data/workspace_store_clock_test.go
+++ b/internal/data/workspace_store_clock_test.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWorkspaceStore_UpsertFromDiscovery_StampsCreatedFromInjectedClock verifies
+// the discovery "no stored record" path stamps Created from the store's
+// injectable clock rather than the wall clock, so the timestamp is assertable.
+func TestWorkspaceStore_UpsertFromDiscovery_StampsCreatedFromInjectedClock(t *testing.T) {
+	store := NewWorkspaceStore(t.TempDir())
+	fixed := time.Date(2021, 6, 21, 9, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+
+	discovered := &Workspace{
+		Name:   "fresh",
+		Branch: "feature",
+		Repo:   "/repo",
+		Root:   "/root/fresh",
+	}
+	if err := store.UpsertFromDiscovery(discovered); err != nil {
+		t.Fatalf("UpsertFromDiscovery() error = %v", err)
+	}
+
+	loaded, err := store.Load(discovered.ID())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !loaded.Created.Equal(fixed) {
+		t.Fatalf("Created = %v, want %v", loaded.Created, fixed)
+	}
+}
+
+// TestWorkspaceStore_ClockFallsBackToTimeNow guards the nil-clock path so a
+// zero-value or literal-constructed store doesn't panic.
+func TestWorkspaceStore_ClockFallsBackToTimeNow(t *testing.T) {
+	var s WorkspaceStore // no constructor: now is nil
+	if got := s.clock(); got.IsZero() {
+		t.Fatal("clock() with nil now should fall back to time.Now, got zero time")
+	}
+}

--- a/internal/data/workspace_store_discovery.go
+++ b/internal/data/workspace_store_discovery.go
@@ -30,7 +30,7 @@ func (s *WorkspaceStore) UpsertFromDiscovery(discovered *Workspace) error {
 
 	if stored == nil {
 		if discovered.Created.IsZero() {
-			discovered.Created = time.Now()
+			discovered.Created = s.clock()
 		}
 		s.applyWorkspaceDefaults(discovered)
 		return s.Save(discovered)
@@ -66,7 +66,7 @@ func (s *WorkspaceStore) mergeDiscoveryLocked(discovered *Workspace, storedID Wo
 			return err
 		}
 		if discovered.Created.IsZero() {
-			discovered.Created = time.Now()
+			discovered.Created = s.clock()
 		}
 		s.applyWorkspaceDefaults(discovered)
 		if discovered.ID() == storedID {


### PR DESCRIPTION
Workspace discovery stamped `Created` with a direct `time.Now()`, so the two "freshly discovered" paths in `UpsertFromDiscovery` couldn't be asserted in tests without tolerating the wall clock.

### Change
- Add an injectable `now func() time.Time` field to `WorkspaceStore` (defaulting to `time.Now` via `NewWorkspaceStore`) plus a nil-guarded `clock()` helper, and stamp `Created` through it. Mirrors the injected-`now` seam already used in `workspace_reload_guard.go`.

### Why it's safe
No production behavior change — the default clock is `time.Now`, and `clock()` falls back to `time.Now` for any zero-value/literal-constructed store. The real `WorkspaceStore` is only built via `NewWorkspaceStore`.

### Verification
- `make devcheck` — green (vet, full tests, harness-golden, lint **0 issues**, file-length).
- New tests: deterministic `Created` on the discovery path via an injected clock, and the nil-clock fallback.

### Note
This is the `WorkspaceStore` half of the audit's clock-injection finding. The `workspaceService` archival `ArchivedAt` sites (`internal/app`) are a separate, larger change left for a follow-up.