### PR TITLE
chore: delete vestigial PTY-tick message types and routing cases

### DIFF
--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -80,7 +80,7 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-	case center.PTYOutput, center.PTYTick, center.PTYFlush, center.PTYStopped:
+	case center.PTYOutput, center.PTYFlush, center.PTYStopped:
 		if cmd := a.handlePTYMessages(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -93,7 +93,7 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.Toast:
 		cmds = append(cmds, a.showToast(msg))
 
-	case messages.SidebarPTYOutput, messages.SidebarPTYTick, messages.SidebarPTYFlush, messages.SidebarPTYStopped, messages.SidebarPTYRestart, sidebar.SidebarTerminalCreated, sidebar.SidebarTerminalCreateFailed, sidebar.SidebarTerminalReattachResult, sidebar.SidebarTerminalReattachFailed, sidebar.SidebarSelectionScrollTick:
+	case messages.SidebarPTYOutput, messages.SidebarPTYFlush, messages.SidebarPTYStopped, messages.SidebarPTYRestart, sidebar.SidebarTerminalCreated, sidebar.SidebarTerminalCreateFailed, sidebar.SidebarTerminalReattachResult, sidebar.SidebarTerminalReattachFailed, sidebar.SidebarSelectionScrollTick:
 		if cmd := a.handleSidebarPTYMessages(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -326,12 +326,6 @@ type SidebarPTYOutput struct {
 	Data        []byte
 }
 
-// SidebarPTYTick triggers a sidebar PTY read
-type SidebarPTYTick struct {
-	WorkspaceID string
-	TabID       string
-}
-
 // SidebarPTYFlush applies buffered PTY output for sidebar terminal
 type SidebarPTYFlush struct {
 	WorkspaceID string
@@ -343,17 +337,6 @@ type SidebarPTYStopped struct {
 	WorkspaceID string
 	TabID       string
 	Err         error
-}
-
-// SidebarTerminalCreated signals that the sidebar terminal was created
-type SidebarTerminalCreated struct {
-	WorkspaceID string
-}
-
-// SidebarTerminalTabCreated signals that a sidebar terminal tab was created
-type SidebarTerminalTabCreated struct {
-	WorkspaceID string
-	TabID       string
 }
 
 // UpdateCheckComplete is sent when the background update check finishes

--- a/internal/ui/center/model_pty_config.go
+++ b/internal/ui/center/model_pty_config.go
@@ -67,12 +67,6 @@ type PTYOutput struct {
 	Data        []byte
 }
 
-// PTYTick triggers a PTY read
-type PTYTick struct {
-	WorkspaceID string
-	TabID       TabID
-}
-
 // PTYFlush applies buffered PTY output for a tab.
 type PTYFlush struct {
 	WorkspaceID string


### PR DESCRIPTION
Go's deadcode tool sees function reachability, not type instantiation, so four message types from the old poll-based PTY read model survived: messages.SidebarPTYTick and center.PTYTick (never constructed, never handled — their only references were two routing case entries for messages that can never arrive) plus messages.SidebarTerminalCreated/SidebarTerminalTabCreated (zero references; the former also name-collides with the live sidebar.SidebarTerminalCreated, misleading grep). Deleted all four and the two dead case identifiers; greps prove gone and the live sidebar type untouched; full suite (32 packages incl. real-tmux) green. (plan 017)