### PR TITLE
test: seam and cover closeSessionIfUnattached kill guard

### DIFF
--- a/internal/ui/sidebar/terminal_tab_ops.go
+++ b/internal/ui/sidebar/terminal_tab_ops.go
@@ -112,26 +112,37 @@ func (m *TerminalModel) CloseActiveTab() tea.Cmd {
 	return closeSessionIfUnattached(sessionName, opts)
 }
 
+// Test-only injection seams for closeSessionIfUnattached. Production defaults
+// stay wired to the real tmux functions / real time; mirrors the runTmuxCmd
+// var-seam precedent in internal/tmux/tmux_runner.go. No production path may
+// reassign these.
+var (
+	closeSessionHasClientsFn = tmux.SessionHasClients
+	closeKillSessionFn       = tmux.KillSession
+	closeSessionSleep        = time.Sleep
+	closeSessionPollDeadline = 1200 * time.Millisecond
+)
+
 func closeSessionIfUnattached(sessionName string, opts tmux.Options) tea.Cmd {
 	return func() tea.Msg {
 		if sessionName == "" {
 			return nil
 		}
-		deadline := time.Now().Add(1200 * time.Millisecond)
+		deadline := time.Now().Add(closeSessionPollDeadline)
 		for {
-			hasClients, err := tmux.SessionHasClients(sessionName, opts)
+			hasClients, err := closeSessionHasClientsFn(sessionName, opts)
 			if err != nil {
 				return nil
 			}
 			if !hasClients {
-				_ = tmux.KillSession(sessionName, opts)
+				_ = closeKillSessionFn(sessionName, opts)
 				return nil
 			}
 			if time.Now().After(deadline) {
 				// Shared or still-attached session; keep it alive.
 				return nil
 			}
-			time.Sleep(75 * time.Millisecond)
+			closeSessionSleep(75 * time.Millisecond)
 		}
 	}
 }

--- a/internal/ui/sidebar/terminal_tab_ops_close_session_test.go
+++ b/internal/ui/sidebar/terminal_tab_ops_close_session_test.go
@@ -1,0 +1,123 @@
+package sidebar
+
+// Tests for the closeSessionIfUnattached kill guard in terminal_tab_ops.go.
+// They live in their own file because terminal_tab_ops_test.go is at the
+// 500-line lint limit. The guard's kill-vs-keep decision (has clients → keep;
+// error → keep; deadline → keep; unattached → kill) is exercised tmux-free by
+// swapping the package-var seams for fakes; the empty-session no-op stays in
+// terminal_tab_ops_test.go.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// swapCloseSessionSeams installs fakes for closeSessionIfUnattached's seam
+// vars and restores the production defaults when the test ends. The sleep is
+// a no-op and the poll deadline is zero so the deadline branch is reachable
+// without any real waiting.
+func swapCloseSessionSeams(t *testing.T, hasClients func(string, tmux.Options) (bool, error), kill func(string, tmux.Options) error) {
+	t.Helper()
+	prevHasClients := closeSessionHasClientsFn
+	prevKill := closeKillSessionFn
+	prevSleep := closeSessionSleep
+	prevDeadline := closeSessionPollDeadline
+	t.Cleanup(func() {
+		closeSessionHasClientsFn = prevHasClients
+		closeKillSessionFn = prevKill
+		closeSessionSleep = prevSleep
+		closeSessionPollDeadline = prevDeadline
+	})
+	closeSessionHasClientsFn = hasClients
+	closeKillSessionFn = kill
+	closeSessionSleep = func(time.Duration) {}
+	closeSessionPollDeadline = 0
+}
+
+func TestCloseSessionIfUnattachedDecision(t *testing.T) {
+	tests := []struct {
+		name       string
+		hasClients func(string, tmux.Options) (bool, error)
+		wantKill   bool
+	}{
+		{
+			// No clients attached: the session is orphaned and must be killed.
+			name:       "unattached session is killed",
+			hasClients: func(string, tmux.Options) (bool, error) { return false, nil },
+			wantKill:   true,
+		},
+		{
+			// Clients stay attached past the poll deadline: the session is shared
+			// (another amux instance or the user) and must be kept alive.
+			name:       "attached session past deadline is kept",
+			hasClients: func(string, tmux.Options) (bool, error) { return true, nil },
+			wantKill:   false,
+		},
+		{
+			// Client query failed: fail closed and keep the session.
+			name: "has-clients error keeps the session",
+			hasClients: func(string, tmux.Options) (bool, error) {
+				return false, errors.New("tmux exec failed")
+			},
+			wantKill: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var killed []string
+			kill := func(name string, _ tmux.Options) error {
+				killed = append(killed, name)
+				return nil
+			}
+			swapCloseSessionSeams(t, tt.hasClients, kill)
+
+			cmd := closeSessionIfUnattached("amux-session-abc", tmux.DefaultOptions())
+			if cmd == nil {
+				t.Fatal("expected a non-nil command")
+			}
+			if msg := cmd(); msg != nil {
+				t.Fatalf("expected nil message, got %#v", msg)
+			}
+
+			if tt.wantKill {
+				if len(killed) != 1 || killed[0] != "amux-session-abc" {
+					t.Fatalf("expected exactly one KillSession(%q) call, got %v", "amux-session-abc", killed)
+				}
+			} else if len(killed) != 0 {
+				t.Fatalf("expected the session to be kept alive, but KillSession was called: %v", killed)
+			}
+		})
+	}
+}
+
+func TestCloseSessionIfUnattachedPollsUntilUnattached(t *testing.T) {
+	// A session that starts attached and then loses its last client within the
+	// deadline is killed once the poll observes it unattached.
+	calls := 0
+	hasClients := func(string, tmux.Options) (bool, error) {
+		calls++
+		return calls < 3, nil // attached for two polls, then unattached
+	}
+	var killed []string
+	kill := func(name string, _ tmux.Options) error {
+		killed = append(killed, name)
+		return nil
+	}
+	swapCloseSessionSeams(t, hasClients, kill)
+	// Generous deadline (the fake sleep is instant) so the loop reaches poll
+	// #3 instead of bailing out on the deadline branch.
+	closeSessionPollDeadline = time.Hour
+
+	if msg := closeSessionIfUnattached("amux-session-poll", tmux.DefaultOptions())(); msg != nil {
+		t.Fatalf("expected nil message, got %#v", msg)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 SessionHasClients polls, got %d", calls)
+	}
+	if len(killed) != 1 || killed[0] != "amux-session-poll" {
+		t.Fatalf("expected exactly one KillSession(%q) call, got %v", "amux-session-poll", killed)
+	}
+}


### PR DESCRIPTION
closeSessionIfUnattached decides whether closing a sidebar tab kills the tmux session — killing an attached session destroys another instance's or the user's running agent. Its kill/keep decision had no tmux-free coverage (only the empty-session no-op). Adds four function-var seams (real tmux funcs / real time as production defaults, byte-equivalent logic — mirrors the runTmuxCmd precedent) and five fast tests: kill-when-unattached, keep-when-attached-past-deadline, keep-on-error (fail closed), poll-until-unattached, empty no-op. Coverage 21%→100%; suite time unchanged (no real waits). Tests live in a new topical file because terminal_tab_ops_test.go sits at 491/500 lint-cap lines. (plan 013)