### PR TITLE
fix: guard pprof against silent non-loopback binds

### DIFF
--- a/cmd/amux-harness/main.go
+++ b/cmd/amux-harness/main.go
@@ -182,7 +182,10 @@ func fps(durations []time.Duration) float64 {
 }
 
 func startPprof() {
-	addr, ok := pprofhttp.AddrFromEnvValue(os.Getenv("AMUX_PPROF"))
+	addr, ok, warning := pprofhttp.AddrFromEnvValue(os.Getenv("AMUX_PPROF"))
+	if warning != "" {
+		fmt.Fprintf(os.Stderr, "pprof: %s\n", warning)
+	}
 	if !ok {
 		return
 	}

--- a/cmd/amux/main.go
+++ b/cmd/amux/main.go
@@ -156,7 +156,10 @@ func mouseEventFilter(m tea.Model, msg tea.Msg) tea.Msg {
 }
 
 func startPprof() {
-	addr, ok := pprofhttp.AddrFromEnvValue(os.Getenv("AMUX_PPROF"))
+	addr, ok, warning := pprofhttp.AddrFromEnvValue(os.Getenv("AMUX_PPROF"))
+	if warning != "" {
+		logging.Warn("pprof: %s", warning)
+	}
 	if !ok {
 		return
 	}

--- a/internal/pprofhttp/server.go
+++ b/internal/pprofhttp/server.go
@@ -2,12 +2,19 @@
 package pprofhttp
 
 import (
+	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// AllowRemoteEnv is the environment variable that opts in to serving pprof on
+// a non-loopback address. Set it to "1" (or "true") alongside a non-loopback
+// AMUX_PPROF value to allow the remote bind.
+const AllowRemoteEnv = "AMUX_PPROF_ALLOW_REMOTE"
 
 const (
 	readHeaderTimeout = 5 * time.Second
@@ -17,22 +24,70 @@ const (
 )
 
 // AddrFromEnvValue converts an AMUX_PPROF value into a listen address.
-func AddrFromEnvValue(raw string) (string, bool) {
+//
+// The convenience forms are loopback-locked: "1"/"true" resolve to
+// 127.0.0.1:6060 and a bare port resolves to 127.0.0.1:<port>. An explicit
+// host:port whose host is non-loopback — including an empty host such as
+// ":6060", which binds all interfaces — is only honored when the
+// AMUX_PPROF_ALLOW_REMOTE=1 opt-in is also set, because the pprof endpoints
+// serve process argv and heap contents (which can include in-memory secrets)
+// to anyone who can reach the port, with no authentication. Without the
+// opt-in, a non-loopback bind with a usable port is downgraded to
+// 127.0.0.1:<port>; one without a usable port is refused (ok=false).
+//
+// The returned warning is non-empty whenever a non-loopback bind was
+// requested (allowed, downgraded, or refused); callers should log it.
+func AddrFromEnvValue(raw string) (addr string, ok bool, warning string) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return "", false
+		return "", false, ""
 	}
 	lower := strings.ToLower(raw)
 	switch lower {
 	case "0", "false", "no":
-		return "", false
+		return "", false, ""
 	case "1", "true":
-		return "127.0.0.1:6060", true
+		return "127.0.0.1:6060", true, ""
 	}
 	if _, err := strconv.Atoi(raw); err == nil {
-		return "127.0.0.1:" + raw, true
+		return "127.0.0.1:" + raw, true, ""
 	}
-	return raw, true
+	if !isRemoteBind(raw) {
+		return raw, true, ""
+	}
+	if remoteAllowed() {
+		return raw, true, "AMUX_PPROF=" + raw + " serves pprof on a non-loopback address with no auth; " +
+			"profiles expose process argv and heap contents (" + AllowRemoteEnv + "=1 is set)"
+	}
+	if _, port, err := net.SplitHostPort(raw); err == nil && port != "" {
+		fallback := "127.0.0.1:" + port
+		return fallback, true, "AMUX_PPROF=" + raw + " requests a non-loopback bind; downgraded to " +
+			fallback + " (set " + AllowRemoteEnv + "=1 to allow the remote bind)"
+	}
+	return "", false, "AMUX_PPROF=" + raw + " requests a non-loopback bind without a usable port; " +
+		"pprof disabled (set " + AllowRemoteEnv + "=1 to allow the remote bind)"
+}
+
+// isRemoteBind reports whether addr asks for a bind on a non-loopback host.
+// An empty host (":6060") binds all interfaces, so it counts as remote, as
+// does any host that is not a literal loopback IP (127.0.0.0/8 or ::1).
+// Unparseable addresses are treated as remote to stay fail-safe.
+func isRemoteBind(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip == nil || !ip.IsLoopback()
+}
+
+// remoteAllowed reports whether the AMUX_PPROF_ALLOW_REMOTE opt-in is set.
+func remoteAllowed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(AllowRemoteEnv))) {
+	case "1", "true":
+		return true
+	}
+	return false
 }
 
 // NewServer returns a pprof-only HTTP server with bounded timeouts.

--- a/internal/pprofhttp/server_test.go
+++ b/internal/pprofhttp/server_test.go
@@ -8,10 +8,12 @@ import (
 
 func TestAddrFromEnvValue(t *testing.T) {
 	tests := []struct {
-		name     string
-		raw      string
-		wantAddr string
-		wantOK   bool
+		name        string
+		raw         string
+		allowRemote string
+		wantAddr    string
+		wantOK      bool
+		wantWarn    bool
 	}{
 		{name: "empty", raw: "", wantOK: false},
 		{name: "spaces", raw: " \t ", wantOK: false},
@@ -19,18 +21,108 @@ func TestAddrFromEnvValue(t *testing.T) {
 		{name: "no", raw: "NO", wantOK: false},
 		{name: "true", raw: "true", wantAddr: "127.0.0.1:6060", wantOK: true},
 		{name: "one", raw: "1", wantAddr: "127.0.0.1:6060", wantOK: true},
-		{name: "port", raw: "7070", wantAddr: "127.0.0.1:7070", wantOK: true},
-		{name: "address", raw: "127.0.0.1:9090", wantAddr: "127.0.0.1:9090", wantOK: true},
+		{name: "port", raw: "6060", wantAddr: "127.0.0.1:6060", wantOK: true},
+		{name: "other port", raw: "7070", wantAddr: "127.0.0.1:7070", wantOK: true},
+		{name: "loopback address", raw: "127.0.0.1:9090", wantAddr: "127.0.0.1:9090", wantOK: true},
+		{name: "loopback nonstandard", raw: "127.0.0.1:7000", wantAddr: "127.0.0.1:7000", wantOK: true},
+		{name: "ipv6 loopback", raw: "[::1]:6060", wantAddr: "[::1]:6060", wantOK: true},
+		{
+			name:     "all interfaces downgraded",
+			raw:      "0.0.0.0:6060",
+			wantAddr: "127.0.0.1:6060",
+			wantOK:   true,
+			wantWarn: true,
+		},
+		{
+			name:     "empty host downgraded",
+			raw:      ":6060",
+			wantAddr: "127.0.0.1:6060",
+			wantOK:   true,
+			wantWarn: true,
+		},
+		{
+			name:     "routable host downgraded",
+			raw:      "192.168.1.5:6060",
+			wantAddr: "127.0.0.1:6060",
+			wantOK:   true,
+			wantWarn: true,
+		},
+		{
+			name:     "remote without port refused",
+			raw:      "192.168.1.5",
+			wantOK:   false,
+			wantWarn: true,
+		},
+		{
+			name:        "all interfaces allowed with opt-in",
+			raw:         "0.0.0.0:6060",
+			allowRemote: "1",
+			wantAddr:    "0.0.0.0:6060",
+			wantOK:      true,
+			wantWarn:    true,
+		},
+		{
+			name:        "empty host allowed with opt-in",
+			raw:         ":6060",
+			allowRemote: "1",
+			wantAddr:    ":6060",
+			wantOK:      true,
+			wantWarn:    true,
+		},
+		{
+			name:        "opt-in does not change loopback",
+			raw:         "127.0.0.1:9090",
+			allowRemote: "1",
+			wantAddr:    "127.0.0.1:9090",
+			wantOK:      true,
+		},
+		{
+			name:        "opt-in zero is not an opt-in",
+			raw:         "0.0.0.0:6060",
+			allowRemote: "0",
+			wantAddr:    "127.0.0.1:6060",
+			wantOK:      true,
+			wantWarn:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAddr, gotOK := AddrFromEnvValue(tt.raw)
+			t.Setenv(AllowRemoteEnv, tt.allowRemote)
+			gotAddr, gotOK, gotWarning := AddrFromEnvValue(tt.raw)
 			if gotOK != tt.wantOK {
 				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
 			}
 			if gotAddr != tt.wantAddr {
 				t.Fatalf("addr = %q, want %q", gotAddr, tt.wantAddr)
+			}
+			if (gotWarning != "") != tt.wantWarn {
+				t.Fatalf("warning = %q, want warn = %v", gotWarning, tt.wantWarn)
+			}
+		})
+	}
+}
+
+func TestIsRemoteBind(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "ipv4 loopback", addr: "127.0.0.1:6060", want: false},
+		{name: "ipv4 loopback range", addr: "127.0.0.2:6060", want: false},
+		{name: "ipv6 loopback", addr: "[::1]:6060", want: false},
+		{name: "all interfaces", addr: "0.0.0.0:6060", want: true},
+		{name: "empty host binds all interfaces", addr: ":6060", want: true},
+		{name: "routable", addr: "192.168.1.5:6060", want: true},
+		{name: "hostname is not a literal loopback IP", addr: "localhost:6060", want: true},
+		{name: "unparseable fails safe", addr: "not-an-address", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRemoteBind(tt.addr); got != tt.want {
+				t.Fatalf("isRemoteBind(%q) = %v, want %v", tt.addr, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
AMUX_PPROF's convenience forms were loopback-locked, but an explicit host:port (0.0.0.0:6060, :6060) was honored verbatim — exposing unauthenticated /debug/pprof (argv, heap contents incl. in-memory secrets, cheap remote CPU-profile DoS) to anyone who could reach the port, with no warning. Now: non-loopback binds require AMUX_PPROF_ALLOW_REMOTE=1 (allowed + warned); without it, a bind with a usable port downgrades to 127.0.0.1:<port> + warning, and one without a usable port is refused. Classification is fail-safe (empty host / unparseable / non-IP hostnames count as remote); loopback and convenience forms are byte-identical. 27 table rows incl. the empty-host case and the opt-in gate via t.Setenv. Warnings surface via logging.Warn (amux) / stderr (harness). (plan 019)