### PR TITLE
[codex] Stabilize scroll selection during streaming

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,10 @@ For the runtime detail of the app package — lifecycle, PTY flow, tmux activity
 tagging, and persistence invariants — see
 [internal/app/ARCHITECTURE.md](internal/app/ARCHITECTURE.md). For the message
 boundaries and command discipline between the app pump and the panes, see
-[internal/app/MESSAGE_FLOW.md](internal/app/MESSAGE_FLOW.md).
+[internal/app/MESSAGE_FLOW.md](internal/app/MESSAGE_FLOW.md). For the
+streaming/scrolling model — flush pipeline, DEC 2026 frame atomicity, viewport
+anchoring, and drag auto-scroll — see
+[internal/ui/center/SCROLLING.md](internal/ui/center/SCROLLING.md).
 
 ## Dependency direction
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ tmux-skip-check:
 	@skipped=$$(go test ./internal/tmux ./internal/e2e ./internal/app -v 2>/dev/null | awk '\
 		/^[[:space:]]+[^[:space:]]+\.go:[0-9]+:/ { reason=$$0 } \
 		/^--- SKIP:/ { \
-			if (reason !~ /cannot start PTY-backed tmux attach|client never attached|signal permissions restricted in this environment/) skipped++; \
+			if (reason !~ /cannot start PTY-backed tmux attach|client never attached|signal permissions restricted in this environment|tmux version does not emit DEC 2026 synchronized-output markers/) skipped++; \
 			reason=""; \
 		} \
 		END { print skipped + 0 }'); \

--- a/internal/e2e/drag_select_scroll_test.go
+++ b/internal/e2e/drag_select_scroll_test.go
@@ -1,0 +1,322 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/layout"
+)
+
+// These tests cover drag-selection edge auto-scroll in the center pane:
+// press inside the terminal, drag the pointer above the viewport, and the
+// view must scroll up into history — and keep scrolling while the button is
+// held — whether the agent is idle, streaming lines, or repainting whole
+// frames with 2J clears (the chat-agent pattern that churns scrollback
+// capture/dedup under the viewport anchor).
+
+// dragMotionInput returns an SGR mouse sequence for left-button drag motion at
+// the given absolute screen cell (0-based).
+func dragMotionInput(screenX, screenY int) string {
+	return fmt.Sprintf("\x1b[<32;%d;%dM", screenX+1, screenY+1)
+}
+
+func leftPressInput(screenX, screenY int) string {
+	return fmt.Sprintf("\x1b[<0;%d;%dM", screenX+1, screenY+1)
+}
+
+func leftReleaseInput(screenX, screenY int) string {
+	return fmt.Sprintf("\x1b[<0;%d;%dm", screenX+1, screenY+1)
+}
+
+// deepHistoryScript emits 80 numbered history lines (more than a screenful of
+// scrollback) once "go" is entered, then runs the given tail script.
+func deepHistoryScript(tail string) string {
+	return `#!/bin/sh
+printf 'REDRAW READY\r\n'
+IFS= read -r _
+i=0
+while [ $i -lt 80 ]; do
+  printf 'old-frame-%02d\r\n' "$i"
+  i=$((i+1))
+done
+` + tail
+}
+
+func writeAssistantScript(t *testing.T, home, name, script string) string {
+	t.Helper()
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+		t.Fatalf("write assistant script: %v", err)
+	}
+	return binDir
+}
+
+// dragScrollSession boots amux with the given fake assistant, opens an agent
+// tab, and triggers the assistant's output with "go". It returns the session,
+// the screen coordinates of a point inside the terminal content area, and the
+// session's HOME directory (for locating logs/traces).
+func dragScrollSession(t *testing.T, serverPrefix, script, readyNeedle string, env []string) (session *PTYSession, screenX, screenY int, home string) {
+	t.Helper()
+	server := fmt.Sprintf("%s-%d", serverPrefix, time.Now().UnixNano())
+	return dragScrollSessionOnServer(t, server, script, readyNeedle, env)
+}
+
+func dragScrollSessionOnServer(t *testing.T, server, script, readyNeedle string, env []string) (session *PTYSession, screenX, screenY int, home string) {
+	t.Helper()
+	skipIfNoGit(t)
+	requireRealTmux(t)
+
+	home = t.TempDir()
+	repo := initRepo(t)
+	writeRegistry(t, home, repo)
+	binDir := writeAssistantScript(t, home, "claude", script)
+
+	t.Cleanup(func() { killTmuxServer(t, server) })
+
+	session, cleanup, err := StartPTYSession(PTYOptions{
+		Home: home,
+		Env:  append(sessionEnv(binDir, server), env...),
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	waitForUIContains(t, session, filepath.Base(repo), closeLoopTimeout)
+	activatePrimaryWorkspace(t, session)
+	waitForUIContains(t, session, "[New agent]", closeLoopTimeout)
+	createAgentTab(t, session)
+	waitForUIContains(t, session, "REDRAW READY", closeLoopTimeout)
+
+	if err := session.SendString(centerPaneLeftClickInput(120, 30, 2, 3)); err != nil {
+		t.Fatalf("focus center pane by mouse: %v", err)
+	}
+	if err := session.SendString("go\r"); err != nil {
+		t.Fatalf("trigger assistant output: %v", err)
+	}
+	waitForUIContains(t, session, readyNeedle, closeLoopTimeout)
+
+	l := layout.NewManager()
+	l.Resize(120, 30)
+	centerStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX()
+	screenX = centerStartX + 2 + 4
+	screenY = l.TopGutter() + 2 + 6
+	return session, screenX, screenY, home
+}
+
+// dragAboveViewportAndHold starts a selection inside the terminal and drags
+// the pointer above the top edge without releasing.
+func dragAboveViewportAndHold(t *testing.T, session *PTYSession, screenX, screenY int) {
+	t.Helper()
+	if err := session.SendString(leftPressInput(screenX, screenY)); err != nil {
+		t.Fatalf("press: %v", err)
+	}
+	if err := session.SendString(dragMotionInput(screenX, screenY-2)); err != nil {
+		t.Fatalf("drag inside viewport: %v", err)
+	}
+	if err := session.SendString(dragMotionInput(screenX, 0)); err != nil {
+		t.Fatalf("drag above viewport: %v", err)
+	}
+}
+
+var scrollIndicatorRE = regexp.MustCompile(`SCROLL:\s+([0-9]+)/`)
+
+// waitForScrolledTo waits until the SCROLL indicator is visible and either
+// needle appears on screen or the viewport reaches minOffset lines into
+// history. CI can overshoot a specific sampled history line while the pointer
+// is held at the edge; the scroll offset still proves the tick loop kept
+// scrolling after the initial edge crossing.
+func waitForScrolledTo(t *testing.T, session *PTYSession, needle string, minOffset int, timeout time.Duration) {
+	t.Helper()
+	sawScroll := false
+	maxOffset := 0
+	deadline := time.Now().Add(timeout)
+	var lastScreen string
+	for time.Now().Before(deadline) {
+		lastScreen = session.ScreenASCII()
+		if strings.Contains(lastScreen, "SCROLL:") {
+			sawScroll = true
+			if m := scrollIndicatorRE.FindStringSubmatch(lastScreen); len(m) == 2 {
+				if offset, err := strconv.Atoi(m[1]); err == nil && offset > maxOffset {
+					maxOffset = offset
+				}
+			}
+		}
+		if sawScroll && strings.Contains(lastScreen, needle) {
+			return
+		}
+		if maxOffset >= minOffset {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !sawScroll {
+		t.Fatalf("drag above viewport never entered scrollback\n\nscreen:\n%s", lastScreen)
+	}
+	t.Fatalf("auto-scroll never reached %q or %d lines into history (max offset %d)\n\nscreen:\n%s",
+		needle, minOffset, maxOffset, lastScreen)
+}
+
+func TestDragSelectUpAutoScrollsIntoHistory(t *testing.T) {
+	script := deepHistoryScript(`sleep 0.1
+printf '\033[2J'
+for i in 00 01 02 03 04 05 06 07 08 09 10 11; do
+  printf 'new-frame-%s\r\n' "$i"
+done
+sleep 1000
+`)
+	session, screenX, screenY, _ := dragScrollSession(t, "amux-e2e-dragscroll", script, "new-frame-00", nil)
+
+	dragAboveViewportAndHold(t, session, screenX, screenY)
+	// The live view starts around old-frame-57 at the top; old-frame-30
+	// requires ~27 lines of continued tick-driven scrolling. tmux 3.2a may
+	// capture a smaller replayable history window in CI, so reaching 10+ lines is
+	// enough to prove repeated edge-scroll ticks after the initial crossing.
+	waitForScrolledTo(t, session, "old-frame-30", 10, 6*time.Second)
+	_ = session.SendString(leftReleaseInput(screenX, 0))
+}
+
+func TestDragSelectUpAutoScrollsWhileStreaming(t *testing.T) {
+	script := deepHistoryScript(`printf 'stream-begin\r\n'
+i=0
+while :; do
+  printf 'stream-%04d\r\n' "$i"
+  i=$((i+1))
+  sleep 0.05
+done
+`)
+	session, screenX, screenY, _ := dragScrollSession(t, "amux-e2e-dragstream", script, "stream-", nil)
+
+	dragAboveViewportAndHold(t, session, screenX, screenY)
+	waitForScrolledTo(t, session, "old-frame-30", 10, 6*time.Second)
+	_ = session.SendString(leftReleaseInput(screenX, 0))
+}
+
+func TestDragSelectUpAutoScrollsWhileRepainting(t *testing.T) {
+	script := deepHistoryScript(repaintLoop)
+	session, screenX, screenY, _ := dragScrollSession(t, "amux-e2e-dragrepaint", script, "spinner-", nil)
+
+	dragAboveViewportAndHold(t, session, screenX, screenY)
+	waitForScrolledTo(t, session, "old-frame-30", 10, 6*time.Second)
+	_ = session.SendString(leftReleaseInput(screenX, 0))
+}
+
+// repaintLoop mimics a coding agent's live status area: it repaints the whole
+// screen (cursor home + 2J + frame) every 100ms with a changing spinner. Each
+// 2J triggers CaptureNormalScreenOnClear, exercising the scrollback
+// capture/dedup churn under an anchored viewport.
+const repaintLoop = `n=0
+while :; do
+  printf '\033[H\033[2J'
+  j=0
+  while [ $j -lt 20 ]; do
+    printf 'transcript-line-%02d\r\n' "$j"
+    j=$((j+1))
+  done
+  printf 'spinner-%04d working...\r\n' "$n"
+  n=$((n+1))
+  sleep 0.1
+done
+`
+
+// TestTmuxDeliversSynchronizedOutputToClient verifies the anti-flicker
+// contract end to end: the terminal-features sync declaration in the session
+// bootstrap makes tmux wrap its redraws in DEC 2026 markers, which the PTY
+// trace observes as bytes delivered to amux's parser. Without the marker the
+// vterm renders mid-repaint flushes as torn frames.
+func TestTmuxDeliversSynchronizedOutputToClient(t *testing.T) {
+	skipIfNoTmux(t)
+	if !tmuxVersionSupportsSyncMarkers(t) {
+		t.Skip("tmux version does not emit DEC 2026 synchronized-output markers")
+	}
+	script := deepHistoryScript(repaintLoop)
+	server := fmt.Sprintf("amux-e2e-sync-%d", time.Now().UnixNano())
+	_, _, _, home := dragScrollSessionOnServer(t, server, script, "spinner-", []string{"AMUX_PTY_TRACE=1"})
+
+	if out, err := exec.Command("tmux", "-L", server, "show-options", "-s", "terminal-features").CombinedOutput(); err == nil {
+		t.Logf("server terminal-features:\n%s", out)
+	} else {
+		t.Logf("show-options failed: %v: %s", err, out)
+	}
+	if out, err := exec.Command("tmux", "-L", server, "list-clients", "-F", "#{client_name} termfeatures=#{client_termfeatures} termtype=#{client_termtype}").CombinedOutput(); err == nil {
+		t.Logf("clients:\n%s", out)
+	} else {
+		t.Logf("list-clients failed: %v: %s", err, out)
+	}
+
+	// The trace lands under <home>/.amux/logs as hex.Dump chunks; poll for a
+	// sync-begin marker in the decoded bytes while repaints stream through.
+	logDir := filepath.Join(home, ".amux", "logs")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(logDir)
+		if err == nil {
+			for _, e := range entries {
+				if !strings.HasPrefix(e.Name(), "amux-pty-claude-") {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(logDir, e.Name()))
+				if err != nil {
+					continue
+				}
+				if strings.Contains(decodeTraceDump(string(data)), "\x1b[?2026h") {
+					return
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("no DEC 2026 sync-begin found in PTY traces under %s; tmux is not wrapping redraws in synchronized output", logDir)
+}
+
+func tmuxVersionSupportsSyncMarkers(t *testing.T) bool {
+	t.Helper()
+	out, err := exec.Command("tmux", "-V").CombinedOutput()
+	if err != nil {
+		t.Fatalf("tmux -V failed: %v: %s", err, out)
+	}
+	m := regexp.MustCompile(`tmux\s+([0-9]+)\.([0-9]+)`).FindStringSubmatch(string(out))
+	if len(m) != 3 {
+		t.Fatalf("could not parse tmux version from %q", strings.TrimSpace(string(out)))
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	return major > 3 || (major == 3 && minor >= 3)
+}
+
+// decodeTraceDump reassembles the raw bytes from a PTY trace file, whose data
+// lines are encoding/hex.Dump output (offset, spaced hex groups, ASCII column)
+// interleaved with RECV/SEND chunk headers.
+func decodeTraceDump(trace string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(trace, "\n") {
+		// hex.Dump line: "00000000  1b 5b 3f 32 30 32 36 68  ...  |.[?2026h...|"
+		if len(line) < 10 || strings.IndexByte(line, '|') < 0 {
+			continue
+		}
+		hexCols := line[10:]
+		if bar := strings.IndexByte(hexCols, '|'); bar >= 0 {
+			hexCols = hexCols[:bar]
+		}
+		for _, tok := range strings.Fields(hexCols) {
+			if len(tok) != 2 {
+				continue
+			}
+			var b byte
+			if _, err := fmt.Sscanf(tok, "%02x", &b); err == nil {
+				out.WriteByte(b)
+			}
+		}
+	}
+	return out.String()
+}

--- a/internal/e2e/helpers.go
+++ b/internal/e2e/helpers.go
@@ -99,14 +99,17 @@ func waitForAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration
 	return sessions
 }
 
-// waitForNoAgentSessions polls until no @amux agent sessions remain, proving the
-// deleted workspace's agent pane was actually torn down through the real handler.
-func waitForNoAgentSessions(t *testing.T, opts tmux.Options, timeout time.Duration) {
+func waitForNoAgentSessionsForWorkspace(t *testing.T, opts tmux.Options, wsID string, timeout time.Duration) {
 	t.Helper()
+	tags := map[string]string{
+		"@amux":           "1",
+		"@amux_type":      "agent",
+		"@amux_workspace": wsID,
+	}
 	testutil.Eventually(t, timeout, sessionPollInterval, func() bool {
-		sessions, err := tmux.ListSessionsMatchingTags(agentSessionTags, opts)
+		sessions, err := tmux.ListSessionsMatchingTags(tags, opts)
 		return err == nil && len(sessions) == 0
-	}, "timeout waiting for agent sessions to be torn down\n%s", lazyString(func() string { return tmuxSessionDebug(opts) }))
+	}, "timeout waiting for agent sessions for workspace %s to be torn down\n%s", wsID, lazyString(func() string { return tmuxSessionDebug(opts) }))
 }
 
 func waitForTerminalSessionCount(t *testing.T, opts tmux.Options, wsID string, count int, timeout time.Duration) {

--- a/internal/e2e/workspace_agent_test.go
+++ b/internal/e2e/workspace_agent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
@@ -59,6 +60,8 @@ func TestWorkspaceDeleteTearsDownAgent(t *testing.T) {
 	binDir := writeStubAssistant(t, home, "claude")
 	server := fmt.Sprintf("amux-e2e-%d", time.Now().UnixNano())
 	defer killTmuxServer(t, server)
+	workspaceRoot := filepath.Join(home, ".amux", "workspaces", filepath.Base(repo), "feature")
+	workspaceID := string(data.NewWorkspace("feature", "feature", "main", repo, workspaceRoot).ID())
 
 	env := sessionEnv(binDir, server)
 	env = append(env, "AMUX_TMUX_SYNC_INTERVAL=1s")
@@ -85,6 +88,6 @@ func TestWorkspaceDeleteTearsDownAgent(t *testing.T) {
 
 	// The agent's tmux session must be torn down and the workspace must leave the
 	// dashboard (which also removes its agent tab from view).
-	waitForNoAgentSessions(t, opts, workspaceAgentTimeout)
+	waitForNoAgentSessionsForWorkspace(t, opts, workspaceID, workspaceAgentTimeout)
 	waitForUIConsistentlyAbsent(t, session, "feature", workspaceAgentTimeout, 3*time.Second)
 }

--- a/internal/tmux/command.go
+++ b/internal/tmux/command.go
@@ -35,13 +35,17 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 	command = "unset TMUX TMUX_PANE; " + command
 	cmd := shellQuote(command)
 
-	// Use atomic new-session -A to create/attach. Only pass -d when detaching others.
-	detachFlag := ""
-	if detachExisting {
-		detachFlag = "d"
-	}
-	create := fmt.Sprintf("%s new-session -A%ss %s -c %s sh -lc %s",
-		base, detachFlag, session, dir, cmd)
+	// Ensure the session/server exists without attaching yet. tmux computes
+	// client features at attach time, so the server option below must be set
+	// while the server is alive but before the final attach command.
+	ensureSession := fmt.Sprintf("(%s has-session -t %s 2>/dev/null || %s new-session -ds %s -c %s sh -lc %s || %s has-session -t %s 2>/dev/null)",
+		base, sessionTgt, base, session, dir, cmd, base, sessionTgt)
+
+	// Advertise DEC 2026 synchronized-output support before attaching. The
+	// indexed slot keeps repeated session creates idempotent on amux's
+	// dedicated server; the pattern matches the TERM amux sets for attach PTYs.
+	// Swallowed on tmux < 3.2 (no terminal-features).
+	syncFeatureSet := "(" + base + " set-option -s 'terminal-features[16]' 'xterm*:sync' 2>/dev/null || true)"
 
 	var settings strings.Builder
 	// Disable tmux prefix for this session only (not global) to make it transparent
@@ -67,7 +71,7 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 	}
 	attach := fmt.Sprintf("%s attach %s %s", base, attachFlag, sessionTgt)
 
-	return fmt.Sprintf("%s && %s%s", create, settings.String(), attach)
+	return fmt.Sprintf("%s && %s && %s%s", ensureSession, syncFeatureSet, settings.String(), attach)
 }
 
 func appendSessionTags(settings *strings.Builder, base, session string, tags SessionTags) {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -143,9 +143,16 @@ func TestNewClientCommand(t *testing.T) {
 		DetachExisting: true,
 	})
 
-	// Should use atomic new-session -Ad
-	if !strings.Contains(cmd, "new-session -Ads") {
-		t.Error("Command should use atomic new-session -Ads")
+	// Should create detached before the final attach so server options can be
+	// set before tmux computes client features.
+	if !strings.Contains(cmd, "has-session -t '=test-session'") {
+		t.Error("Command should check for an existing session")
+	}
+	if strings.Count(cmd, "has-session -t '=test-session'") < 2 {
+		t.Error("Command should retry has-session after detached create races")
+	}
+	if !strings.Contains(cmd, "new-session -ds") {
+		t.Error("Command should create the session detached before attaching")
 	}
 
 	// Should disable prefix per-session (not globally) with exact-match target
@@ -160,11 +167,6 @@ func TestNewClientCommand(t *testing.T) {
 	if !strings.Contains(cmd, "attach -dt") {
 		t.Error("Command should use attach -dt to detach other clients")
 	}
-	// Should use new-session -Ad when detaching
-	if !strings.Contains(cmd, "new-session -Ads") {
-		t.Error("Command should use new-session -Ads when detaching")
-	}
-
 	// Should use && not ; for chaining
 	if !strings.Contains(cmd, " && ") {
 		t.Error("Command should chain with && not ;")
@@ -177,6 +179,25 @@ func TestNewClientCommand(t *testing.T) {
 	// Should run pane command via sh -lc
 	if !strings.Contains(cmd, "sh -lc 'unset TMUX TMUX_PANE; echo hello'") {
 		t.Error("Command should run pane command via sh -lc with tmux env sanitized")
+	}
+
+	// Should advertise DEC 2026 sync support before attaching so tmux wraps
+	// redraws in sync markers (prevents partial-frame flicker in the vterm).
+	syncSet := "set-option -s 'terminal-features[16]' 'xterm*:sync'"
+	syncIdx := strings.Index(cmd, syncSet)
+	createIdx := strings.Index(cmd, "new-session -ds")
+	attachIdx := strings.Index(cmd, "attach -dt")
+	if syncIdx < 0 {
+		t.Error("Command should set the sync terminal-feature")
+	}
+	if !strings.Contains(cmd, "|| true) &&") {
+		t.Error("sync terminal-feature fallback should be grouped before continuing")
+	}
+	if createIdx >= 0 && syncIdx < createIdx {
+		t.Error("sync terminal-feature should be set after detached session create keeps the server alive")
+	}
+	if attachIdx >= 0 && syncIdx > attachIdx {
+		t.Error("sync terminal-feature must be set before attach (features are computed at attach time)")
 	}
 }
 
@@ -273,11 +294,21 @@ func TestNewClientCommandSharedAttach(t *testing.T) {
 	if !strings.Contains(cmd, "attach -t") {
 		t.Error("Command should attach without detaching other clients")
 	}
-	if strings.Contains(cmd, "new-session -Ads") {
-		t.Error("Command should not detach on new-session when detachExisting=false")
+	if !strings.Contains(cmd, "new-session -ds") {
+		t.Error("Command should create detached before shared attach")
 	}
-	if !strings.Contains(cmd, "new-session -As") {
-		t.Error("Command should use new-session -As when detachExisting=false")
+	syncSet := "set-option -s 'terminal-features[16]' 'xterm*:sync'"
+	syncIdx := strings.Index(cmd, syncSet)
+	createIdx := strings.Index(cmd, "new-session -ds")
+	attachIdx := strings.Index(cmd, "attach -t")
+	if syncIdx < 0 {
+		t.Error("Command should set the sync terminal-feature")
+	}
+	if createIdx >= 0 && syncIdx < createIdx {
+		t.Error("sync terminal-feature should be set after detached create keeps the server alive")
+	}
+	if attachIdx >= 0 && syncIdx > attachIdx {
+		t.Error("sync terminal-feature must be set before shared attach")
 	}
 }
 

--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -1,0 +1,125 @@
+# Streaming and scrolling
+
+This document is the map for the two most regression-prone behaviors in the
+center pane: how streamed agent output becomes rendered frames, and how the
+user's scroll/selection state survives that stream. Read it before touching
+`model_scrolled_history.go`, `model_input_mouse.go`, `tab_actor*.go`,
+`internal/ui/ptyio`, or `internal/vterm`'s scroll/sync/capture code.
+
+## The pipeline: PTY bytes → rendered frame
+
+```
+tmux client PTY
+  → ptyio.RunPTYReader        coalesce reads (size + FrameInterval ticker)
+  → ptyio.ForwardPTYMsgs      merge consecutive PTYOutput msgs per tab
+  → center Update(PTYOutput)  append to tab.PendingOutput, debounce PTYFlush
+  → Update(PTYFlush)          quiet-period defer, take a bounded chunk
+  → tab actor (WriteOutput)   noise filter → vterm.Write (parse)
+  → TerminalLayerWithCursorOwner   version-keyed snapshot cache
+  → compositor VTermLayer     cell diffing happens below, in ultraviolet
+```
+
+Every hop coalesces or throttles; none of them may reorder or drop output
+bytes (`tabEventWriteOutput` is never shed — see the invariants in
+`tab_actor.go`).
+
+### Frame atomicity (why agents don't flicker)
+
+A flush can land mid-repaint: the parser may have consumed a `2J` clear but
+not yet the repaint that follows, and rendering that state shows a torn or
+blank frame. Two mechanisms prevent that:
+
+1. The session bootstrap (`internal/tmux/command.go`) advertises the `sync`
+   terminal feature for amux's client TERM before attaching, so tmux wraps
+   each redraw in DEC 2026 markers (`ESC[?2026h` … `ESC[?2026l`).
+2. `internal/vterm` freezes `RenderBuffers()` at the sync-begin snapshot until
+   sync-end. Bytes parsed inside the window mutate the live buffers (and mark
+   lines dirty) but are never rendered mid-frame.
+
+Sync-end deliberately does **not** invalidate the render cache: dirty marks
+accumulated during the window are preserved because frozen renders skip
+`ClearDirty` (`liveRenderCacheActive()` is false), so a synced one-line append
+still repaints one line, not the whole screen.
+
+A sync-begin whose end never arrives (writer died, output trimmed under
+overflow) is force-released after `vterm.SyncStallTimeout`, checked on both
+`Write` and `RenderBuffers`, so the UI can freeze for at most that long.
+`LoadPaneCapture*` also clears sync state on restore.
+
+The e2e contract test is `TestTmuxDeliversSynchronizedOutputToClient`.
+
+## Scroll state model
+
+There is exactly one scroll offset: `vterm.ViewOffset`, per tab, measured in
+lines up from the live view (`0` = live). Everything else is derived.
+
+- Clamping: `ViewOffset` is clamped to the scrollback length of the *current
+  render buffers* (frozen during sync).
+- **Anchoring**: when output pushes lines into scrollback while the user is
+  scrolled (`ViewOffset > 0`), `anchorViewOffsetForAddedLines` grows the
+  offset so the same content stays on screen. Scrollback shrinkage (capture
+  dedup, trim) adjusts it back. During sync the delta accrues in
+  `syncViewOffsetDelta` and is applied at sync-end only if the user interacted
+  with the viewport (`NoteSyncViewportInteraction`).
+- Scrollback is capped at `vterm.MaxScrollback`; trimming shifts selection
+  anchors (`shiftSelectionAfterTrim`) but not `ViewOffset` (it is measured
+  from the bottom).
+
+### Chat tabs: the history-only view
+
+Chat agents (Claude-style) repaint their whole screen every frame, so their
+scrollback is a series of captured previous frames (`CaptureNormalScreenOnClear`
+capture on `2J`, deduplicated in `alt_screen_capture*.go`). Concatenating
+scrollback + live screen would show the live prompt box in the middle of
+history, so for chat tabs a scrolled viewport (`ViewOffset > 0`) renders a
+**scrollback-only** window (`applyScrolledChatHistoryViewLocked`):
+
+- window start = `scrollbackLen - height - effectiveOffset + 1`
+- max offset = `scrollbackLen - height + 1` (a *different* max than the
+  vterm's own clamp — `clampScrolledChatHistoryViewOffsetLocked` reconciles
+  the two around every scroll; keep using `scrollTerminalViewLocked` rather
+  than calling `Terminal.ScrollView` directly)
+- screen-Y ↔ absolute-line mapping goes through
+  `displayedScreenYToAbsoluteLineLocked`, which picks the chat mapping or the
+  native vterm mapping.
+
+Invariant (pinned by `TestChatTab_DragUpAutoScroll_AnchorStableWhileStreaming`):
+while an agent repaints and scrollback churns through capture/dedup, an
+anchored chat view must not move except by explicit scroll steps.
+
+## Gestures: one implementation per gesture
+
+All selection/scroll gestures are implemented once, as tab-actor handlers
+(`tab_actor_selection.go`, `tab_actor.go`), and every entry point routes
+through `dispatchOrHandleTabEvent`: actor queue when available, synchronous
+`handleTabEvent` on the caller's goroutine otherwise. Both routes serialize on
+`tab.mu`. Do not re-introduce inline fallback copies of gesture logic in
+`Update` — that dual-path duplication was the primary source of drift bugs.
+
+Follow-up work flows back through `msgSink` messages (`selectionTickRequest`,
+`tabSelectionResult`, `PTYCursorRefresh`), never as return values from the
+actor.
+
+### Drag-selection auto-scroll
+
+Dragging past the viewport edge starts a 100ms tick chain
+(`common.SelectionScrollState`): each tick scrolls one line and extends the
+selection to the exposed edge. The chain's messages traverse bounded queues
+that may shed load (`shouldDropTabEvent`, the external message queue), so the
+chain is **self-healing by design**: every drag-motion event restarts it with
+the current expected tick sequence (`NeedsTick`), and `HandleTick` ignores
+stale generations or duplicate sequences without stopping the current chain.
+A lost tick therefore pauses auto-scroll only until the next mouse motion. Do
+not "optimize" `NeedsTick` back to start-only-when-not-active; that turns any
+dropped message into a dead auto-scroll for the rest of the drag.
+
+E2E coverage: `internal/e2e/drag_select_scroll_test.go` drives real SGR mouse
+input through the real binary against idle, streaming, and repainting agents.
+
+## Where to add tests
+
+- vterm scroll/sync/capture semantics → `internal/vterm` unit tests.
+- chat-view math, gesture handlers → `internal/ui/center` (drive
+  `handleTabEvent` directly, or `Update` for entry-point wiring).
+- anything involving real tmux framing, mouse input, or attach/restore →
+  `internal/e2e` (unit-level fakes cannot reproduce tmux's redraw framing).

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -2,7 +2,9 @@
 // strip, per-tab PTY I/O and flushing, the diff viewer, and mouse/keyboard
 // text selection. It is the largest UI subsystem; tab work is serialized
 // through a per-model actor (see tab_actor.go) and output is parsed by
-// internal/vterm.
+// internal/vterm. For the streaming/scrolling model (flush pipeline, DEC 2026
+// frame atomicity, viewport anchoring, chat history view, drag auto-scroll)
+// see SCROLLING.md in this package.
 package center
 
 import (

--- a/internal/ui/center/model_input_keys.go
+++ b/internal/ui/center/model_input_keys.go
@@ -40,24 +40,13 @@ func (m *Model) handleCopyKey(msg tea.KeyPressMsg, tabs []*Tab, activeIdx int) (
 		return m, nil, false
 	}
 	tab := tabs[activeIdx]
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSelectionCopy,
-			notifyCopy:  true,
-		}) {
-			return m, nil, true
-		}
-	}
-	tab.mu.Lock()
-	text := ""
-	if tab.Terminal != nil && tab.Terminal.HasSelection() {
-		text = tab.Terminal.SelectedText()
-	}
-	tab.mu.Unlock()
-	common.CopyToClipboardWithLog(text, "Cmd+C clipboard")
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSelectionCopy,
+		notifyCopy:  true,
+	})
 	return m, nil, true
 }
 
@@ -66,24 +55,12 @@ func (m *Model) clearSelectionOnType(tabs []*Tab, activeIdx int) {
 		return
 	}
 	tab := tabs[activeIdx]
-	sent := false
-	if m.isTabActorReady() {
-		sent = m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSelectionClear,
-		})
-	}
-	if !sent {
-		tab.mu.Lock()
-		if tab.Terminal != nil {
-			tab.Terminal.ClearSelection()
-		}
-		tab.Selection = common.SelectionState{}
-		tab.selectionScroll.Reset()
-		tab.mu.Unlock()
-	}
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSelectionClear,
+	})
 }
 
 func (m *Model) forwardKeyToActiveTab(msg tea.KeyPressMsg, tab *Tab) (*Model, tea.Cmd) {
@@ -202,41 +179,23 @@ func (m *Model) scrollTerminalPage(tab *Tab, scrollPage int) *Model {
 	if tab == nil || scrollPage == 0 {
 		return m
 	}
-	if m.isTabActorReady() && m.sendTabEvent(tabEvent{
+	m.dispatchOrHandleTabEvent(tabEvent{
 		tab:         tab,
 		workspaceID: m.workspaceID(),
 		tabID:       tab.ID,
 		kind:        tabEventScrollPage,
 		scrollPage:  scrollPage,
-	}) {
-		return m
-	}
-	tab.mu.Lock()
-	if tab.Terminal != nil {
-		delta := common.ScrollDeltaForHeight(tab.Terminal.Height, 4)
-		m.scrollTerminalViewLocked(tab, delta*scrollPage)
-	}
-	tab.mu.Unlock()
+	})
 	return m
 }
 
 func (m *Model) scrollToBottomOnType(tab *Tab) {
-	sent := false
-	if m.isTabActorReady() {
-		sent = m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventScrollToBottom,
-		})
-	}
-	if !sent {
-		tab.mu.Lock()
-		if tab.Terminal != nil && tab.Terminal.IsScrolled() {
-			m.scrollTerminalToBottomLocked(tab)
-		}
-		tab.mu.Unlock()
-	}
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventScrollToBottom,
+	})
 }
 
 func (m *Model) sendKeyToTerminal(msg tea.KeyPressMsg, tab *Tab) (*Model, tea.Cmd) {

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -248,7 +248,7 @@ func (m *Model) updateTabSelectionResult(msg tabSelectionResult) (*Model, tea.Cm
 // updateSelectionTickRequest handles selectionTickRequest.
 func (m *Model) updateSelectionTickRequest(msg selectionTickRequest) (*Model, tea.Cmd) {
 	cmd := common.SafeTick(100*time.Millisecond, func(time.Time) tea.Msg {
-		return selectionScrollTick{WorkspaceID: msg.workspaceID, TabID: msg.tabID, Gen: msg.gen}
+		return selectionScrollTick{WorkspaceID: msg.workspaceID, TabID: msg.tabID, Gen: msg.gen, Seq: msg.seq}
 	})
 	return m, cmd
 }

--- a/internal/ui/center/model_input_lifecycle_handlers_misc_test.go
+++ b/internal/ui/center/model_input_lifecycle_handlers_misc_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/diff"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -86,6 +87,27 @@ func TestUpdateOpenDiff_CreatesDiffTab(t *testing.T) {
 	}
 	if m.tabs.ActiveByWorkspace[wsID] != 0 {
 		t.Fatalf("expected the new diff tab to become active, got %d", m.tabs.ActiveByWorkspace[wsID])
+	}
+}
+
+func TestDispatchDiffInputFallbackReturnsCommand(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	m.SetWorkspace(ws)
+	dv := diff.New(ws, &git.Change{Path: "pkg/foo.go", Kind: git.ChangeModified}, git.DiffModeUnstaged, 80, 24)
+	dv.SetFocused(true)
+	tab := &Tab{ID: TabID("diff-tab"), Workspace: ws, Assistant: "diff", DiffViewer: dv}
+
+	handled, cmd := m.dispatchDiffInput(tab, tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if !handled {
+		t.Fatal("expected diff input to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected fallback diff input to return close command")
+	}
+	msg := cmd()
+	if _, ok := msg.(messages.CloseTab); !ok {
+		t.Fatalf("expected CloseTab command, got %T", msg)
 	}
 }
 

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -2,7 +2,6 @@ package center
 
 import (
 	"fmt"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -11,10 +10,28 @@ import (
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
+// Mouse gestures route through the tab actor via dispatchOrHandleTabEvent:
+// there is exactly one implementation of each gesture (the handlers in
+// tab_actor_selection.go / tab_actor.go), whether the actor accepts the event
+// or the fallback runs it synchronously. Redraws and follow-up commands
+// (selection-scroll ticks, clipboard results) come back through msgSink.
+
+// activeMouseTab returns the tab that should receive mouse input, or nil when
+// the pane is unfocused, has no active agent, or the index is stale.
+func (m *Model) activeMouseTab() *Tab {
+	if !m.focused || !m.hasActiveAgent() {
+		return nil
+	}
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if activeIdx >= len(tabs) {
+		return nil
+	}
+	return tabs[activeIdx]
+}
+
 // updateMouseClick handles tea.MouseClickMsg in the Update switch.
 func (m *Model) updateMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
-	var cmds []tea.Cmd
-
 	// Handle tab bar clicks (e.g., the plus button) even without an active agent.
 	if msg.Button == tea.MouseLeft {
 		if cmd := m.handleTabBarClick(msg); cmd != nil {
@@ -22,191 +39,88 @@ func (m *Model) updateMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 		}
 	}
 
-	// Handle mouse events for text selection
-	if !m.focused || !m.hasActiveAgent() {
+	tab := m.activeMouseTab()
+	if tab == nil {
 		return m, nil
 	}
-
-	tabs := m.getTabs()
-	activeIdx := m.getActiveTabIdx()
-	if activeIdx >= len(tabs) {
-		return m, nil
-	}
-	tab := tabs[activeIdx]
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
-
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
 
-	// Convert screen coordinates to terminal coordinates
 	termX, termY, inBounds := m.screenToTerminal(msg.X, msg.Y)
-
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSelectionStart,
-			termX:       termX,
-			termY:       termY,
-			inBounds:    inBounds,
-		}) {
-			return m, common.SafeBatch(cmds...)
-		}
-	}
-	tab.mu.Lock()
-	if tab.Terminal != nil {
-		tab.Terminal.ClearSelection()
-	}
-	tab.Selection = common.SelectionState{}
-	tab.selectionScroll.Reset()
-	if inBounds && tab.Terminal != nil {
-		absLine, ok := m.displayedScreenYToAbsoluteLineLocked(tab, termY)
-		if !ok {
-			tab.mu.Unlock()
-			return m, common.SafeBatch(cmds...)
-		}
-		tab.Selection = common.SelectionState{
-			Active:    true,
-			StartX:    termX,
-			StartLine: absLine,
-			EndX:      termX,
-			EndLine:   absLine,
-		}
-		tab.Terminal.SetSelection(termX, absLine, termX, absLine, true, false)
-	}
-	tab.mu.Unlock()
-	return m, common.SafeBatch(cmds...)
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSelectionStart,
+		termX:       termX,
+		termY:       termY,
+		inBounds:    inBounds,
+	})
+	return m, nil
 }
 
 // updateMouseMotion handles tea.MouseMotionMsg in the Update switch.
 func (m *Model) updateMouseMotion(msg tea.MouseMotionMsg) (*Model, tea.Cmd) {
-	var cmds []tea.Cmd
-
-	// Handle mouse drag events for text selection
-	if !m.focused || !m.hasActiveAgent() {
-		return m, nil
-	}
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
-	tabs := m.getTabs()
-	activeIdx := m.getActiveTabIdx()
-	if activeIdx >= len(tabs) {
+	tab := m.activeMouseTab()
+	if tab == nil {
 		return m, nil
 	}
-	tab := tabs[activeIdx]
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
 
 	termX, termY, _ := m.screenToTerminal(msg.X, msg.Y)
-
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSelectionUpdate,
-			termX:       termX,
-			termY:       termY,
-		}) {
-			return m, common.SafeBatch(cmds...)
-		}
-	}
-	tab.mu.Lock()
-	if tab.Selection.Active && tab.Terminal != nil {
-		needTick, gen := common.DragSelect(
-			tab.Terminal,
-			&tab.Selection,
-			&tab.selectionScroll,
-			termX, termY, tab.Terminal.Width, tab.Terminal.Height,
-			&tab.selectionLastTermX,
-			func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
-			func(screenY int) int {
-				absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
-				return absLine
-			},
-		)
-		if needTick {
-			wsID := m.workspaceID()
-			tabID := tab.ID
-			cmds = append(cmds, common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
-				return selectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
-			}))
-		}
-	}
-	tab.mu.Unlock()
-	return m, common.SafeBatch(cmds...)
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSelectionUpdate,
+		termX:       termX,
+		termY:       termY,
+	})
+	return m, nil
 }
 
 // updateMouseRelease handles tea.MouseReleaseMsg in the Update switch.
 func (m *Model) updateMouseRelease(msg tea.MouseReleaseMsg) (*Model, tea.Cmd) {
-	var cmds []tea.Cmd
-
-	// Handle mouse release events for text selection
-	if !m.focused || !m.hasActiveAgent() {
-		return m, nil
-	}
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
-	tabs := m.getTabs()
-	activeIdx := m.getActiveTabIdx()
-	if activeIdx >= len(tabs) {
+	tab := m.activeMouseTab()
+	if tab == nil {
 		return m, nil
 	}
-	tab := tabs[activeIdx]
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
 
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSelectionFinish,
-		}) {
-			return m, common.SafeBatch(cmds...)
-		}
-	}
-	tab.mu.Lock()
-	text := ""
-	if tab.Selection.Active {
-		if tab.Terminal != nil &&
-			(tab.Selection.StartX != tab.Selection.EndX ||
-				tab.Selection.StartLine != tab.Selection.EndLine) {
-			text = tab.Terminal.SelectedText()
-		}
-		tab.Selection.Active = false
-		tab.selectionScroll.Reset()
-	}
-	tab.mu.Unlock()
-	common.CopyToClipboardWithLog(text, "clipboard")
-	return m, common.SafeBatch(cmds...)
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSelectionFinish,
+	})
+	return m, nil
 }
 
 // updateMouseWheel handles tea.MouseWheelMsg in the Update switch.
 func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
-	if !m.focused || !m.hasActiveAgent() {
+	tab := m.activeMouseTab()
+	if tab == nil {
 		return m, nil
 	}
-
-	tabs := m.getTabs()
-	activeIdx := m.getActiveTabIdx()
-	if activeIdx >= len(tabs) {
-		return m, nil
-	}
-	tab := tabs[activeIdx]
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
-	if model, cmd, handled := m.forwardMouseWheelToTerminal(msg, tab); handled {
-		return model, cmd
+	if m.forwardMouseWheelToTerminal(msg, tab) {
+		return m, nil
 	}
 
 	delta := 0
@@ -215,50 +129,36 @@ func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 		delta = common.ScrollDeltaForHeight(tab.Terminal.Height, 8)
 	}
 	tab.mu.Unlock()
-	if delta > 0 {
-		if m.isTabActorReady() {
-			sent := false
-			if msg.Button == tea.MouseWheelUp {
-				sent = m.sendTabEvent(tabEvent{
-					tab:         tab,
-					workspaceID: m.workspaceID(),
-					tabID:       tab.ID,
-					kind:        tabEventScrollBy,
-					delta:       delta,
-				})
-			} else if msg.Button == tea.MouseWheelDown {
-				sent = m.sendTabEvent(tabEvent{
-					tab:         tab,
-					workspaceID: m.workspaceID(),
-					tabID:       tab.ID,
-					kind:        tabEventScrollBy,
-					delta:       -delta,
-				})
-			}
-			if sent {
-				return m, nil
-			}
-		}
-		tab.mu.Lock()
-		if tab.Terminal != nil {
-			if msg.Button == tea.MouseWheelUp {
-				m.scrollTerminalViewLocked(tab, delta)
-			} else if msg.Button == tea.MouseWheelDown {
-				m.scrollTerminalViewLocked(tab, -delta)
-			}
-		}
-		tab.mu.Unlock()
+	if delta == 0 {
+		return m, nil
 	}
+	switch msg.Button {
+	case tea.MouseWheelUp:
+	case tea.MouseWheelDown:
+		delta = -delta
+	default:
+		return m, nil
+	}
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventScrollBy,
+		delta:       delta,
+	})
 	return m, nil
 }
 
-func (m *Model) forwardMouseWheelToTerminal(msg tea.MouseWheelMsg, tab *Tab) (*Model, tea.Cmd, bool) {
+// forwardMouseWheelToTerminal forwards a wheel event to the hosted terminal
+// when the agent has mouse reporting enabled and the pointer is inside the
+// content area. Returns true when the event was consumed.
+func (m *Model) forwardMouseWheelToTerminal(msg tea.MouseWheelMsg, tab *Tab) bool {
 	if tab == nil {
-		return m, nil, false
+		return false
 	}
 	termX, termY, inBounds := m.screenToTerminal(msg.X, msg.Y)
 	if !inBounds {
-		return m, nil, false
+		return false
 	}
 
 	input := ""
@@ -268,22 +168,17 @@ func (m *Model) forwardMouseWheelToTerminal(msg tea.MouseWheelMsg, tab *Tab) (*M
 	}
 	tab.mu.Unlock()
 	if input == "" {
-		return m, nil, false
+		return false
 	}
 
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventSendMouse,
-			input:       []byte(input),
-		}) {
-			return m, nil, true
-		}
-	}
-	model, sent, cmd := m.directSendToTerminal(tab, input, "Mouse wheel")
-	return model, cmd, sent || cmd != nil
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventSendMouse,
+		input:       []byte(input),
+	})
+	return true
 }
 
 func mouseWheelInputSequence(term *vterm.VTerm, button tea.MouseButton, termX, termY int) string {
@@ -328,69 +223,32 @@ func (m *Model) dispatchDiffInput(tab *Tab, msg tea.Msg) (bool, tea.Cmd) {
 	if dv == nil {
 		return false, nil
 	}
-	if m.isTabActorReady() {
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: m.workspaceID(),
-			tabID:       tab.ID,
-			kind:        tabEventDiffInput,
-			diffMsg:     msg,
-		}) {
-			return true, nil
-		}
+	ev := tabEvent{
+		tab:         tab,
+		workspaceID: m.workspaceID(),
+		tabID:       tab.ID,
+		kind:        tabEventDiffInput,
+		diffMsg:     msg,
 	}
-	newDV, cmd := dv.Update(msg)
-	tab.mu.Lock()
-	tab.DiffViewer = newDV
-	tab.mu.Unlock()
-	return true, cmd
+	if m.isTabActorReady() && m.sendTabEvent(ev) {
+		return true, nil
+	}
+	return true, m.updateDiffViewer(tab, msg)
 }
 
 // updateSelectionScrollTick handles selectionScrollTick.
 func (m *Model) updateSelectionScrollTick(msg selectionScrollTick) tea.Cmd {
-	var cmds []tea.Cmd
-	if m.isTabActorReady() {
-		tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
-		if tab == nil {
-			return nil
-		}
-		if m.sendTabEvent(tabEvent{
-			tab:         tab,
-			workspaceID: msg.WorkspaceID,
-			tabID:       msg.TabID,
-			kind:        tabEventSelectionScrollTick,
-			gen:         msg.Gen,
-		}) {
-			return nil
-		}
-	}
 	tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
 	if tab == nil {
 		return nil
 	}
-	tab.mu.Lock()
-	if !tab.Selection.Active || tab.Terminal == nil || !tab.selectionScroll.HandleTick(msg.Gen) {
-		tab.mu.Unlock()
-		return nil
-	}
-	common.SelectionScrollTickStep(
-		tab.Terminal,
-		&tab.Selection,
-		&tab.selectionScroll,
-		tab.Terminal.Height,
-		tab.selectionLastTermX,
-		func(delta int) { m.scrollTerminalViewLocked(tab, delta) },
-		func(screenY int) int {
-			absLine, _ := m.displayedScreenYToAbsoluteLineLocked(tab, screenY)
-			return absLine
-		},
-	)
-
-	tab.mu.Unlock()
-	tabID := msg.TabID
-	wtID := msg.WorkspaceID
-	cmds = append(cmds, common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
-		return selectionScrollTick{WorkspaceID: wtID, TabID: tabID, Gen: msg.Gen}
-	}))
-	return common.SafeBatch(cmds...)
+	m.dispatchOrHandleTabEvent(tabEvent{
+		tab:         tab,
+		workspaceID: msg.WorkspaceID,
+		tabID:       msg.TabID,
+		kind:        tabEventSelectionScrollTick,
+		gen:         msg.Gen,
+		seq:         msg.Seq,
+	})
+	return nil
 }

--- a/internal/ui/center/model_pty_config.go
+++ b/internal/ui/center/model_pty_config.go
@@ -104,4 +104,5 @@ type selectionScrollTick struct {
 	WorkspaceID string
 	TabID       TabID
 	Gen         uint64
+	Seq         uint64
 }

--- a/internal/ui/center/selection_scroll_chat_test.go
+++ b/internal/ui/center/selection_scroll_chat_test.go
@@ -1,0 +1,223 @@
+package center
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// Chat tabs (coding agents) render scrolled history as a scrollback-only view
+// (model_scrolled_history.go) instead of the vterm's native window, and their
+// agents constantly repaint via 2J clears that churn scrollback through
+// capture/dedup while the viewport anchor holds position. These tests pin the
+// drag-selection auto-scroll behavior on that display mode; plain-tab
+// equivalents live in selection_scroll_test.go.
+
+// setupChatScrollModel builds a center model with an active chat tab whose
+// terminal has real scrollback and chat capture behavior enabled.
+func setupChatScrollModel(t *testing.T, lines int) (*Model, *Tab, string) {
+	t.Helper()
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	m := New(cfg)
+	wt := &data.Workspace{Name: "wt", Repo: "/tmp/repo", Root: "/tmp/repo"}
+	m.SetWorkspace(wt)
+	wtID := string(wt.ID())
+
+	vt := vterm.New(80, 24)
+	vt.AllowAltScreenScrollback = true
+	vt.CaptureNormalScreenOnClear = true
+	for i := 0; i < lines; i++ {
+		vt.Write([]byte(fmt.Sprintf("line %d\r\n", i)))
+	}
+
+	tab := &Tab{
+		ID:        TabID("tab-chat-1"),
+		Assistant: "claude",
+		Workspace: wt,
+		Terminal:  vt,
+	}
+	m.tabs.ByWorkspace[wtID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wtID] = 0
+	m.SetSize(100, 40)
+	m.SetOffset(0)
+	m.Focus()
+	return m, tab, wtID
+}
+
+// chatViewStartLine returns the first scrollback line of the chat history
+// view, or -1 when the tab is at the live view.
+func chatViewStartLine(tab *Tab) int {
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	start, _, ok := scrolledChatHistoryVisibleRange(tab.Terminal, tab.Terminal.Height)
+	if !ok {
+		return -1
+	}
+	return start
+}
+
+func TestChatTab_DragUpAutoScroll_TicksKeepScrolling(t *testing.T) {
+	m, tab, wtID := setupChatScrollModel(t, 100)
+
+	var sinkMsgs []tea.Msg
+	m.msgSink = func(msg tea.Msg) { sinkMsgs = append(sinkMsgs, msg) }
+
+	m.handleTabEvent(tabEvent{
+		tab: tab, workspaceID: wtID, tabID: tab.ID,
+		kind: tabEventSelectionStart, termX: 10, termY: 10, inBounds: true,
+	})
+	m.handleTabEvent(tabEvent{
+		tab: tab, workspaceID: wtID, tabID: tab.ID,
+		kind: tabEventSelectionUpdate, termX: 10, termY: -1,
+	})
+
+	tab.mu.Lock()
+	off := tab.Terminal.ViewOffset
+	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
+	tab.mu.Unlock()
+	if off <= 0 {
+		t.Fatalf("drag above viewport did not scroll a chat tab up (ViewOffset=%d)", off)
+	}
+	if len(sinkMsgs) == 0 {
+		t.Fatal("no tick request emitted for chat tab")
+	}
+
+	for i := 0; i < 5; i++ {
+		m.handleTabEvent(tabEvent{
+			tab: tab, workspaceID: wtID, tabID: tab.ID,
+			kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
+		})
+		seq++
+		tab.mu.Lock()
+		next := tab.Terminal.ViewOffset
+		active := tab.selectionScroll.Active
+		tab.mu.Unlock()
+		if !active {
+			t.Fatalf("tick %d: chain died", i)
+		}
+		if next <= off {
+			t.Fatalf("tick %d: offset did not advance (%d -> %d)", i, off, next)
+		}
+		off = next
+	}
+}
+
+// TestChatTab_DragUpAutoScroll_AnchorStableWhileStreaming is the streaming
+// invariant: while the agent repaints via 2J (scrollback grows through capture
+// and shrinks through dedup, with the viewport anchor adjusting both ways),
+// each auto-scroll tick must still move the visible history window up by
+// exactly one line — no jumps, no stalls.
+func TestChatTab_DragUpAutoScroll_AnchorStableWhileStreaming(t *testing.T) {
+	m, tab, wtID := setupChatScrollModel(t, 100)
+	m.msgSink = func(tea.Msg) {}
+
+	m.handleTabEvent(tabEvent{
+		tab: tab, workspaceID: wtID, tabID: tab.ID,
+		kind: tabEventSelectionStart, termX: 10, termY: 10, inBounds: true,
+	})
+	m.handleTabEvent(tabEvent{
+		tab: tab, workspaceID: wtID, tabID: tab.ID,
+		kind: tabEventSelectionUpdate, termX: 10, termY: -1,
+	})
+
+	tab.mu.Lock()
+	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
+	tab.mu.Unlock()
+
+	prevStart := chatViewStartLine(tab)
+	if prevStart < 0 {
+		t.Fatal("expected chat history view after drag up")
+	}
+
+	for i := 0; i < 5; i++ {
+		// Agent repaint between ticks: home + clear + fresh frame. The 2J
+		// capture appends the visible frame to scrollback; the next repaint's
+		// dedup collapses it again.
+		tab.mu.Lock()
+		tab.Terminal.Write([]byte(fmt.Sprintf("\x1b[H\x1b[2Jframe %d\r\noutput %d\r\n", i, i)))
+		tab.mu.Unlock()
+
+		m.handleTabEvent(tabEvent{
+			tab: tab, workspaceID: wtID, tabID: tab.ID,
+			kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
+		})
+		seq++
+
+		tab.mu.Lock()
+		active := tab.selectionScroll.Active
+		tab.mu.Unlock()
+		if !active {
+			t.Fatalf("tick %d: chain died during streaming", i)
+		}
+
+		start := chatViewStartLine(tab)
+		if start != prevStart-1 {
+			t.Fatalf("tick %d: view window moved %d -> %d, want exactly one line up (%d)",
+				i, prevStart, start, prevStart-1)
+		}
+		prevStart = start
+	}
+}
+
+// TestChatTab_DragUp_FullUpdateChain drives the real Update entry points
+// (click, motion) with the actor not ready, verifying the synchronous fallback
+// runs the same handlers and requests the tick via msgSink.
+func TestChatTab_DragUp_FullUpdateChain(t *testing.T) {
+	m, tab, _ := setupChatScrollModel(t, 100)
+	var sinkMsgs []tea.Msg
+	m.msgSink = func(msg tea.Msg) { sinkMsgs = append(sinkMsgs, msg) }
+
+	tm := m.terminalMetrics()
+	clickX := tm.ContentStartX + 5
+	clickY := tm.ContentStartY + 5
+	m, _ = m.Update(tea.MouseClickMsg{X: clickX, Y: clickY, Button: tea.MouseLeft})
+
+	tab.mu.Lock()
+	active := tab.Selection.Active
+	tab.mu.Unlock()
+	if !active {
+		t.Fatalf("selection not active after click at (%d,%d)", clickX, clickY)
+	}
+
+	// Drag above the content area (screen Y = 0 → negative termY).
+	m, _ = m.Update(tea.MouseMotionMsg{X: clickX, Y: 0, Button: tea.MouseLeft})
+
+	tab.mu.Lock()
+	off := tab.Terminal.ViewOffset
+	dir := tab.selectionScroll.ScrollDir
+	tab.mu.Unlock()
+	if dir != 1 {
+		t.Fatalf("scroll direction = %d, want 1 (up)", dir)
+	}
+	if off <= 0 {
+		t.Fatalf("no scroll on drag above viewport (ViewOffset=%d)", off)
+	}
+	tickRequested := false
+	for _, sm := range sinkMsgs {
+		if _, ok := sm.(selectionTickRequest); ok {
+			tickRequested = true
+		}
+	}
+	if !tickRequested {
+		t.Fatal("no tick request posted via msgSink")
+	}
+
+	// Release finishes the selection and stops the chain.
+	_, _ = m.Update(tea.MouseReleaseMsg{X: clickX, Y: 0, Button: tea.MouseLeft})
+	tab.mu.Lock()
+	stillActive := tab.Selection.Active
+	tab.mu.Unlock()
+	if stillActive {
+		t.Fatal("selection still active after release")
+	}
+}

--- a/internal/ui/center/selection_scroll_test.go
+++ b/internal/ui/center/selection_scroll_test.go
@@ -106,6 +106,7 @@ func TestTabActor_SelectionScrollTick_ScrollsUp(t *testing.T) {
 		t.Fatal("expected scroll to be active")
 	}
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	tab.mu.Unlock()
 
 	// Should have sent a selectionTickRequest
@@ -118,6 +119,9 @@ func TestTabActor_SelectionScrollTick_ScrollsUp(t *testing.T) {
 	}
 	if tickReq.gen != gen {
 		t.Fatalf("tick request gen=%d, expected %d", tickReq.gen, gen)
+	}
+	if tickReq.seq != seq {
+		t.Fatalf("tick request seq=%d, expected %d", tickReq.seq, seq)
 	}
 
 	// Process scroll tick via tab actor
@@ -132,6 +136,7 @@ func TestTabActor_SelectionScrollTick_ScrollsUp(t *testing.T) {
 		tabID:       tab.ID,
 		kind:        tabEventSelectionScrollTick,
 		gen:         gen,
+		seq:         seq,
 	})
 
 	tab.mu.Lock()
@@ -197,6 +202,7 @@ func TestTabActor_SelectionScrollTick_ScrollsDown(t *testing.T) {
 		t.Fatalf("expected ScrollDir=-1 (down), got %d", tab.selectionScroll.ScrollDir)
 	}
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	scrollBefore, _ := tab.Terminal.GetScrollInfo()
 	tab.mu.Unlock()
 
@@ -208,6 +214,7 @@ func TestTabActor_SelectionScrollTick_ScrollsDown(t *testing.T) {
 		tabID:       tab.ID,
 		kind:        tabEventSelectionScrollTick,
 		gen:         gen,
+		seq:         seq,
 	})
 
 	tab.mu.Lock()
@@ -245,6 +252,7 @@ func TestTabActor_SelectionScrollTick_StopsAfterFinish(t *testing.T) {
 
 	tab.mu.Lock()
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	tab.mu.Unlock()
 
 	// Finish selection (mouse release)
@@ -257,7 +265,7 @@ func TestTabActor_SelectionScrollTick_StopsAfterFinish(t *testing.T) {
 	sinkMsgs = nil
 	m.handleTabEvent(tabEvent{
 		tab: tab, workspaceID: wtID, tabID: tab.ID,
-		kind: tabEventSelectionScrollTick, gen: gen,
+		kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
 	})
 
 	// Should NOT have requested another tick
@@ -287,6 +295,7 @@ func TestTabActor_SelectionScrollTick_StopsAfterClear(t *testing.T) {
 
 	tab.mu.Lock()
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	tab.mu.Unlock()
 
 	// Clear selection (e.g., user types a key)
@@ -299,7 +308,7 @@ func TestTabActor_SelectionScrollTick_StopsAfterClear(t *testing.T) {
 	sinkMsgs = nil
 	m.handleTabEvent(tabEvent{
 		tab: tab, workspaceID: wtID, tabID: tab.ID,
-		kind: tabEventSelectionScrollTick, gen: gen,
+		kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
 	})
 
 	for _, msg := range sinkMsgs {
@@ -328,6 +337,7 @@ func TestTabActor_SelectionScrollTick_Continuous(t *testing.T) {
 
 	tab.mu.Lock()
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	tab.mu.Unlock()
 
 	// Simulate 5 consecutive ticks
@@ -335,7 +345,7 @@ func TestTabActor_SelectionScrollTick_Continuous(t *testing.T) {
 		sinkMsgs = nil
 		m.handleTabEvent(tabEvent{
 			tab: tab, workspaceID: wtID, tabID: tab.ID,
-			kind: tabEventSelectionScrollTick, gen: gen,
+			kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
 		})
 
 		hasTickReq := false
@@ -348,6 +358,7 @@ func TestTabActor_SelectionScrollTick_Continuous(t *testing.T) {
 		if !hasTickReq {
 			t.Fatalf("tick %d: expected continuation tick request", i)
 		}
+		seq++
 	}
 
 	// Verify accumulated scrolling
@@ -379,12 +390,13 @@ func TestTabActor_SelectionScrollTick_EndpointTracksX(t *testing.T) {
 
 	tab.mu.Lock()
 	gen := tab.selectionScroll.Gen
+	seq := tab.selectionScroll.TickSeq
 	tab.mu.Unlock()
 
 	// Process tick
 	m.handleTabEvent(tabEvent{
 		tab: tab, workspaceID: wtID, tabID: tab.ID,
-		kind: tabEventSelectionScrollTick, gen: gen,
+		kind: tabEventSelectionScrollTick, gen: gen, seq: seq,
 	})
 
 	tab.mu.Lock()

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -62,6 +62,7 @@ type tabEvent struct {
 	inBounds        bool
 	delta           int
 	gen             uint64
+	seq             uint64
 	notifyCopy      bool
 	scrollPage      int
 	diffMsg         tea.Msg
@@ -84,6 +85,7 @@ type selectionTickRequest struct {
 	workspaceID string
 	tabID       TabID
 	gen         uint64
+	seq         uint64
 }
 
 type tabActorRedraw struct{}
@@ -125,6 +127,19 @@ func (m *Model) sendTabEvent(ev tabEvent) bool {
 		perf.Count("tab_event_drop", 1)
 	}
 	return false
+}
+
+// dispatchOrHandleTabEvent delivers ev to the tab actor, or handles it
+// synchronously on the caller's goroutine when the actor is not ready or its
+// queue rejected the event. Both routes run the same per-kind handler under
+// tab.mu, so gesture behavior cannot diverge between the actor path and the
+// fallback path. Use this for coalescible UI gestures (selection, scroll);
+// terminal writes have their own rollback-aware fallback (recoverFailedActorSend).
+func (m *Model) dispatchOrHandleTabEvent(ev tabEvent) {
+	if m.isTabActorReady() && m.sendTabEvent(ev) {
+		return
+	}
+	m.handleTabEvent(ev)
 }
 
 func shouldDropTabEvent(ch chan tabEvent, kind tabEventKind) bool {
@@ -265,19 +280,23 @@ func (m *Model) handleScrollToTop(ev tabEvent) {
 }
 
 func (m *Model) handleDiffInput(ev tabEvent) {
-	tab := ev.tab
+	cmd := m.updateDiffViewer(ev.tab, ev.diffMsg)
+	if cmd != nil && m.msgSink != nil {
+		m.msgSink(tabDiffCmd{cmd: cmd})
+	}
+}
+
+func (m *Model) updateDiffViewer(tab *Tab, msg tea.Msg) tea.Cmd {
 	tab.mu.Lock()
 	dv := tab.DiffViewer
 	if dv == nil {
 		tab.mu.Unlock()
-		return
+		return nil
 	}
-	newDV, cmd := dv.Update(ev.diffMsg)
+	newDV, cmd := dv.Update(msg)
 	tab.DiffViewer = newDV
 	tab.mu.Unlock()
-	if cmd != nil && m.msgSink != nil {
-		m.msgSink(tabDiffCmd{cmd: cmd})
-	}
+	return cmd
 }
 
 func (m *Model) handleSendInput(ev tabEvent) {

--- a/internal/ui/center/tab_actor_selection.go
+++ b/internal/ui/center/tab_actor_selection.go
@@ -86,7 +86,7 @@ func (m *Model) handleSelectionUpdate(ev tabEvent) {
 		return
 	}
 
-	needTick, gen := common.DragSelect(
+	needTick, gen, seq := common.DragSelect(
 		tab.Terminal,
 		&tab.Selection,
 		&tab.selectionScroll,
@@ -104,6 +104,7 @@ func (m *Model) handleSelectionUpdate(ev tabEvent) {
 			workspaceID: ev.workspaceID,
 			tabID:       ev.tabID,
 			gen:         gen,
+			seq:         seq,
 		})
 	}
 }
@@ -132,7 +133,7 @@ func (m *Model) handleSelectionFinish(ev tabEvent) {
 func (m *Model) handleSelectionScrollTick(ev tabEvent) {
 	tab := ev.tab
 	tab.mu.Lock()
-	if !tab.Selection.Active || tab.Terminal == nil || !tab.selectionScroll.HandleTick(ev.gen) {
+	if !tab.Selection.Active || tab.Terminal == nil || !tab.selectionScroll.HandleTick(ev.gen, ev.seq) {
 		tab.mu.Unlock()
 		return
 	}
@@ -148,6 +149,7 @@ func (m *Model) handleSelectionScrollTick(ev tabEvent) {
 			return absLine
 		},
 	)
+	nextSeq := tab.selectionScroll.TickSeq
 
 	tab.mu.Unlock()
 	if m.msgSink != nil {
@@ -155,6 +157,7 @@ func (m *Model) handleSelectionScrollTick(ev tabEvent) {
 			workspaceID: ev.workspaceID,
 			tabID:       ev.tabID,
 			gen:         ev.gen,
+			seq:         nextSeq,
 		})
 	}
 }

--- a/internal/ui/common/selection.go
+++ b/internal/ui/common/selection.go
@@ -27,8 +27,8 @@ type SelectionState struct {
 // The two closures absorb the only per-pane divergence: scroll performs the
 // pane's viewport move (center's chat-history-aware scroll vs the sidebar's raw
 // ScrollView+note), and screenYToAbs maps a screen row to an absolute line.
-// The returned (needTick, gen) come straight from scrollState.NeedsTick(); the
-// caller owns scheduling the actual tick command.
+// The returned (needTick, gen, seq) come straight from
+// scrollState.NeedsTick(); the caller owns scheduling the actual tick command.
 func DragSelect(
 	v *vterm.VTerm,
 	sel *SelectionState,
@@ -37,7 +37,7 @@ func DragSelect(
 	lastTermX *int,
 	scroll func(delta int),
 	screenYToAbs func(screenY int) int,
-) (needTick bool, gen uint64) {
+) (needTick bool, gen, seq uint64) {
 	if termX < 0 {
 		termX = 0
 	}
@@ -67,8 +67,8 @@ func DragSelect(
 // it scrolls the viewport one line in scrollState.ScrollDir and extends the
 // selection endpoint to the now-exposed viewport edge. The caller must hold the
 // owning tab/terminal mutex and must have already validated the tick via
-// scrollState.HandleTick (which confirms the generation, direction, and active
-// state) plus sel.Active and a non-nil v.
+// scrollState.HandleTick (which confirms the generation, tick sequence,
+// direction, and active state) plus sel.Active and a non-nil v.
 //
 // The edge row is the top of the viewport when scrolling up into history and
 // the bottom (termHeight-1) when scrolling down toward live; screenYToAbs maps

--- a/internal/ui/common/selection_drag_test.go
+++ b/internal/ui/common/selection_drag_test.go
@@ -86,14 +86,16 @@ func TestDragSelect(t *testing.T) {
 			wantNeedTick:    true,
 		},
 		{
-			name:  "already-active tick loop does not request another",
+			// Motion while a chain is active re-requests the expected tick
+			// sequence (self-healing when a tick was shed by a queue).
+			name:  "already-active tick loop re-requests the chain",
 			termX: 10, termY: -3,
 			startDir: 1, startActive: true,
 			wantScrollDelta: 1,
 			wantAbsScreenY:  0,
 			wantLastTermX:   10,
 			wantDir:         1,
-			wantNeedTick:    false,
+			wantNeedTick:    true,
 		},
 	}
 
@@ -107,7 +109,7 @@ func TestDragSelect(t *testing.T) {
 			var gotScreenY int
 			lastTermX := -999
 
-			needTick, gen := DragSelect(
+			needTick, gen, seq := DragSelect(
 				v, sel, scrollState,
 				tt.termX, tt.termY, termWidth, termHeight,
 				&lastTermX,
@@ -140,6 +142,9 @@ func TestDragSelect(t *testing.T) {
 			}
 			if needTick && gen == 0 {
 				t.Error("needTick true but gen is zero")
+			}
+			if needTick && seq == 0 {
+				t.Error("needTick true but seq is zero")
 			}
 		})
 	}

--- a/internal/ui/common/selection_scroll.go
+++ b/internal/ui/common/selection_scroll.go
@@ -12,6 +12,10 @@ const SelectionScrollTickInterval = 100 * time.Millisecond
 type SelectionScrollState struct {
 	// Gen is a generation counter used to invalidate stale tick loops.
 	Gen uint64
+	// TickSeq is the next tick sequence expected for Gen. Duplicate requests for
+	// the same sequence are harmless: the first tick advances TickSeq and later
+	// copies are ignored without stopping the loop.
+	TickSeq uint64
 	// ScrollDir is +1 (scroll up into history) or -1 (scroll down toward
 	// live output) or 0 (no auto-scroll).
 	ScrollDir int
@@ -31,27 +35,41 @@ func (s *SelectionScrollState) SetDirection(termY, termHeight int) {
 	}
 }
 
-// NeedsTick returns (true, gen) when a new tick loop should be started.
-// It bumps the generation counter and marks the state active. If a tick
-// loop is already running or scrolling is not needed, it returns (false, 0).
-func (s *SelectionScrollState) NeedsTick() (bool, uint64) {
-	if s.ScrollDir != 0 && !s.Active {
+// NeedsTick reports whether the caller should schedule an auto-scroll tick and,
+// if so, returns the current generation and next expected tick sequence.
+// Motions while a loop is already active re-request the same generation/sequence
+// instead of invalidating the live timer. If a request was dropped, the next
+// motion can replace it; if both copies arrive, HandleTick accepts whichever
+// one arrives first and rejects the duplicate by sequence number.
+func (s *SelectionScrollState) NeedsTick() (bool, uint64, uint64) {
+	if s.ScrollDir == 0 {
+		return false, 0, 0
+	}
+	if !s.Active || s.TickSeq == 0 {
 		s.Active = true
 		s.Gen++
-		return true, s.Gen
+		s.TickSeq = 1
 	}
-	return false, 0
+	return true, s.Gen, s.TickSeq
 }
 
 // HandleTick checks whether an incoming tick with the given generation is
-// still valid. Returns true if the tick loop should continue (caller
-// should scroll and schedule the next tick). Returns false if the tick
-// loop should stop (generation mismatch, direction cleared, or not active).
-func (s *SelectionScrollState) HandleTick(gen uint64) bool {
-	if s.Gen != gen || s.ScrollDir == 0 || !s.Active {
+// still valid. Returns true if the tick loop should continue (caller should
+// scroll and schedule the next tick). Stale generations or duplicate sequences
+// are ignored without stopping the current generation; explicit stop conditions
+// (direction cleared or inactive state) end the loop.
+func (s *SelectionScrollState) HandleTick(gen, seq uint64) bool {
+	if !s.Active {
+		return false
+	}
+	if s.ScrollDir == 0 {
 		s.Active = false
 		return false
 	}
+	if s.Gen != gen || s.TickSeq != seq {
+		return false
+	}
+	s.TickSeq++
 	return true
 }
 

--- a/internal/ui/common/selection_scroll_test.go
+++ b/internal/ui/common/selection_scroll_test.go
@@ -54,12 +54,15 @@ func TestNeedsTick_StartsLoop(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24) // above viewport
 
-	need, gen := s.NeedsTick()
+	need, gen, seq := s.NeedsTick()
 	if !need {
 		t.Fatal("expected NeedsTick to return true")
 	}
 	if gen != 1 {
 		t.Fatalf("expected gen=1, got %d", gen)
+	}
+	if seq != 1 {
+		t.Fatalf("expected seq=1, got %d", seq)
 	}
 	if !s.Active {
 		t.Fatal("expected Active=true after NeedsTick")
@@ -69,25 +72,36 @@ func TestNeedsTick_StartsLoop(t *testing.T) {
 	}
 }
 
-func TestNeedsTick_NoOpWhenActive(t *testing.T) {
+func TestNeedsTick_ReRequestsCurrentSequenceWhileActive(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
 
-	need1, gen1 := s.NeedsTick()
+	need1, gen1, seq1 := s.NeedsTick()
 	if !need1 {
 		t.Fatal("first NeedsTick should return true")
 	}
 
-	// Second call while Active — should be no-op
-	need2, gen2 := s.NeedsTick()
-	if need2 {
-		t.Fatal("second NeedsTick should return false (already active)")
+	// A second drag motion re-requests the same tick. If the first request was
+	// dropped, this replaces it; if both arrive, the sequence check rejects the
+	// duplicate after the first one advances the chain.
+	need2, gen2, seq2 := s.NeedsTick()
+	if !need2 {
+		t.Fatal("second NeedsTick should re-request the chain")
 	}
-	if gen2 != 0 {
-		t.Fatalf("expected gen=0 when not needed, got %d", gen2)
+	if gen2 != gen1 {
+		t.Fatalf("active chain should keep generation %d, got %d", gen1, gen2)
 	}
-	if s.Gen != gen1 {
-		t.Fatalf("Gen should not change, was %d now %d", gen1, s.Gen)
+	if seq2 != seq1 {
+		t.Fatalf("active chain should re-request sequence %d, got %d", seq1, seq2)
+	}
+	if !s.HandleTick(gen2, seq2) {
+		t.Fatal("current chain generation should be accepted")
+	}
+	if s.HandleTick(gen1, seq1) {
+		t.Fatal("duplicate tick sequence should be rejected")
+	}
+	if !s.Active {
+		t.Fatal("duplicate tick should not stop the current chain")
 	}
 }
 
@@ -95,12 +109,15 @@ func TestNeedsTick_NoOpWhenNoScroll(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(12, 24) // in bounds
 
-	need, gen := s.NeedsTick()
+	need, gen, seq := s.NeedsTick()
 	if need {
 		t.Fatal("NeedsTick should return false when ScrollDir=0")
 	}
 	if gen != 0 {
 		t.Fatalf("expected gen=0, got %d", gen)
+	}
+	if seq != 0 {
+		t.Fatalf("expected seq=0, got %d", seq)
 	}
 	if s.Active {
 		t.Fatal("Active should remain false")
@@ -110,9 +127,9 @@ func TestNeedsTick_NoOpWhenNoScroll(t *testing.T) {
 func TestHandleTick_ValidTick(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
-	_, gen := s.NeedsTick()
+	_, gen, seq := s.NeedsTick()
 
-	ok := s.HandleTick(gen)
+	ok := s.HandleTick(gen, seq)
 	if !ok {
 		t.Fatal("HandleTick should return true for matching gen")
 	}
@@ -121,29 +138,51 @@ func TestHandleTick_ValidTick(t *testing.T) {
 	}
 }
 
-func TestHandleTick_StaleTick(t *testing.T) {
+func TestHandleTick_StaleTickDoesNotStopCurrentChain(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
-	_, gen := s.NeedsTick()
+	_, gen, seq := s.NeedsTick()
 
 	// Simulate stale tick (wrong gen)
-	ok := s.HandleTick(gen + 1)
+	ok := s.HandleTick(gen+1, seq)
 	if ok {
 		t.Fatal("HandleTick should return false for mismatched gen")
 	}
-	if s.Active {
-		t.Fatal("Active should be false after stale tick")
+	if !s.Active {
+		t.Fatal("Active should remain true after stale tick")
+	}
+	if !s.HandleTick(gen, seq) {
+		t.Fatal("current generation should still be accepted after stale tick")
+	}
+}
+
+func TestHandleTick_DuplicateSequenceDoesNotStopCurrentChain(t *testing.T) {
+	var s SelectionScrollState
+	s.SetDirection(-1, 24)
+	_, gen, seq := s.NeedsTick()
+
+	if !s.HandleTick(gen, seq) {
+		t.Fatal("first tick should be accepted")
+	}
+	if s.HandleTick(gen, seq) {
+		t.Fatal("duplicate tick sequence should be rejected")
+	}
+	if !s.Active {
+		t.Fatal("duplicate tick should not stop current chain")
+	}
+	if !s.HandleTick(gen, seq+1) {
+		t.Fatal("next tick sequence should be accepted")
 	}
 }
 
 func TestHandleTick_AfterReset(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
-	_, gen := s.NeedsTick()
+	_, gen, seq := s.NeedsTick()
 
 	s.Reset()
 
-	ok := s.HandleTick(gen)
+	ok := s.HandleTick(gen, seq)
 	if ok {
 		t.Fatal("HandleTick should return false after Reset (gen mismatch)")
 	}
@@ -152,12 +191,12 @@ func TestHandleTick_AfterReset(t *testing.T) {
 func TestHandleTick_DirectionCleared(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
-	_, gen := s.NeedsTick()
+	_, gen, seq := s.NeedsTick()
 
 	// Mouse moved back into viewport
 	s.SetDirection(12, 24)
 
-	ok := s.HandleTick(gen)
+	ok := s.HandleTick(gen, seq)
 	if ok {
 		t.Fatal("HandleTick should return false when ScrollDir=0")
 	}
@@ -169,13 +208,13 @@ func TestHandleTick_DirectionCleared(t *testing.T) {
 func TestHandleTick_DirectionChanged(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24) // above → +1
-	_, gen := s.NeedsTick()
+	_, gen, seq := s.NeedsTick()
 
 	// Direction changed without going through center
 	s.SetDirection(30, 24) // below → -1
 
 	// Tick should still be valid (gen matches, dir != 0, active)
-	ok := s.HandleTick(gen)
+	ok := s.HandleTick(gen, seq)
 	if !ok {
 		t.Fatal("HandleTick should still be valid when direction changed but gen matches")
 	}
@@ -206,13 +245,13 @@ func TestReset(t *testing.T) {
 func TestReset_AllowsNewTickLoop(t *testing.T) {
 	var s SelectionScrollState
 	s.SetDirection(-1, 24)
-	_, gen1 := s.NeedsTick()
+	_, gen1, _ := s.NeedsTick()
 
 	s.Reset()
 
 	// Should be able to start a new tick loop
 	s.SetDirection(-1, 24)
-	need, gen2 := s.NeedsTick()
+	need, gen2, _ := s.NeedsTick()
 	if !need {
 		t.Fatal("should be able to start new tick loop after Reset")
 	}
@@ -231,29 +270,30 @@ func TestFullLifecycle(t *testing.T) {
 	}
 
 	// 2. First motion triggers tick loop
-	need, gen := s.NeedsTick()
+	need, gen, seq := s.NeedsTick()
 	if !need {
 		t.Fatal("step 2: expected NeedsTick=true")
 	}
 
 	// 3. Multiple ticks while mouse is held still
 	for i := 0; i < 5; i++ {
-		ok := s.HandleTick(gen)
+		ok := s.HandleTick(gen, seq)
 		if !ok {
 			t.Fatalf("step 3 tick %d: expected HandleTick=true", i)
 		}
+		seq++
 	}
 
 	// 4. Mouse released → Reset
 	s.Reset()
-	ok := s.HandleTick(gen)
+	ok := s.HandleTick(gen, seq)
 	if ok {
 		t.Fatal("step 4: HandleTick should fail after Reset")
 	}
 
 	// 5. New selection starts and drags below viewport
 	s.SetDirection(30, 24)
-	need2, gen2 := s.NeedsTick()
+	need2, gen2, seq2 := s.NeedsTick()
 	if !need2 {
 		t.Fatal("step 5: expected new tick loop")
 	}
@@ -265,19 +305,13 @@ func TestFullLifecycle(t *testing.T) {
 	}
 
 	// 6. Old gen tick should be rejected
-	ok = s.HandleTick(gen)
+	ok = s.HandleTick(gen, seq)
 	if ok {
 		t.Fatal("step 6: old gen should be rejected")
 	}
 
-	// 7. New gen tick should work (need to restart since HandleTick
-	//    with wrong gen set Active=false)
-	s.SetDirection(30, 24) // re-set direction
-	need3, gen3 := s.NeedsTick()
-	if !need3 {
-		t.Fatal("step 7: expected NeedsTick=true after re-activation")
-	}
-	ok = s.HandleTick(gen3)
+	// 7. New gen tick should still work after the old gen was ignored.
+	ok = s.HandleTick(gen2, seq2)
 	if !ok {
 		t.Fatal("step 7: HandleTick with correct gen should succeed")
 	}

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -81,6 +81,7 @@ type SidebarSelectionScrollTick struct {
 	WorkspaceID string
 	TabID       TerminalTabID
 	Gen         uint64
+	Seq         uint64
 }
 
 // TerminalModel is the Bubbletea model for the sidebar terminal section

--- a/internal/ui/sidebar/terminal_scroll_test.go
+++ b/internal/ui/sidebar/terminal_scroll_test.go
@@ -84,6 +84,7 @@ func TestSelectionScrollTick_DragAboveViewport(t *testing.T) {
 		t.Fatal("expected scroll tick loop to be active")
 	}
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	ts.mu.Unlock()
 
 	// Scroll to a known position first so we can verify the tick scrolls
@@ -93,7 +94,7 @@ func TestSelectionScrollTick_DragAboveViewport(t *testing.T) {
 	ts.mu.Unlock()
 
 	// Process the tick message
-	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 	_, cmd = m.Update(tickMsg)
 
 	if cmd == nil {
@@ -145,11 +146,12 @@ func TestSelectionScrollTick_DragBelowViewport(t *testing.T) {
 		t.Fatalf("expected ScrollDir=-1 (down), got %d", ts.selectionScroll.ScrollDir)
 	}
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	scrollBefore, _ := ts.VTerm.GetScrollInfo()
 	ts.mu.Unlock()
 
 	// Process tick
-	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 	_, cmd = m.Update(tickMsg)
 
 	if cmd == nil {
@@ -179,6 +181,7 @@ func TestSelectionScrollTick_StopsOnRelease(t *testing.T) {
 
 	ts.mu.Lock()
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	ts.mu.Unlock()
 
 	// Release mouse
@@ -186,7 +189,7 @@ func TestSelectionScrollTick_StopsOnRelease(t *testing.T) {
 	m, _ = m.Update(release)
 
 	// Process tick with old gen → should be rejected
-	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 	_, cmd := m.Update(tickMsg)
 
 	if cmd != nil {
@@ -208,6 +211,7 @@ func TestSelectionScrollTick_StopsOnNewClick(t *testing.T) {
 
 	ts.mu.Lock()
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	ts.mu.Unlock()
 
 	// New click (starts new selection, resets scroll)
@@ -215,7 +219,7 @@ func TestSelectionScrollTick_StopsOnNewClick(t *testing.T) {
 	m, _ = m.Update(click2)
 
 	// Old tick should be rejected
-	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 	_, cmd := m.Update(tickMsg)
 
 	if cmd != nil {
@@ -237,16 +241,18 @@ func TestSelectionScrollTick_ContinuousScrolling(t *testing.T) {
 
 	ts.mu.Lock()
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	ts.mu.Unlock()
 
 	// Simulate 5 consecutive ticks (mouse held still)
 	for i := 0; i < 5; i++ {
-		tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+		tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 		var cmd tea.Cmd
 		m, cmd = m.Update(tickMsg)
 		if cmd == nil {
 			t.Fatalf("tick %d: expected next tick command (continuous scrolling)", i)
 		}
+		seq++
 	}
 
 	// Verify we've scrolled multiple lines
@@ -287,10 +293,11 @@ func TestSelectionScrollTick_EndpointTracksLastX(t *testing.T) {
 
 	ts.mu.Lock()
 	gen := ts.selectionScroll.Gen
+	seq := ts.selectionScroll.TickSeq
 	ts.mu.Unlock()
 
 	// Process tick
-	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+	tickMsg := SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 	_, _ = m.Update(tickMsg)
 
 	// Verify endpoint X matches the last motion X

--- a/internal/ui/sidebar/terminal_selection.go
+++ b/internal/ui/sidebar/terminal_selection.go
@@ -165,7 +165,7 @@ func (m *TerminalModel) handleMouseMotion(msg tea.MouseMotionMsg) (*TerminalMode
 
 	ts.mu.Lock()
 	if ts.Selection.Active && ts.VTerm != nil {
-		needTick, gen := common.DragSelect(
+		needTick, gen, seq := common.DragSelect(
 			ts.VTerm,
 			&ts.Selection,
 			&ts.selectionScroll,
@@ -182,7 +182,7 @@ func (m *TerminalModel) handleMouseMotion(msg tea.MouseMotionMsg) (*TerminalMode
 				wsID := m.workspaceID()
 				tabID := activeTab.ID
 				cmd = common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
-					return SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen}
+					return SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: gen, Seq: seq}
 				})
 			}
 		}
@@ -241,7 +241,7 @@ func (m *TerminalModel) handleSelectionScrollTick(msg SidebarSelectionScrollTick
 	}
 	ts := tab.State
 	ts.mu.Lock()
-	if !ts.Selection.Active || ts.VTerm == nil || !ts.selectionScroll.HandleTick(msg.Gen) {
+	if !ts.Selection.Active || ts.VTerm == nil || !ts.selectionScroll.HandleTick(msg.Gen, msg.Seq) {
 		ts.mu.Unlock()
 		return nil
 	}
@@ -254,13 +254,14 @@ func (m *TerminalModel) handleSelectionScrollTick(msg SidebarSelectionScrollTick
 		ts.VTerm.ScrollViewAndNote,
 		ts.VTerm.ScreenYToAbsoluteLine,
 	)
+	nextSeq := ts.selectionScroll.TickSeq
 
 	ts.mu.Unlock()
 
 	wsID := msg.WorkspaceID
 	tabID := msg.TabID
 	return common.SafeTick(common.SelectionScrollTickInterval, func(time.Time) tea.Msg {
-		return SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: msg.Gen}
+		return SidebarSelectionScrollTick{WorkspaceID: wsID, TabID: tabID, Gen: msg.Gen, Seq: nextSeq}
 	})
 }
 

--- a/internal/vterm/accessors.go
+++ b/internal/vterm/accessors.go
@@ -75,6 +75,7 @@ func (v *VTerm) SelEndY() int {
 // Version returns the current version counter.
 // This increments whenever visible content changes.
 func (v *VTerm) Version() uint64 {
+	v.maybeReleaseStaleSync()
 	return v.version
 }
 

--- a/internal/vterm/render.go
+++ b/internal/vterm/render.go
@@ -17,8 +17,11 @@ func (v *VTerm) Render() string {
 }
 
 // RenderBuffers returns the current screen buffer and scrollback length.
-// During synchronized output, it returns the frozen snapshot.
+// During synchronized output, it returns the frozen snapshot. As a failsafe it
+// force-releases a sync region whose end marker is overdue (SyncStallTimeout)
+// so a writer that died mid-frame cannot freeze the terminal forever.
 func (v *VTerm) RenderBuffers() ([][]Cell, int) {
+	v.maybeReleaseStaleSync()
 	if v.syncActive && v.syncScreen != nil {
 		scrollbackLen := v.syncScrollbackLen
 		if scrollbackLen > len(v.Scrollback) {

--- a/internal/vterm/sync.go
+++ b/internal/vterm/sync.go
@@ -1,8 +1,29 @@
 package vterm
 
+import "time"
+
+// SyncStallTimeout bounds how long a DEC 2026 sync-begin may freeze rendering
+// without its matching sync-end. A well-behaved writer closes a sync region
+// within one frame; if the end marker never arrives (writer died mid-frame,
+// output trimmed under overflow), the frozen snapshot must not persist
+// forever. Write, RenderBuffers, and Version check the deadline, so the
+// terminal recovers on the next output, rendered frame, or snapshot-cache key
+// check, whichever comes first.
+const SyncStallTimeout = 2 * time.Second
+
+// syncNow returns the current time for sync stall tracking; tests may stub it.
+var syncNow = time.Now
+
 // SyncActive reports whether synchronized output is currently active.
 func (v *VTerm) SyncActive() bool {
 	return v.syncActive
+}
+
+// maybeReleaseStaleSync force-ends a sync region whose end marker is overdue.
+func (v *VTerm) maybeReleaseStaleSync() {
+	if v.syncActive && syncNow().Sub(v.syncStartedAt) > SyncStallTimeout {
+		v.setSynchronizedOutput(false)
+	}
 }
 
 func (v *VTerm) setSynchronizedOutput(active bool) {
@@ -11,11 +32,15 @@ func (v *VTerm) setSynchronizedOutput(active bool) {
 			return
 		}
 		v.syncActive = true
+		v.syncStartedAt = syncNow()
 		v.syncScreen = copyScreen(v.Screen)
 		v.syncScrollbackLen = len(v.Scrollback)
 		v.syncViewOffsetDelta = 0
 		v.syncPreserveViewport = v.ViewOffset > 0
-		v.invalidateRenderCache()
+		// No cache invalidation: freezing does not change the displayed frame,
+		// and renders during sync bypass the live-line cache without clearing
+		// dirty state (see liveRenderCacheActive), so per-line dirty tracking
+		// stays accurate across the sync window.
 		return
 	}
 
@@ -36,7 +61,11 @@ func (v *VTerm) setSynchronizedOutput(active bool) {
 	} else {
 		v.clampViewOffsetToCurrentMax()
 	}
-	v.invalidateRenderCache()
+	// Writes made during the sync window marked their lines dirty and bumped
+	// the version, and no render cleared that state while the freeze was up,
+	// so the next live render repaints exactly the changed lines. A blanket
+	// invalidation here would turn every synced frame into a full repaint.
+	v.bumpVersion()
 }
 
 func copyScreen(src [][]Cell) [][]Cell {

--- a/internal/vterm/sync_stall_test.go
+++ b/internal/vterm/sync_stall_test.go
@@ -1,0 +1,150 @@
+package vterm
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	syncBegin = "\x1b[?2026h"
+	syncEnd   = "\x1b[?2026l"
+)
+
+// stubSyncClock replaces the sync clock with a controllable one and restores
+// it when the test ends.
+func stubSyncClock(t *testing.T) *time.Time {
+	t.Helper()
+	now := time.Unix(1000, 0)
+	prev := syncNow
+	syncNow = func() time.Time { return now }
+	t.Cleanup(func() { syncNow = prev })
+	return &now
+}
+
+// TestSyncStall_WriteReleasesOverdueSync: a sync-begin with no end must not
+// freeze rendering past SyncStallTimeout; the next Write force-releases it.
+func TestSyncStall_WriteReleasesOverdueSync(t *testing.T) {
+	now := stubSyncClock(t)
+	vt := New(20, 4)
+
+	vt.Write([]byte("before\r\n"))
+	vt.Write([]byte(syncBegin + "during"))
+	if !vt.SyncActive() {
+		t.Fatal("sync should be active after begin")
+	}
+	// Writes inside the timeout keep the sync open.
+	*now = now.Add(SyncStallTimeout / 2)
+	vt.Write([]byte(" more"))
+	if !vt.SyncActive() {
+		t.Fatal("sync should stay active within the stall timeout")
+	}
+
+	*now = now.Add(SyncStallTimeout + time.Second)
+	vt.Write([]byte(" late"))
+	if vt.SyncActive() {
+		t.Fatal("overdue sync must be force-released on Write")
+	}
+	if !strings.Contains(vt.Render(), "during more late") {
+		t.Fatalf("expected content written during stalled sync to be visible, got:\n%s", vt.Render())
+	}
+}
+
+// TestSyncStall_RenderReleasesOverdueSync: with no further output at all, the
+// next rendered frame must unfreeze an overdue sync.
+func TestSyncStall_RenderReleasesOverdueSync(t *testing.T) {
+	now := stubSyncClock(t)
+	vt := New(20, 4)
+
+	vt.Write([]byte("frozen-frame\r\n"))
+	vt.Write([]byte(syncBegin + "hidden"))
+	if got := vt.Render(); strings.Contains(got, "hidden") {
+		t.Fatalf("content inside an open sync must stay hidden, got:\n%s", got)
+	}
+
+	*now = now.Add(SyncStallTimeout + time.Second)
+	if got := vt.Render(); !strings.Contains(got, "hidden") {
+		t.Fatalf("overdue sync must be force-released on render, got:\n%s", got)
+	}
+	if vt.SyncActive() {
+		t.Fatal("sync should be released after stale render")
+	}
+}
+
+// TestSyncStall_VersionReleasesOverdueSync pins the UI snapshot-cache path:
+// center/sidebar compare cached snapshots by VTerm.Version before calling
+// RenderBuffers, so Version must also release stale sync regions.
+func TestSyncStall_VersionReleasesOverdueSync(t *testing.T) {
+	now := stubSyncClock(t)
+	vt := New(20, 4)
+
+	vt.Write([]byte("before\r\n"))
+	versionBeforeSync := vt.Version()
+	vt.Write([]byte(syncBegin + "hidden"))
+	versionDuringSync := vt.Version()
+	if versionDuringSync == versionBeforeSync {
+		t.Fatal("write during sync should still bump version")
+	}
+	if !vt.SyncActive() {
+		t.Fatal("sync should be active before timeout")
+	}
+
+	*now = now.Add(SyncStallTimeout + time.Second)
+	versionAfterTimeout := vt.Version()
+	if vt.SyncActive() {
+		t.Fatal("Version should release overdue sync before cache comparison")
+	}
+	if versionAfterTimeout == versionDuringSync {
+		t.Fatal("Version should advance when it force-releases stale sync")
+	}
+}
+
+// TestSync_PreservesLineDirtyTracking: a sync begin/end pair must not blow the
+// per-line dirty state into a full invalidation. Only lines written during the
+// sync window should render dirty afterwards.
+func TestSync_PreservesLineDirtyTracking(t *testing.T) {
+	vt := New(20, 4)
+	vt.Write([]byte("l0\r\nl1\r\nl2"))
+
+	// Establish a clean baseline.
+	_ = vt.Render()
+	vt.ClearDirty()
+	if _, all := vt.DirtyLines(); all {
+		t.Fatal("expected clean baseline before sync")
+	}
+
+	// One synced frame that touches only the current cursor line.
+	vt.Write([]byte(syncBegin + "X" + syncEnd))
+
+	dirty, all := vt.DirtyLines()
+	if all {
+		t.Fatal("sync end must not force a full invalidation")
+	}
+	wantDirty := []bool{false, false, true, false}
+	for y, want := range wantDirty {
+		if dirty[y] != want {
+			t.Fatalf("line %d dirty = %v, want %v (dirty=%v)", y, dirty[y], want, dirty)
+		}
+	}
+}
+
+// TestSync_FrozenFrameHidesPartialWrites is the flicker property: content
+// written between sync begin and end must never be observable in a render.
+func TestSync_FrozenFrameHidesPartialWrites(t *testing.T) {
+	vt := New(40, 6)
+	vt.Write([]byte("stable\r\n"))
+
+	vt.Write([]byte(syncBegin + "\x1b[2J\x1b[H")) // clear inside sync
+	if got := vt.Render(); !strings.Contains(got, "stable") {
+		t.Fatalf("frozen frame must keep pre-sync content visible, got:\n%s", got)
+	}
+
+	vt.Write([]byte("repainted" + syncEnd))
+	got := vt.Render()
+	if !strings.Contains(got, "repainted") {
+		t.Fatalf("post-sync render must show the completed frame, got:\n%s", got)
+	}
+	if strings.Contains(got, "stable") {
+		t.Fatalf("cleared content must be gone after the synced repaint, got:\n%s", got)
+	}
+}

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -4,6 +4,8 @@
 // like, feeding the compositor and the center/sidebar UI models.
 package vterm
 
+import "time"
+
 const MaxScrollback = 10000
 
 // ResponseWriter is called when the terminal needs to send a response back to the PTY
@@ -107,7 +109,10 @@ type VTerm struct {
 	preserveScrollbackOnNextClear3 bool
 
 	// Synchronized output (DEC mode 2026)
-	syncActive        bool
+	syncActive bool
+	// syncStartedAt is when the open sync region began; used by the stall
+	// failsafe (SyncStallTimeout) to force-release a sync whose end never came.
+	syncStartedAt     time.Time
 	syncScreen        [][]Cell
 	syncScrollbackLen int
 	syncDeferTrim     bool
@@ -310,6 +315,7 @@ func (v *VTerm) resize(width, height int, revealHistoryOnGrow bool) {
 
 // Write processes input bytes from PTY
 func (v *VTerm) Write(data []byte) {
+	v.maybeReleaseStaleSync()
 	v.parser.Parse(data)
 }
 

--- a/internal/vterm/vterm_scroll_test.go
+++ b/internal/vterm/vterm_scroll_test.go
@@ -2,6 +2,7 @@ package vterm
 
 import (
 	"testing"
+	"time"
 )
 
 // addScrollbackLines appends n blank scrollback rows so that
@@ -144,7 +145,9 @@ func TestScrollViewToDuringSync(t *testing.T) {
 	addScrollbackLines(vt, 100)
 
 	// Freeze the viewport at a smaller scrollback length than the live buffer.
+	// syncStartedAt must be fresh or the stall failsafe releases the sync.
 	vt.syncActive = true
+	vt.syncStartedAt = time.Now()
 	vt.syncScreen = vt.Screen
 	vt.syncScrollbackLen = 20
 


### PR DESCRIPTION
## Summary

- routes mouse, key, wheel, diff, and selection-scroll gestures through the tab actor/fallback handler while preserving synchronous fallback commands
- advertises DEC 2026 synchronized output to tmux clients before attach, including fresh-server and create-race paths, and adds a vterm stale-sync failsafe that snapshot caches cannot bypass
- documents the streaming/scrolling model and adds unit/e2e coverage for drag auto-scroll while idle, streaming, and repainting

## Validation

- PATH="$(go env GOPATH)/bin:$PATH" make devcheck
- PATH="$(go env GOPATH)/bin:$PATH" make verify-loop
- PATH="$(go env GOPATH)/bin:$PATH" make lint-strict-new
- go test ./internal/e2e -run 'TestDragSelectUpAutoScrolls|TestTmuxDeliversSynchronizedOutputToClient' -count=1 -v
- /Users/andrewlee/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

## Notes

- make harness-presets passed.
- make perf-check was rerun but failed on this host while unrelated Node/Cursor/Ando processes were consuming multiple cores; earlier in the PR flow it passed before the host load spike.
