### PR TITLE
chore: add local race and tidy gates mirroring CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,19 @@ setting, the `go` command switches to that patched toolchain automatically. If
 you force `GOTOOLCHAIN=local`, install the pinned patch release yourself before
 running repo checks.
 
-Run the local checks that mirror CI:
+Run the fast local checks:
 
 ```bash
 make devcheck
 ```
 
-`make devcheck` is the required pre-PR gate: it runs vet, tests, and lint (including file-length checks).
+`make devcheck` is the required pre-PR gate: it runs vet, tests, and lint (including file-length checks). It is the fast **subset** of CI, not the whole of it — CI additionally enforces the race detector and `go mod tidy` cleanliness. For the full local CI mirror, run:
+
+```bash
+make ci
+```
+
+`make ci` runs `devcheck` plus `make test-race` (CI's race gate; slow) and `make tidy-check` (CI's tidy gate). CI's govulncheck and harness smoke steps are not mirrored locally.
 
 For the inner loop, launch the TUI with `make run` in a real terminal — amux requires stdin, stdout, and stderr to all be TTYs, so it only runs directly in your terminal. `air` cannot host the TUI: it launches the rebuilt binary with stdin on `/dev/null`, which fails that TTY check, so `make dev` is not a hot-reload TUI loop. Use it instead for automatic rebuilds and compile-error feedback while you edit — run `make dev` in a second pane alongside `make run`. It runs [`air`](https://github.com/air-verse/air) with the repo's `.air.toml` and rebuilds on save. Install it once with:
 
@@ -54,6 +60,9 @@ make lint-strict-new
 Pull requests are CI-gated (automated). For local confidence before opening a PR:
 
 - always: `make devcheck`, `make lint-strict-new`
+- if touching concurrency (supervisor workers, PTY read loops, watchers, activity leases, anything with goroutines/channels/mutexes): `make test-race` — CI runs the race detector and `make devcheck` does not, so this is the most common green-local/red-CI surprise
+- after any dependency change (adding/removing an import, editing `go.mod`): `make tidy-check` — CI fails on an untidy `go.mod`/`go.sum` even when `devcheck` passes
+- before opening a PR you want green on the first push: `make ci` (devcheck + test-race + tidy-check, the full local CI mirror; slow)
 - if touching `internal/ui/`, `internal/vterm/`, or `cmd/amux-harness/`: `make harness-presets`
 - if touching `internal/tmux/`, `internal/e2e/`, or `internal/pty/`: `go test ./internal/tmux ./internal/e2e`
 - if touching the agent input/send path (`internal/pty/terminal.go`, `internal/ui/center/tab_actor_write.go`, `internal/pty/`, agent keystroke forwarding): `make verify-loop` — proves a real agent receives keystrokes end-to-end (incl. a literal CR); `make devcheck` does not, since the real-tmux tests skip there

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 GOLANGCI ?= golangci-lint
 lint lint-strict lint-strict-new lint-ci-parity check-golangci-version: GOLANGCI := $(shell want=`tr -d '[:space:]' < .golangci-version 2>/dev/null | sed 's/^v//'`; local="$$PWD/.cache/bin/golangci-lint"; have=`"$$local" version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//'`; if [ -x "$$local" ] && [ "$$have" = "$$want" ]; then echo "$$local"; else echo golangci-lint; fi)
 
-.PHONY: build install test bench lint lint-tools lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop tmux-skip-check help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
+.PHONY: build install test test-race tidy-check ci bench lint lint-tools lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop tmux-skip-check help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
 
 build:
 	go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
@@ -39,6 +39,32 @@ test:
 	echo "go test $$(printf '%s' "$$filtered" | tr '\n' ' ')"; \
 	go test $$filtered
 	@$(MAKE) --no-print-directory tmux-skip-check
+
+# test-race mirrors CI's "Test (race)" step: `go test -race` over CI's package
+# set, which excludes only internal/e2e and internal/tmux. Note this is wider
+# than `make test`/`make devcheck` (their filter also excludes internal/app) —
+# keep this filter coupled to .github/workflows/ci.yml, not to the test filter
+# above. Race runs are slow; that is why this is a separate target rather than
+# part of devcheck (same reasoning as verify-loop).
+test-race:
+	@packages=$$(go list ./...) || exit 1; \
+	filtered=$$(printf '%s\n' "$$packages" | grep -v -E '/internal/(tmux|e2e)$$') || exit 1; \
+	echo "go test -race $$(printf '%s' "$$filtered" | tr '\n' ' ')"; \
+	go test -race $$filtered
+
+# tidy-check mirrors CI's "Tidy check" step: it fails when go.mod/go.sum are
+# not tidy. Note it runs `go mod tidy`, so an untidy module is rewritten in
+# your working tree — inspect `git diff go.mod go.sum` on failure.
+tidy-check:
+	go mod tidy
+	git diff --exit-code go.mod go.sum
+
+# ci is the local mirror of the CI `test` job's gate set: devcheck (vet +
+# tests + lint + file-length) plus the race and tidy gates that devcheck
+# skips. Keep this target in sync with .github/workflows/ci.yml — if CI gains
+# a gate, add it here. Not mirrored locally (yet): govulncheck and the
+# harness/perf smoke steps.
+ci: devcheck test-race tidy-check
 
 devcheck:
 	go vet ./...
@@ -244,6 +270,9 @@ help:
 	@echo "Available targets:"
 	@echo "  build      - Build the binary"
 	@echo "  test       - Run all tests"
+	@echo "  test-race  - Run go test -race over CI's package set (slow; mirrors CI's race gate)"
+	@echo "  tidy-check - Run go mod tidy and fail if go.mod/go.sum change (mirrors CI's tidy gate)"
+	@echo "  ci         - Full local CI mirror: devcheck + test-race + tidy-check"
 	@echo "  devcheck   - vet + tests + golden harness + lint (warns when real-tmux/e2e tests skip)"
 	@echo "  lint       - Run golangci-lint and file length checks (max 500 lines)"
 	@echo "  lint-tools - Build the pinned golangci-lint (.golangci-version) into ./.cache/bin (idempotent)"


### PR DESCRIPTION
## Summary
CI enforces the race detector and go.mod tidiness; the documented local gate (make devcheck + hooks) runs neither, making them silent green-local/red-CI traps — race especially, in a TUI full of goroutines (supervisor, PTY read loops, watchers, leases). Adds make test-race (CI's exact package filter — wider than devcheck's, which also excludes internal/app; the difference is documented in the target comment), make tidy-check (byte-identical to CI's step), and a make ci umbrella. CONTRIBUTING now routes concurrency changes to test-race, dependency changes to tidy-check, and is accurate that devcheck is the fast subset of CI.

## Review evidence (plan 022)
- Reviewer ran both new targets in the executor worktree: make test-race exit 0 (full -race sweep incl. internal/app), make tidy-check exit 0.
- No Go code changes (Makefile + CONTRIBUTING.md only); make lint green on main. The executor worktree's devcheck lint failure was root-caused as a pre-existing nested-worktree golangci path-resolution artifact (proven by stash-and-rerun on the pristine base in a sibling worktree), unrelated to this diff.
- govulncheck intentionally not folded into make ci yet — plan 023 does that next and updates the target comment.