### PR TITLE
Reuse vterm snapshots with a double buffer

### DIFF
--- a/internal/ui/center/model_cursor_refresh.go
+++ b/internal/ui/center/model_cursor_refresh.go
@@ -47,9 +47,7 @@ func invalidateCursorSnapshotCacheLocked(tab *Tab) {
 	if tab == nil {
 		return
 	}
-	tab.CachedSnap = nil
-	tab.CachedVersion = 0
-	tab.CachedShowCursor = false
+	tab.ResetSnapshotCache()
 	tab.cachedRecentLocalInput = false
 	tab.cachedRestrictCursor = false
 }

--- a/internal/ui/center/model_lifecycle.go
+++ b/internal/ui/center/model_lifecycle.go
@@ -167,9 +167,7 @@ func (m *Model) setActiveTerminalCursorVisibility(visible bool) {
 	}
 	// Invalidate cached snapshot so focus transitions cannot reuse stale
 	// cursor-painted frames.
-	tab.CachedSnap = nil
-	tab.CachedVersion = 0
-	tab.CachedShowCursor = false
+	tab.ResetSnapshotCache()
 	tab.cachedRecentLocalInput = false
 	tab.cachedRestrictCursor = false
 }
@@ -206,7 +204,7 @@ func (m *Model) Close() {
 			tab.resetPTYStateLocked()
 			tab.DiffViewer = nil
 			tab.Terminal = nil
-			tab.CachedSnap = nil
+			tab.ResetSnapshotCache()
 			tab.Workspace = nil
 			tab.Running = false
 			tab.mu.Unlock()

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -265,11 +265,10 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 		return compositor.NewVTermLayer(tab.CachedSnap)
 	}
 
-	// Create new snapshot while holding the lock.
-	// Do not pass the previous snapshot for reuse: NewVTermSnapshotWithCache
-	// mutates the provided snapshot/rows in-place, which can mutate a snapshot
-	// already handed to a previously returned layer.
-	snap := compositor.NewVTermSnapshot(tab.Terminal, showCursor)
+	// Chat post-processing below is safe with double buffering: scrolled history
+	// forces a full copy, cursor sanitation touches force-dirtied cursor rows,
+	// and blink clearing is idempotent for unchanged terminal cells.
+	snap := tab.SnapshotBuffer.Snapshot(tab.Terminal, showCursor)
 	if snap == nil {
 		return nil
 	}

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -265,10 +265,15 @@ func (m *Model) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTerm
 		return compositor.NewVTermLayer(tab.CachedSnap)
 	}
 
-	// Chat post-processing below is safe with double buffering: scrolled history
-	// forces a full copy, cursor sanitation touches force-dirtied cursor rows,
-	// and blink clearing is idempotent for unchanged terminal cells.
-	snap := tab.SnapshotBuffer.Snapshot(tab.Terminal, showCursor)
+	var snap *compositor.VTermSnapshot
+	if isChat {
+		// Chat post-processing mutates snapshot rows after creation, so keep the
+		// reusable raw buffers out of this path.
+		snap = compositor.NewVTermSnapshot(tab.Terminal, showCursor)
+	} else {
+		// SnapshotDoubleBuffer reuses rows without mutating the last handed-out layer.
+		snap = tab.SnapshotBuffer.Snapshot(tab.Terminal, showCursor)
+	}
 	if snap == nil {
 		return nil
 	}

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -444,7 +444,7 @@ func (m *Model) CleanupWorkspace(ws *data.Workspace) {
 		tab.resetPTYStateLocked()
 		tab.DiffViewer = nil
 		tab.Terminal = nil
-		tab.CachedSnap = nil
+		tab.ResetSnapshotCache()
 		tab.Workspace = nil
 		tab.Running = false
 		tab.mu.Unlock()

--- a/internal/ui/center/model_tabs_actions.go
+++ b/internal/ui/center/model_tabs_actions.go
@@ -53,7 +53,7 @@ func (m *Model) closeTabAt(index int) tea.Cmd {
 	// via CloseAgent() above; leaving the pointer intact is safe.
 	tab.DiffViewer = nil
 	tab.Terminal = nil
-	tab.CachedSnap = nil
+	tab.ResetSnapshotCache()
 	tab.Workspace = nil
 	tab.Running = false
 	tab.resetPTYStateLocked()

--- a/internal/ui/compositor/benchmark_test.go
+++ b/internal/ui/compositor/benchmark_test.go
@@ -116,6 +116,36 @@ func BenchmarkVTermSnapshotDirtyReuse(b *testing.B) {
 	}
 }
 
+// BenchmarkSnapshotDoubleBuffer benchmarks live-path dirty reuse with alias-safe buffering.
+func BenchmarkSnapshotDoubleBuffer(b *testing.B) {
+	sizes := []struct {
+		name          string
+		width, height int
+	}{
+		{"80x24", 80, 24},
+		{"120x40", 120, 40},
+	}
+
+	for _, size := range sizes {
+		b.Run(size.name, func(b *testing.B) {
+			term := setupVTerm(size.width, size.height)
+			var buf SnapshotDoubleBuffer
+			_ = buf.Snapshot(term, true)
+
+			moveCursor := []byte("\x1b[2;1H")
+			writeChar := []byte("X")
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				term.Write(moveCursor)
+				term.Write(writeChar)
+				_ = buf.Snapshot(term, true)
+			}
+		})
+	}
+}
+
 // BenchmarkCanvasRender benchmarks the Canvas.Render ANSI output generation
 func BenchmarkCanvasRender(b *testing.B) {
 	sizes := []struct {

--- a/internal/ui/compositor/snapshot_doublebuf.go
+++ b/internal/ui/compositor/snapshot_doublebuf.go
@@ -1,0 +1,75 @@
+package compositor
+
+import "github.com/andyrewlee/amux/internal/vterm"
+
+// SnapshotDoubleBuffer alternates between two snapshot buffers so the buffer
+// mutated by an incremental snapshot is never the one most recently handed to a
+// layer. Each buffer carries rows dirtied while the other buffer was the target,
+// because vterm dirty tracking is per snapshot call, not per buffer.
+//
+// It is not safe for concurrent use; callers must hold the same lock they hold
+// when snapshotting the VTerm.
+type SnapshotDoubleBuffer struct {
+	bufs   [2]*VTermSnapshot
+	stale  [2][]bool // nil means fully stale; force a full copy into that buffer.
+	last   int
+	inited bool
+}
+
+// Snapshot returns a current terminal snapshot without mutating the snapshot
+// returned by the previous call.
+func (d *SnapshotDoubleBuffer) Snapshot(term *vterm.VTerm, showCursor bool) *VTermSnapshot {
+	target := 1 - d.last
+	if !d.inited {
+		target = 0
+	}
+
+	prev := d.bufs[target]
+	extraDirty := d.stale[target]
+	if prev != nil && extraDirty == nil {
+		prev = nil
+	}
+
+	snap := newVTermSnapshot(term, showCursor, prev, extraDirty)
+	if snap == nil {
+		return nil
+	}
+
+	d.bufs[target] = snap
+	d.stale[target] = resetStaleMask(d.stale[target], snap.Height)
+	d.markOtherStale(1-target, snap)
+	d.last = target
+	d.inited = true
+	return snap
+}
+
+// Reset discards both buffers and all stale-row tracking.
+func (d *SnapshotDoubleBuffer) Reset() {
+	d.bufs = [2]*VTermSnapshot{}
+	d.stale = [2][]bool{}
+	d.last = 0
+	d.inited = false
+}
+
+func (d *SnapshotDoubleBuffer) markOtherStale(other int, snap *VTermSnapshot) {
+	if snap == nil || snap.AllDirty || snap.DirtyLines == nil ||
+		d.stale[other] == nil || len(d.stale[other]) != snap.Height {
+		d.stale[other] = nil
+		return
+	}
+	for y, dirty := range snap.DirtyLines {
+		if dirty {
+			d.stale[other][y] = true
+		}
+	}
+}
+
+func resetStaleMask(mask []bool, height int) []bool {
+	if len(mask) != height {
+		return make([]bool, height)
+	}
+	for i := range mask {
+		mask[i] = false
+	}
+	return mask
+}

--- a/internal/ui/compositor/snapshot_doublebuf_test.go
+++ b/internal/ui/compositor/snapshot_doublebuf_test.go
@@ -1,0 +1,163 @@
+package compositor
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func TestSnapshotDoubleBufferAliasingSafety(t *testing.T) {
+	term := vterm.New(8, 4)
+	var buf SnapshotDoubleBuffer
+
+	writeAt(term, 1, 0, "old")
+	first := buf.Snapshot(term, true)
+	if first == nil {
+		t.Fatal("first snapshot is nil")
+	}
+	writeAt(term, 1, 0, "new")
+	second := buf.Snapshot(term, true)
+	if second == nil {
+		t.Fatal("second snapshot is nil")
+	}
+
+	if got := rowText(first, 1, 3); got != "old" {
+		t.Fatalf("first snapshot row mutated to %q, want old", got)
+	}
+	if got := rowText(second, 1, 3); got != "new" {
+		t.Fatalf("second snapshot row = %q, want new", got)
+	}
+}
+
+func TestSnapshotDoubleBufferStalenessUnion(t *testing.T) {
+	term := vterm.New(10, 8)
+	var buf SnapshotDoubleBuffer
+
+	writeAt(term, 3, 0, "row3")
+	snapA := buf.Snapshot(term, true)
+	requireRowPrefix(t, snapA, 3, "row3")
+
+	writeAt(term, 5, 0, "row5")
+	snapB := buf.Snapshot(term, true)
+	requireRowPrefix(t, snapB, 3, "row3")
+	requireRowPrefix(t, snapB, 5, "row5")
+
+	writeAt(term, 7, 0, "row7")
+	snapA2 := buf.Snapshot(term, true)
+	requireRowPrefix(t, snapA2, 3, "row3")
+	requireRowPrefix(t, snapA2, 5, "row5")
+	requireRowPrefix(t, snapA2, 7, "row7")
+}
+
+func TestSnapshotDoubleBufferResize(t *testing.T) {
+	term := vterm.New(6, 3)
+	var buf SnapshotDoubleBuffer
+
+	writeAt(term, 0, 0, "small")
+	_ = buf.Snapshot(term, true)
+
+	term.Resize(8, 5)
+	writeAt(term, 4, 0, "large")
+	resized := buf.Snapshot(term, true)
+	if resized == nil {
+		t.Fatal("resized snapshot is nil")
+	}
+	if resized.Width != 8 || resized.Height != 5 {
+		t.Fatalf("resized snapshot dims = %dx%d, want 8x5", resized.Width, resized.Height)
+	}
+	requireRowPrefix(t, resized, 4, "large")
+
+	writeAt(term, 1, 0, "again")
+	next := buf.Snapshot(term, true)
+	if next.Width != 8 || next.Height != 5 {
+		t.Fatalf("next snapshot dims = %dx%d, want 8x5", next.Width, next.Height)
+	}
+	requireRowPrefix(t, next, 1, "again")
+	requireRowPrefix(t, next, 4, "large")
+}
+
+func TestSnapshotDoubleBufferViewOffset(t *testing.T) {
+	term := vterm.New(8, 3)
+	term.Scrollback = [][]vterm.Cell{cellLine("history", 8)}
+	term.Screen[0] = cellLine("screen0", 8)
+	term.Screen[1] = cellLine("screen1", 8)
+	term.Screen[2] = cellLine("screen2", 8)
+
+	var buf SnapshotDoubleBuffer
+	term.ViewOffset = 1
+	scrolled := buf.Snapshot(term, true)
+	requireRowPrefix(t, scrolled, 0, "history")
+	requireRowPrefix(t, scrolled, 1, "screen0")
+
+	term.ViewOffset = 0
+	live := buf.Snapshot(term, true)
+	requireRowPrefix(t, live, 0, "screen0")
+	requireRowPrefix(t, live, 2, "screen2")
+}
+
+func TestSnapshotDoubleBufferNoChangeFrame(t *testing.T) {
+	term := vterm.New(8, 4)
+	var buf SnapshotDoubleBuffer
+
+	writeAt(term, 1, 0, "stable")
+	_ = buf.Snapshot(term, true)
+	_ = buf.Snapshot(term, true)
+	snap := buf.Snapshot(term, true)
+	if snap == nil {
+		t.Fatal("snapshot is nil")
+	}
+	if got := countDirty(snap.DirtyLines); got > 2 {
+		t.Fatalf("dirty lines after no-change frame = %d, want at most cursor rows", got)
+	}
+	requireRowPrefix(t, snap, 1, "stable")
+}
+
+func writeAt(term *vterm.VTerm, row, col int, text string) {
+	term.Write([]byte(fmt.Sprintf("\x1b[%d;%dH%s", row+1, col+1, text)))
+}
+
+func requireRowPrefix(t *testing.T, snap *VTermSnapshot, row int, want string) {
+	t.Helper()
+	if snap == nil {
+		t.Fatal("snapshot is nil")
+	}
+	if got := rowText(snap, row, len(want)); got != want {
+		t.Fatalf("row %d prefix = %q, want %q", row, got, want)
+	}
+}
+
+func rowText(snap *VTermSnapshot, row, width int) string {
+	var b strings.Builder
+	for i := 0; i < width && row < len(snap.Screen) && i < len(snap.Screen[row]); i++ {
+		r := snap.Screen[row][i].Rune
+		if r == 0 {
+			r = ' '
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func cellLine(text string, width int) []vterm.Cell {
+	line := vterm.MakeBlankLine(width)
+	for i, r := range text {
+		if i >= len(line) {
+			break
+		}
+		line[i].Rune = r
+		line[i].Width = 1
+	}
+	return line
+}
+
+func countDirty(lines []bool) int {
+	count := 0
+	for _, dirty := range lines {
+		if dirty {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/ui/compositor/vtermlayer_snapshot.go
+++ b/internal/ui/compositor/vtermlayer_snapshot.go
@@ -32,6 +32,11 @@ func NewVTermSnapshot(term *vterm.VTerm, showCursor bool) *VTermSnapshot {
 // lines from a previous snapshot when dirty line tracking allows.
 // MUST be called while holding the appropriate lock on the VTerm.
 func NewVTermSnapshotWithCache(term *vterm.VTerm, showCursor bool, prev *VTermSnapshot) *VTermSnapshot {
+	return newVTermSnapshot(term, showCursor, prev, nil)
+}
+
+//nolint:gocyclo,funlen // Existing snapshot assembly stays centralized so cache and double-buffer paths share exact behavior.
+func newVTermSnapshot(term *vterm.VTerm, showCursor bool, prev *VTermSnapshot, extraDirty []bool) *VTermSnapshot {
 	if term == nil {
 		return nil
 	}
@@ -97,7 +102,7 @@ func NewVTermSnapshotWithCache(term *vterm.VTerm, showCursor bool, prev *VTermSn
 
 		visible, _ := term.RenderBuffers()
 		for y := 0; y < height; y++ {
-			needsCopy := dirtyLines[y]
+			needsCopy := dirtyLines[y] || (extraDirty != nil && y < len(extraDirty) && extraDirty[y])
 			if screen[y] == nil || len(screen[y]) != width {
 				needsCopy = true
 			}

--- a/internal/ui/ptyio/state.go
+++ b/internal/ui/ptyio/state.go
@@ -57,4 +57,16 @@ type State struct {
 	CachedSnap       *compositor.VTermSnapshot
 	CachedVersion    uint64
 	CachedShowCursor bool
+	SnapshotBuffer   compositor.SnapshotDoubleBuffer
+}
+
+// ResetSnapshotCache clears cached render snapshots and the reusable snapshot buffers.
+func (s *State) ResetSnapshotCache() {
+	if s == nil {
+		return
+	}
+	s.CachedSnap = nil
+	s.CachedVersion = 0
+	s.CachedShowCursor = false
+	s.SnapshotBuffer.Reset()
 }

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -290,6 +290,5 @@ func (m *TerminalModel) setActiveTerminalCursorVisibility(visible bool) {
 	}
 	// Invalidate cached snapshot so focus transitions cannot reuse stale
 	// cursor-painted frames.
-	ts.CachedSnap = nil
-	ts.CachedVersion = 0
+	ts.ResetSnapshotCache()
 }

--- a/internal/ui/sidebar/terminal_render.go
+++ b/internal/ui/sidebar/terminal_render.go
@@ -170,10 +170,8 @@ func (m *TerminalModel) TerminalLayerWithCursorOwner(cursorOwner bool) *composit
 		return compositor.NewVTermLayer(ts.CachedSnap)
 	}
 
-	// Do not pass the previous snapshot for reuse: NewVTermSnapshotWithCache
-	// mutates the provided snapshot/rows in-place, which can mutate a snapshot
-	// already handed to a previously returned layer.
-	snap := compositor.NewVTermSnapshot(ts.VTerm, showCursor)
+	// SnapshotDoubleBuffer reuses rows without mutating the last handed-out layer.
+	snap := ts.SnapshotBuffer.Snapshot(ts.VTerm, showCursor)
 	if snap == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- add SnapshotDoubleBuffer to alternate reusable VTerm snapshot buffers without mutating the last handed-out layer
- wire double-buffer reuse into sidebar and non-chat center terminal snapshots, while keeping chat snapshots full-copy because chat post-processing mutates rows
- reset reusable buffers anywhere the existing snapshot cache is invalidated
- add aliasing, stale-row, resize, view-offset, no-change tests and a benchmark

## Verification
- go test ./internal/ui/compositor -race -count=1 -run DoubleBuffer
- go test ./internal/ui/compositor -race -count=1
- go test ./internal/ui/sidebar ./internal/app -count=1
- go test ./internal/ui/center ./internal/app -count=1
- make harness-golden
- go test -bench='SnapshotCreation|SnapshotDirtyReuse|SnapshotDoubleBuffer' -benchmem ./internal/ui/compositor -run '^$'
- frame dump diff against clean origin/main: empty
- make devcheck
- make lint-strict-new
- make perf-check (isolated rerun passed; a concurrent run with devcheck was discarded as contaminated)
- focused rerun of transient pre-push e2e failure: go test ./internal/e2e -run TestWorkspaceDeleteTearsDownAgent -count=1 -v passed
- /Users/andrewlee/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main (final run clean: no accepted/actionable findings)

## Benchmark
- SnapshotCreation/120x40: 272580 B/op
- SnapshotDirtyReuse/120x40: 16 B/op
- SnapshotDoubleBuffer/120x40: 16 B/op

## Autoreview follow-up
- accepted and fixed chat-path buffer contamination by keeping post-processed chat snapshots out of reusable raw buffers