### PR TITLE
chore: add local govulncheck target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ make devcheck
 make ci
 ```
 
-`make ci` runs `devcheck` plus `make test-race` (CI's race gate; slow) and `make tidy-check` (CI's tidy gate). CI's govulncheck and harness smoke steps are not mirrored locally.
+`make ci` runs `devcheck` plus `make test-race` (CI's race gate; slow), `make tidy-check` (CI's tidy gate), and `make govulncheck` (CI's vulnerability scan, using the same pinned govulncheck version — it also works standalone to reproduce a CI vuln failure). CI's harness smoke steps are not mirrored locally.
 
 For the inner loop, launch the TUI with `make run` in a real terminal — amux requires stdin, stdout, and stderr to all be TTYs, so it only runs directly in your terminal. `air` cannot host the TUI: it launches the rebuilt binary with stdin on `/dev/null`, which fails that TTY check, so `make dev` is not a hot-reload TUI loop. Use it instead for automatic rebuilds and compile-error feedback while you edit — run `make dev` in a second pane alongside `make run`. It runs [`air`](https://github.com/air-verse/air) with the repo's `.air.toml` and rebuilds on save. Install it once with:
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ STRICT_RATCHET_LINTERS := --enable funlen --enable gocyclo --enable nestif
 GOLANGCI ?= golangci-lint
 lint lint-strict lint-strict-new lint-ci-parity check-golangci-version: GOLANGCI := $(shell want=`tr -d '[:space:]' < .golangci-version 2>/dev/null | sed 's/^v//'`; local="$$PWD/.cache/bin/golangci-lint"; have=`"$$local" version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//'`; if [ -x "$$local" ] && [ "$$have" = "$$want" ]; then echo "$$local"; else echo golangci-lint; fi)
 
-.PHONY: build install test test-race tidy-check ci bench lint lint-tools lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop tmux-skip-check help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
+.PHONY: build install test test-race tidy-check govulncheck ci bench lint lint-tools lint-strict lint-strict-new lint-ci-parity check-golangci-version check-file-length fmt fmt-check vet clean run dev devcheck verify-loop tmux-skip-check help release-check release-tag release-push release harness-center harness-sidebar harness-monitor harness-presets harness-golden perf-check
 
 build:
 	go build -o $(BINARY_NAME) $(MAIN_PACKAGE)
@@ -59,12 +59,18 @@ tidy-check:
 	go mod tidy
 	git diff --exit-code go.mod go.sum
 
+# govulncheck scans for known vulnerabilities using the same pinned version CI
+# uses (keep GOVULNCHECK_VERSION in sync with .github/workflows/ci.yml).
+GOVULNCHECK_VERSION ?= v1.1.4
+govulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+
 # ci is the local mirror of the CI `test` job's gate set: devcheck (vet +
-# tests + lint + file-length) plus the race and tidy gates that devcheck
-# skips. Keep this target in sync with .github/workflows/ci.yml — if CI gains
-# a gate, add it here. Not mirrored locally (yet): govulncheck and the
-# harness/perf smoke steps.
-ci: devcheck test-race tidy-check
+# tests + lint + file-length) plus the race, tidy, and govulncheck gates that
+# devcheck skips. Keep this target in sync with .github/workflows/ci.yml — if
+# CI gains a gate, add it here. Not mirrored locally (yet): the harness/perf
+# smoke steps.
+ci: devcheck test-race tidy-check govulncheck
 
 devcheck:
 	go vet ./...
@@ -272,7 +278,8 @@ help:
 	@echo "  test       - Run all tests"
 	@echo "  test-race  - Run go test -race over CI's package set (slow; mirrors CI's race gate)"
 	@echo "  tidy-check - Run go mod tidy and fail if go.mod/go.sum change (mirrors CI's tidy gate)"
-	@echo "  ci         - Full local CI mirror: devcheck + test-race + tidy-check"
+	@echo "  govulncheck - Scan for known vulnerabilities with the CI-pinned govulncheck (mirrors CI's vuln gate)"
+	@echo "  ci         - Full local CI mirror: devcheck + test-race + tidy-check + govulncheck"
 	@echo "  devcheck   - vet + tests + golden harness + lint (warns when real-tmux/e2e tests skip)"
 	@echo "  lint       - Run golangci-lint and file length checks (max 500 lines)"
 	@echo "  lint-tools - Build the pinned golangci-lint (.golangci-version) into ./.cache/bin (idempotent)"


### PR DESCRIPTION
Adds a make govulncheck target pinned to the CI version (v1.1.4) and folds it into make ci, so the full CI vuln gate is reproducible locally. Verified clean (No vulnerabilities found) after the go1.26.5 bump. Makefile + CONTRIBUTING only. Depends on #560/#561 (both merged).