### PR TITLE
refactor: de-duplicate session-bootstrap wiring into ptyio

### DIFF
--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -42,39 +42,45 @@ var (
 
 type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 
-func sessionBootstrapFns() ptyio.SessionBootstrapFns {
-	return ptyio.SessionBootstrapFns{
-		SessionHasClients:       sessionHasClientsFn,
-		SessionClientCount:      sessionClientCountFn,
-		SessionActiveWithin:     sessionActiveWithinFn,
-		SessionLatestActivity:   sessionLatestActivityFn,
-		SessionCreatedAt:        sessionCreatedAtFn,
-		SessionPaneID:           sessionPaneIDFn,
-		SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
-		SessionPaneSize:         sessionPaneSizeFn,
-		ResizePaneToSize:        resizePaneToSizeFn,
-		CapturePaneSnapshot:     capturePaneSnapshotFn,
+// sessionBootstrap builds a ptyio.SessionBootstrap from this package's seam
+// vars. It is rebuilt per call (reading the seam vars each time) so a test that
+// overrides a seam var still flows through the next bootstrap operation.
+func sessionBootstrap() ptyio.SessionBootstrap {
+	return ptyio.SessionBootstrap{
+		Fns: ptyio.SessionBootstrapFns{
+			SessionHasClients:       sessionHasClientsFn,
+			SessionClientCount:      sessionClientCountFn,
+			SessionActiveWithin:     sessionActiveWithinFn,
+			SessionLatestActivity:   sessionLatestActivityFn,
+			SessionCreatedAt:        sessionCreatedAtFn,
+			SessionPaneID:           sessionPaneIDFn,
+			SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
+			SessionPaneSize:         sessionPaneSizeFn,
+			ResizePaneToSize:        resizePaneToSizeFn,
+			CapturePaneSnapshot:     capturePaneSnapshotFn,
+		},
+		CapturePane: capturePaneFn,
 	}
 }
 
 func captureExistingSessionBootstrap(sessionName string, cols, rows int, opts tmux.Options) sessionBootstrapCapture {
-	return ptyio.CaptureExistingSessionBootstrap(sessionName, cols, rows, ptyio.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
+	return sessionBootstrap().CaptureExisting(sessionName, cols, rows, opts)
 }
 
 func bootstrapSnapshotStillMatchesSession(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) bool {
-	return ptyio.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
+	return sessionBootstrap().SnapshotStillMatches(sessionName, bootstrap, opts)
 }
 
 func rollbackExistingSessionBootstrap(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) {
-	ptyio.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
+	sessionBootstrap().Rollback(sessionName, bootstrap, opts)
 }
 
 func sessionHistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) (int, int) {
-	return ptyio.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
+	return sessionBootstrap().HistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts)
 }
 
 func captureSessionHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
-	return ptyio.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
+	return sessionBootstrap().CaptureHistory(sessionName, fallbackCols, fallbackRows, opts)
 }
 
 func (m *Model) sessionBootstrapViewportSize() (int, int) {

--- a/internal/ui/ptyio/session_bootstrap.go
+++ b/internal/ui/ptyio/session_bootstrap.go
@@ -34,6 +34,44 @@ type SessionBootstrapFns struct {
 	CapturePaneSnapshot     func(string, tmux.Options) (tmux.PaneSnapshot, error)
 }
 
+// SessionBootstrap bundles a SessionBootstrapFns (and the pane-capture fn) with
+// the bootstrap operations that consume them, so each caller constructs a single
+// instance from its own test-seam vars and invokes the operations as methods
+// instead of re-declaring a parallel set of package-level wrappers. The instance
+// is value-typed and cheap: callers rebuild it per call from their seam vars so a
+// test override of a seam var flows through the next operation.
+type SessionBootstrap struct {
+	Fns         SessionBootstrapFns
+	CapturePane func(string, tmux.Options) ([]byte, error)
+}
+
+// CaptureExisting captures a pre-attach full-pane bootstrap snapshot of an
+// existing session, using the standard full-pane quiet window.
+func (s SessionBootstrap) CaptureExisting(sessionName string, cols, rows int, opts tmux.Options) SessionBootstrapCapture {
+	return CaptureExistingSessionBootstrap(sessionName, cols, rows, FullPaneCaptureQuietWindow, opts, s.Fns)
+}
+
+// SnapshotStillMatches reports whether the captured bootstrap snapshot is still
+// authoritative for the session.
+func (s SessionBootstrap) SnapshotStillMatches(sessionName string, bootstrap SessionBootstrapCapture, opts tmux.Options) bool {
+	return BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, s.Fns)
+}
+
+// Rollback restores the pane size mutated while capturing the bootstrap snapshot.
+func (s SessionBootstrap) Rollback(sessionName string, bootstrap SessionBootstrapCapture, opts tmux.Options) {
+	RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, s.Fns)
+}
+
+// HistoryCaptureSize resolves the capture dimensions for a history fallback.
+func (s SessionBootstrap) HistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) (int, int) {
+	return SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, s.Fns)
+}
+
+// CaptureHistory captures the session scrollback plus its capture dimensions.
+func (s SessionBootstrap) CaptureHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
+	return CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, s.Fns, s.CapturePane)
+}
+
 func SessionBootstrapExclusive(sessionName string, quietWindow time.Duration, opts tmux.Options, fns SessionBootstrapFns) bool {
 	hasClients, clientsErr := fns.SessionHasClients(sessionName, opts)
 	recentActivity, activityErr := fns.SessionActiveWithin(sessionName, quietWindow, opts)

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -36,39 +36,45 @@ var (
 
 type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 
-func sessionBootstrapFns() ptyio.SessionBootstrapFns {
-	return ptyio.SessionBootstrapFns{
-		SessionHasClients:       sessionHasClientsFn,
-		SessionClientCount:      sessionClientCountFn,
-		SessionActiveWithin:     sessionActiveWithinFn,
-		SessionLatestActivity:   sessionLatestActivityFn,
-		SessionCreatedAt:        sessionCreatedAtFn,
-		SessionPaneID:           sessionPaneIDFn,
-		SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
-		SessionPaneSize:         sessionPaneSizeFn,
-		ResizePaneToSize:        resizePaneToSizeFn,
-		CapturePaneSnapshot:     capturePaneSnapshotFn,
+// sessionBootstrap builds a ptyio.SessionBootstrap from this package's seam
+// vars. It is rebuilt per call (reading the seam vars each time) so a test that
+// overrides a seam var still flows through the next bootstrap operation.
+func sessionBootstrap() ptyio.SessionBootstrap {
+	return ptyio.SessionBootstrap{
+		Fns: ptyio.SessionBootstrapFns{
+			SessionHasClients:       sessionHasClientsFn,
+			SessionClientCount:      sessionClientCountFn,
+			SessionActiveWithin:     sessionActiveWithinFn,
+			SessionLatestActivity:   sessionLatestActivityFn,
+			SessionCreatedAt:        sessionCreatedAtFn,
+			SessionPaneID:           sessionPaneIDFn,
+			SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
+			SessionPaneSize:         sessionPaneSizeFn,
+			ResizePaneToSize:        resizePaneToSizeFn,
+			CapturePaneSnapshot:     capturePaneSnapshotFn,
+		},
+		CapturePane: capturePaneFn,
 	}
 }
 
 func captureExistingSessionBootstrap(sessionName string, cols, rows int, opts tmux.Options) sessionBootstrapCapture {
-	return ptyio.CaptureExistingSessionBootstrap(sessionName, cols, rows, ptyio.FullPaneCaptureQuietWindow, opts, sessionBootstrapFns())
+	return sessionBootstrap().CaptureExisting(sessionName, cols, rows, opts)
 }
 
 func bootstrapSnapshotStillMatchesSession(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) bool {
-	return ptyio.BootstrapSnapshotStillMatchesSession(sessionName, bootstrap, opts, sessionBootstrapFns())
+	return sessionBootstrap().SnapshotStillMatches(sessionName, bootstrap, opts)
 }
 
 func rollbackExistingSessionBootstrap(sessionName string, bootstrap sessionBootstrapCapture, opts tmux.Options) {
-	ptyio.RollbackExistingSessionBootstrap(sessionName, bootstrap, opts, sessionBootstrapFns())
+	sessionBootstrap().Rollback(sessionName, bootstrap, opts)
 }
 
 func sessionHistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) (int, int) {
-	return ptyio.SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns())
+	return sessionBootstrap().HistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts)
 }
 
 func captureSessionHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
-	return ptyio.CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, sessionBootstrapFns(), capturePaneFn)
+	return sessionBootstrap().CaptureHistory(sessionName, fallbackCols, fallbackRows, opts)
 }
 
 func (m *TerminalModel) sessionBootstrapViewportSize() (int, int) {


### PR DESCRIPTION
The ptyio unification left the session-bootstrap wiring duplicated: both center and sidebar carried a 10-field SessionBootstrapFns builder plus five thin operation wrappers that could silently drift. Introduce a value-typed ptyio.SessionBootstrap holder whose methods own the five bootstrap operations; each package now builds one instance from its own seam vars via a per-call constructor and delegates one line per wrapper. Critical constraint preserved: the test-seam vars stay PER-PACKAGE and are read at call time, so a test overriding sessionHasClientsFn etc. still flows through — proven by the reattach order tests (override all 12 seams, assert exact call order) passing under -race in both packages. Wrappers kept (not inlined) only because they have out-of-scope callers, which the plan's done-criterion permits. verify-loop + lint-ci-parity green. (plan 016)