### PR TITLE
Fix port allocator reuse after release

### DIFF
--- a/internal/process/ports.go
+++ b/internal/process/ports.go
@@ -41,10 +41,13 @@ func (p *PortAllocator) AllocatePort(workspaceRoot string) int {
 }
 
 func (p *PortAllocator) nextAvailablePortLocked() int {
-	if n := len(p.freeBases); n > 0 {
+	used := p.usedRangesLocked()
+	for n := len(p.freeBases); n > 0; n = len(p.freeBases) {
 		port := p.freeBases[n-1]
 		p.freeBases = p.freeBases[:n-1]
-		return port
+		if p.rangeAvailable(port, used) {
+			return port
+		}
 	}
 
 	if p.rangeFits(p.nextPort) {
@@ -54,12 +57,13 @@ func (p *PortAllocator) nextAvailablePortLocked() int {
 	}
 
 	if p.rangeSize > 0 {
-		used := make(map[int]bool, len(p.allocated))
-		for _, base := range p.allocated {
-			used[base] = true
-		}
 		for base := p.portStart; p.rangeFits(base); base += p.rangeSize {
-			if !used[base] {
+			if p.rangeAvailable(base, used) {
+				return base
+			}
+		}
+		for base := 1; p.rangeFits(base); base++ {
+			if p.rangeAvailable(base, used) {
 				return base
 			}
 		}
@@ -69,7 +73,33 @@ func (p *PortAllocator) nextAvailablePortLocked() int {
 
 func (p *PortAllocator) rangeFits(base int) bool {
 	const maxPort = 65535
-	return p.rangeSize > 0 && base <= maxPort && base+p.rangeSize-1 <= maxPort
+	return p.rangeSize > 0 && base >= 1 && base <= maxPort && base+p.rangeSize-1 <= maxPort
+}
+
+func (p *PortAllocator) usedRangesLocked() []portRange {
+	used := make([]portRange, 0, len(p.allocated))
+	for _, base := range p.allocated {
+		used = append(used, portRange{start: base, end: base + p.rangeSize - 1})
+	}
+	return used
+}
+
+func (p *PortAllocator) rangeAvailable(base int, used []portRange) bool {
+	if !p.rangeFits(base) {
+		return false
+	}
+	end := base + p.rangeSize - 1
+	for _, existing := range used {
+		if base <= existing.end && end >= existing.start {
+			return false
+		}
+	}
+	return true
+}
+
+type portRange struct {
+	start int
+	end   int
 }
 
 // GetPort returns the allocated port for a workspace

--- a/internal/process/ports.go
+++ b/internal/process/ports.go
@@ -66,11 +66,6 @@ func (p *PortAllocator) nextAvailablePortLocked() int {
 				return base
 			}
 		}
-		for base := 1; p.rangeFits(base); base++ {
-			if p.rangeAvailable(base, used) {
-				return base
-			}
-		}
 	}
 	panic(ErrPortRangeExhausted)
 }

--- a/internal/process/ports.go
+++ b/internal/process/ports.go
@@ -1,8 +1,12 @@
 package process
 
 import (
+	"errors"
 	"sync"
 )
+
+// ErrPortRangeExhausted reports that no valid, non-overlapping port range remains.
+var ErrPortRangeExhausted = errors.New("port allocator exhausted")
 
 // PortAllocator manages port allocation for workspaces
 type PortAllocator struct {
@@ -68,7 +72,7 @@ func (p *PortAllocator) nextAvailablePortLocked() int {
 			}
 		}
 	}
-	return p.portStart
+	panic(ErrPortRangeExhausted)
 }
 
 func (p *PortAllocator) rangeFits(base int) bool {

--- a/internal/process/ports.go
+++ b/internal/process/ports.go
@@ -10,6 +10,7 @@ type PortAllocator struct {
 	portStart int
 	rangeSize int
 	allocated map[string]int // workspace root -> port base
+	freeBases []int
 	nextPort  int
 }
 
@@ -33,12 +34,42 @@ func (p *PortAllocator) AllocatePort(workspaceRoot string) int {
 		return port
 	}
 
-	// Allocate new port range
-	port := p.nextPort
+	port := p.nextAvailablePortLocked()
 	p.allocated[workspaceRoot] = port
-	p.nextPort += p.rangeSize
 
 	return port
+}
+
+func (p *PortAllocator) nextAvailablePortLocked() int {
+	if n := len(p.freeBases); n > 0 {
+		port := p.freeBases[n-1]
+		p.freeBases = p.freeBases[:n-1]
+		return port
+	}
+
+	if p.rangeFits(p.nextPort) {
+		port := p.nextPort
+		p.nextPort += p.rangeSize
+		return port
+	}
+
+	if p.rangeSize > 0 {
+		used := make(map[int]bool, len(p.allocated))
+		for _, base := range p.allocated {
+			used[base] = true
+		}
+		for base := p.portStart; p.rangeFits(base); base += p.rangeSize {
+			if !used[base] {
+				return base
+			}
+		}
+	}
+	return p.portStart
+}
+
+func (p *PortAllocator) rangeFits(base int) bool {
+	const maxPort = 65535
+	return p.rangeSize > 0 && base <= maxPort && base+p.rangeSize-1 <= maxPort
 }
 
 // GetPort returns the allocated port for a workspace
@@ -50,11 +81,14 @@ func (p *PortAllocator) GetPort(workspaceRoot string) (int, bool) {
 	return port, ok
 }
 
-// ReleasePort releases the port allocation for a workspace
+// ReleasePort releases the port allocation for a workspace so the base can be reused.
 func (p *PortAllocator) ReleasePort(workspaceRoot string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if base, ok := p.allocated[workspaceRoot]; ok {
+		p.freeBases = append(p.freeBases, base)
+	}
 	delete(p.allocated, workspaceRoot)
 }
 

--- a/internal/process/ports_test.go
+++ b/internal/process/ports_test.go
@@ -61,6 +61,58 @@ func TestPortAllocator_ReleasePort(t *testing.T) {
 	}
 }
 
+func TestPortAllocator_ReusesReleasedBase(t *testing.T) {
+	p := NewPortAllocator(6200, 10)
+
+	if got := p.AllocatePort("/workspace-a"); got != 6200 {
+		t.Fatalf("AllocatePort(A) = %d, want 6200", got)
+	}
+	p.ReleasePort("/workspace-a")
+	if got := p.AllocatePort("/workspace-b"); got != 6200 {
+		t.Fatalf("AllocatePort(B after release) = %d, want 6200", got)
+	}
+	if got := p.AllocatePort("/workspace-c"); got != 6210 {
+		t.Fatalf("AllocatePort(C) = %d, want 6210", got)
+	}
+}
+
+func TestPortAllocator_SameRootRecreateDoesNotLeak(t *testing.T) {
+	p := NewPortAllocator(6200, 10)
+
+	for i := 0; i < 100; i++ {
+		if got := p.AllocatePort("/workspace"); got != 6200 {
+			t.Fatalf("iteration %d AllocatePort(/workspace) = %d, want 6200", i, got)
+		}
+		p.ReleasePort("/workspace")
+	}
+	if got := p.AllocatePort("/fresh"); got != 6200 {
+		t.Fatalf("AllocatePort(/fresh) = %d, want 6200", got)
+	}
+	if got := p.AllocatePort("/fresh-2"); got >= 6230 {
+		t.Fatalf("next fresh base ran away to %d", got)
+	}
+}
+
+func TestPortAllocator_ExhaustionScanStaysInRange(t *testing.T) {
+	p := NewPortAllocator(65500, 10)
+
+	for i, want := range []int{65500, 65510, 65520} {
+		if got := p.AllocatePort(fmt.Sprintf("/workspace-%d", i)); got != want {
+			t.Fatalf("AllocatePort(%d) = %d, want %d", i, got, want)
+		}
+	}
+	p.ReleasePort("/workspace-1")
+	if got := p.AllocatePort("/workspace-reused"); got != 65510 {
+		t.Fatalf("AllocatePort(reused) = %d, want 65510", got)
+	}
+	if got := p.AllocatePort("/workspace-exhausted"); got != 65500 {
+		t.Fatalf("AllocatePort(exhausted) = %d, want 65500 last-resort base", got)
+	}
+	if port, rangeEnd := p.PortRange("/workspace-exhausted"); port != 65500 || rangeEnd > 65535 {
+		t.Fatalf("PortRange(exhausted) = (%d, %d), want base 65500 and end <= 65535", port, rangeEnd)
+	}
+}
+
 func TestPortAllocator_PortRange(t *testing.T) {
 	p := NewPortAllocator(6200, 10)
 
@@ -128,6 +180,38 @@ func TestPortAllocator_ConcurrentAccess(t *testing.T) {
 			t.Errorf("overlapping ranges: [%d, %d] and [%d, %d]",
 				sorted[i-1], prevEnd, sorted[i], sorted[i]+rangeSize-1)
 		}
+	}
+}
+
+func TestPortAllocator_ConcurrentAllocateRelease(t *testing.T) {
+	const (
+		workers   = 8
+		cycles    = 100
+		portStart = 6200
+		rangeSize = 10
+	)
+	p := NewPortAllocator(portStart, rangeSize)
+	errCh := make(chan string, workers*cycles)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			root := fmt.Sprintf("/workspace-%d", i)
+			for j := 0; j < cycles; j++ {
+				base := p.AllocatePort(root)
+				if base < portStart || base > 65535 || (base-portStart)%rangeSize != 0 {
+					errCh <- fmt.Sprintf("worker %d cycle %d got invalid base %d", i, j, base)
+				}
+				p.ReleasePort(root)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
 	}
 }
 

--- a/internal/process/ports_test.go
+++ b/internal/process/ports_test.go
@@ -105,12 +105,22 @@ func TestPortAllocator_ExhaustionScanStaysInRange(t *testing.T) {
 	if got := p.AllocatePort("/workspace-reused"); got != 65510 {
 		t.Fatalf("AllocatePort(reused) = %d, want 65510", got)
 	}
-	if got := p.AllocatePort("/workspace-exhausted"); got != 65500 {
-		t.Fatalf("AllocatePort(exhausted) = %d, want 65500 last-resort base", got)
+	got := p.AllocatePort("/workspace-exhausted")
+	if got+9 > 65535 {
+		t.Fatalf("AllocatePort(exhausted) = %d, range end exceeds 65535", got)
 	}
-	if port, rangeEnd := p.PortRange("/workspace-exhausted"); port != 65500 || rangeEnd > 65535 {
-		t.Fatalf("PortRange(exhausted) = (%d, %d), want base 65500 and end <= 65535", port, rangeEnd)
+	for _, live := range []int{65500, 65510, 65520} {
+		if portRangesOverlap(got, got+9, live, live+9) {
+			t.Fatalf("AllocatePort(exhausted) = %d overlaps live base %d", got, live)
+		}
 	}
+	if port, rangeEnd := p.PortRange("/workspace-exhausted"); port != got || rangeEnd > 65535 {
+		t.Fatalf("PortRange(exhausted) = (%d, %d), want base %d and end <= 65535", port, rangeEnd, got)
+	}
+}
+
+func portRangesOverlap(startA, endA, startB, endB int) bool {
+	return startA <= endB && endA >= startB
 }
 
 func TestPortAllocator_PortRange(t *testing.T) {

--- a/internal/process/ports_test.go
+++ b/internal/process/ports_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -121,6 +122,22 @@ func TestPortAllocator_ExhaustionScanStaysInRange(t *testing.T) {
 
 func portRangesOverlap(startA, endA, startB, endB int) bool {
 	return startA <= endB && endA >= startB
+}
+
+func TestPortAllocator_FullExhaustionPanics(t *testing.T) {
+	p := NewPortAllocator(1, 32768)
+
+	if got := p.AllocatePort("/workspace-1"); got != 1 {
+		t.Fatalf("AllocatePort(first) = %d, want 1", got)
+	}
+	defer func() {
+		recovered := recover()
+		err, ok := recovered.(error)
+		if !ok || !errors.Is(err, ErrPortRangeExhausted) {
+			t.Fatalf("panic = %v, want ErrPortRangeExhausted", recovered)
+		}
+	}()
+	p.AllocatePort("/workspace-2")
 }
 
 func TestPortAllocator_PortRange(t *testing.T) {

--- a/internal/process/ports_test.go
+++ b/internal/process/ports_test.go
@@ -106,22 +106,9 @@ func TestPortAllocator_ExhaustionScanStaysInRange(t *testing.T) {
 	if got := p.AllocatePort("/workspace-reused"); got != 65510 {
 		t.Fatalf("AllocatePort(reused) = %d, want 65510", got)
 	}
-	got := p.AllocatePort("/workspace-exhausted")
-	if got+9 > 65535 {
-		t.Fatalf("AllocatePort(exhausted) = %d, range end exceeds 65535", got)
-	}
-	for _, live := range []int{65500, 65510, 65520} {
-		if portRangesOverlap(got, got+9, live, live+9) {
-			t.Fatalf("AllocatePort(exhausted) = %d overlaps live base %d", got, live)
-		}
-	}
-	if port, rangeEnd := p.PortRange("/workspace-exhausted"); port != got || rangeEnd > 65535 {
-		t.Fatalf("PortRange(exhausted) = (%d, %d), want base %d and end <= 65535", port, rangeEnd, got)
-	}
-}
-
-func portRangesOverlap(startA, endA, startB, endB int) bool {
-	return startA <= endB && endA >= startB
+	expectPortExhaustionPanic(t, func() {
+		p.AllocatePort("/workspace-exhausted")
+	})
 }
 
 func TestPortAllocator_FullExhaustionPanics(t *testing.T) {
@@ -130,6 +117,13 @@ func TestPortAllocator_FullExhaustionPanics(t *testing.T) {
 	if got := p.AllocatePort("/workspace-1"); got != 1 {
 		t.Fatalf("AllocatePort(first) = %d, want 1", got)
 	}
+	expectPortExhaustionPanic(t, func() {
+		p.AllocatePort("/workspace-2")
+	})
+}
+
+func expectPortExhaustionPanic(t *testing.T, fn func()) {
+	t.Helper()
 	defer func() {
 		recovered := recover()
 		err, ok := recovered.(error)
@@ -137,7 +131,7 @@ func TestPortAllocator_FullExhaustionPanics(t *testing.T) {
 			t.Fatalf("panic = %v, want ErrPortRangeExhausted", recovered)
 		}
 	}()
-	p.AllocatePort("/workspace-2")
+	fn()
 }
 
 func TestPortAllocator_PortRange(t *testing.T) {


### PR DESCRIPTION
## Summary
- reuse released port-range bases with a free list
- keep allocations inside the configured pool and fail explicitly when it is exhausted
- add reuse, churn, exhaustion, and race-smoke coverage for PortAllocator

## Verification
- go build ./internal/process
- go test ./internal/process -race -count=1 -run Port
- go test ./internal/process -race -count=1
- make devcheck
- make lint-strict-new
- /Users/andrewlee/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main (final run clean: no accepted/actionable findings)

## Autoreview follow-up
- accepted and fixed findings about duplicate live ranges and below-start fallback during exhaustion