### PR TITLE
refactor: share the PTY-stopped restart/detach decision in ptyio

### DIFF
--- a/internal/ui/center/model_input_lifecycle_pty_restart.go
+++ b/internal/ui/center/model_input_lifecycle_pty_restart.go
@@ -43,31 +43,26 @@ func (m *Model) updatePTYStopped(msg PTYStopped) tea.Cmd {
 			})
 		}
 		tab.resetActivityANSIState()
-		if termAlive {
-			tab.mu.Lock()
-			backoff, shouldRestart := tab.State.NextRestartBackoffLocked(ptyRestartWindow, ptyRestartMax)
-			if !shouldRestart {
-				tab.markDetachedLocked()
-			}
-			tab.mu.Unlock()
-			if shouldRestart {
-				tabID := msg.TabID
-				wtID := msg.WorkspaceID
-				cmds = append(cmds, common.SafeTick(backoff, func(time.Time) tea.Msg {
-					return PTYRestart{WorkspaceID: wtID, TabID: tabID}
-				}))
-				logging.Warn("PTY stopped for tab %s; restarting in %s: %v", msg.TabID, backoff, msg.Err)
-			} else {
-				logging.Warn("PTY stopped for tab %s; restart limit reached, marking detached: %v", msg.TabID, msg.Err)
-				cmds = append(cmds, func() tea.Msg {
-					return messages.TabStateChanged{WorkspaceID: msg.WorkspaceID, TabID: string(msg.TabID)}
-				})
-			}
-		} else {
-			tab.mu.Lock()
+		tab.mu.Lock()
+		shouldRestart, backoff := tab.State.DecidePTYRestartLocked(termAlive, ptyRestartWindow, ptyRestartMax)
+		if !shouldRestart {
 			tab.markDetachedLocked()
-			tab.State.ResetRestartBackoffLocked()
-			tab.mu.Unlock()
+		}
+		tab.mu.Unlock()
+		switch {
+		case shouldRestart:
+			tabID := msg.TabID
+			wtID := msg.WorkspaceID
+			cmds = append(cmds, common.SafeTick(backoff, func(time.Time) tea.Msg {
+				return PTYRestart{WorkspaceID: wtID, TabID: tabID}
+			}))
+			logging.Warn("PTY stopped for tab %s; restarting in %s: %v", msg.TabID, backoff, msg.Err)
+		case termAlive:
+			logging.Warn("PTY stopped for tab %s; restart limit reached, marking detached: %v", msg.TabID, msg.Err)
+			cmds = append(cmds, func() tea.Msg {
+				return messages.TabStateChanged{WorkspaceID: msg.WorkspaceID, TabID: string(msg.TabID)}
+			})
+		default:
 			logging.Info("PTY stopped for tab %s, marking detached: %v", msg.TabID, msg.Err)
 			cmds = append(cmds, func() tea.Msg {
 				return messages.TabStateChanged{WorkspaceID: msg.WorkspaceID, TabID: string(msg.TabID)}

--- a/internal/ui/ptyio/restart_decision.go
+++ b/internal/ui/ptyio/restart_decision.go
@@ -1,0 +1,29 @@
+package ptyio
+
+import "time"
+
+// DecidePTYRestartLocked computes the shared restart-vs-detach decision after
+// a PTY reader stops. It owns only the policy — panes keep their own side
+// effects (messages, tab/terminal field writes) around the returned decision.
+//
+// termAlive reports whether the underlying terminal is still open. When it is,
+// the restart budget is advanced via NextRestartBackoffLocked(window,
+// maxRestarts): restart==true means the caller should schedule a restart after
+// backoff; restart==false means the budget is exhausted and the caller should
+// apply its detach side effects (RestartBackoff has already been zeroed by the
+// budget check, matching the historical panes, while RestartCount/RestartSince
+// keep the window). When termAlive is false the helper calls
+// ResetRestartBackoffLocked — restarts no longer apply — and returns
+// restart==false so the caller detaches.
+//
+// The caller must hold the state lock (same convention as
+// NextRestartBackoffLocked), and should apply its detach side effects under
+// that same critical section before releasing it.
+func (st *State) DecidePTYRestartLocked(termAlive bool, window time.Duration, maxRestarts int) (restart bool, backoff time.Duration) {
+	if !termAlive {
+		st.ResetRestartBackoffLocked()
+		return false, 0
+	}
+	backoff, ok := st.NextRestartBackoffLocked(window, maxRestarts)
+	return ok, backoff
+}

--- a/internal/ui/ptyio/restart_decision_test.go
+++ b/internal/ui/ptyio/restart_decision_test.go
@@ -1,0 +1,67 @@
+package ptyio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecidePTYRestartLockedUnderLimit(t *testing.T) {
+	st := &State{}
+	last := time.Duration(-1)
+	for i := 0; i < 3; i++ {
+		restart, backoff := st.DecidePTYRestartLocked(true, time.Minute, 3)
+		if !restart {
+			t.Fatalf("call %d: expected restart==true under the limit", i+1)
+		}
+		if backoff <= 0 {
+			t.Fatalf("call %d: expected positive backoff, got %v", i+1, backoff)
+		}
+		if backoff < last {
+			t.Fatalf("call %d: expected backoff to grow or hold, got %v after %v", i+1, backoff, last)
+		}
+		last = backoff
+	}
+}
+
+func TestDecidePTYRestartLockedPastLimitDetaches(t *testing.T) {
+	st := &State{}
+	for i := 0; i < 3; i++ {
+		if restart, _ := st.DecidePTYRestartLocked(true, time.Minute, 3); !restart {
+			t.Fatalf("call %d: expected restart==true while under the limit", i+1)
+		}
+	}
+	restart, backoff := st.DecidePTYRestartLocked(true, time.Minute, 3)
+	if restart {
+		t.Fatal("expected restart==false once the budget is exhausted")
+	}
+	if backoff != 0 {
+		t.Fatalf("expected zero backoff past the limit, got %v", backoff)
+	}
+	if st.RestartBackoff != 0 {
+		t.Fatalf("expected RestartBackoff zeroed past the limit, got %v", st.RestartBackoff)
+	}
+	// The window bookkeeping is intentionally kept (matches the historical
+	// pane behavior): only the dead-terminal branch fully resets.
+	if st.RestartCount == 0 || st.RestartSince.IsZero() {
+		t.Fatal("expected the restart window bookkeeping to survive a limit-reached decision")
+	}
+}
+
+func TestDecidePTYRestartLockedDeadTerminalResets(t *testing.T) {
+	st := &State{}
+	// Seed some backoff state first.
+	if restart, _ := st.DecidePTYRestartLocked(true, time.Minute, 3); !restart {
+		t.Fatal("seed: expected restart==true")
+	}
+	restart, backoff := st.DecidePTYRestartLocked(false, time.Minute, 3)
+	if restart {
+		t.Fatal("expected restart==false for a dead terminal")
+	}
+	if backoff != 0 {
+		t.Fatalf("expected zero backoff for a dead terminal, got %v", backoff)
+	}
+	if st.RestartBackoff != 0 || st.RestartCount != 0 || !st.RestartSince.IsZero() {
+		t.Fatalf("expected full backoff reset for a dead terminal, got backoff=%v count=%d since=%v",
+			st.RestartBackoff, st.RestartCount, st.RestartSince)
+	}
+}

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -125,33 +125,26 @@ func (m *TerminalModel) handlePTYStopped(msg messages.SidebarPTYStopped) tea.Cmd
 	}
 	ts.mu.Unlock()
 	m.stopPTYReader(ts)
-	if termAlive {
-		ts.mu.Lock()
-		backoff, shouldRestart := ts.State.NextRestartBackoffLocked(ptyRestartWindow, ptyRestartMax)
-		if !shouldRestart {
-			ts.Running = false
-			// Mark as detached (tmux session may still be alive)
-			ts.Detached = true
-			ts.UserDetached = false
-		}
-		ts.mu.Unlock()
-		if shouldRestart {
-			restartTab := msg.TabID
-			restartWt := msg.WorkspaceID
-			logging.Warn("Sidebar PTY stopped for workspace %s tab %s; restarting in %s: %v", wsID, tabID, backoff, msg.Err)
-			return common.SafeTick(backoff, func(time.Time) tea.Msg {
-				return messages.SidebarPTYRestart{WorkspaceID: restartWt, TabID: restartTab}
-			})
-		}
-		logging.Warn("Sidebar PTY stopped for workspace %s tab %s; restart limit reached, marking detached: %v", wsID, tabID, msg.Err)
-	} else {
-		ts.mu.Lock()
+	ts.mu.Lock()
+	shouldRestart, backoff := ts.State.DecidePTYRestartLocked(termAlive, ptyRestartWindow, ptyRestartMax)
+	if !shouldRestart {
 		ts.Running = false
-		// Mark as detached - tmux session may still be alive
+		// Mark as detached (tmux session may still be alive)
 		ts.Detached = true
 		ts.UserDetached = false
-		ts.State.ResetRestartBackoffLocked()
-		ts.mu.Unlock()
+	}
+	ts.mu.Unlock()
+	if shouldRestart {
+		restartTab := msg.TabID
+		restartWt := msg.WorkspaceID
+		logging.Warn("Sidebar PTY stopped for workspace %s tab %s; restarting in %s: %v", wsID, tabID, backoff, msg.Err)
+		return common.SafeTick(backoff, func(time.Time) tea.Msg {
+			return messages.SidebarPTYRestart{WorkspaceID: restartWt, TabID: restartTab}
+		})
+	}
+	if termAlive {
+		logging.Warn("Sidebar PTY stopped for workspace %s tab %s; restart limit reached, marking detached: %v", wsID, tabID, msg.Err)
+	} else {
 		logging.Info("Sidebar PTY stopped for workspace %s tab %s, marking detached: %v", wsID, tabID, msg.Err)
 	}
 	return nil


### PR DESCRIPTION
The center and sidebar panes carried the identical restart-vs-detach skeleton (termAlive gate → NextRestartBackoffLocked → restart tick or detach+reset). Step-1 verified the decision is identical (only side effects differ) and both packages alias the same ptyio restart consts. Extract State.DecidePTYRestartLocked (policy only; panes keep their own message/field side effects under the same lock) with 3 unit tests. Behavior preserved: markDetachedLocked runs on both non-restart paths, both emit TabStateChanged — plan-009's center tests and the sidebar restart tests pass unchanged. lint-ci-parity + verify-loop green. Optional restart-handler twins deliberately not folded (MAY-only, avoids the concurrently-edited files). (plan 018, depends on 009)