### PR TITLE
perf: normalize selection bounds once per DrawAt

### DIFF
--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -101,6 +101,15 @@ func (c *Canvas) DrawScreen(x, y, w, h int, screen [][]vterm.Cell, cursor Cursor
 	if w <= 0 || h <= 0 {
 		return
 	}
+	// Normalize the selection bounds once instead of per cell: the start/end
+	// ordering is identical for every cell, so recomputing it in the per-cell
+	// loop is pure redundancy.
+	selActive := selection.Active
+	var selStartX, selStartY, selEndX, selEndY int
+	if selActive {
+		selStartX, selStartY, selEndX, selEndY = vterm.NormalizeSelectionRange(
+			selection.StartX, selection.StartY, selection.EndX, selection.EndY)
+	}
 	maxY := min(h, len(screen))
 	for row := 0; row < maxY; row++ {
 		line := screen[row]
@@ -110,7 +119,7 @@ func (c *Canvas) DrawScreen(x, y, w, h int, screen [][]vterm.Cell, cursor Cursor
 			if cell.Width == 2 && col+1 >= w {
 				cell = vterm.DefaultCell()
 			}
-			if inSelection(selection, col, row) {
+			if selActive && vterm.SelectionContains(selStartX, selStartY, selEndX, selEndY, col, row) {
 				cell.Style.Reverse = !cell.Style.Reverse
 			}
 			targetX := x + col
@@ -133,15 +142,6 @@ func (c *Canvas) DrawScreen(x, y, w, h int, screen [][]vterm.Cell, cursor Cursor
 			}
 		}
 	}
-}
-
-func inSelection(sel SelectionRegion, x, y int) bool {
-	if !sel.Active {
-		return false
-	}
-	startX, startY, endX, endY := vterm.NormalizeSelectionRange(
-		sel.StartX, sel.StartY, sel.EndX, sel.EndY)
-	return vterm.SelectionContains(startX, startY, endX, endY, x, y)
 }
 
 // Render converts the canvas to an ANSI string.

--- a/internal/ui/compositor/vtermlayer.go
+++ b/internal/ui/compositor/vtermlayer.go
@@ -81,6 +81,16 @@ func (l *VTermLayer) DrawAt(s uv.Screen, posX, posY, maxWidth, maxHeight int) {
 		height = snap.Height
 	}
 
+	// Normalize the selection bounds once per frame instead of per cell: the
+	// start/end ordering is identical for every cell, so recomputing it in the
+	// per-cell loop is pure redundancy.
+	selActive := snap.SelActive
+	var selStartX, selStartY, selEndX, selEndY int
+	if selActive {
+		selStartX, selStartY, selEndX, selEndY = vterm.NormalizeSelectionRange(
+			snap.SelStartX, snap.SelStartY, snap.SelEndX, snap.SelEndY)
+	}
+
 	// When compositing layers, we must draw ALL cells every frame.
 	// The dirty line optimization only works for single-layer rendering.
 	// Ultraviolet's cell-level diffing handles the actual screen updates.
@@ -107,7 +117,9 @@ func (l *VTermLayer) DrawAt(s uv.Screen, posX, posY, maxWidth, maxHeight int) {
 			}
 
 			// Build the ultraviolet cell into the reused local.
-			cellToUVSnapshot(&uvCell, cell, snap, x, y)
+			inSel := selActive && vterm.SelectionContains(
+				selStartX, selStartY, selEndX, selEndY, x, y)
+			cellToUVSnapshot(&uvCell, cell, snap, x, y, inSel)
 
 			// Set cell at screen position (ultraviolet copies the value).
 			s.SetCell(posX+x, posY+y, &uvCell)
@@ -117,12 +129,12 @@ func (l *VTermLayer) DrawAt(s uv.Screen, posX, posY, maxWidth, maxHeight int) {
 
 // cellToUVSnapshot fills uvCell with the ultraviolet representation of a
 // vterm.Cell. It fully overwrites uvCell so the same value can be reused
-// across draw iterations.
-func cellToUVSnapshot(uvCell *uv.Cell, cell vterm.Cell, snap *VTermSnapshot, x, y int) {
+// across draw iterations. inSel is precomputed by the caller (the selection
+// bounds are normalized once per frame in DrawAt, not per cell).
+func cellToUVSnapshot(uvCell *uv.Cell, cell vterm.Cell, snap *VTermSnapshot, x, y int, inSel bool) {
 	style := cell.Style
 
 	// Apply selection and cursor reverse (selection has precedence over cursor)
-	inSel := inSelectionSnapshot(snap, x, y)
 	cursorHere := snap.ShowCursor && !snap.CursorHidden &&
 		y == snap.CursorY && x == snap.CursorX && snap.ViewOffset == 0
 	if inSel || cursorHere {
@@ -147,16 +159,6 @@ func cellToUVSnapshot(uvCell *uv.Cell, cell vterm.Cell, snap *VTermSnapshot, x, 
 		Style:   vtermStyleToUV(style),
 		Width:   cell.Width,
 	}
-}
-
-// inSelectionSnapshot checks if a coordinate is within the snapshot's selection.
-func inSelectionSnapshot(snap *VTermSnapshot, x, y int) bool {
-	if snap == nil || !snap.SelActive {
-		return false
-	}
-	startX, startY, endX, endY := vterm.NormalizeSelectionRange(
-		snap.SelStartX, snap.SelStartY, snap.SelEndX, snap.SelEndY)
-	return vterm.SelectionContains(startX, startY, endX, endY, x, y)
 }
 
 // vtermStyleToUV converts a vterm.Style to ultraviolet's Style.

--- a/internal/ui/compositor/vtermlayer_test.go
+++ b/internal/ui/compositor/vtermlayer_test.go
@@ -22,10 +22,87 @@ func TestVTermLayerSelectionCursorOverlap(t *testing.T) {
 
 	cell := snap.Screen[0][0]
 	var uvCell uv.Cell
-	cellToUVSnapshot(&uvCell, cell, snap, 0, 0)
+	// Precompute the selection containment the way DrawAt does (bounds are
+	// normalized once per frame and passed in).
+	selStartX, selStartY, selEndX, selEndY := vterm.NormalizeSelectionRange(
+		snap.SelStartX, snap.SelStartY, snap.SelEndX, snap.SelEndY)
+	inSel := snap.SelActive && vterm.SelectionContains(
+		selStartX, selStartY, selEndX, selEndY, 0, 0)
+	cellToUVSnapshot(&uvCell, cell, snap, 0, 0, inSel)
 
 	if uvCell.Style.Attrs&uv.AttrReverse == 0 {
 		t.Fatalf("expected reverse attribute for selection+cursor overlap")
+	}
+}
+
+// selectionSnapshot builds a blank w x h snapshot with an active selection.
+func selectionSnapshot(w, h, startX, startY, endX, endY int) *VTermSnapshot {
+	screen := make([][]vterm.Cell, h)
+	for y := range screen {
+		screen[y] = vterm.MakeBlankLine(w)
+	}
+	return &VTermSnapshot{
+		Screen:    screen,
+		Width:     w,
+		Height:    h,
+		SelActive: true,
+		SelStartX: startX,
+		SelStartY: startY,
+		SelEndX:   endX,
+		SelEndY:   endY,
+	}
+}
+
+// reversedCells draws the snapshot and returns which cells have the reverse
+// attribute (i.e. are rendered as selected).
+func reversedCells(t *testing.T, snap *VTermSnapshot, w, h int) map[[2]int]bool {
+	t.Helper()
+	screen := &bufferScreen{Buffer: uv.NewBuffer(w, h)}
+	NewVTermLayer(snap).Draw(screen, screen.Bounds())
+
+	got := make(map[[2]int]bool)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			cell := screen.CellAt(x, y)
+			if cell == nil {
+				t.Fatalf("expected cell at (%d,%d)", x, y)
+			}
+			got[[2]int{x, y}] = cell.Style.Attrs&uv.AttrReverse != 0
+		}
+	}
+	return got
+}
+
+// TestVTermLayerDrawMultiRowSelectionHighlight asserts a multi-row selection
+// highlights exactly the selected range, and that a reversed selection (end
+// before start) highlights the same cells as the forward one — normalization
+// is the only thing making end<start highlight correctly.
+func TestVTermLayerDrawMultiRowSelectionHighlight(t *testing.T) {
+	const w, h = 5, 3
+
+	// Forward selection: (1,0) through (3,1).
+	forward := reversedCells(t, selectionSnapshot(w, h, 1, 0, 3, 1), w, h)
+
+	// Exactly the selected range: row 0 from x=1, row 1 through x=3, row 2 none.
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			want := (y == 0 && x >= 1) || (y == 1 && x <= 3)
+			if forward[[2]int{x, y}] != want {
+				t.Errorf("forward selection at (%d,%d): reverse=%v, want %v",
+					x, y, forward[[2]int{x, y}], want)
+			}
+		}
+	}
+
+	// Reversed selection: same endpoints with end before start.
+	reversed := reversedCells(t, selectionSnapshot(w, h, 3, 1, 1, 0), w, h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			if reversed[[2]int{x, y}] != forward[[2]int{x, y}] {
+				t.Errorf("reversed selection at (%d,%d): reverse=%v, want %v (same as forward)",
+					x, y, reversed[[2]int{x, y}], forward[[2]int{x, y}])
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
During drag-select, NormalizeSelectionRange was recomputed for every cell (10k times per frame on a 200×50 pane) producing identical bounds. Both paths (VTermLayer.DrawAt and Canvas.DrawScreen) now normalize once before the loop; per-cell check is a pure SelectionContains on precomputed bounds; the two zero-caller helpers are deleted. New multi-row + reversed-selection test on the layer path; canvas path already had a reversed-anchor test (passes unchanged). make harness-golden byte-identical. (plan 007)