### PR TITLE
feat: warn at trust time about in-repo script indirection

### DIFF
--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -3,11 +3,13 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/validation"
 )
@@ -75,8 +77,10 @@ func (a *App) handleShowTrustScriptsDialog(msg messages.ShowTrustScriptsDialog) 
 	a.dialogWorkspace = msg.Workspace
 	a.dialogTrustScriptsHash = msg.ConfigHash
 	workspaceName := ""
+	repoRoot := ""
 	if msg.Workspace != nil {
 		workspaceName = msg.Workspace.Name
+		repoRoot = msg.Workspace.Repo
 	}
 	a.dialog = common.NewConfirmDialog(
 		DialogTrustScripts,
@@ -84,7 +88,73 @@ func (a *App) handleShowTrustScriptsDialog(msg messages.ShowTrustScriptsDialog) 
 		fmt.Sprintf("Trust .amux/workspaces.json scripts for '%s' and run setup now?", workspaceName),
 	)
 	a.dialog.SetDefaultOption(1)
+	// Informational only: surface in-repo scripts the approved commands reach
+	// into, which the trust gate's manifest hash cannot cover. This changes no
+	// gating; an empty warning is NOT a safety guarantee (see
+	// scriptIndirectionWarning / process.ReferencesInRepoFiles).
+	if warning := scriptIndirectionWarning(a.repoScriptCommandsForTrust(repoRoot), repoRoot); warning != "" {
+		a.dialog.SetWarning(warning)
+	}
 	a.presentDialog(a.dialog)
+}
+
+// repoScriptCommandsForTrust returns the repo-supplied commands from repo's
+// .amux/workspaces.json (setup-workspace/run/archive — the same commands the
+// trust gate hashes), best-effort and read-only, for the trust dialog's
+// indirection warning. It never gates: a nil service, empty repo, or load error
+// simply yields no commands (and therefore no warning). It does not hash and so
+// cannot disagree with what the gate hashed.
+func (a *App) repoScriptCommandsForTrust(repo string) []string {
+	if a.workspaceService == nil || a.workspaceService.scripts == nil || repo == "" {
+		return nil
+	}
+	config, err := a.workspaceService.scripts.LoadConfig(repo)
+	if err != nil || config == nil {
+		return nil
+	}
+	commands := append([]string(nil), config.SetupWorkspace...)
+	if config.RunScript != "" {
+		commands = append(commands, config.RunScript)
+	}
+	if config.ArchiveScript != "" {
+		commands = append(commands, config.ArchiveScript)
+	}
+	return commands
+}
+
+// scriptIndirectionWarning builds the trust dialog's advisory text about
+// commands that reach into in-repo files the manifest hash cannot pin. It runs
+// the shipped, already-tested detector (process.ReferencesInRepoFiles /
+// CommandIsUnresolvable) over the repo-supplied commands and reports what it
+// found. It returns "" only when the detector found neither a referenced file
+// nor an unresolvable construct — which is explicitly NOT a guarantee the
+// commands run no repo code (the detector's contract), so the empty case renders
+// nothing rather than any reassurance. It never authorizes or blocks anything.
+func scriptIndirectionWarning(commands []string, repoRoot string) string {
+	var refs []string
+	seen := make(map[string]struct{})
+	unresolvable := false
+	for _, cmd := range commands {
+		if process.CommandIsUnresolvable(cmd) {
+			unresolvable = true
+		}
+		for _, ref := range process.ReferencesInRepoFiles(cmd, repoRoot) {
+			if _, dup := seen[ref]; dup {
+				continue
+			}
+			seen[ref] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+
+	var lines []string
+	if len(refs) > 0 {
+		lines = append(lines, "Runs in-repo scripts amux can't re-verify after approval: "+strings.Join(refs, ", "))
+	}
+	if unresolvable {
+		lines = append(lines, "One or more commands use variables/globs — amux can't list every file they run.")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // handleShowRemoveProjectDialog shows the remove project dialog.

--- a/internal/app/app_input_workspace_test.go
+++ b/internal/app/app_input_workspace_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/andyrewlee/amux/internal/config"
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/process"
@@ -211,6 +212,86 @@ func TestTrustScriptsRetryRejectsChangedConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(changedMarker); !os.IsNotExist(err) {
 		t.Fatalf("changed setup command should not run under stale approval, stat err=%v", err)
+	}
+}
+
+// newTrustDialogApp builds a minimal App whose workspaceService can load a
+// repo's .amux/workspaces.json, so the trust-dialog show handler can compute its
+// indirection warning. config is non-nil because presentDialog reads UI hints.
+func newTrustDialogApp() *App {
+	return &App{
+		config:           &config.Config{},
+		width:            120,
+		height:           40,
+		workspaceService: newWorkspaceService(nil, nil, process.NewScriptRunner(6200, 10), ""),
+	}
+}
+
+// TestHandleShowTrustScriptsDialog_WarnsOnInRepoScriptReference proves the trust
+// dialog surfaces in-repo files an approved command reaches into (via the
+// already-shipped process.ReferencesInRepoFiles detector), so the user knows the
+// manifest hash they approve does not cover those scripts' later contents. This
+// is informational only and changes nothing the trust gate blocks.
+func TestHandleShowTrustScriptsDialog_WarnsOnInRepoScriptReference(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scripts", "dev.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write dev.sh: %v", err)
+	}
+	workspaceSetupConfig(t, repo, `{"setup-workspace":["bash ./scripts/dev.sh"]}`)
+	ws := data.NewWorkspace("feature", "feature", "main", repo, filepath.Join(repo, "ws"))
+
+	app := newTrustDialogApp()
+	app.handleShowTrustScriptsDialog(messages.ShowTrustScriptsDialog{Workspace: ws, ConfigHash: "hash"})
+
+	view := dialogView(t, app.dialog)
+	if !strings.Contains(view, "scripts/dev.sh") {
+		t.Fatalf("expected trust dialog to name the referenced in-repo script, got:\n%s", view)
+	}
+	if !strings.Contains(view, "re-verify") {
+		t.Fatalf("expected the indirection warning wording, got:\n%s", view)
+	}
+}
+
+// TestHandleShowTrustScriptsDialog_WarnsOnUnresolvableCommand proves a command
+// with expansion/glob constructs (which hide references from the static
+// detector) raises the "amux can't list every file" warning.
+func TestHandleShowTrustScriptsDialog_WarnsOnUnresolvableCommand(t *testing.T) {
+	repo := t.TempDir()
+	workspaceSetupConfig(t, repo, `{"run":"$MYVAR/foo"}`)
+	ws := data.NewWorkspace("feature", "feature", "main", repo, filepath.Join(repo, "ws"))
+
+	app := newTrustDialogApp()
+	app.handleShowTrustScriptsDialog(messages.ShowTrustScriptsDialog{Workspace: ws, ConfigHash: "hash"})
+
+	view := dialogView(t, app.dialog)
+	if !strings.Contains(view, "variables/globs") {
+		t.Fatalf("expected unresolvable-command warning, got:\n%s", view)
+	}
+}
+
+// TestHandleShowTrustScriptsDialog_NoIndirectionMakesNoSafetyClaim proves that
+// when the detector finds neither a referenced file nor an unresolvable
+// construct, the dialog renders no extra warning AND no reassuring "safe" text:
+// an empty detector result is explicitly NOT a safety guarantee.
+func TestHandleShowTrustScriptsDialog_NoIndirectionMakesNoSafetyClaim(t *testing.T) {
+	repo := t.TempDir()
+	workspaceSetupConfig(t, repo, `{"setup-workspace":["echo hello"]}`)
+	ws := data.NewWorkspace("feature", "feature", "main", repo, filepath.Join(repo, "ws"))
+
+	app := newTrustDialogApp()
+	app.handleShowTrustScriptsDialog(messages.ShowTrustScriptsDialog{Workspace: ws, ConfigHash: "hash"})
+
+	view := dialogView(t, app.dialog)
+	if strings.Contains(view, "re-verify") || strings.Contains(view, "variables/globs") {
+		t.Fatalf("expected no indirection warning for a plain command, got:\n%s", view)
+	}
+	for _, banned := range []string{"safe", "no in-repo", "nothing to run", "verified"} {
+		if strings.Contains(strings.ToLower(view), banned) {
+			t.Fatalf("dialog must not imply safety (%q), got:\n%s", banned, view)
+		}
 	}
 }
 

--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -38,6 +38,11 @@ type Dialog struct {
 	dtype   DialogType
 	title   string
 	message string
+	// warning is optional informational text rendered below message on confirm
+	// dialogs (e.g. the trust dialog's in-repo script indirection notice). Its
+	// absence never implies "safe"; callers only set it to warn, never to
+	// reassure.
+	warning string
 	options []string
 
 	// State
@@ -108,6 +113,17 @@ func (d *Dialog) SetDefaultOption(index int) {
 	}
 	d.defaultCursor = index
 	d.cursor = index
+}
+
+// SetWarning sets optional informational warning text rendered below the
+// message on a confirm dialog. Passing "" clears it. This is purely advisory
+// (e.g. surfacing in-repo script indirection at trust time); an empty warning
+// must never be read or presented as a safety guarantee.
+func (d *Dialog) SetWarning(text string) {
+	if d == nil {
+		return
+	}
+	d.warning = text
 }
 
 // fuzzyMatch returns true if pattern fuzzy-matches target (case-insensitive)

--- a/internal/ui/common/dialog_render.go
+++ b/internal/ui/common/dialog_render.go
@@ -150,6 +150,13 @@ func (d *Dialog) renderLines() []string {
 		lines = append(lines, line)
 	case DialogConfirm:
 		appendLines(d.message)
+		if d.warning != "" {
+			warnStyle := lipgloss.NewStyle().
+				Foreground(ColorWarning()).
+				MarginTop(1)
+			appendBlank(1)
+			appendLines(warnStyle.Render(d.warning))
+		}
 		appendBlank(1)
 		baseLine := d.renderedLineCount(lines)
 		lines = append(lines, d.renderOptionsLines(baseLine)...)


### PR DESCRIPTION
The trust gate hashes .amux/workspaces.json but is blind to the scripts those commands point at: a trusted 'bash ./scripts/dev.sh' runs whatever that file contains today, and an attacker editing it later re-runs new code with no re-prompt. Wires the already-shipped, already-tested detector (ReferencesInRepoFiles / CommandIsUnresolvable) into the trust dialog as INFORMATIONAL warnings computed at dialog-build time from the same gated commands the hash covers. The trust gate is byte-unchanged (script_trust.go/scripts.go/script_reference.go: 0 lines, blob hashes identical) and the detector never gates — empty result renders nothing and a test locks 'empty != safe'. (plan 028)