### PR TITLE
perf: skip rebuilding unchanged pane strings each frame

### DIFF
--- a/internal/app/app_cache.go
+++ b/internal/app/app_cache.go
@@ -52,6 +52,37 @@ func (c *borderCache) get(x, y, width, height int) []*compositor.StringDrawable 
 	return c.drawables
 }
 
+// paneGate records the pane-reported content version and compose geometry
+// that produced the current cached pane drawable, letting the compose path
+// skip a clean pane's string build entirely (an earlier skip than the
+// content-keyed drawableCache, which still has to rebuild the string to key
+// on it). rendered remembers whether that build composed a drawable so a
+// clean skip reproduces the same layout decision (e.g. tab bar height)
+// without rebuilding. Correctness rests on the pane bumping its version on
+// every content-affecting update; see the version-field invariants on the
+// pane structs.
+type paneGate struct {
+	valid    bool
+	version  uint64
+	geom     [4]int
+	rendered bool
+}
+
+// clean reports whether the pane's string build can be skipped: the gate has
+// recorded a build for the same pane version at the same compose geometry.
+func (g *paneGate) clean(version uint64, geom [4]int) bool {
+	return g.valid && g.version == version && g.geom == geom
+}
+
+// record notes the version/geometry that produced the current cache entry and
+// whether that build composed a drawable.
+func (g *paneGate) record(version uint64, geom [4]int, rendered bool) {
+	g.valid = true
+	g.version = version
+	g.geom = geom
+	g.rendered = rendered
+}
+
 // renderCacheState groups the chrome/drawable caches used by layer-based
 // rendering. Each cache is keyed on the inputs that produced it and reused
 // across frames until those inputs change.
@@ -62,6 +93,7 @@ type renderCacheState struct {
 	dashboardContent     drawableCache
 	dashboardBorders     borderCache
 	sidebarTopTabBar     drawableCache
+	sidebarTopTabBarGate paneGate
 	sidebarTopContent    drawableCache
 	sidebarBottomContent drawableCache
 	sidebarBottomTabBar  drawableCache
@@ -72,6 +104,7 @@ type renderCacheState struct {
 	centerTabBar         drawableCache
 	centerStatus         drawableCache
 	centerHelp           drawableCache
+	centerHelpGate       paneGate
 	centerBorders        borderCache
 }
 

--- a/internal/app/app_view_pane_gate_test.go
+++ b/internal/app/app_view_pane_gate_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/sidebar"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// newGateCenterHarness builds a center-mode harness with keymap hints enabled
+// so the center help pane renders and its compose gate is exercised.
+func newGateCenterHarness(t *testing.T) *Harness {
+	t.Helper()
+	h, err := NewHarness(HarnessOptions{
+		Mode:            HarnessCenter,
+		Tabs:            2,
+		Width:           120,
+		Height:          40,
+		ShowKeymapHints: true,
+	})
+	if err != nil {
+		t.Fatalf("center harness init: %v", err)
+	}
+	return h
+}
+
+// TestCenterHelpGate_SkipsRebuildWhenClean renders the same frame repeatedly
+// with no state change and asserts the center help string-build path
+// (Model.HelpLines) is not re-entered: the paneGate must reuse the cached
+// drawable instead of rebuilding an identical string every spinner tick.
+func TestCenterHelpGate_SkipsRebuildWhenClean(t *testing.T) {
+	h := newGateCenterHarness(t)
+
+	h.Render()
+	builds := h.app.center.HelpBuildCount()
+	if builds == 0 {
+		t.Fatal("first render never built the center help pane; the gate path was not exercised")
+	}
+	if !h.app.renderCache.centerHelpGate.rendered {
+		t.Fatal("first render did not record a composed help drawable")
+	}
+
+	h.Render()
+	h.Render()
+
+	if got := h.app.center.HelpBuildCount(); got != builds {
+		t.Fatalf("help string rebuilt on clean re-render: builds %d -> %d", builds, got)
+	}
+}
+
+// TestCenterHelpGate_RebuildsWhenDirty mutates the center pane (adds a tab,
+// which bumps the help version via noteTabsChanged) and asserts the next
+// render re-enters the help string build.
+func TestCenterHelpGate_RebuildsWhenDirty(t *testing.T) {
+	h := newGateCenterHarness(t)
+
+	h.Render()
+	h.Render()
+	builds := h.app.center.HelpBuildCount()
+	if builds == 0 {
+		t.Fatal("renders never built the center help pane; the gate path was not exercised")
+	}
+
+	ws := harnessWorkspace()
+	h.app.center.AddTab(&center.Tab{
+		ID:        center.TabID("gate-tab"),
+		Name:      "amp-gate",
+		Assistant: "amp",
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+	})
+	h.Render()
+
+	if got := h.app.center.HelpBuildCount(); got <= builds {
+		t.Fatalf("help string not rebuilt after tab add: builds stayed at %d", builds)
+	}
+}
+
+// TestCenterHelpGate_RebuildsWhenHintsToggled flips keymap hints off and
+// asserts the gate invalidates: the help build path re-runs and the gate stops
+// composing a help drawable (the pane's rendered content is now empty).
+func TestCenterHelpGate_RebuildsWhenHintsToggled(t *testing.T) {
+	h := newGateCenterHarness(t)
+
+	h.Render()
+	builds := h.app.center.HelpBuildCount()
+	if builds == 0 {
+		t.Fatal("first render never built the center help pane; the gate path was not exercised")
+	}
+
+	h.app.setKeymapHintsEnabled(false)
+	h.Render()
+
+	if got := h.app.center.HelpBuildCount(); got <= builds {
+		t.Fatalf("help build path not re-entered after hints toggle: builds stayed at %d", builds)
+	}
+	if h.app.renderCache.centerHelpGate.rendered {
+		t.Fatal("gate still composes a help drawable after hints were disabled")
+	}
+}
+
+// TestSidebarTabBarGate_SkipsCleanAndRebuildsDirty covers both gate behaviors
+// for the sidebar Changes/Project tab bar: clean re-renders must not re-enter
+// TabBarView, and an active-tab switch must force a rebuild.
+func TestSidebarTabBarGate_SkipsCleanAndRebuildsDirty(t *testing.T) {
+	// Wide enough for the three-pane layout; the sidebar top pane only
+	// composes in LayoutThreePane.
+	h, err := NewHarness(HarnessOptions{
+		Mode:   HarnessSidebar,
+		Tabs:   1,
+		Width:  200,
+		Height: 50,
+	})
+	if err != nil {
+		t.Fatalf("sidebar harness init: %v", err)
+	}
+
+	h.Render()
+	builds := h.app.sidebar.TabBarBuildCount()
+	if builds == 0 {
+		t.Fatal("first render never built the sidebar tab bar; the gate path was not exercised")
+	}
+	if !h.app.renderCache.sidebarTopTabBarGate.rendered {
+		t.Fatal("first render did not record a composed sidebar tab bar drawable")
+	}
+
+	h.Render()
+	h.Render()
+	if got := h.app.sidebar.TabBarBuildCount(); got != builds {
+		t.Fatalf("sidebar tab bar rebuilt on clean re-render: builds %d -> %d", builds, got)
+	}
+
+	h.app.sidebar.SetActiveTab(sidebar.TabProject)
+	h.Render()
+	if got := h.app.sidebar.TabBarBuildCount(); got <= builds {
+		t.Fatalf("sidebar tab bar not rebuilt after active-tab switch: builds stayed at %d", builds)
+	}
+}
+
+// TestPaneGate_GeometryChangeForcesRebuild pins the reviewer-flagged resize
+// invariant: a pane that is content-clean must still rebuild when the compose
+// geometry changes, because the cached drawable bakes in position and width.
+func TestPaneGate_GeometryChangeForcesRebuild(t *testing.T) {
+	gate := paneGate{}
+	geom := [4]int{10, 2, 80, 40}
+	gate.record(7, geom, true)
+
+	if !gate.clean(7, geom) {
+		t.Fatal("gate should be clean for the recorded version and geometry")
+	}
+	for i := 0; i < len(geom); i++ {
+		changed := geom
+		changed[i]++
+		if gate.clean(7, changed) {
+			t.Fatalf("gate reported clean despite geometry component %d changing", i)
+		}
+	}
+	if gate.clean(8, geom) {
+		t.Fatal("gate reported clean despite a version bump")
+	}
+}

--- a/internal/app/app_view_panes.go
+++ b/internal/app/app_view_panes.go
@@ -101,18 +101,28 @@ func (a *App) composeCenterTerminalLayer(canvas *lipgloss.Canvas, centerX, topGu
 		}
 	}
 
-	// Help lines at bottom of pane.
-	helpLines := a.center.HelpLines(contentWidth)
-	if len(helpLines) == 0 {
-		return
+	// Help lines at bottom of pane. The gate skips the help string build
+	// entirely while the center model reports the same help version at the
+	// same compose geometry; see Model.helpVersion for the dirtiness
+	// invariant. helpY depends on topGutter+centerHeight only through their
+	// sum, so the sum is what the geometry key carries.
+	helpGate := &a.renderCache.centerHelpGate
+	helpGeom := [4]int{termX, termY, contentWidth, topGutter + centerHeight}
+	if version := a.center.HelpVersion(); !helpGate.clean(version, helpGeom) {
+		rendered := false
+		if helpLines := a.center.HelpLines(contentWidth); len(helpLines) > 0 {
+			helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
+			helpY := topGutter + centerHeight - 1 - len(helpLines)
+			if helpY > termY {
+				rendered = a.renderCache.centerHelp.get(helpContent, termX, helpY) != nil
+			}
+		}
+		helpGate.record(version, helpGeom, rendered)
 	}
-	helpContent := clampLines(strings.Join(helpLines, "\n"), contentWidth, len(helpLines))
-	helpY := topGutter + centerHeight - 1 - len(helpLines)
-	if helpY <= termY {
-		return
-	}
-	if helpDrawable := a.renderCache.centerHelp.get(helpContent, termX, helpY); helpDrawable != nil {
-		canvas.Compose(helpDrawable)
+	if helpGate.rendered {
+		if helpDrawable := a.renderCache.centerHelp.drawable; helpDrawable != nil {
+			canvas.Compose(helpDrawable)
+		}
 	}
 }
 
@@ -162,14 +172,25 @@ func (a *App) composeSidebarTopPane(canvas *lipgloss.Canvas, sidebarX, topGutter
 		topContentHeight = 1
 	}
 
-	// Sidebar tab bar (Changes/Project tabs)
-	tabBar := a.sidebar.TabBarView()
+	// Sidebar tab bar (Changes/Project tabs). The gate skips the tab bar
+	// string build entirely while the sidebar reports the same tab bar
+	// version at the same compose geometry; see TabbedSidebar.tabBarVersion
+	// for the dirtiness invariant.
+	tabBarY := topGutter + 1 // Inside the border
+	tabBarGate := &a.renderCache.sidebarTopTabBarGate
+	tabBarGeom := [4]int{sidebarX + 2, tabBarY, contentWidth, 1}
+	if version := a.sidebar.TabBarVersion(); !tabBarGate.clean(version, tabBarGeom) {
+		rendered := false
+		if tabBar := a.sidebar.TabBarView(); tabBar != "" {
+			tabBarContent := clampLines(tabBar, contentWidth, 1)
+			rendered = a.renderCache.sidebarTopTabBar.get(tabBarContent, sidebarX+2, tabBarY) != nil
+		}
+		tabBarGate.record(version, tabBarGeom, rendered)
+	}
 	tabBarHeight := 0
-	if tabBar != "" {
+	if tabBarGate.rendered {
 		tabBarHeight = 1
-		tabBarContent := clampLines(tabBar, contentWidth, 1)
-		tabBarY := topGutter + 1 // Inside the border
-		if tabBarDrawable := a.renderCache.sidebarTopTabBar.get(tabBarContent, sidebarX+2, tabBarY); tabBarDrawable != nil {
+		if tabBarDrawable := a.renderCache.sidebarTopTabBar.drawable; tabBarDrawable != nil {
 			canvas.Compose(tabBarDrawable)
 		}
 	}

--- a/internal/ui/center/model.go
+++ b/internal/ui/center/model.go
@@ -24,14 +24,23 @@ import (
 // Model is the Bubbletea model for the center pane
 type Model struct {
 	// State
-	workspace             *data.Workspace
-	workspaceIDCached     string
-	workspaceIDRepo       string
-	workspaceIDRoot       string
-	tabs                  common.TabSet[*Tab] // tabs + active index per workspace ID
-	focused               bool
-	canFocusRight         bool
-	tabsRevision          uint64
+	workspace         *data.Workspace
+	workspaceIDCached string
+	workspaceIDRepo   string
+	workspaceIDRoot   string
+	tabs              common.TabSet[*Tab] // tabs + active index per workspace ID
+	focused           bool
+	canFocusRight     bool
+	tabsRevision      uint64
+	// helpVersion is a monotonic version of every input that shapes HelpLines
+	// output (tab count, workspace presence, keymap-hint visibility, styles,
+	// pane size). INVARIANT: every update path that changes what HelpLines
+	// renders MUST call markHelpDirty, or the compose-time gate in
+	// internal/app will keep reusing a stale help drawable.
+	helpVersion uint64
+	// helpBuilds counts HelpLines invocations; test instrumentation for the
+	// compose-time skip gate in internal/app.
+	helpBuilds            uint64
 	agentManager          *appPty.AgentManager
 	msgSink               func(tea.Msg)
 	msgSinkTry            func(tea.Msg) bool
@@ -236,6 +245,7 @@ func (m *Model) clearTabActorRedrawPending() {
 }
 
 func (m *Model) setWorkspace(ws *data.Workspace) {
+	m.markHelpDirty()
 	m.workspace = ws
 	m.workspaceIDCached = ""
 	m.workspaceIDRepo = ""

--- a/internal/ui/center/model_lifecycle.go
+++ b/internal/ui/center/model_lifecycle.go
@@ -75,11 +75,13 @@ func (m *Model) SetCanFocusRight(can bool) {
 // SetShowKeymapHints controls whether helper text is rendered.
 func (m *Model) SetShowKeymapHints(show bool) {
 	m.showKeymapHints = show
+	m.markHelpDirty()
 }
 
 // SetStyles updates the component's styles (for theme changes).
 func (m *Model) SetStyles(styles common.Styles) {
 	m.styles = styles
+	m.markHelpDirty()
 	// Propagate to all viewers in tabs
 	for _, tabs := range m.tabs.ByWorkspace {
 		for _, tab := range tabs {
@@ -117,6 +119,7 @@ func (m *Model) SetMsgSinkTry(sink func(tea.Msg) bool) {
 func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
+	m.markHelpDirty()
 
 	// Use centralized metrics for terminal sizing
 	tm := m.terminalMetrics()

--- a/internal/ui/center/model_render.go
+++ b/internal/ui/center/model_render.go
@@ -127,6 +127,7 @@ func (m *Model) TabBarView() string {
 
 // HelpLines returns the help lines for the given width, respecting visibility.
 func (m *Model) HelpLines(width int) []string {
+	m.helpBuilds++
 	if !m.showKeymapHints {
 		return nil
 	}
@@ -134,6 +135,25 @@ func (m *Model) HelpLines(width int) []string {
 		width = 1
 	}
 	return m.helpLines(width)
+}
+
+// HelpVersion returns the monotonic version of the inputs to HelpLines. The
+// compose layer in internal/app skips rebuilding the help string while this
+// version and the compose geometry are unchanged.
+func (m *Model) HelpVersion() uint64 {
+	return m.helpVersion
+}
+
+// markHelpDirty bumps helpVersion. It MUST be called by every update path
+// that changes HelpLines output; see the helpVersion field invariant.
+func (m *Model) markHelpDirty() {
+	m.helpVersion++
+}
+
+// HelpBuildCount reports how many times HelpLines has been invoked. Test
+// instrumentation for the compose-time skip gate; not for production use.
+func (m *Model) HelpBuildCount() uint64 {
+	return m.helpBuilds
 }
 
 func (m *Model) helpItem(key, desc string) string {

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -383,6 +383,7 @@ func (m *Model) markTabFocused(wsID string, idx int) {
 
 func (m *Model) noteTabsChanged() {
 	m.tabsRevision++
+	m.markHelpDirty()
 	m.syncPostWriteVisibility()
 }
 

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -54,6 +54,7 @@ func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
 	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
 	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+	m.markHelpDirty()
 }
 
 // addPlaceholderTab synchronously creates a placeholder tab in the correct slice
@@ -107,6 +108,7 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 	term.CaptureNormalScreenOnClear = isChat
 	wsID := string(ws.ID())
 	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
+	m.markHelpDirty()
 	return tabID, sessionName
 }
 

--- a/internal/ui/sidebar/tabs.go
+++ b/internal/ui/sidebar/tabs.go
@@ -40,6 +40,15 @@ type TabbedSidebar struct {
 	changes     *Model
 	projectTree *ProjectTree
 	tabHits     []tabHit
+	// tabBarVersion is a monotonic version of every input that shapes the
+	// tab bar render (active tab, styles/theme). INVARIANT: every update path
+	// that changes what renderTabBar produces MUST call markTabBarDirty, or
+	// the compose-time gate in internal/app will keep reusing a stale tab bar
+	// drawable.
+	tabBarVersion uint64
+	// tabBarBuilds counts TabBarView invocations; test instrumentation for
+	// the compose-time skip gate in internal/app.
+	tabBarBuilds uint64
 
 	workspace       *data.Workspace
 	focused         bool
@@ -70,6 +79,7 @@ func (m *TabbedSidebar) SetShowKeymapHints(show bool) {
 // SetStyles updates the component's styles (for theme changes).
 func (m *TabbedSidebar) SetStyles(styles common.Styles) {
 	m.styles = styles
+	m.markTabBarDirty()
 	m.changes.SetStyles(styles)
 	m.projectTree.SetStyles(styles)
 }
@@ -96,9 +106,11 @@ func (m *TabbedSidebar) Update(msg tea.Msg) (*TabbedSidebar, tea.Cmd) {
 					switch hit.kind {
 					case tabHitChanges:
 						m.activeTab = TabChanges
+						m.markTabBarDirty()
 						m.updateFocus()
 					case tabHitProject:
 						m.activeTab = TabProject
+						m.markTabBarDirty()
 						m.updateFocus()
 					}
 					return m, nil
@@ -151,10 +163,12 @@ func (m *TabbedSidebar) Update(msg tea.Msg) (*TabbedSidebar, tea.Cmd) {
 			switch {
 			case key.Matches(msg, key.NewBinding(key.WithKeys("1"))):
 				m.activeTab = TabChanges
+				m.markTabBarDirty()
 				m.updateFocus()
 				return m, nil
 			case key.Matches(msg, key.NewBinding(key.WithKeys("2"))):
 				m.activeTab = TabProject
+				m.markTabBarDirty()
 				m.updateFocus()
 				return m, nil
 			}
@@ -285,7 +299,28 @@ func (m *TabbedSidebar) View() string {
 
 // TabBarView returns only the tab bar view (for compositor)
 func (m *TabbedSidebar) TabBarView() string {
+	m.tabBarBuilds++
 	return m.renderTabBar()
+}
+
+// TabBarVersion returns the monotonic version of the inputs to TabBarView.
+// The compose layer in internal/app skips rebuilding the tab bar string
+// while this version and the compose geometry are unchanged.
+func (m *TabbedSidebar) TabBarVersion() uint64 {
+	return m.tabBarVersion
+}
+
+// markTabBarDirty bumps tabBarVersion. It MUST be called by every update
+// path that changes renderTabBar output; see the tabBarVersion field
+// invariant.
+func (m *TabbedSidebar) markTabBarDirty() {
+	m.tabBarVersion++
+}
+
+// TabBarBuildCount reports how many times TabBarView has been invoked. Test
+// instrumentation for the compose-time skip gate; not for production use.
+func (m *TabbedSidebar) TabBarBuildCount() uint64 {
+	return m.tabBarBuilds
 }
 
 // ContentView returns only the content view without tab bar (for compositor)
@@ -357,6 +392,7 @@ func (m *TabbedSidebar) ActiveTab() SidebarTab {
 // SetActiveTab sets the active tab
 func (m *TabbedSidebar) SetActiveTab(tab SidebarTab) {
 	m.activeTab = tab
+	m.markTabBarDirty()
 	m.updateFocus()
 }
 
@@ -367,6 +403,7 @@ func (m *TabbedSidebar) NextTab() {
 	} else {
 		m.activeTab = TabChanges
 	}
+	m.markTabBarDirty()
 	m.updateFocus()
 }
 
@@ -377,6 +414,7 @@ func (m *TabbedSidebar) PrevTab() {
 	} else {
 		m.activeTab = TabChanges
 	}
+	m.markTabBarDirty()
 	m.updateFocus()
 }
 


### PR DESCRIPTION
The 80ms dashboard spinner forces a full App.View() ~12.5x/s while agents run, rebuilding every pane's content string before the drawable cache can dedupe it. Add a compose-time paneGate (per-pane monotonic version + compose geometry) that skips the string build entirely when a pane reports unchanged version at unchanged geometry. Gated the two panes with precise, fully-enumerated invalidation: center help lines (markHelpDirty at all 8 content-affecting sites — help is a pure function of hints-toggle/workspace/hasTabs/styles/width, all covered or in the geometry key) and the sidebar Changes/Project tab bar (markTabBarDirty at every activeTab site + styles). Left rebuilding, per the plan's STOP fallback: the center tab bar (2s wall-clock activity window, no Update hook) and status line (reader-goroutine-mutated scroll state; also empty in the common case) — diffuse dirtiness, reported not forced. harness-golden byte-identical; instrumented skip-when-clean/rebuild-when-dirty tests; lint-ci-parity green. (plan 006)