### PR TITLE
docs: point PERF_BASELINES at the enforced .env and refresh the header

### DIFF
--- a/PERF_BASELINES.md
+++ b/PERF_BASELINES.md
@@ -1,27 +1,38 @@
 # Performance Baselines
 
-Date: 2026-02-04
+Date: 2026-07-12
 
 Machine
-- Host: Andrews-MacBook-Pro
-- OS: macOS (Darwin 24.6.0, arm64)
-- CPU: Apple M1 Max (10 cores)
-- Memory: 32 GB
-- Go: go1.25.6
+- Host: darwin-arm64 dev host (Apple Silicon)
+- Go: go1.26.4
+
+Enforced baselines (source of truth)
+
+The enforced p95 baselines live in `scripts/perf_baselines.env`, keyed by
+OS/ARCH (`DARWIN_ARM64_*` for the dev host, `LINUX_AMD64_*` for CI runners).
+This document deliberately does not repeat the numbers so they cannot drift.
+
+- Read the current values: `cat scripts/perf_baselines.env`
+- Check against them: `make perf-check` (runs `scripts/perf_compare.sh`, which
+  sources the `.env`, runs each harness preset below, parses the reported p95,
+  and fails if it exceeds the baseline by more than `PERF_TOLERANCE`).
+- Re-baseline: run `PERF_STRICT=1 make perf-check` three times on a quiescent
+  host and commit the per-preset medians to `scripts/perf_baselines.env` (see
+  the `perf-check` notes in the Makefile).
 
 Harness Presets (terminal size 160x48)
 
 Center (16 tabs, 2 hot tabs, 64B payload)
 - Command: `go run ./cmd/amux-harness -mode center -tabs 16 -hot-tabs 2 -payload-bytes 64 -frames 300 -warmup 30 -width 160 -height 48`
-- Result: `total=345.290042ms avg=1.038829ms p50=987.25µs p95=1.319417ms p99=1.943333ms min=906.125µs max=3.556ms fps=962.62`
+- Baseline: `DARWIN_ARM64_CENTER_P95_MS` in `scripts/perf_baselines.env`
 
 Monitor (16 tabs, 4 hot tabs, 64B payload)
 - Command: `go run ./cmd/amux-harness -mode monitor -tabs 16 -hot-tabs 4 -payload-bytes 64 -frames 300 -warmup 30 -width 160 -height 48`
-- Result: `total=452.965791ms avg=1.346043ms p50=1.277416ms p95=1.744709ms p99=2.143916ms min=1.170375ms max=5.612041ms fps=742.92`
+- Baseline: `DARWIN_ARM64_MONITOR_P95_MS` in `scripts/perf_baselines.env`
 
 Sidebar (deep scrollback: newline every frame)
 - Command: `go run ./cmd/amux-harness -mode sidebar -tabs 16 -hot-tabs 1 -payload-bytes 64 -newline-every 1 -frames 600 -warmup 30 -width 160 -height 48`
-- Result: `total=844.516834ms avg=1.329752ms p50=1.266459ms p95=1.68ms p99=2.266375ms min=1.160375ms max=3.673417ms fps=752.02`
+- Baseline: `DARWIN_ARM64_SIDEBAR_P95_MS` in `scripts/perf_baselines.env`
 
 pprof Capture (AMUX_PPROF)
 - Scenario: monitor preset under sustained load.


### PR DESCRIPTION
## Summary
PERF_BASELINES.md was stale-and-wrong: dated 2026-02-04, Go 1.25.6, and publishing p95 numbers 10-27% off the values make perf-check actually enforces (scripts/perf_baselines.env, rebaselined 2026-07-12). The doc now points at the .env as the single source of truth (so the two cannot drift again), documents the compare/tolerance/re-baseline procedure, and carries a current header (Go 1.26.4). Harness-command and pprof sections untouched.

## Review evidence (plan 024)
- Verified: no scripts or tests parse this doc (pointer form is safe); `grep go1.25` and the three stale p95 values return no matches; docs-only diff, `go vet ./...` clean.