### PR TITLE
fix: refuse downgrade at install time unless forced

### DIFF
--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -45,6 +45,12 @@ type Updater struct {
 	date    string
 	github  *GitHubClient
 	deps    upgradeDeps
+	// ForceDowngrade permits installing a release whose version is strictly
+	// lower than the running version. Default false (safe): Upgrade refuses
+	// downgrades so a re-pointed "latest" tag cannot roll back to an older,
+	// still validly-signed release. Callers set it only for deliberate,
+	// operator-driven downgrades.
+	ForceDowngrade bool
 	// fetchLatestRelease mirrors the upgradeDeps function-field pattern so
 	// Check's version-compare logic can be unit-tested without network access.
 	// NewUpdater defaults it to github.FetchLatestRelease; tests override it.
@@ -140,6 +146,15 @@ func (u *Updater) Upgrade(release *Release) error {
 		return errors.New("installed via 'go install'; run: go install github.com/andyrewlee/amux/cmd/amux@latest")
 	}
 
+	// Version-monotonicity guard: refuse to install a strictly-lower version
+	// than the one running unless explicitly forced. The signature chain below
+	// proves authenticity, not freshness; this closes the "validly-signed but
+	// older release re-pointed as latest" gap before anything is downloaded.
+	// Equal versions proceed (same-version reinstall is legitimate).
+	if err := u.checkDowngrade(release.TagName); err != nil {
+		return err
+	}
+
 	// Find the platform asset
 	asset := u.deps.findAsset(release)
 	if asset == nil {
@@ -229,5 +244,36 @@ func (u *Updater) Upgrade(release *Release) error {
 	}
 
 	logging.Info("Upgrade complete: %s", release.TagName)
+	return nil
+}
+
+// checkDowngrade returns an error when targetTag parses to a version strictly
+// lower than the running version, unless ForceDowngrade is set. Dev builds
+// have no comparable version, and an unparseable current or target version
+// cannot be compared; those cases proceed (the signature/checksum chain still
+// gates what gets installed).
+func (u *Updater) checkDowngrade(targetTag string) error {
+	if u.ForceDowngrade {
+		logging.Info("ForceDowngrade set; skipping version-monotonicity check for %s", targetTag)
+		return nil
+	}
+	if IsDevBuild(u.version) {
+		logging.Debug("Skipping downgrade check for dev build")
+		return nil
+	}
+	currentVer, err := ParseVersion(u.version)
+	if err != nil {
+		logging.Debug("Skipping downgrade check: cannot parse current version %q: %v", u.version, err)
+		return nil
+	}
+	targetVer, err := ParseVersion(targetTag)
+	if err != nil {
+		logging.Debug("Skipping downgrade check: cannot parse target version %q: %v", targetTag, err)
+		return nil
+	}
+	if targetVer.LessThan(currentVer) {
+		return fmt.Errorf("refusing to downgrade from %s to %s; set ForceDowngrade to override",
+			currentVer.String(), targetVer.String())
+	}
 	return nil
 }

--- a/internal/update/updater_upgrade_test.go
+++ b/internal/update/updater_upgrade_test.go
@@ -359,6 +359,84 @@ func TestUpgradeSignatureRejectedNeverInstalls(t *testing.T) {
 	}
 }
 
+// TestUpgradeVersionMonotonicity covers the downgrade guard: equal and higher
+// targets proceed (reinstall stays legitimate), a strictly-lower target is
+// refused before download/extract/install run (same assertion style as
+// TestUpgradeSignatureRejectedNeverInstalls) unless ForceDowngrade is set,
+// and dev/unparseable current versions skip the check entirely.
+func TestUpgradeVersionMonotonicity(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		targetTag      string
+		force          bool
+		wantErr        string // "" means Upgrade must succeed and install
+	}{
+		{
+			name:           "higher target proceeds",
+			currentVersion: "v1.0.0",
+			targetTag:      "v1.1.0",
+		},
+		{
+			name:           "equal target proceeds (reinstall allowed)",
+			currentVersion: "v1.0.0",
+			targetTag:      "v1.0.0",
+		},
+		{
+			name:           "strictly lower target blocked before download",
+			currentVersion: "v1.0.0",
+			targetTag:      "v0.9.0",
+			wantErr:        "refusing to downgrade from v1.0.0 to v0.9.0",
+		},
+		{
+			name:           "strictly lower target proceeds when forced",
+			currentVersion: "v1.0.0",
+			targetTag:      "v0.9.0",
+			force:          true,
+		},
+		{
+			name:           "dev build skips downgrade check",
+			currentVersion: "dev",
+			targetTag:      "v0.9.0",
+		},
+		{
+			name:           "unparseable current version skips downgrade check",
+			currentVersion: "1.0",
+			targetTag:      "v0.9.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			u := upgraderWith(recordingDeps(&calls))
+			u.version = tt.currentVersion
+			u.ForceDowngrade = tt.force
+
+			err := u.Upgrade(&Release{TagName: tt.targetTag})
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Upgrade() error = %v, want success", err)
+				}
+				if indexOf(calls, "install") == -1 {
+					t.Fatalf("expected install to run, calls=%v", calls)
+				}
+				return
+			}
+
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+			for _, c := range calls {
+				if c == "download" || c == "extract" || c == "install" {
+					t.Fatalf("step %q ran after downgrade guard tripped: %v", c, calls)
+				}
+			}
+		})
+	}
+}
+
 func indexOf(s []string, target string) int {
 	for i, v := range s {
 		if v == target {


### PR DESCRIPTION
Downgrade protection lived only in Check(); Upgrade() installed whatever release it was handed and never compared versions — the signature chain proves authenticity, not freshness, so a re-pointed 'latest' tag to an older but still validly-signed release could roll back a patched vuln. Adds checkDowngrade before any download: refuse a strictly-lower target (error, no download/extract/install — asserted like the signature-rejection test), allow equal (reinstall) and higher, skip for dev builds and unparseable versions. Escape hatch is an unexported-default-safe ForceDowngrade field (no signature-chain or Check() change, no UI wiring). 6 table rows green. (plan 020)