### PR TITLE
test: add mostly-static DrawAt amplification benchmark

### DIFF
--- a/internal/ui/compositor/benchmark_test.go
+++ b/internal/ui/compositor/benchmark_test.go
@@ -82,6 +82,40 @@ func BenchmarkVTermLayerDrawAt(b *testing.B) {
 	}
 }
 
+// BenchmarkVTermLayerDrawAtMostlyStatic measures repeated DrawAt of a
+// mostly-static 200x50 snapshot: a full screen of content where only one row
+// changed since the previous frame (DirtyLines carries a single entry, the
+// shape the snapshot double-buffer produces on an idle terminal that only the
+// spinner forced to re-render).
+//
+// DrawAt currently ignores DirtyLines and re-walks every cell every frame, so
+// this benchmark's per-op cost is dominated by the ~49 clean rows that never
+// changed. That is the per-frame amplification BenchmarkVTermLayerDrawAt does
+// not isolate: DrawAt above legitimately redraws everything, whereas here the
+// work is almost entirely redundant. If a future compose-layer change honors
+// DirtyLines to skip clean rows against a retained canvas, this same benchmark
+// reports the win (its cost should collapse toward a single dirty row).
+func BenchmarkVTermLayerDrawAtMostlyStatic(b *testing.B) {
+	const width, height = 200, 50
+	snap := setupVTermSnapshot(width, height)
+
+	// Simulate an idle frame: exactly one row changed since the last snapshot.
+	snap.AllDirty = false
+	dirty := make([]bool, height)
+	dirty[height/2] = true
+	snap.DirtyLines = dirty
+
+	layer := NewVTermLayer(snap)
+	screen := newMockScreen(width, height)
+	rect := image.Rect(0, 0, width, height)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		layer.Draw(screen, rect)
+	}
+}
+
 // BenchmarkVTermLayerDrawAtTruecolor benchmarks the draw path for a full-screen
 // truecolor (RGB) agent, guarding the ColorRGB conversion against per-cell allocs.
 func BenchmarkVTermLayerDrawAtTruecolor(b *testing.B) {


### PR DESCRIPTION
Keeper deliverable from the plan-008 spike. BenchmarkVTermLayerDrawAt measures a fully-dynamic redraw; this new BenchmarkVTermLayerDrawAtMostlyStatic isolates the per-frame amplification it misses — a 200x50 snapshot with a single dirty row (the shape the double-buffer produces on an idle, spinner-forced frame). On main it costs the same per cell as a full redraw because DrawAt ignores DirtyLines; it will report the win directly if a future compose-layer change honors DirtyLines against a retained canvas.

Spike outcome (POC measured then discarded): retaining the canvas + skipping clean rows gave ~57x on this isolated loop and ~27% whole-frame idle CPU, byte-identical goldens — BUT the golden oracle only exercises live-center streaming; it never drives overlay-dismiss, tab-switch, focus, or scroll, so byte-identical is a false green for exactly the 7 force-full-redraw triggers a real impl must handle. Verdict: follow-up implementation plan justified but conditional (transition goldens first, explicit dirty-controller, and Canvas.Render's full-ANSI regen is actually the larger residual target). Recorded in plan 041.