### PR TITLE
refactor: bundle the session-restore snapshot into one struct

### DIFF
--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -121,19 +121,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 			// Any preserved local PTY backlog may already be represented there and
 			// would duplicate on the next flush if we kept it alive.
 			tab.PendingOutput = nil
-			ptyio.RestorePaneCapture(
-				tab.Terminal,
-				msg.ScrollbackCapture,
-				msg.PostAttachScrollbackCapture,
-				msg.SnapshotCursorX,
-				msg.SnapshotCursorY,
-				msg.SnapshotHasCursor,
-				msg.SnapshotModeState,
-				msg.SnapshotCols,
-				msg.SnapshotRows,
-				cols,
-				rows,
-			)
+			ptyio.RestorePaneCapture(tab.Terminal, msg.SessionRestoreCapture, cols, rows)
 		} else if createdTerminal || len(tab.Terminal.Scrollback) == 0 {
 			ptyio.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 		} else if m.width > 0 && m.height > 0 {

--- a/internal/ui/center/model_input_lifecycle_capture_size_test.go
+++ b/internal/ui/center/model_input_lifecycle_capture_size_test.go
@@ -34,15 +34,17 @@ func TestUpdatePtyTabReattachResult_UsesSnapshotSizeBeforeResizingToCurrentSize(
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-snapshot-size"},
-		Rows:              snapshotHeight,
-		Cols:              snapshotWidth,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   true,
-		SnapshotCols:      snapshotWidth,
-		SnapshotRows:      snapshotHeight,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-snapshot-size"},
+		Rows:        snapshotHeight,
+		Cols:        snapshotWidth,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   true,
+			SnapshotCols:      snapshotWidth,
+			SnapshotRows:      snapshotHeight,
+		},
 	})
 
 	if got := tab.Terminal.Width; got != current.Width {
@@ -74,17 +76,19 @@ func TestHandlePtyTabCreated_UsesSnapshotSizeBeforeResizingToCurrentSize(t *test
 	wsID := string(ws.ID())
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-created-snapshot-size"},
-		TabID:             TabID("tab-created-snapshot-size"),
-		Rows:              snapshotHeight,
-		Cols:              snapshotWidth,
-		Activate:          true,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   true,
-		SnapshotCols:      snapshotWidth,
-		SnapshotRows:      snapshotHeight,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-created-snapshot-size"},
+		TabID:     TabID("tab-created-snapshot-size"),
+		Rows:      snapshotHeight,
+		Cols:      snapshotWidth,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   true,
+			SnapshotCols:      snapshotWidth,
+			SnapshotRows:      snapshotHeight,
+		},
 	})
 
 	tab := m.tabs.ByWorkspace[wsID][0]
@@ -119,13 +123,15 @@ func TestUpdatePtyTabReattachResult_UsesCaptureSizeBeforeResizingForHistoryOnly(
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-history-size"},
-		Rows:              captureHeight,
-		Cols:              captureWidth,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   false,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-history-size"},
+		Rows:        captureHeight,
+		Cols:        captureWidth,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   false,
+		},
 	})
 
 	if got := tab.Terminal.Width; got != current.Width {
@@ -155,15 +161,17 @@ func TestHandlePtyTabCreated_UsesCaptureSizeBeforeResizingForHistoryOnly(t *test
 	wsID := string(ws.ID())
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-created-history-size"},
-		TabID:             TabID("tab-created-history-size"),
-		Rows:              captureHeight,
-		Cols:              captureWidth,
-		Activate:          true,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   false,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-created-history-size"},
+		TabID:     TabID("tab-created-history-size"),
+		Rows:      captureHeight,
+		Cols:      captureWidth,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   false,
+		},
 	})
 
 	tab := m.tabs.ByWorkspace[wsID][0]
@@ -198,13 +206,15 @@ func TestUpdatePtyTabReattachResult_UsesLiveDefaultPTYSizeBeforeFirstLayout(t *t
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-startup-live-size", Terminal: &appPty.Terminal{}},
-		Rows:              captureHeight,
-		Cols:              captureWidth,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   false,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-startup-live-size", Terminal: &appPty.Terminal{}},
+		Rows:        captureHeight,
+		Cols:        captureWidth,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   false,
+		},
 	})
 
 	if tab.ptyRows != current.Height || tab.ptyCols != current.Width {
@@ -226,15 +236,17 @@ func TestHandlePtyTabCreated_UsesLiveDefaultPTYSizeBeforeFirstLayout(t *testing.
 	wsID := string(ws.ID())
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-created-startup-live-size", Terminal: &appPty.Terminal{}},
-		TabID:             TabID("tab-created-startup-live-size"),
-		Rows:              captureHeight,
-		Cols:              captureWidth,
-		Activate:          true,
-		ScrollbackCapture: capture,
-		CaptureFullPane:   false,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-created-startup-live-size", Terminal: &appPty.Terminal{}},
+		TabID:     TabID("tab-created-startup-live-size"),
+		Rows:      captureHeight,
+		Cols:      captureWidth,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   false,
+		},
 	})
 
 	tab := m.tabs.ByWorkspace[wsID][0]

--- a/internal/ui/center/model_input_lifecycle_pane_capture_test.go
+++ b/internal/ui/center/model_input_lifecycle_pane_capture_test.go
@@ -45,13 +45,15 @@ func TestUpdatePtyTabReattachResult_NormalizesCapturedPaneLFForChatTabs(t *testi
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-lf"},
-		Rows:              24,
-		Cols:              80,
-		ScrollbackCapture: []byte("abc\nx"),
-		CaptureFullPane:   true,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-lf"},
+		Rows:        24,
+		Cols:        80,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("abc\nx"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	if tab.Terminal == nil {
@@ -81,13 +83,15 @@ func TestUpdatePtyTabReattachResult_LoadsPaneCaptureIntoVisibleScreen(t *testing
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-pane-capture"},
-		Rows:              2,
-		Cols:              20,
-		ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane:   true,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-pane-capture"},
+		Rows:        2,
+		Cols:        20,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	if tab.Terminal == nil {
@@ -123,14 +127,16 @@ func TestUpdatePtyTabReattachResult_ReconcilesPostAttachHistoryAfterFullPaneRest
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:                 wsID,
-		TabID:                       tab.ID,
-		Agent:                       &appPty.Agent{Session: "sess-reattach-history-reconcile"},
-		Rows:                        2,
-		Cols:                        20,
-		ScrollbackCapture:           []byte("history\nscreen one\nscreen two\n"),
-		PostAttachScrollbackCapture: []byte("history\nscreen one\n"),
-		CaptureFullPane:             true,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-history-reconcile"},
+		Rows:        2,
+		Cols:        20,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture:           []byte("history\nscreen one\nscreen two\n"),
+			PostAttachScrollbackCapture: []byte("history\nscreen one\n"),
+			CaptureFullPane:             true,
+		},
 	})
 
 	if len(tab.Terminal.Scrollback) != 2 {
@@ -161,13 +167,15 @@ func TestUpdatePtyTabReattachResult_ResizesExistingTerminalBeforeFullPaneRestore
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-pane-resize"},
-		Rows:              2,
-		Cols:              8,
-		ScrollbackCapture: []byte("history\n12345678\nabcdefgh\n"),
-		CaptureFullPane:   true,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-pane-resize"},
+		Rows:        2,
+		Cols:        8,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\n12345678\nabcdefgh\n"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	if tab.Terminal == nil {
@@ -245,16 +253,18 @@ func TestUpdatePtyTabReattachResult_PreservesExistingAltScreenStateWithoutSnapsh
 	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
 
 	_, _ = m.updatePtyTabReattachResult(ptyTabReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tab.ID,
-		Agent:             &appPty.Agent{Session: "sess-reattach-missing-modes"},
-		Rows:              3,
-		Cols:              6,
-		ScrollbackCapture: []byte("one\ntwo\nthree\n"),
-		CaptureFullPane:   true,
-		SnapshotCursorX:   0,
-		SnapshotCursorY:   2,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tab.ID,
+		Agent:       &appPty.Agent{Session: "sess-reattach-missing-modes"},
+		Rows:        3,
+		Cols:        6,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("one\ntwo\nthree\n"),
+			CaptureFullPane:   true,
+			SnapshotCursorX:   0,
+			SnapshotCursorY:   2,
+			SnapshotHasCursor: true,
+		},
 	})
 
 	if !tab.Terminal.AltScreen {
@@ -277,15 +287,17 @@ func TestHandlePtyTabCreated_NewTabNormalizesCapturedPaneLFForChatTabs(t *testin
 	wsID := string(ws.ID())
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-created-lf"},
-		TabID:             TabID("tab-created-lf"),
-		Rows:              24,
-		Cols:              80,
-		Activate:          true,
-		ScrollbackCapture: []byte("abc\nx"),
-		CaptureFullPane:   true,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-created-lf"},
+		TabID:     TabID("tab-created-lf"),
+		Rows:      24,
+		Cols:      80,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("abc\nx"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	tabs := m.tabs.ByWorkspace[wsID]
@@ -307,15 +319,17 @@ func TestHandlePtyTabCreated_LoadsPaneCaptureIntoVisibleScreen(t *testing.T) {
 	wsID := string(ws.ID())
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-created-pane-capture"},
-		TabID:             TabID("tab-created-pane-capture"),
-		Rows:              2,
-		Cols:              20,
-		Activate:          true,
-		ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane:   true,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-created-pane-capture"},
+		TabID:     TabID("tab-created-pane-capture"),
+		Rows:      2,
+		Cols:      20,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	tabs := m.tabs.ByWorkspace[wsID]
@@ -359,15 +373,17 @@ func TestHandlePtyTabCreated_ReplacesExistingTerminalWithPaneCapture(t *testing.
 	m.tabs.ByWorkspace[wsID][0].pendingOutputBytes = len(m.tabs.ByWorkspace[wsID][0].PendingOutput)
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-existing-pane-capture"},
-		TabID:             tabID,
-		Rows:              2,
-		Cols:              20,
-		Activate:          true,
-		ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane:   true,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-existing-pane-capture"},
+		TabID:     tabID,
+		Rows:      2,
+		Cols:      20,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	tab := m.tabs.ByWorkspace[wsID][0]
@@ -408,15 +424,17 @@ func TestHandlePtyTabCreated_ResizesExistingTerminalBeforeFullPaneRestore(t *tes
 	}
 
 	_ = m.handlePtyTabCreated(ptyTabCreateResult{
-		Workspace:         ws,
-		Assistant:         "codex",
-		Agent:             &appPty.Agent{Session: "sess-existing-pane-resize"},
-		TabID:             tabID,
-		Rows:              2,
-		Cols:              8,
-		Activate:          true,
-		ScrollbackCapture: []byte("history\n12345678\nabcdefgh\n"),
-		CaptureFullPane:   true,
+		Workspace: ws,
+		Assistant: "codex",
+		Agent:     &appPty.Agent{Session: "sess-existing-pane-resize"},
+		TabID:     tabID,
+		Rows:      2,
+		Cols:      8,
+		Activate:  true,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\n12345678\nabcdefgh\n"),
+			CaptureFullPane:   true,
+		},
 	})
 
 	tab := m.tabs.ByWorkspace[wsID][0]

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -49,40 +49,24 @@ func nextAssistantName(assistant string, tabs []*Tab) string {
 }
 
 type ptyTabCreateResult struct {
-	Workspace                   *data.Workspace
-	Assistant                   string
-	DisplayName                 string
-	Agent                       *appPty.Agent
-	TabID                       TabID
-	Activate                    bool
-	Rows                        int
-	Cols                        int
-	ScrollbackCapture           []byte
-	PostAttachScrollbackCapture []byte
-	CaptureFullPane             bool
-	SnapshotCols                int
-	SnapshotRows                int
-	SnapshotCursorX             int
-	SnapshotCursorY             int
-	SnapshotHasCursor           bool
-	SnapshotModeState           tmux.PaneModeState
+	Workspace   *data.Workspace
+	Assistant   string
+	DisplayName string
+	Agent       *appPty.Agent
+	TabID       TabID
+	Activate    bool
+	Rows        int
+	Cols        int
+	ptyio.SessionRestoreCapture
 }
 
 type ptyTabReattachResult struct {
-	WorkspaceID                 string
-	TabID                       TabID
-	Agent                       *appPty.Agent
-	Rows                        int
-	Cols                        int
-	ScrollbackCapture           []byte
-	PostAttachScrollbackCapture []byte
-	CaptureFullPane             bool
-	SnapshotCols                int
-	SnapshotRows                int
-	SnapshotCursorX             int
-	SnapshotCursorY             int
-	SnapshotHasCursor           bool
-	SnapshotModeState           tmux.PaneModeState
+	WorkspaceID string
+	TabID       TabID
+	Agent       *appPty.Agent
+	Rows        int
+	Cols        int
+	ptyio.SessionRestoreCapture
 }
 
 type ptyTabReattachFailed struct {
@@ -174,18 +158,20 @@ func (m *Model) createAgentTabWithSession(assistant string, ws *data.Workspace, 
 		scrollback, _ := tmux.CapturePane(sessionName, m.tmuxOpts)
 
 		return ptyTabCreateResult{
-			Workspace:         ws,
-			Assistant:         assistant,
-			Agent:             agent,
-			TabID:             tabID,
-			DisplayName:       displayName,
-			Activate:          activate,
-			Rows:              captureRows,
-			Cols:              captureCols,
-			ScrollbackCapture: scrollback,
-			CaptureFullPane:   false,
-			SnapshotCols:      termWidth,
-			SnapshotRows:      termHeight,
+			Workspace:   ws,
+			Assistant:   assistant,
+			Agent:       agent,
+			TabID:       tabID,
+			DisplayName: displayName,
+			Activate:    activate,
+			Rows:        captureRows,
+			Cols:        captureCols,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture: scrollback,
+				CaptureFullPane:   false,
+				SnapshotCols:      termWidth,
+				SnapshotRows:      termHeight,
+			},
 		}
 	}
 }
@@ -256,19 +242,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 				// A full tmux pane snapshot supersedes any preserved local PTY
 				// backlog for this terminal state.
 				tab.PendingOutput = nil
-				ptyio.RestorePaneCapture(
-					tab.Terminal,
-					msg.ScrollbackCapture,
-					msg.PostAttachScrollbackCapture,
-					msg.SnapshotCursorX,
-					msg.SnapshotCursorY,
-					msg.SnapshotHasCursor,
-					msg.SnapshotModeState,
-					msg.SnapshotCols,
-					msg.SnapshotRows,
-					cols,
-					rows,
-				)
+				ptyio.RestorePaneCapture(tab.Terminal, msg.SessionRestoreCapture, cols, rows)
 			} else if createdTerminal || len(tab.Terminal.Scrollback) == 0 {
 				ptyio.RestoreScrollbackCapture(tab.Terminal, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 			} else if m.width > 0 && m.height > 0 {
@@ -361,19 +335,7 @@ func (m *Model) handlePtyTabCreated(msg ptyTabCreateResult) tea.Cmd {
 	term.TreatLFAsCRLF = isChat
 	term.CaptureNormalScreenOnClear = isChat
 	if msg.CaptureFullPane {
-		ptyio.RestorePaneCapture(
-			term,
-			msg.ScrollbackCapture,
-			msg.PostAttachScrollbackCapture,
-			msg.SnapshotCursorX,
-			msg.SnapshotCursorY,
-			msg.SnapshotHasCursor,
-			msg.SnapshotModeState,
-			msg.SnapshotCols,
-			msg.SnapshotRows,
-			cols,
-			rows,
-		)
+		ptyio.RestorePaneCapture(term, msg.SessionRestoreCapture, cols, rows)
 	} else {
 		ptyio.RestoreScrollbackCapture(term, msg.ScrollbackCapture, captureCols, captureRows, cols, rows)
 	}

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -184,20 +185,22 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 			scrollback, captureCols, captureRows = captureSessionHistory(sessionName, attachWidth, attachHeight, opts)
 		}
 		return ptyTabReattachResult{
-			WorkspaceID:                 string(ws.ID()),
-			TabID:                       tabID,
-			Agent:                       agent,
-			Rows:                        captureRows,
-			Cols:                        captureCols,
-			ScrollbackCapture:           scrollback,
-			PostAttachScrollbackCapture: postAttachScrollback,
-			CaptureFullPane:             captureFullPane,
-			SnapshotCols:                snapshot.Cols,
-			SnapshotRows:                snapshot.Rows,
-			SnapshotCursorX:             snapshot.CursorX,
-			SnapshotCursorY:             snapshot.CursorY,
-			SnapshotHasCursor:           snapshot.HasCursor,
-			SnapshotModeState:           snapshot.ModeState,
+			WorkspaceID: string(ws.ID()),
+			TabID:       tabID,
+			Agent:       agent,
+			Rows:        captureRows,
+			Cols:        captureCols,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture:           scrollback,
+				PostAttachScrollbackCapture: postAttachScrollback,
+				CaptureFullPane:             captureFullPane,
+				SnapshotCols:                snapshot.Cols,
+				SnapshotRows:                snapshot.Rows,
+				SnapshotCursorX:             snapshot.CursorX,
+				SnapshotCursorY:             snapshot.CursorY,
+				SnapshotHasCursor:           snapshot.HasCursor,
+				SnapshotModeState:           snapshot.ModeState,
+			},
 		}
 	}
 }

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -191,15 +191,17 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 			captureCols, captureRows := sessionHistoryCaptureSize(sessionName, attachWidth, attachHeight, opts)
 			scrollback, _ := capturePaneFn(sessionName, opts)
 			return ptyTabReattachResult{
-				WorkspaceID:       string(ws.ID()),
-				TabID:             tabID,
-				Agent:             agent,
-				Rows:              captureRows,
-				Cols:              captureCols,
-				ScrollbackCapture: scrollback,
-				CaptureFullPane:   false,
-				SnapshotCols:      attachWidth,
-				SnapshotRows:      attachHeight,
+				WorkspaceID: string(ws.ID()),
+				TabID:       tabID,
+				Agent:       agent,
+				Rows:        captureRows,
+				Cols:        captureCols,
+				SessionRestoreCapture: ptyio.SessionRestoreCapture{
+					ScrollbackCapture: scrollback,
+					CaptureFullPane:   false,
+					SnapshotCols:      attachWidth,
+					SnapshotRows:      attachHeight,
+				},
 			}
 		}
 		tags := tmux.SessionTags{
@@ -248,20 +250,22 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 			scrollback, captureCols, captureRows = captureSessionHistory(sessionName, attachWidth, attachHeight, opts)
 		}
 		return ptyTabReattachResult{
-			WorkspaceID:                 string(ws.ID()),
-			TabID:                       tabID,
-			Agent:                       agent,
-			Rows:                        captureRows,
-			Cols:                        captureCols,
-			ScrollbackCapture:           scrollback,
-			PostAttachScrollbackCapture: postAttachScrollback,
-			CaptureFullPane:             captureFullPane,
-			SnapshotCols:                snapshot.Cols,
-			SnapshotRows:                snapshot.Rows,
-			SnapshotCursorX:             snapshot.CursorX,
-			SnapshotCursorY:             snapshot.CursorY,
-			SnapshotHasCursor:           snapshot.HasCursor,
-			SnapshotModeState:           snapshot.ModeState,
+			WorkspaceID: string(ws.ID()),
+			TabID:       tabID,
+			Agent:       agent,
+			Rows:        captureRows,
+			Cols:        captureCols,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture:           scrollback,
+				PostAttachScrollbackCapture: postAttachScrollback,
+				CaptureFullPane:             captureFullPane,
+				SnapshotCols:                snapshot.Cols,
+				SnapshotRows:                snapshot.Rows,
+				SnapshotCursorX:             snapshot.CursorX,
+				SnapshotCursorY:             snapshot.CursorY,
+				SnapshotHasCursor:           snapshot.HasCursor,
+				SnapshotModeState:           snapshot.ModeState,
+			},
 		}
 	}
 }
@@ -369,15 +373,17 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 		captureCols, captureRows := sessionHistoryCaptureSize(sessionName, termWidth, termHeight, tmuxOpts)
 		scrollback, _ := capturePaneFn(sessionName, tmuxOpts)
 		return ptyTabReattachResult{
-			WorkspaceID:       string(ws.ID()),
-			TabID:             tabID,
-			Agent:             agent,
-			Rows:              captureRows,
-			Cols:              captureCols,
-			ScrollbackCapture: scrollback,
-			CaptureFullPane:   false,
-			SnapshotCols:      termWidth,
-			SnapshotRows:      termHeight,
+			WorkspaceID: string(ws.ID()),
+			TabID:       tabID,
+			Agent:       agent,
+			Rows:        captureRows,
+			Cols:        captureCols,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture: scrollback,
+				CaptureFullPane:   false,
+				SnapshotCols:      termWidth,
+				SnapshotRows:      termHeight,
+			},
 		}
 	}
 }

--- a/internal/ui/ptyio/session_restore.go
+++ b/internal/ui/ptyio/session_restore.go
@@ -27,36 +27,45 @@ func SessionRestorePaneModeState(mode tmux.PaneModeState) vterm.PaneModeState {
 	}
 }
 
-func RestorePaneCapture(
-	term *vterm.VTerm,
-	data []byte,
-	postAttachScrollback []byte,
-	cursorX, cursorY int,
-	hasCursor bool,
-	mode tmux.PaneModeState,
-	snapshotCols, snapshotRows int,
-	currentCols, currentRows int,
-) {
+// SessionRestoreCapture is the pane snapshot captured at (re)attach time and
+// replayed into a fresh vterm by RestorePaneCapture.
+//
+// Invariant: a new snapshot field is a one-line addition here plus the
+// producer struct literals — the message structs embed this type, so the
+// field is promoted everywhere without touching consumer signatures.
+type SessionRestoreCapture struct {
+	ScrollbackCapture           []byte
+	PostAttachScrollbackCapture []byte
+	CaptureFullPane             bool
+	SnapshotCols                int
+	SnapshotRows                int
+	SnapshotCursorX             int
+	SnapshotCursorY             int
+	SnapshotHasCursor           bool
+	SnapshotModeState           tmux.PaneModeState
+}
+
+func RestorePaneCapture(term *vterm.VTerm, c SessionRestoreCapture, currentCols, currentRows int) {
 	if term == nil {
 		return
 	}
-	restoreCols, restoreRows := SessionSnapshotSize(true, snapshotCols, snapshotRows, currentCols, currentRows)
+	restoreCols, restoreRows := SessionSnapshotSize(true, c.SnapshotCols, c.SnapshotRows, currentCols, currentRows)
 	visibleHistoryRows := 0
 	if term.Width != restoreCols || term.Height != restoreRows {
 		term.Resize(restoreCols, restoreRows)
 	}
 	term.LoadSnapshot(vterm.TerminalSnapshot{
-		Data:      data,
+		Data:      c.ScrollbackCapture,
 		Cols:      restoreCols,
 		Rows:      restoreRows,
-		CursorX:   cursorX,
-		CursorY:   cursorY,
-		HasCursor: hasCursor,
-		ModeState: SessionRestorePaneModeState(mode),
+		CursorX:   c.SnapshotCursorX,
+		CursorY:   c.SnapshotCursorY,
+		HasCursor: c.SnapshotHasCursor,
+		ModeState: SessionRestorePaneModeState(c.SnapshotModeState),
 	})
 	if restoreCols != currentCols || restoreRows != currentRows {
 		prevScrollbackLen := len(term.Scrollback)
-		if mode.AltScreen && currentRows > restoreRows {
+		if c.SnapshotModeState.AltScreen && currentRows > restoreRows {
 			term.ResizeWithoutHistoryReveal(currentCols, currentRows)
 		} else {
 			term.Resize(currentCols, currentRows)
@@ -66,7 +75,7 @@ func RestorePaneCapture(
 		}
 	}
 	term.AppendDelta(vterm.TerminalSnapshot{
-		Data: postAttachScrollback,
+		Data: c.PostAttachScrollbackCapture,
 		Cols: restoreCols,
 		Rows: restoreRows,
 	}, visibleHistoryRows)

--- a/internal/ui/ptyio/session_restore_resize_test.go
+++ b/internal/ui/ptyio/session_restore_resize_test.go
@@ -230,14 +230,11 @@ func TestSessionRestorePaneModeState_PreservesExistingStateWhenNoCapturedState(t
 
 func TestRestorePaneCapture_NilTerminalIsNoOp(t *testing.T) {
 	// The early nil guard protects reused tabs whose VTerm is not yet live.
-	RestorePaneCapture(
-		nil,
-		[]byte("history\n"),
-		nil,
-		0, 0, false,
-		tmux.PaneModeState{},
-		20, 2, 20, 2,
-	)
+	RestorePaneCapture(nil, SessionRestoreCapture{
+		ScrollbackCapture: []byte("history\n"),
+		SnapshotCols:      20,
+		SnapshotRows:      2,
+	}, 20, 2)
 }
 
 func TestRestoreScrollbackCapture_NilTerminalIsNoOp(t *testing.T) {

--- a/internal/ui/ptyio/session_restore_test.go
+++ b/internal/ui/ptyio/session_restore_test.go
@@ -10,19 +10,12 @@ import (
 func TestRestorePaneCapture_ViewportGrowthCountsOnlyRevealedHistoryRows(t *testing.T) {
 	term := vterm.New(20, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\nscreen one\nscreen two\n"),
-		[]byte("older\nhistory\n"),
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		20,
-		2,
-		20,
-		5,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture:           []byte("history\nscreen one\nscreen two\n"),
+		PostAttachScrollbackCapture: []byte("older\nhistory\n"),
+		SnapshotCols:                20,
+		SnapshotRows:                2,
+	}, 20, 5)
 
 	if len(term.Scrollback) != 1 {
 		t.Fatalf("expected only the truly new history row to be appended after viewport growth, got %d rows", len(term.Scrollback))
@@ -39,19 +32,11 @@ func TestRestorePaneCapture_DropsStaleParserCarryBeforeNewClientRedraw(t *testin
 	term := vterm.New(20, 2)
 	term.Write([]byte("\x1b"))
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\nscreen one\nscreen two\n"),
-		nil,
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		20,
-		2,
-		20,
-		2,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+		SnapshotCols:      20,
+		SnapshotRows:      2,
+	}, 20, 2)
 
 	if got := term.ParserCarryState(); got != (vterm.ParserCarryState{}) {
 		t.Fatalf("expected full-pane restore to drop stale parser carry before the new tmux client attaches, got %+v", got)
@@ -69,19 +54,12 @@ func TestRestorePaneCapture_DropsStaleParserCarryBeforeNewClientRedraw(t *testin
 func TestRestorePaneCapture_DoesNotDuplicateHistoryWhenViewportShrinks(t *testing.T) {
 	term := vterm.New(20, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\nscreen zero\nscreen one\nscreen two\n"),
-		[]byte("history\nscreen zero\n"),
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		20,
-		3,
-		20,
-		2,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture:           []byte("history\nscreen zero\nscreen one\nscreen two\n"),
+		PostAttachScrollbackCapture: []byte("history\nscreen zero\n"),
+		SnapshotCols:                20,
+		SnapshotRows:                3,
+	}, 20, 2)
 
 	if term.Width != 20 || term.Height != 2 {
 		t.Fatalf("expected restored terminal resized to the live viewport, got %dx%d", term.Width, term.Height)
@@ -106,19 +84,12 @@ func TestRestorePaneCapture_DoesNotDuplicateHistoryWhenViewportShrinks(t *testin
 func TestRestorePaneCapture_DoesNotDuplicateHistoryWhenViewportGrows(t *testing.T) {
 	term := vterm.New(20, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\nscreen one\nscreen two\n"),
-		[]byte("history\nscreen one\n"),
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		20,
-		2,
-		20,
-		3,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture:           []byte("history\nscreen one\nscreen two\n"),
+		PostAttachScrollbackCapture: []byte("history\nscreen one\n"),
+		SnapshotCols:                20,
+		SnapshotRows:                2,
+	}, 20, 3)
 
 	if term.Width != 20 || term.Height != 3 {
 		t.Fatalf("expected restored terminal resized to the larger live viewport, got %dx%d", term.Width, term.Height)
@@ -134,19 +105,12 @@ func TestRestorePaneCapture_DoesNotDuplicateHistoryWhenViewportGrows(t *testing.
 func TestRestorePaneCapture_DoesNotDuplicateVisibleTailWhenResizeChangesDuringAttach(t *testing.T) {
 	term := vterm.New(20, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\nscreen one\nscreen two\n"),
-		[]byte("history\nscreen one\nscreen two\n"),
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		20,
-		2,
-		20,
-		3,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture:           []byte("history\nscreen one\nscreen two\n"),
+		PostAttachScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+		SnapshotCols:                20,
+		SnapshotRows:                2,
+	}, 20, 3)
 
 	if len(term.Scrollback) != 0 {
 		t.Fatalf("expected visible post-attach rows to stay out of scrollback after resize, got %d", len(term.Scrollback))
@@ -162,19 +126,12 @@ func TestRestorePaneCapture_DoesNotDuplicateVisibleTailWhenResizeChangesDuringAt
 func TestRestorePaneCapture_ReconcilesDeltaAtSnapshotWidthAfterResize(t *testing.T) {
 	term := vterm.New(8, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("history\n12345678\nabcdefgh\n"),
-		[]byte("history\n12345678\n"),
-		0,
-		0,
-		false,
-		tmux.PaneModeState{},
-		8,
-		2,
-		4,
-		2,
-	)
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture:           []byte("history\n12345678\nabcdefgh\n"),
+		PostAttachScrollbackCapture: []byte("history\n12345678\n"),
+		SnapshotCols:                8,
+		SnapshotRows:                2,
+	}, 4, 2)
 
 	if term.Width != 4 || term.Height != 2 {
 		t.Fatalf("expected restore resized to the narrower live viewport, got %dx%d", term.Width, term.Height)
@@ -190,24 +147,20 @@ func TestRestorePaneCapture_ReconcilesDeltaAtSnapshotWidthAfterResize(t *testing
 func TestRestorePaneCapture_AltScreenViewportGrowthDoesNotRevealHistory(t *testing.T) {
 	term := vterm.New(8, 2)
 
-	RestorePaneCapture(
-		term,
-		[]byte("older\nmenu one\nmenu two\n"),
-		nil,
-		0,
-		1,
-		true,
-		tmux.PaneModeState{
+	RestorePaneCapture(term, SessionRestoreCapture{
+		ScrollbackCapture: []byte("older\nmenu one\nmenu two\n"),
+		SnapshotCursorX:   0,
+		SnapshotCursorY:   1,
+		SnapshotHasCursor: true,
+		SnapshotModeState: tmux.PaneModeState{
 			HasState:     true,
 			AltScreen:    true,
 			ScrollTop:    0,
 			ScrollBottom: 2,
 		},
-		8,
-		2,
-		8,
-		4,
-	)
+		SnapshotCols: 8,
+		SnapshotRows: 2,
+	}, 8, 4)
 
 	if !term.AltScreen {
 		t.Fatal("expected restored pane to remain in alt-screen mode")

--- a/internal/ui/sidebar/terminal_capture_size_test.go
+++ b/internal/ui/sidebar/terminal_capture_size_test.go
@@ -41,9 +41,11 @@ func TestReattach_UsesCaptureSizeBeforeResizingForHistoryOnly(t *testing.T) {
 		WorkspaceID: wsID,
 		TabID:       tabID,
 		SessionName: "session-1",
-		Scrollback:  capture,
 		CaptureCols: captureWidth,
 		CaptureRows: captureHeight,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)
@@ -82,9 +84,11 @@ func TestHandleTerminalCreated_UsesCaptureSizeBeforeResizingForHistoryOnly(t *te
 		WorkspaceID: wsID,
 		TabID:       tabID,
 		SessionName: "session-created",
-		Scrollback:  capture,
 		CaptureCols: captureWidth,
 		CaptureRows: captureHeight,
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)
@@ -175,14 +179,16 @@ func TestHandleTerminalCreated_DelaysPTYResizeUntilAfterFullPaneRestore(t *testi
 	}
 
 	_, _ = m.Update(SidebarTerminalCreated{
-		WorkspaceID:     wsID,
-		TabID:           tabID,
-		SessionName:     "session-full-pane",
-		Terminal:        &pty.Terminal{},
-		Scrollback:      []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane: true,
-		SnapshotCols:    snapshotWidth,
-		SnapshotRows:    2,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-full-pane",
+		Terminal:    &pty.Terminal{},
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+			SnapshotCols:      snapshotWidth,
+			SnapshotRows:      2,
+		},
 	})
 
 	if resizeCalls == 0 {
@@ -209,14 +215,16 @@ func TestHandleTerminalCreated_UsesSnapshotSizeBeforeSidebarLayout(t *testing.T)
 	}
 
 	_, _ = m.Update(SidebarTerminalCreated{
-		WorkspaceID:     wsID,
-		TabID:           tabID,
-		SessionName:     "session-full-pane",
-		Terminal:        &pty.Terminal{},
-		Scrollback:      []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane: true,
-		SnapshotCols:    18,
-		SnapshotRows:    4,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-full-pane",
+		Terminal:    &pty.Terminal{},
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+			SnapshotCols:      18,
+			SnapshotRows:      4,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)
@@ -255,14 +263,16 @@ func TestHandleReattachResult_UsesSnapshotSizeBeforeSidebarLayout(t *testing.T) 
 	}
 
 	_, _ = m.Update(SidebarTerminalReattachResult{
-		WorkspaceID:     wsID,
-		TabID:           tabID,
-		SessionName:     "session-1",
-		Terminal:        &pty.Terminal{},
-		Scrollback:      []byte("history\nscreen one\nscreen two\n"),
-		CaptureFullPane: true,
-		SnapshotCols:    18,
-		SnapshotRows:    4,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		Terminal:    &pty.Terminal{},
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+			SnapshotCols:      18,
+			SnapshotRows:      4,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -159,21 +159,23 @@ func (m *TerminalModel) createTerminalTab(ws *data.Workspace) tea.Cmd {
 		}
 
 		return SidebarTerminalCreated{
-			WorkspaceID:          wsID,
-			TabID:                tabID,
-			Terminal:             term,
-			SessionName:          sessionName,
-			Scrollback:           scrollback,
-			PostAttachScrollback: postAttachScrollback,
-			CaptureCols:          captureCols,
-			CaptureRows:          captureRows,
-			CaptureFullPane:      captureFullPane,
-			SnapshotCols:         snapshot.Cols,
-			SnapshotRows:         snapshot.Rows,
-			SnapshotCursorX:      snapshot.CursorX,
-			SnapshotCursorY:      snapshot.CursorY,
-			SnapshotHasCursor:    snapshot.HasCursor,
-			SnapshotModeState:    snapshot.ModeState,
+			WorkspaceID: wsID,
+			TabID:       tabID,
+			Terminal:    term,
+			SessionName: sessionName,
+			CaptureCols: captureCols,
+			CaptureRows: captureRows,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture:           scrollback,
+				PostAttachScrollbackCapture: postAttachScrollback,
+				CaptureFullPane:             captureFullPane,
+				SnapshotCols:                snapshot.Cols,
+				SnapshotRows:                snapshot.Rows,
+				SnapshotCursorX:             snapshot.CursorX,
+				SnapshotCursorY:             snapshot.CursorY,
+				SnapshotHasCursor:           snapshot.HasCursor,
+				SnapshotModeState:           snapshot.ModeState,
+			},
 		}
 	}
 }
@@ -351,21 +353,23 @@ func (m *TerminalModel) attachToSession(ws *data.Workspace, tabID TerminalTabID,
 			scrollback, _ = capturePaneFn(sessionName, opts)
 		}
 		return SidebarTerminalReattachResult{
-			WorkspaceID:          wsID,
-			TabID:                tabID,
-			Terminal:             term,
-			SessionName:          sessionName,
-			Scrollback:           scrollback,
-			PostAttachScrollback: postAttachScrollback,
-			CaptureCols:          captureCols,
-			CaptureRows:          captureRows,
-			CaptureFullPane:      captureFullPane,
-			SnapshotCols:         snapshot.Cols,
-			SnapshotRows:         snapshot.Rows,
-			SnapshotCursorX:      snapshot.CursorX,
-			SnapshotCursorY:      snapshot.CursorY,
-			SnapshotHasCursor:    snapshot.HasCursor,
-			SnapshotModeState:    snapshot.ModeState,
+			WorkspaceID: wsID,
+			TabID:       tabID,
+			Terminal:    term,
+			SessionName: sessionName,
+			CaptureCols: captureCols,
+			CaptureRows: captureRows,
+			SessionRestoreCapture: ptyio.SessionRestoreCapture{
+				ScrollbackCapture:           scrollback,
+				PostAttachScrollbackCapture: postAttachScrollback,
+				CaptureFullPane:             captureFullPane,
+				SnapshotCols:                snapshot.Cols,
+				SnapshotRows:                snapshot.Rows,
+				SnapshotCursorX:             snapshot.CursorX,
+				SnapshotCursorY:             snapshot.CursorY,
+				SnapshotHasCursor:           snapshot.HasCursor,
+				SnapshotModeState:           snapshot.ModeState,
+			},
 		}
 	}
 }

--- a/internal/ui/sidebar/terminal_pty_attach_safety_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_safety_test.go
@@ -104,7 +104,7 @@ func TestAttachToSession_SharedClientFallsBackToHistoryOnly(t *testing.T) {
 	if reattach.CaptureFullPane {
 		t.Fatal("expected shared-client reattach to skip pre-attach full-pane restore")
 	}
-	if got := string(reattach.Scrollback); got != "history only" {
+	if got := string(reattach.ScrollbackCapture); got != "history only" {
 		t.Fatalf("expected history-only fallback, got %q", got)
 	}
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
@@ -225,7 +225,7 @@ func TestCreateTerminalTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T
 	if created.CaptureFullPane {
 		t.Fatal("expected ineligible snapshot to disable authoritative full-pane restore")
 	}
-	if got := string(created.Scrollback); got != "history only" {
+	if got := string(created.ScrollbackCapture); got != "history only" {
 		t.Fatalf("expected history-only fallback, got %q", got)
 	}
 	if created.CaptureCols != 123 || created.CaptureRows != 45 {
@@ -330,7 +330,7 @@ func TestAttachToSession_SnapshotIneligibleFallsBackWithoutResize(t *testing.T) 
 	if reattach.CaptureFullPane {
 		t.Fatal("expected ineligible snapshot to disable authoritative full-pane restore")
 	}
-	if got := string(reattach.Scrollback); got != "history only" {
+	if got := string(reattach.ScrollbackCapture); got != "history only" {
 		t.Fatalf("expected history-only fallback, got %q", got)
 	}
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {

--- a/internal/ui/sidebar/terminal_pty_attach_snapshot_race_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_snapshot_race_test.go
@@ -113,11 +113,11 @@ func TestCreateTerminalTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 	if created.CaptureFullPane {
 		t.Fatal("expected recreated session to discard the pre-attach snapshot")
 	}
-	if got := string(created.Scrollback); got != "post history" {
+	if got := string(created.ScrollbackCapture); got != "post history" {
 		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
 	}
-	if len(created.PostAttachScrollback) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(created.PostAttachScrollback))
+	if len(created.PostAttachScrollbackCapture) != 0 {
+		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(created.PostAttachScrollbackCapture))
 	}
 	if created.CaptureCols != 123 || created.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", created.CaptureCols, created.CaptureRows)
@@ -232,11 +232,11 @@ func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testin
 	if reattach.CaptureFullPane {
 		t.Fatal("expected recreated session to discard the pre-attach snapshot")
 	}
-	if got := string(reattach.Scrollback); got != "post history" {
+	if got := string(reattach.ScrollbackCapture); got != "post history" {
 		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
 	}
-	if len(reattach.PostAttachScrollback) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(reattach.PostAttachScrollback))
+	if len(reattach.PostAttachScrollbackCapture) != 0 {
+		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(reattach.PostAttachScrollbackCapture))
 	}
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", reattach.CaptureCols, reattach.CaptureRows)
@@ -346,11 +346,11 @@ func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionBecomesActive(t *te
 	if reattach.CaptureFullPane {
 		t.Fatal("expected activity after snapshot capture to demote sidebar restore back to history-only")
 	}
-	if got := string(reattach.Scrollback); got != "post history" {
+	if got := string(reattach.ScrollbackCapture); got != "post history" {
 		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
 	}
-	if len(reattach.PostAttachScrollback) != 0 {
-		t.Fatalf("expected no reconciliation delta after stale snapshot demotion, got %q", string(reattach.PostAttachScrollback))
+	if len(reattach.PostAttachScrollbackCapture) != 0 {
+		t.Fatalf("expected no reconciliation delta after stale snapshot demotion, got %q", string(reattach.PostAttachScrollbackCapture))
 	}
 	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
 }
@@ -452,11 +452,11 @@ func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionBecomesShared(t *te
 	if reattach.CaptureFullPane {
 		t.Fatal("expected shared sidebar session after snapshot capture to demote back to history-only")
 	}
-	if got := string(reattach.Scrollback); got != "post history" {
+	if got := string(reattach.ScrollbackCapture); got != "post history" {
 		t.Fatalf("expected post-attach history recapture after shared-session demotion, got %q", got)
 	}
-	if len(reattach.PostAttachScrollback) != 0 {
-		t.Fatalf("expected no reconciliation delta after shared-session demotion, got %q", string(reattach.PostAttachScrollback))
+	if len(reattach.PostAttachScrollbackCapture) != 0 {
+		t.Fatalf("expected no reconciliation delta after shared-session demotion, got %q", string(reattach.PostAttachScrollbackCapture))
 	}
 	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
 }

--- a/internal/ui/sidebar/terminal_pty_attach_snapshot_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_snapshot_test.go
@@ -115,10 +115,10 @@ func TestCreateTerminalTab_CapturesReusedSessionBeforeAttachAfterResize(t *testi
 	if !created.CaptureFullPane {
 		t.Fatal("expected reused session startup to restore a full-pane snapshot")
 	}
-	if got := string(created.Scrollback); got != "resized frame" {
+	if got := string(created.ScrollbackCapture); got != "resized frame" {
 		t.Fatalf("expected snapshot data from pre-attach capture, got %q", got)
 	}
-	if got := string(created.PostAttachScrollback); got != "fallback" {
+	if got := string(created.PostAttachScrollbackCapture); got != "fallback" {
 		t.Fatalf("expected post-attach history reconciliation capture, got %q", got)
 	}
 	if created.SnapshotCols != 77 || created.SnapshotRows != 19 {
@@ -311,10 +311,10 @@ func TestAttachToSession_CapturesReattachSnapshotBeforeAttach(t *testing.T) {
 	if !reattach.CaptureFullPane {
 		t.Fatal("expected reattach to carry a full-pane snapshot")
 	}
-	if got := string(reattach.Scrollback); got != "pre-attach frame" {
+	if got := string(reattach.ScrollbackCapture); got != "pre-attach frame" {
 		t.Fatalf("expected pre-attach snapshot data, got %q", got)
 	}
-	if got := string(reattach.PostAttachScrollback); got != "fallback" {
+	if got := string(reattach.PostAttachScrollbackCapture); got != "fallback" {
 		t.Fatalf("expected post-attach history reconciliation capture, got %q", got)
 	}
 	if reattach.SnapshotCols != 77 || reattach.SnapshotRows != 19 {

--- a/internal/ui/sidebar/terminal_pty_attach_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_test.go
@@ -155,7 +155,7 @@ func TestCreateTerminalTab_FallsBackToHistoryWhenPreAttachResizeFails(t *testing
 	if created.CaptureFullPane {
 		t.Fatal("expected resize failure to disable authoritative full-pane restore")
 	}
-	if got := string(created.Scrollback); got != "history only" {
+	if got := string(created.ScrollbackCapture); got != "history only" {
 		t.Fatalf("expected history-only fallback, got %q", got)
 	}
 	if created.CaptureCols != 123 || created.CaptureRows != 45 {
@@ -282,7 +282,7 @@ func TestAttachToSession_FallsBackToHistoryWhenPreAttachResizeFails(t *testing.T
 	if reattach.CaptureFullPane {
 		t.Fatal("expected resize failure to disable authoritative full-pane restore")
 	}
-	if got := string(reattach.Scrollback); got != "history only" {
+	if got := string(reattach.ScrollbackCapture); got != "history only" {
 		t.Fatalf("expected history-only fallback, got %q", got)
 	}
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {

--- a/internal/ui/sidebar/terminal_pty_config.go
+++ b/internal/ui/sidebar/terminal_pty_config.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/andyrewlee/amux/internal/pty"
-	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/ptyio"
 )
 
@@ -43,21 +42,13 @@ const (
 
 // SidebarTerminalCreated is a message for terminal creation
 type SidebarTerminalCreated struct {
-	WorkspaceID          string
-	TabID                TerminalTabID
-	Terminal             *pty.Terminal
-	SessionName          string
-	Scrollback           []byte
-	PostAttachScrollback []byte
-	CaptureCols          int
-	CaptureRows          int
-	CaptureFullPane      bool
-	SnapshotCols         int
-	SnapshotRows         int
-	SnapshotCursorX      int
-	SnapshotCursorY      int
-	SnapshotHasCursor    bool
-	SnapshotModeState    tmux.PaneModeState
+	WorkspaceID string
+	TabID       TerminalTabID
+	Terminal    *pty.Terminal
+	SessionName string
+	CaptureCols int
+	CaptureRows int
+	ptyio.SessionRestoreCapture
 }
 
 // SidebarTerminalCreateFailed is a message for terminal creation failure
@@ -67,21 +58,13 @@ type SidebarTerminalCreateFailed struct {
 }
 
 type SidebarTerminalReattachResult struct {
-	WorkspaceID          string
-	TabID                TerminalTabID
-	Terminal             *pty.Terminal
-	SessionName          string
-	Scrollback           []byte
-	PostAttachScrollback []byte
-	CaptureCols          int
-	CaptureRows          int
-	CaptureFullPane      bool
-	SnapshotCols         int
-	SnapshotRows         int
-	SnapshotCursorX      int
-	SnapshotCursorY      int
-	SnapshotHasCursor    bool
-	SnapshotModeState    tmux.PaneModeState
+	WorkspaceID string
+	TabID       TerminalTabID
+	Terminal    *pty.Terminal
+	SessionName string
+	CaptureCols int
+	CaptureRows int
+	ptyio.SessionRestoreCapture
 }
 
 type SidebarTerminalReattachFailed struct {

--- a/internal/ui/sidebar/terminal_reattach_test.go
+++ b/internal/ui/sidebar/terminal_reattach_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
 	"github.com/andyrewlee/amux/internal/vterm"
 )
 
@@ -31,7 +32,9 @@ func TestReattachPrependsScrollbackWhenCaptureExcludesScreen(t *testing.T) {
 		WorkspaceID: wsID,
 		TabID:       tabID,
 		SessionName: "session-1",
-		Scrollback:  []byte("line-1\nline-2\n"),
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("line-1\nline-2\n"),
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -75,7 +78,9 @@ func TestReattachHistoryOnlyResizesExistingVTermBeforeRecordingSize(t *testing.T
 		WorkspaceID: wsID,
 		TabID:       tabID,
 		SessionName: "session-1",
-		Scrollback:  []byte("line-1\nline-2\n"),
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("line-1\nline-2\n"),
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -118,11 +123,13 @@ func TestReattachLoadsPaneCapture(t *testing.T) {
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
-		WorkspaceID:     wsID,
-		TabID:           tabID,
-		SessionName:     "session-1",
-		Scrollback:      []byte("line-1\nline-2\n"),
-		CaptureFullPane: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("line-1\nline-2\n"),
+			CaptureFullPane:   true,
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -171,14 +178,16 @@ func TestReattachReconcilesPostAttachHistoryAfterFullPaneRestore(t *testing.T) {
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
-		WorkspaceID:          wsID,
-		TabID:                tabID,
-		SessionName:          "session-1",
-		Scrollback:           []byte("history\nscreen zero\nscreen one\nscreen two\n"),
-		PostAttachScrollback: []byte("history\nscreen zero\n"),
-		CaptureFullPane:      true,
-		SnapshotCols:         20,
-		SnapshotRows:         3,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture:           []byte("history\nscreen zero\nscreen one\nscreen two\n"),
+			PostAttachScrollbackCapture: []byte("history\nscreen zero\n"),
+			CaptureFullPane:             true,
+			SnapshotCols:                20,
+			SnapshotRows:                3,
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -211,14 +220,16 @@ func TestHandleTerminalCreated_LoadsPaneCaptureBeforeStartingReader(t *testing.T
 	m.height = 4
 
 	_, _ = m.Update(SidebarTerminalCreated{
-		WorkspaceID:       wsID,
-		TabID:             tabID,
-		SessionName:       "session-1",
-		Scrollback:        []byte("history\nscreen zero\nscreen one\nscreen two\n"),
-		CaptureFullPane:   true,
-		SnapshotCursorX:   5,
-		SnapshotCursorY:   2,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("history\nscreen zero\nscreen one\nscreen two\n"),
+			CaptureFullPane:   true,
+			SnapshotCursorX:   5,
+			SnapshotCursorY:   2,
+			SnapshotHasCursor: true,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)
@@ -252,13 +263,15 @@ func TestHandleTerminalCreated_BlankPaneCaptureClearsStaleFrame(t *testing.T) {
 	m.height = 4
 
 	_, _ = m.Update(SidebarTerminalCreated{
-		WorkspaceID:       wsID,
-		TabID:             tabID,
-		SessionName:       "session-blank",
-		CaptureFullPane:   true,
-		SnapshotCursorX:   1,
-		SnapshotCursorY:   0,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-blank",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			CaptureFullPane:   true,
+			SnapshotCursorX:   1,
+			SnapshotCursorY:   0,
+			SnapshotHasCursor: true,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)
@@ -299,13 +312,15 @@ func TestReattachBlankPaneCaptureClearsStaleFrame(t *testing.T) {
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tabID,
-		SessionName:       "session-1",
-		CaptureFullPane:   true,
-		SnapshotCursorX:   2,
-		SnapshotCursorY:   0,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			CaptureFullPane:   true,
+			SnapshotCursorX:   2,
+			SnapshotCursorY:   0,
+			SnapshotHasCursor: true,
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -353,14 +368,16 @@ func TestReattachPreservesExistingAltScreenStateWithoutSnapshotModes(t *testing.
 	m.workspace = ws
 
 	msg := SidebarTerminalReattachResult{
-		WorkspaceID:       wsID,
-		TabID:             tabID,
-		SessionName:       "session-1",
-		Scrollback:        []byte("one\ntwo\nthree"),
-		CaptureFullPane:   true,
-		SnapshotCursorX:   0,
-		SnapshotCursorY:   2,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-1",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: []byte("one\ntwo\nthree"),
+			CaptureFullPane:   true,
+			SnapshotCursorX:   0,
+			SnapshotCursorY:   2,
+			SnapshotHasCursor: true,
+		},
 	}
 
 	_, _ = m.Update(msg)
@@ -405,16 +422,18 @@ func TestHandleTerminalCreated_UsesSnapshotDimensionsForFullPaneRestore(t *testi
 	expected.Resize(currentWidth, currentHeight)
 
 	_, _ = m.Update(SidebarTerminalCreated{
-		WorkspaceID:       wsID,
-		TabID:             tabID,
-		SessionName:       "session-sized",
-		Scrollback:        capture,
-		CaptureFullPane:   true,
-		SnapshotCols:      snapshotWidth,
-		SnapshotRows:      snapshotHeight,
-		SnapshotCursorX:   0,
-		SnapshotCursorY:   1,
-		SnapshotHasCursor: true,
+		WorkspaceID: wsID,
+		TabID:       tabID,
+		SessionName: "session-sized",
+		SessionRestoreCapture: ptyio.SessionRestoreCapture{
+			ScrollbackCapture: capture,
+			CaptureFullPane:   true,
+			SnapshotCols:      snapshotWidth,
+			SnapshotRows:      snapshotHeight,
+			SnapshotCursorX:   0,
+			SnapshotCursorY:   1,
+			SnapshotHasCursor: true,
+		},
 	})
 
 	tab := m.getTabByID(wsID, tabID)

--- a/internal/ui/sidebar/terminal_update_session.go
+++ b/internal/ui/sidebar/terminal_update_session.go
@@ -38,25 +38,13 @@ func (m *TerminalModel) handleTerminalCreated(msg SidebarTerminalCreated) tea.Cm
 		ts.mu.Lock()
 		if ts.VTerm != nil {
 			if msg.CaptureFullPane {
-				ptyio.RestorePaneCapture(
-					ts.VTerm,
-					msg.Scrollback,
-					msg.PostAttachScrollback,
-					msg.SnapshotCursorX,
-					msg.SnapshotCursorY,
-					msg.SnapshotHasCursor,
-					msg.SnapshotModeState,
-					msg.SnapshotCols,
-					msg.SnapshotRows,
-					currentWidth,
-					currentHeight,
-				)
+				ptyio.RestorePaneCapture(ts.VTerm, msg.SessionRestoreCapture, currentWidth, currentHeight)
 				ts.lastWidth = currentWidth
 				ts.lastHeight = currentHeight
-			} else if len(msg.Scrollback) > 0 {
+			} else if len(msg.ScrollbackCapture) > 0 {
 				ptyio.RestoreScrollbackCapture(
 					ts.VTerm,
-					msg.Scrollback,
+					msg.ScrollbackCapture,
 					msg.CaptureCols,
 					msg.CaptureRows,
 					currentWidth,
@@ -92,24 +80,12 @@ func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) 
 	if ts.VTerm != nil {
 		ts.VTerm.AllowAltScreenScrollback = true
 		if msg.CaptureFullPane {
-			ptyio.RestorePaneCapture(
-				ts.VTerm,
-				msg.Scrollback,
-				msg.PostAttachScrollback,
-				msg.SnapshotCursorX,
-				msg.SnapshotCursorY,
-				msg.SnapshotHasCursor,
-				msg.SnapshotModeState,
-				msg.SnapshotCols,
-				msg.SnapshotRows,
-				termWidth,
-				termHeight,
-			)
+			ptyio.RestorePaneCapture(ts.VTerm, msg.SessionRestoreCapture, termWidth, termHeight)
 		} else {
-			if len(msg.Scrollback) > 0 && len(ts.VTerm.Scrollback) == 0 {
+			if len(msg.ScrollbackCapture) > 0 && len(ts.VTerm.Scrollback) == 0 {
 				ptyio.RestoreScrollbackCapture(
 					ts.VTerm,
-					msg.Scrollback,
+					msg.ScrollbackCapture,
 					msg.CaptureCols,
 					msg.CaptureRows,
 					termWidth,


### PR DESCRIPTION
The tmux pane-snapshot bundle was threaded as 9 loose fields through 4 message structs and consumed by a 10-arg positional RestorePaneCapture — a silent same-typed cols/rows/cursorX/cursorY transposition hazard, and a ~14-site lockstep edit per new field. Introduce ptyio.SessionRestoreCapture (re-declared Snapshot*-prefixed fields, NOT embedding tmux.PaneSnapshot — the names don't line up and embedding would shadow the messages' loose capture-size Cols/Rows), embed it in all message structs, build it once per producer, and change RestorePaneCapture to (term, capture, currentCols, currentRows). All 5 call sites now pass msg.SessionRestoreCapture wholesale (no positional args); every producer maps by name. Internal vterm reconstruction byte-identical. Gates: ui/... race suite, harness-golden (no diffs), verify-loop, lint-ci-parity all green. (plan 015)