### PR TITLE
fix: render full grapheme clusters in the compositor canvas

### DIFF
--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -174,7 +174,11 @@ func (c *Canvas) Render() string {
 				lastStyle = style
 			}
 			firstCell = false
-			b.WriteRune(vterm.RenderableRune(cell.Rune))
+			if cell.GraphemeCluster != "" {
+				b.WriteString(cell.GraphemeCluster)
+			} else {
+				b.WriteRune(vterm.RenderableRune(cell.Rune))
+			}
 		}
 		if y < c.Height-1 {
 			b.WriteRune('\n')

--- a/internal/ui/compositor/canvas_test.go
+++ b/internal/ui/compositor/canvas_test.go
@@ -1,10 +1,43 @@
 package compositor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/vterm"
 )
+
+func TestCanvasRenderEmitsGraphemeCluster(t *testing.T) {
+	canvas := NewCanvas(2, 1)
+	// "é" as base rune 'e' plus combining acute accent U+0301, stored the way
+	// vterm stores clusters: base rune + full cluster string.
+	cluster := "e\u0301"
+	canvas.SetCell(0, 0, vterm.Cell{Rune: 'e', Width: 1, GraphemeCluster: cluster})
+
+	out := canvas.Render()
+	if !strings.Contains(out, cluster) {
+		t.Fatalf("expected render output to contain full grapheme cluster %q (U+0301 bytes 0xCC 0x81), got %q", cluster, out)
+	}
+}
+
+func TestCanvasRenderEmptyClusterFallsBackToRenderableRune(t *testing.T) {
+	canvas := NewCanvas(2, 1)
+	canvas.SetCell(0, 0, vterm.Cell{Rune: 'x', Width: 1})
+	canvas.SetCell(1, 0, vterm.Cell{Rune: 0, Width: 1})
+
+	out := canvas.Render()
+	if !strings.Contains(out, "x") {
+		t.Fatalf("expected fallback to emit rune 'x', got %q", out)
+	}
+	// A zero rune with no cluster must render as RenderableRune(0) == ' ',
+	// never as a NUL byte.
+	if strings.ContainsRune(out, 0) {
+		t.Fatalf("expected NUL rune to render as space via RenderableRune, got %q", out)
+	}
+	if !strings.Contains(out, "x ") {
+		t.Fatalf("expected zero-rune cell to fall back to a space after 'x', got %q", out)
+	}
+}
 
 func TestCanvasRenderSuppressesUnderlineOnBlankCells(t *testing.T) {
 	canvas := NewCanvas(3, 1)


### PR DESCRIPTION
## Summary
Canvas.Render emitted only the base rune of each cell and ignored cell.GraphemeCluster, so the center pane (where agents run) silently dropped combining marks and emoji variation selectors — "café" written as e+U+0301 rendered as "cafe", while the identical content rendered correctly in the sidebar (vtermlayer.go) and vterm's own Render. This makes the canvas path use the same cluster-then-fallback rule as the two correct paths.

## Review evidence (plan 033)
- New test TestCanvasRenderEmitsGraphemeCluster confirmed FAILING pre-fix (U+0301 bytes dropped) and passing post-fix; fallback test pins NUL→space via RenderableRune.
- Full compositor suite ok; `make harness-golden` byte-identical; `make devcheck` and `make lint` clean in the executor worktree.
- Scope: canvas.go + canvas_test.go only. Overwrite safety verified: putChar writes fresh Cell literals, so stale clusters cannot survive an overwrite.
- Known follow-up (plans 001/021): VS16/ZWJ clusters now emit fully but the width-1-cell vs 2-wide-glyph mismatch remains until the vterm width fix lands.