### PR TITLE
fix: drain the real PTY read error before falling back to EOF

### DIFF
--- a/internal/ui/ptyio/pty_reader.go
+++ b/internal/ui/ptyio/pty_reader.go
@@ -153,6 +153,16 @@ func RunPTYReader(
 					}
 				}
 				if stoppedErr == nil {
+					// The inner goroutine sends the real read error on errCh
+					// and then closes dataCh, so both cases can be ready at
+					// once; drain the pending error before assuming clean EOF.
+					select {
+					case e := <-errCh:
+						stoppedErr = e
+					default:
+					}
+				}
+				if stoppedErr == nil {
 					stoppedErr = io.EOF
 				}
 				SendPTYMsg(msgCh, cancel, factory.Stopped(stoppedErr))

--- a/internal/ui/ptyio/pty_reader_test.go
+++ b/internal/ui/ptyio/pty_reader_test.go
@@ -184,15 +184,38 @@ func TestRunPTYReaderClosesOnceOnError(t *testing.T) {
 	cancel := make(chan struct{})
 	got := runReaderAndForward(t, &scriptedReader{finalErr: errors.New("boom")}, cancel, baseReaderCfg())
 
-	// The terminal error may be the read error or io.EOF depending on whether
-	// the err channel or the closed data channel is observed first; both are
-	// non-nil. The contract under test is exactly-once close, asserted by
+	// The contract under test is exactly-once close, asserted by
 	// runReaderAndForward returning rather than hanging or panicking.
+	// (TestRunPTYReaderStoppedCarriesReadError covers the error identity.)
 	if len(got.stops) != 1 {
 		t.Fatalf("got %d Stopped msgs, want 1", len(got.stops))
 	}
 	if got.stops[0].err == nil {
 		t.Fatal("Stopped err = nil, want non-nil")
+	}
+}
+
+func TestRunPTYReaderStoppedCarriesReadError(t *testing.T) {
+	sentinel := errors.New("simulated EIO")
+	cancel := make(chan struct{})
+
+	// The chunks keep the outer loop busy on dataCh receives so that the
+	// inner goroutine's errCh send and its deferred close(dataCh) can both
+	// be ready when the outer loop re-enters its select; Go then picks a
+	// ready case at random. Run under -race -count=50: without the errCh
+	// drain in the closed-dataCh branch this intermittently reports io.EOF
+	// instead of the real read error.
+	chunks := make([][]byte, 64)
+	for i := range chunks {
+		chunks[i] = []byte{byte('a' + i%26)}
+	}
+	got := runReaderAndForward(t, &scriptedReader{chunks: chunks, finalErr: sentinel}, cancel, baseReaderCfg())
+
+	if len(got.stops) != 1 {
+		t.Fatalf("got %d Stopped msgs, want 1", len(got.stops))
+	}
+	if !errors.Is(got.stops[0].err, sentinel) {
+		t.Fatalf("Stopped err = %v, want sentinel %v (io.EOF means the real error was masked)", got.stops[0].err, sentinel)
 	}
 }
 


### PR DESCRIPTION
## Summary
When an agent's child process dies, the inner reader goroutine sends the real error (typically EIO) on errCh and then closes dataCh — making both select cases ready at once. If the closed-dataCh case won the coin flip (~50%), stoppedErr was still nil and the code substituted io.EOF, discarding the real error forever: agent crash and clean exit became indistinguishable in the logs. Adds a non-blocking errCh drain in the closed-dataCh branch before the EOF fallback; genuine clean EOF (empty errCh) is unchanged.

## Review evidence (plan 002)
- The plan's plain "error on first Read" repro provably could NOT fail (400/400 pre-fix passes — the outer goroutine parks in select before both cases are ready). The executor engineered a sharper repro: 64 data chunks keep the outer loop busy so both cases are ready on select re-entry — 3/50 pre-fix failures reporting io.EOF, 200/200 post-fix passes under -race.
- Full ptyio suite green under -race; devcheck + lint clean; the older TestRunPTYReaderClosesOnceOnError comment documenting the nondeterminism updated to point at the new error-identity test.
- Diagnostic-only change: restart logic keys off termAlive, not the error.