### PR TITLE
perf: hash the activity digest in place without a full-screen string

### DIFF
--- a/internal/ui/center/model_activity_visibility.go
+++ b/internal/ui/center/model_activity_visibility.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/andyrewlee/amux/internal/vterm"
 )
@@ -200,8 +201,14 @@ func visibleScreenDigest(term *vterm.VTerm) [16]byte {
 
 	// Use the live screen buffer, not the current viewport. If user scrolls
 	// back, viewport content can stay static while live output continues.
+	//
+	// Feed each row's runes straight into the hash instead of building a
+	// full-screen string first: the byte stream is identical (same UTF-8
+	// encoding, same trailing-blank trimming, same '\n' per row), but this
+	// avoids two full-screen allocations on every PTY flush.
 	screen, _ := term.RenderBuffers()
-	var b strings.Builder
+	hash := sha256.New()
+	var scratch []byte
 	for _, row := range screen {
 		last := len(row) - 1
 		for last >= 0 {
@@ -217,6 +224,7 @@ func visibleScreenDigest(term *vterm.VTerm) [16]byte {
 			}
 			break
 		}
+		scratch = scratch[:0]
 		for i := 0; i <= last; i++ {
 			cell := row[i]
 			if cell.Width == 0 {
@@ -226,11 +234,15 @@ func visibleScreenDigest(term *vterm.VTerm) [16]byte {
 			if r == 0 {
 				r = ' '
 			}
-			b.WriteRune(r)
+			scratch = utf8.AppendRune(scratch, r)
 		}
-		b.WriteByte('\n')
+		scratch = append(scratch, '\n')
+		hash.Write(scratch)
 	}
-	return visibleDigestHash([]byte(b.String()))
+	var sum [sha256.Size]byte
+	var digest [16]byte
+	copy(digest[:], hash.Sum(sum[:0])[:16])
+	return digest
 }
 
 func visibleDigestHash(content []byte) [16]byte {

--- a/internal/ui/center/model_activity_visibility_test.go
+++ b/internal/ui/center/model_activity_visibility_test.go
@@ -1,6 +1,8 @@
 package center
 
 import (
+	"crypto/sha256"
+	"strings"
 	"testing"
 	"time"
 
@@ -195,6 +197,115 @@ func TestNoteVisibleActivityLocked_SubmittedPasteSuppressionDoesNotLeakOnInvisib
 	}
 	if pending {
 		t.Fatal("expected pendingVisibleOutput to clear after the invisible follow-up flush")
+	}
+}
+
+// referenceVisibleScreenDigest is the original string-then-hash implementation
+// of visibleScreenDigest, kept here as the equivalence reference. If the
+// digest's content-selection rules ever change, this reference must change in
+// lockstep — it exists to pin the byte stream fed to the hash.
+func referenceVisibleScreenDigest(term *vterm.VTerm) [16]byte {
+	if term == nil {
+		return visibleDigestHash(nil)
+	}
+	screen, _ := term.RenderBuffers()
+	var b strings.Builder
+	for _, row := range screen {
+		last := len(row) - 1
+		for last >= 0 {
+			cell := row[last]
+			if cell.Width == 0 {
+				last--
+				continue
+			}
+			r := cell.Rune
+			if r == 0 || r == ' ' {
+				last--
+				continue
+			}
+			break
+		}
+		for i := 0; i <= last; i++ {
+			cell := row[i]
+			if cell.Width == 0 {
+				continue
+			}
+			r := cell.Rune
+			if r == 0 {
+				r = ' '
+			}
+			b.WriteRune(r)
+		}
+		b.WriteByte('\n')
+	}
+	hash := sha256.Sum256([]byte(b.String()))
+	var digest [16]byte
+	copy(digest[:], hash[:16])
+	return digest
+}
+
+func TestVisibleScreenDigest_MatchesStringReference(t *testing.T) {
+	cases := []struct {
+		name  string
+		cols  int
+		rows  int
+		write string
+	}{
+		{
+			name: "representative screen",
+			cols: 20,
+			rows: 8,
+			write: "hello world\r\n" +
+				"wide: 漢字 テスト\r\n" +
+				"\r\n" +
+				"trailing blanks   \r\n" +
+				"emoji ☕️ done\r\n" +
+				"accents: éüß",
+		},
+		{
+			name:  "empty screen",
+			cols:  10,
+			rows:  3,
+			write: "",
+		},
+		{
+			name:  "wide chars at row end",
+			cols:  8,
+			rows:  2,
+			write: "abcdef漢\r\n漢字漢字",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			term := vterm.New(tc.cols, tc.rows)
+			if tc.write != "" {
+				term.Write([]byte(tc.write))
+			}
+			got := visibleScreenDigest(term)
+			want := referenceVisibleScreenDigest(term)
+			if got != want {
+				t.Fatalf("visibleScreenDigest = %x, reference = %x", got, want)
+			}
+		})
+	}
+
+	if got, want := visibleScreenDigest(nil), referenceVisibleScreenDigest(nil); got != want {
+		t.Fatalf("nil terminal: visibleScreenDigest = %x, reference = %x", got, want)
+	}
+}
+
+func BenchmarkVisibleScreenDigest(b *testing.B) {
+	term := vterm.New(200, 50)
+	line := strings.Repeat("abcdefghij", 19) + "wide 漢字 end"
+	lines := make([]string, 50)
+	for i := range lines {
+		lines[i] = line
+	}
+	term.Write([]byte(strings.Join(lines, "\r\n")))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = visibleScreenDigest(term)
 	}
 }
 


### PR DESCRIPTION
visibleScreenDigest ran on every PTY flush per streaming tab, building a full-screen strings.Builder then copying it to []byte before sha256 — two O(rows×cols) allocations on the hottest path. Now feeds each row into the hash via a reused utf8.AppendRune scratch: 14→3 allocs/op, 23288→448 B/op (200×50 bench). Byte-stream identical by construction; an equivalence test rebuilds the old string-then-hash implementation in-test as the oracle and pins wide-char/VS16/trailing-blank/empty-row cases. All activity/echo tests green. (plan 005)