### PR TITLE
chore: bump pinned toolchain to go1.26.5 for stdlib CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/andyrewlee/amux
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Summary
CI's govulncheck gate is red on every commit since the GO-2026-5856 (crypto/tls) and GO-2026-4970 (os.Root) advisories published — both in the pinned go1.26.4 stdlib, both reachable from amux code, both fixed in go1.26.5. One-line toolchain bump; GOTOOLCHAIN=auto propagates it to local builds, CI (setup-go reads go.mod), and releases.

## Review evidence
- `govulncheck ./...` on this branch: **No vulnerabilities found** (was: 2 stdlib vulns).
- `go build ./...` and the full test sweep incl. the real-tmux set pass on go1.26.5 (one initial tmux-skip-check failure reproduced as shared-tmux-server contention from parallel worktree test runs; clean on isolated rerun).
- Unblocks the govulncheck job for all open/queued PRs.