### PR TITLE
test: cover agent/viewer PTY create path (tmux-gated) and add pty to CI tmux job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,12 @@ jobs:
       - name: Test (app, real tmux)
         run: go test ./internal/app -count=1
 
+      # internal/pty's agent/viewer create path short-circuits at
+      # tmux.EnsureAvailable() in the tmux-less `test` job, so its tmux-gated
+      # create tests only run here, where tmux is installed.
+      - name: Test (pty, real tmux)
+        run: go test ./internal/pty -count=1
+
       - name: Assert no real-tmux tests skipped
         run: STRICT_TMUX=1 make tmux-skip-check
 

--- a/internal/pty/agent_test.go
+++ b/internal/pty/agent_test.go
@@ -1,8 +1,12 @@
 package pty
 
 import (
+	"fmt"
+	"os/exec"
+	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
@@ -364,6 +368,86 @@ func TestAgentManager_MultipleAgentsPerWorkspace(t *testing.T) {
 
 	// Cleanup
 	term2.Close()
+}
+
+// TestAgentManager_CreateViewer_RegistersAgent exercises the successful
+// spawn-and-register path (env assembly, NewWithSize, registration under
+// ws.ID()) against a real, isolated tmux server. It skips when tmux is not
+// installed so tmux-less local runs stay green; CI runs it in the tmux job.
+func TestAgentManager_CreateViewer_RegistersAgent(t *testing.T) {
+	if err := tmux.EnsureAvailable(); err != nil {
+		t.Skipf("tmux unavailable: %v", err)
+	}
+
+	// Isolated tmux server so the test never touches the user's amux server.
+	serverName := fmt.Sprintf("amux-ptytest-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", serverName, "kill-server").Run()
+	})
+
+	m := NewAgentManager(testConfig())
+	m.SetTmuxOptions(tmux.Options{
+		ServerName:     serverName,
+		ConfigPath:     "/dev/null",
+		CommandTimeout: 5 * time.Second,
+	})
+
+	ws := &data.Workspace{
+		Name: "create-ws",
+		Root: t.TempDir(),
+		Repo: "/tmp/test-repo",
+	}
+	sessionName := fmt.Sprintf("amux-test-viewer-%d", time.Now().UnixNano())
+
+	agent, err := m.CreateViewer(ws, "cat", sessionName, 24, 80)
+	if err != nil {
+		t.Fatalf("CreateViewer failed: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CloseAgent(agent) })
+
+	if agent == nil {
+		t.Fatal("CreateViewer returned nil agent")
+	}
+	if agent.Type != AgentType("viewer") {
+		t.Errorf("expected type %q, got %q", "viewer", agent.Type)
+	}
+	if agent.Session != sessionName {
+		t.Errorf("expected session %q, got %q", sessionName, agent.Session)
+	}
+	if agent.Workspace != ws {
+		t.Error("agent workspace should be the workspace it was created for")
+	}
+	if agent.Terminal == nil {
+		t.Fatal("agent terminal should be non-nil")
+	}
+
+	// Env assembly: the workspace vars must reach the spawned command.
+	env := agent.Terminal.cmd.Env
+	for _, want := range []string{"WORKSPACE_ROOT=" + ws.Root, "WORKSPACE_NAME=" + ws.Name} {
+		if !slices.Contains(env, want) {
+			t.Errorf("terminal env missing %q", want)
+		}
+	}
+
+	// Registration under ws.ID().
+	wsID := ws.ID()
+	m.mu.Lock()
+	registered := len(m.agents[wsID]) == 1 && m.agents[wsID][0] == agent
+	m.mu.Unlock()
+	if !registered {
+		t.Fatal("agent not registered under ws.ID()")
+	}
+
+	// CloseAgent removes it from the registry.
+	if err := m.CloseAgent(agent); err != nil {
+		t.Fatalf("CloseAgent failed: %v", err)
+	}
+	m.mu.Lock()
+	remaining := len(m.agents[wsID])
+	m.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("expected 0 agents after CloseAgent, got %d", remaining)
+	}
 }
 
 func TestAgentType_ConfigBridge(t *testing.T) {


### PR DESCRIPTION
The successful spawn-and-register path (env assembly, NewWithSize, registry under ws.ID()) had no direct coverage anywhere: unit tests hit only error branches, and CI's tmux-e2e job ran tmux/e2e/app but NOT internal/pty. Adds a tmux-gated create test (isolated -L server, asserts type/session/env/registration and CloseAgent removal; verified to SKIP cleanly without tmux and PASS with it) and a Test (pty, real tmux) step in both tmux-e2e matrix legs. YAML validated. (plan 039)