### PR TITLE
fix: widen VS16 emoji clusters to two cells in vterm

### DIFF
--- a/internal/vterm/ops.go
+++ b/internal/vterm/ops.go
@@ -30,6 +30,34 @@ func (v *VTerm) putChar(r rune) {
 					base = string(cell.Rune)
 				}
 				cell.GraphemeCluster = base + string(r)
+				// VS16 (emoji variation selector) upgrades a narrow base
+				// glyph to a full-width emoji: retroactively widen the base
+				// cell to 2 columns, mirroring the wide-char path below.
+				if r == 0xFE0F && cell.Width == 1 && prevX+1 < v.Width && prevX+1 < len(v.Screen[prevY]) {
+					cell.Width = 2
+
+					// Clear any wide char that starts at the continuation
+					// position (same guard the wide path uses).
+					nextCell := v.Screen[prevY][prevX+1]
+					if nextCell.Width == 2 && prevX+2 < v.Width {
+						v.Screen[prevY][prevX+2] = DefaultCell()
+					}
+
+					v.Screen[prevY][prevX+1] = Cell{
+						Rune:  0, // Continuation marker
+						Style: cell.Style,
+						Width: 0, // Continuation cell
+					}
+
+					// The base was placed at CursorX-1 and the cursor already
+					// advanced past it by 1; widening it to 2 columns means
+					// the cursor must move one more column right. Only when
+					// the base cell is immediately left of the cursor — after
+					// a wrap to a previous row the cursor has already moved on.
+					if prevY == v.CursorY && prevX == v.CursorX-1 {
+						v.CursorX++
+					}
+				}
 				v.markDirtyLine(prevY)
 			}
 		}

--- a/internal/vterm/ops_test.go
+++ b/internal/vterm/ops_test.go
@@ -374,3 +374,56 @@ func TestAutoWrapBelowScrollRegionDoesNotScroll(t *testing.T) {
 		t.Errorf("CursorY after wrap below region = %d, want 5", vt.CursorY)
 	}
 }
+
+// TestPutCharVS16WidensBaseCell verifies that a VS16 (U+FE0F) emoji variation
+// selector retroactively widens its base cell to 2 columns, writes a
+// continuation cell, and advances the cursor past both columns.
+func TestPutCharVS16WidensBaseCell(t *testing.T) {
+	t.Parallel()
+
+	vt := New(8, 3)
+	vt.Write([]byte("❤️")) // ❤️ = heart + VS16
+
+	if got := vt.Screen[0][0].Width; got != 2 {
+		t.Errorf("base cell Width = %d, want 2", got)
+	}
+	if got := vt.Screen[0][1].Width; got != 0 {
+		t.Errorf("continuation cell Width = %d, want 0", got)
+	}
+	if got := vt.Screen[0][0].GraphemeCluster; got != "❤️" {
+		t.Errorf("base cell GraphemeCluster = %q, want %q", got, "❤️")
+	}
+	if vt.CursorX != 2 {
+		t.Errorf("CursorX = %d, want 2 (cursor advanced past both columns)", vt.CursorX)
+	}
+}
+
+// TestPutCharVS16ThenTextAligns verifies text following a VS16 emoji cluster
+// lands after the emoji's two columns, not shifted left onto it.
+func TestPutCharVS16ThenTextAligns(t *testing.T) {
+	t.Parallel()
+
+	vt := New(8, 3)
+	vt.Write([]byte("❤️X")) // ❤️X
+
+	if got := vt.Screen[0][2].Rune; got != 'X' {
+		t.Errorf("Screen[0][2].Rune = %q, want 'X' (text shifted onto emoji)", got)
+	}
+}
+
+// TestPutCharPlainCombiningStillWidth1 verifies an ordinary width-0 combining
+// mark (not VS16) still leaves the base cell at width 1 with no cursor
+// advance — only VS16 widens.
+func TestPutCharPlainCombiningStillWidth1(t *testing.T) {
+	t.Parallel()
+
+	vt := New(8, 3)
+	vt.Write([]byte("é")) // é = e + combining acute accent
+
+	if got := vt.Screen[0][0].Width; got != 1 {
+		t.Errorf("base cell Width = %d, want 1", got)
+	}
+	if vt.CursorX != 1 {
+		t.Errorf("CursorX = %d, want 1", vt.CursorX)
+	}
+}


### PR DESCRIPTION
## Summary
putChar measured width one rune at a time, so a VS16 (U+FE0F) emoji variation selector — which upgrades a narrow glyph to a full-width emoji (❤️ ⚠️ ☀️) — left its base cell at width 1 while real terminals render 2 columns. Every VS16 emoji on a line shifted the rest of that line one column left of the agent's model. The width-0 branch now retroactively widens the base cell to 2 columns, writes a continuation cell (mirroring the wide-char path, including the overlapped-wide-char clear), and advances the cursor by one — only when the base cell is immediately left of the cursor, so the wrapped-from-previous-row case stays untouched. VS16 only: ZWJ sequences and width-library choices are explicitly out of scope (plans 021+).

## Review evidence (plan 001)
- Three new tests: VS16 widens base cell + continuation + cursor; following text lands at column 2 (no overlap); a plain combining mark (e+U+0301) still yields width 1 with no cursor advance.
- Reviewer traced the edge cases: repeated VS16 is idempotent (step-back lands on the width-2 base; the Width==1 guard blocks re-entry); wide-base+VS16 is a no-op; last-column base skips widening in-bounds; the CursorX==Width end state matches the wide path's pending-wrap semantics.
- `go test ./internal/vterm -race -count=1` ok; `make harness-golden` byte-identical; devcheck + lint clean in the executor worktree.