### PR TITLE
feat: bell when an agent finishes (opt-in)

### DIFF
--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -67,6 +67,7 @@ func newAppShell(cfg *config.Config) *App {
 	app.propagateStyles()
 	if cfg != nil {
 		app.setKeymapHintsEnabled(cfg.UI.ShowKeymapHints)
+		app.dashboard.SetNotifyOnDone(cfg.UI.NotifyOnDone)
 	}
 	return app
 }

--- a/internal/app/app_input_keys.go
+++ b/internal/app/app_input_keys.go
@@ -17,7 +17,7 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 	activeWorkspaces := make(map[string]bool)
 	if !a.tmuxActivity.settled {
 		a.dashboard.SetActiveWorkspaces(activeWorkspaces)
-		a.dashboard.SetAgentStates(nil)
+		a.emitDashboardStateCmd(a.dashboard.SetAgentStates(nil))
 		return
 	}
 	for wsID := range a.tmuxActivity.activeWorkspaceIDs {
@@ -29,7 +29,21 @@ func (a *App) syncActiveWorkspacesToDashboard() {
 		activeWorkspaces[wsID] = true
 	}
 	a.dashboard.SetActiveWorkspaces(activeWorkspaces)
-	a.dashboard.SetAgentStates(a.tmuxActivity.agentStates)
+	a.emitDashboardStateCmd(a.dashboard.SetAgentStates(a.tmuxActivity.agentStates))
+}
+
+// emitDashboardStateCmd delivers a fire-and-forget command produced by a
+// dashboard state update (currently the opt-in agent-done bell) to the runtime.
+// syncActiveWorkspacesToDashboard is a void helper called from ~9 non-Update
+// sites, so the command is injected out-of-band via the external-message pump
+// rather than threaded back through every caller. A nil command is a no-op.
+func (a *App) emitDashboardStateCmd(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if msg := cmd(); msg != nil {
+		a.enqueueExternalMsg(msg)
+	}
 }
 
 // handleKeyPress handles keyboard input

--- a/internal/app/app_notify_wiring_test.go
+++ b/internal/app/app_notify_wiring_test.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestEmitDashboardStateCmd_EnqueuesBell verifies the connector that wires a
+// dashboard state-update command (the opt-in agent-done bell) to the runtime's
+// external-message pump: a non-nil command's message is enqueued; a nil command
+// is a no-op.
+func TestEmitDashboardStateCmd_EnqueuesBell(t *testing.T) {
+	a := &App{externalMsgs: make(chan tea.Msg, 4)}
+
+	a.emitDashboardStateCmd(nil)
+	select {
+	case msg := <-a.externalMsgs:
+		t.Fatalf("nil command must enqueue nothing, got %#v", msg)
+	default:
+	}
+
+	bell := tea.Raw("\a")
+	a.emitDashboardStateCmd(bell)
+	select {
+	case msg := <-a.externalMsgs:
+		if _, ok := msg.(tea.RawMsg); !ok {
+			t.Fatalf("expected a tea.RawMsg (the bell) enqueued, got %#v", msg)
+		}
+	default:
+		t.Fatal("bell command's message was not enqueued to the external pump")
+	}
+}

--- a/internal/config/user_settings.go
+++ b/internal/config/user_settings.go
@@ -17,6 +17,9 @@ type UISettings struct {
 	TmuxServer       string
 	TmuxConfigPath   string
 	TmuxSyncInterval string
+	// NotifyOnDone rings a terminal bell when an agent finishes. Default off so
+	// existing users are not surprised by sound.
+	NotifyOnDone bool
 }
 
 func defaultUISettings() UISettings {
@@ -26,6 +29,7 @@ func defaultUISettings() UISettings {
 		TmuxServer:       "",
 		TmuxConfigPath:   "",
 		TmuxSyncInterval: "",
+		NotifyOnDone:     false,
 	}
 }
 
@@ -37,6 +41,7 @@ type uiSettingsRaw struct {
 	TmuxServer       *string `json:"tmux_server"`
 	TmuxConfigPath   *string `json:"tmux_config"`
 	TmuxSyncInterval *string `json:"tmux_sync_interval"`
+	NotifyOnDone     *bool   `json:"notify_on_done"`
 }
 
 // applyUISettings overlays the parsed config-file section onto the defaults.
@@ -55,6 +60,9 @@ func applyUISettings(settings UISettings, raw uiSettingsRaw) UISettings {
 	}
 	if raw.TmuxSyncInterval != nil {
 		settings.TmuxSyncInterval = *raw.TmuxSyncInterval
+	}
+	if raw.NotifyOnDone != nil {
+		settings.NotifyOnDone = *raw.NotifyOnDone
 	}
 	return settings
 }
@@ -84,6 +92,7 @@ func saveUISettings(path string, settings UISettings) error {
 	ui["tmux_server"] = settings.TmuxServer
 	ui["tmux_config"] = settings.TmuxConfigPath
 	ui["tmux_sync_interval"] = settings.TmuxSyncInterval
+	ui["notify_on_done"] = settings.NotifyOnDone
 	payload["ui"] = ui
 
 	// Crash-safe write (temp + fsync + atomic rename) so a crash mid-save can't

--- a/internal/config/user_settings_test.go
+++ b/internal/config/user_settings_test.go
@@ -44,6 +44,7 @@ func TestSaveUISettingsWritesAllFields(t *testing.T) {
 				TmuxServer:       "amux-test",
 				TmuxConfigPath:   "/tmp/tmux.conf",
 				TmuxSyncInterval: "5s",
+				NotifyOnDone:     true,
 			},
 		},
 		{
@@ -88,6 +89,9 @@ func TestSaveUISettingsWritesAllFields(t *testing.T) {
 			}
 			if got := ui["tmux_sync_interval"]; got != tt.settings.TmuxSyncInterval {
 				t.Errorf("tmux_sync_interval = %#v, want %#v", got, tt.settings.TmuxSyncInterval)
+			}
+			if got := ui["notify_on_done"]; got != tt.settings.NotifyOnDone {
+				t.Errorf("notify_on_done = %#v, want %#v", got, tt.settings.NotifyOnDone)
 			}
 
 			// What we wrote must round-trip back through the read path.

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -17,6 +17,17 @@ type SpinnerTickMsg struct{}
 // spinnerInterval is how often the spinner updates
 const spinnerInterval = 80 * time.Millisecond
 
+// bellSequence is the ASCII BEL control byte (0x07). Written verbatim to the
+// program output it rings the user's terminal bell.
+const bellSequence = "\a"
+
+// bellCmd rings the terminal bell. tea.Raw writes the byte straight to the
+// program's output buffer (via the RawMsg path), bypassing the alt-screen
+// canvas so the BEL reaches the real terminal rather than a rendered cell.
+func bellCmd() tea.Cmd {
+	return tea.Raw(bellSequence)
+}
+
 // RowType identifies the type of row in the dashboard
 type RowType int
 
@@ -86,6 +97,7 @@ type Model struct {
 	activeWorkspaceIDs map[string]bool                // Workspace IDs with active agents (synced from center)
 	agentStates        map[string]activity.AgentState // Per-workspace semantic agent states
 	doneAcked          map[string]bool                // Workspace IDs whose "done" indicator has been seen by the user
+	notifyOnDone       bool                           // Ring a terminal bell on the unacked Working→Done edge
 
 	// Styles
 	styles common.Styles
@@ -112,16 +124,41 @@ func (m *Model) SetActiveWorkspaces(active map[string]bool) {
 	m.activeWorkspaceIDs = active
 }
 
+// SetNotifyOnDone controls whether a terminal bell fires when a workspace
+// transitions Working→Done (the same edge the "done" indicator surfaces).
+func (m *Model) SetNotifyOnDone(enabled bool) {
+	m.notifyOnDone = enabled
+}
+
 // SetAgentStates updates the per-workspace semantic agent states.
 // It also clears the doneAcked flag for any workspace that has started
 // working again, so the next "done" is visible to the user.
-func (m *Model) SetAgentStates(states map[string]activity.AgentState) {
+//
+// It returns a bell command exactly once per unacked Working→Done edge when
+// notify-on-done is enabled: the previous state is compared against the new one
+// so a workspace that stays Done across frames does not re-bell. A frame with
+// several simultaneous edges still rings a single bell.
+func (m *Model) SetAgentStates(states map[string]activity.AgentState) tea.Cmd {
+	prev := m.agentStates
 	m.agentStates = states
+	bell := false
 	for wsID, st := range states {
-		if st == activity.StateWorking {
+		switch st {
+		case activity.StateWorking:
 			delete(m.doneAcked, wsID)
+		case activity.StateDone:
+			// Fire only on the fresh, unacked Working→Done transition. Gating on
+			// prev == Working de-dupes steady-state Done (prev is already Done)
+			// and skips Idle/absent→Done, which is not a finish the user watched.
+			if m.notifyOnDone && prev[wsID] == activity.StateWorking && !m.doneAcked[wsID] {
+				bell = true
+			}
 		}
 	}
+	if bell {
+		return bellCmd()
+	}
+	return nil
 }
 
 // InvalidateStatus marks a workspace's cached status stale.

--- a/internal/ui/dashboard/notify_test.go
+++ b/internal/ui/dashboard/notify_test.go
@@ -1,0 +1,109 @@
+package dashboard
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/app/activity"
+)
+
+// assertBell fails unless cmd produces exactly the terminal-bell RawMsg.
+func assertBell(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected a bell command, got nil")
+	}
+	msg := cmd()
+	raw, ok := msg.(tea.RawMsg)
+	if !ok {
+		t.Fatalf("expected tea.RawMsg, got %T", msg)
+	}
+	if raw.Msg != bellSequence {
+		t.Fatalf("expected bell sequence %q, got %q", bellSequence, raw.Msg)
+	}
+}
+
+// assertNoBell fails if cmd is non-nil (any command at all counts as a bell,
+// since SetAgentStates only ever emits the bell command).
+func assertNoBell(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd != nil {
+		t.Fatalf("expected no bell command, got %T producing %#v", cmd, cmd())
+	}
+}
+
+const notifyWS = "ws-1"
+
+func TestNotifyOnDoneBellOnEnabledEdge(t *testing.T) {
+	m := New()
+	m.SetNotifyOnDone(true)
+
+	// Working frame primes the previous state; no edge yet.
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateWorking}))
+
+	// Working→Done edge: bell fires exactly once.
+	assertBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+}
+
+func TestNotifyOnDoneNoBellOnSteadyDone(t *testing.T) {
+	m := New()
+	m.SetNotifyOnDone(true)
+
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateWorking}))
+	assertBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+
+	// Done→Done (no fresh edge): must not re-bell, even across several frames.
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+}
+
+func TestNotifyOnDoneNoBellWhenDisabled(t *testing.T) {
+	m := New()
+	// notifyOnDone defaults off; do not enable it.
+
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateWorking}))
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+}
+
+func TestNotifyOnDoneNoBellOnIdleToDone(t *testing.T) {
+	m := New()
+	m.SetNotifyOnDone(true)
+
+	// First observation is already Done (agent never seen Working): not a
+	// finish the user watched, so no bell.
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+}
+
+func TestNotifyOnDoneReBellsOnFreshWorkCycle(t *testing.T) {
+	m := New()
+	m.SetNotifyOnDone(true)
+
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateWorking}))
+	assertBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+
+	// Ack the done indicator (user viewed the row).
+	m.ackDone(notifyWS)
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+
+	// A fresh work cycle: Working clears the ack, and the next Working→Done edge
+	// bells again.
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateWorking}))
+	assertBell(t, m.SetAgentStates(map[string]activity.AgentState{notifyWS: activity.StateDone}))
+}
+
+func TestNotifyOnDoneSingleBellForSimultaneousEdges(t *testing.T) {
+	m := New()
+	m.SetNotifyOnDone(true)
+
+	assertNoBell(t, m.SetAgentStates(map[string]activity.AgentState{
+		"ws-a": activity.StateWorking,
+		"ws-b": activity.StateWorking,
+	}))
+
+	// Both finish in the same frame: one bell, not two.
+	assertBell(t, m.SetAgentStates(map[string]activity.AgentState{
+		"ws-a": activity.StateDone,
+		"ws-b": activity.StateDone,
+	}))
+}


### PR DESCRIPTION
amux runs agents in parallel precisely so you aren't babysitting one — but nothing told you when agent 3 finished while you were looking elsewhere. The semantic Working/Done state and doneAcked de-dup already existed; the only missing piece was delivery. Adds ui.notify_on_done (default off, round-trips SaveUISettings) and, on the unacked Working->Done edge in the dashboard, fires tea.Raw("\a") — the documented bubbletea out-of-band write that bypasses the alt-screen canvas so the BEL reaches the real terminal. De-dup is structural (bells once per fresh work cycle, not on steady Done or simultaneous edges; 6 dashboard tests). Reviewer completed the app wiring the plan scoped out (SetAgentStates cmd delivered via the external-message pump; config flag threaded into the dashboard) + a connector test, so setting the flag actually rings. OS notifications deferred. (plan 029)