### PR TITLE
Fix script trust fallback and worktree separators

### DIFF
--- a/internal/git/workspace.go
+++ b/internal/git/workspace.go
@@ -34,7 +34,7 @@ func CreateWorkspace(repoPath, workspacePath, branch, base string) error {
 
 	// Create branch from base and checkout into workspace path
 	ctx, cancel := context.WithTimeout(context.Background(), worktreeTimeout)
-	_, err := runGitCtx(ctx, repoPath, "worktree", "add", "-b", branch, workspacePath, base)
+	_, err := runGitCtx(ctx, repoPath, "worktree", "add", "-b", branch, "--", workspacePath, base)
 	cancel()
 	if err == nil {
 		return nil
@@ -47,7 +47,7 @@ func CreateWorkspace(repoPath, workspacePath, branch, base string) error {
 	// Retry with a fresh timeout context so a slow first attempt does not
 	// consume the entire budget for the fallback path.
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), worktreeTimeout)
-	_, retryErr := runGitCtx(retryCtx, repoPath, "worktree", "add", workspacePath, branch)
+	_, retryErr := runGitCtx(retryCtx, repoPath, "worktree", "add", "--", workspacePath, branch)
 	retryCancel()
 	if retryErr != nil {
 		firstErrMsg := err.Error()

--- a/internal/git/workspace_test.go
+++ b/internal/git/workspace_test.go
@@ -180,7 +180,7 @@ func TestCreateWorkspace_RetryUsesFreshContext(t *testing.T) {
 		switch call {
 		case 1:
 			firstCtx = ctx
-			if got, want := strings.Join(args, " "), "worktree add -b feature-ws /tmp/ws HEAD"; got != want {
+			if got, want := strings.Join(args, " "), "worktree add -b feature-ws -- /tmp/ws HEAD"; got != want {
 				t.Fatalf("first call args = %q, want %q", got, want)
 			}
 			return "", &Error{Command: "worktree add", ExitCode: 128, Stderr: "fatal: a branch named 'feature-ws' already exists", Err: errors.New("exit status 128")}
@@ -191,7 +191,7 @@ func TestCreateWorkspace_RetryUsesFreshContext(t *testing.T) {
 			if ctx == firstCtx {
 				t.Fatalf("expected retry to use a fresh context")
 			}
-			if got, want := strings.Join(args, " "), "worktree add /tmp/ws feature-ws"; got != want {
+			if got, want := strings.Join(args, " "), "worktree add -- /tmp/ws feature-ws"; got != want {
 				t.Fatalf("retry args = %q, want %q", got, want)
 			}
 			return "", nil
@@ -226,7 +226,7 @@ func TestCreateWorkspaceClearsOrphanedCleanupMarker(t *testing.T) {
 		t.Fatalf("writeWorkspaceCleanupState() error = %v", err)
 	}
 	runGitCtx = func(ctx context.Context, _ string, args ...string) (string, error) {
-		if got, want := strings.Join(args, " "), "worktree add -b feature-ws "+workspacePath+" HEAD"; got != want {
+		if got, want := strings.Join(args, " "), "worktree add -b feature-ws -- "+workspacePath+" HEAD"; got != want {
 			t.Fatalf("worktree add args = %q, want %q", got, want)
 		}
 		return "", nil

--- a/internal/process/script_trust.go
+++ b/internal/process/script_trust.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -21,6 +22,8 @@ const trustRegistryFilename = "trusted-scripts.json"
 // content the user has explicitly approved. It maps a normalized repo path to
 // the hex SHA-256 of the config content that was approved, so any later edit to
 // the repo's config invalidates the approval (the hash no longer matches).
+// That hash pins only the .amux/workspaces.json content itself; it does not
+// pin other repo files that an approved command may execute.
 //
 // The security property it enforces: repo-supplied executable config keys
 // (config.SetupWorkspace / config.RunScript / config.ArchiveScript loaded from
@@ -39,13 +42,13 @@ func NewScriptTrust(dir string) *ScriptTrust {
 
 // defaultScriptTrust returns a registry rooted at the amux home dir, resolved
 // the same way internal/config resolves the data/config dir (no hardcoded
-// ~/.amux). On any resolution error it falls back to a relative path so the
-// registry simply never matches (fail-closed) rather than panicking at startup.
+// ~/.amux). On any resolution error it returns an empty-path sentinel that
+// never trusts and refuses to record approvals.
 func defaultScriptTrust() *ScriptTrust {
 	paths, err := config.DefaultPaths()
 	if err != nil || paths == nil {
 		logging.Warn("Could not resolve amux home for script trust registry: %v", err)
-		return NewScriptTrust(".")
+		return &ScriptTrust{path: ""}
 	}
 	return NewScriptTrust(paths.Home)
 }
@@ -60,7 +63,7 @@ func hashConfig(configContent []byte) string {
 // an unreadable or unparseable file yields an empty map and a logged warning, so
 // callers fail closed.
 func (t *ScriptTrust) load() map[string]string {
-	if t == nil {
+	if t == nil || t.path == "" {
 		return map[string]string{}
 	}
 	raw, err := os.ReadFile(t.path)
@@ -106,6 +109,9 @@ func (t *ScriptTrust) IsTrusted(repoPath string, configContent []byte) bool {
 func (t *ScriptTrust) Trust(repoPath string, configContent []byte) error {
 	if t == nil {
 		return nil
+	}
+	if t.path == "" {
+		return errors.New("script trust registry unavailable: amux home could not be resolved")
 	}
 	key := data.NormalizePath(repoPath)
 	if key == "" {

--- a/internal/process/script_trust_test.go
+++ b/internal/process/script_trust_test.go
@@ -1,9 +1,12 @@
 package process
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
 )
 
 func TestScriptTrustNotTrustedUntilApproved(t *testing.T) {
@@ -94,6 +97,42 @@ func TestScriptTrustCorruptRegistryFailsClosed(t *testing.T) {
 	// Must not panic and must fail closed.
 	if trust.IsTrusted(repo, content) {
 		t.Fatal("expected a corrupt registry to fail closed (not trusted)")
+	}
+}
+
+func TestScriptTrustSentinelIgnoresCWDRegistry(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	repo := t.TempDir()
+	content := []byte(`{"setup-workspace":["touch marker"]}`)
+	entries := map[string]string{
+		data.NormalizePath(repo): hashConfig(content),
+	}
+	raw, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, trustRegistryFilename), raw, 0o600); err != nil {
+		t.Fatalf("write hostile cwd registry: %v", err)
+	}
+
+	trust := &ScriptTrust{path: ""}
+	if trust.IsTrusted(repo, content) {
+		t.Fatal("sentinel trust must ignore matching registries in the current directory")
+	}
+}
+
+func TestScriptTrustSentinelTrustErrorsAndWritesNothing(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	trust := &ScriptTrust{path: ""}
+	if err := trust.Trust(t.TempDir(), []byte(`{"setup-workspace":["touch marker"]}`)); err == nil {
+		t.Fatal("expected sentinel Trust() to return an error")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, trustRegistryFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected sentinel Trust() to write no registry, stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the script trust fallback use an empty-path sentinel instead of a current-directory registry
- return an error when approvals cannot be recorded because the registry is unavailable
- add -- separators to both git worktree add invocations and update coverage expectations

## Verification
- go test ./internal/process -count=1 -run ScriptTrust
- go test ./internal/process -count=1
- go vet ./internal/process
- go test ./internal/git -count=1
- make devcheck
- make lint-strict-new
- /Users/andrewlee/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main (clean: no accepted/actionable findings)