### PR TITLE
fix: log KillSession pane-PID lookup errors instead of silently skipping reap

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/process"
 )
 
@@ -265,13 +266,15 @@ func KillSession(sessionName string, opts Options) error {
 	if err := EnsureAvailable(); err != nil {
 		return err
 	}
-	// Kill process trees in each pane before killing the session.
-	// This prevents orphaned processes (e.g. node/turbo/pnpm trees)
-	// that survive SIGHUP from tmux kill-session.
-	if pids, err := panePIDs(sessionName, opts); err == nil {
-		for _, pid := range pids {
-			_ = process.KillProcessGroup(pid, process.KillOptions{})
+	// Kill each pane's process tree first: node/turbo/pnpm trees survive the SIGHUP from kill-session.
+	pids, err := panePIDs(sessionName, opts)
+	if err != nil { // retry once — a transient list-panes failure may clear
+		if pids, err = panePIDs(sessionName, opts); err != nil {
+			logging.Warn("KillSession %q: pane-PID lookup failed after retry; skipping process-tree reap: %v", sessionName, err)
 		}
+	}
+	for _, pid := range pids {
+		_ = process.KillProcessGroup(pid, process.KillOptions{})
 	}
 	return runTmux(opts, "kill-session", "-t", sessionTarget(sessionName))
 }

--- a/internal/tmux/tmux_runner_seam_test.go
+++ b/internal/tmux/tmux_runner_seam_test.go
@@ -236,3 +236,91 @@ func TestRunTmuxCmdSeamsDefaultToRealImpl(t *testing.T) {
 		t.Fatalf("default runTmuxCmdCombined should capture stdout+stderr, got %q err=%v", combined, err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// KillSession pane-PID error branch. Before the fix, a panePIDs error was
+// silently discarded and the reap loop skipped; now the lookup is retried
+// once, the failure is logged, and kill-session must still run regardless.
+// ---------------------------------------------------------------------------
+
+// killSessionSeam installs a runTmuxCmd fake that records every tmux
+// subcommand and dispatches on it: the pane-PID lookup commands
+// (has-session, list-panes) return the given errors (consumed in order, the
+// last one repeating), kill-session always succeeds.
+func killSessionSeam(t *testing.T, lookupErrs []error) *[]string {
+	t.Helper()
+	var subcommands []string
+	orig := runTmuxCmd
+	runTmuxCmd = func(cmd *exec.Cmd) ([]byte, error) {
+		sub := ""
+		for _, arg := range cmd.Args {
+			switch arg {
+			case "has-session", "list-panes", "kill-session":
+				sub = arg
+			}
+		}
+		subcommands = append(subcommands, sub)
+		if sub == "kill-session" {
+			return nil, nil
+		}
+		err := lookupErrs[0]
+		if len(lookupErrs) > 1 {
+			lookupErrs = lookupErrs[1:]
+		}
+		return nil, err
+	}
+	t.Cleanup(func() { runTmuxCmd = orig })
+	return &subcommands
+}
+
+func countString(items []string, want string) int {
+	n := 0
+	for _, item := range items {
+		if item == want {
+			n++
+		}
+	}
+	return n
+}
+
+func TestKillSession_PanePIDErrorIsRetriedAndKillSessionStillRuns(t *testing.T) {
+	skipIfNoTmux(t)
+	calls := killSessionSeam(t, []error{errors.New("lost server")})
+
+	if err := KillSession("amux-seam-kill", testOpts()); err != nil {
+		t.Fatalf("KillSession must not fail just because the pane-PID lookup failed, got %v", err)
+	}
+	got := *calls
+	// panePIDs fails at the has-session pre-check on both the initial attempt
+	// and the retry, so the error branch must show exactly two lookups.
+	if n := countString(got, "has-session"); n != 2 {
+		t.Fatalf("pane-PID lookup should be attempted twice (initial + retry), got %d has-session calls in %v", n, got)
+	}
+	if n := countString(got, "kill-session"); n != 1 {
+		t.Fatalf("kill-session must still run exactly once, got %d in %v", n, got)
+	}
+	if got[len(got)-1] != "kill-session" {
+		t.Fatalf("kill-session must be the final tmux command, got %v", got)
+	}
+}
+
+func TestKillSession_PanePIDRetrySucceedsAfterTransientError(t *testing.T) {
+	skipIfNoTmux(t)
+	calls := killSessionSeam(t, []error{errors.New("transient failure"), nil})
+
+	if err := KillSession("amux-seam-kill", testOpts()); err != nil {
+		t.Fatalf("KillSession should succeed when the retry recovers, got %v", err)
+	}
+	got := *calls
+	// First has-session errors; the retry's has-session succeeds and proceeds
+	// to list-panes (empty output: nothing to reap), then kill-session.
+	want := []string{"has-session", "has-session", "list-panes", "kill-session"}
+	if len(got) != len(want) {
+		t.Fatalf("expected commands %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command %d: got %q want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}


### PR DESCRIPTION
KillSession discarded any panePIDs error and silently skipped the pane process-tree reap — leaking exactly the SIGHUP-surviving trees (node/turbo/pnpm) the loop exists to kill, invisibly. Now: retry the lookup once (a transient list-panes failure often clears; costs at most one extra bounded attempt on a non-interactive teardown path), log a warning on double failure so leaked trees are diagnosable, and always run kill-session regardless. Two seam-driven tests (no live tmux) pin the retry count, the log-not-fail contract, and kill-session always running. Reviewer note: tmux.go now sits at exactly the 500-line lint cap; the next change to this file must split it. Full tmux suite + devcheck green. (plan 034)