### PR TITLE
feat: rename a workspace label (Tier-1)

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -27,6 +27,7 @@ const (
 	DialogAddProject      = "add_project"
 	DialogCreateWorkspace = "create_workspace"
 	DialogDeleteWorkspace = "delete_workspace"
+	DialogRenameWorkspace = "rename_workspace"
 	DialogTrustScripts    = "trust_scripts"
 	DialogRemoveProject   = "remove_project"
 	// DialogSelectAssistant is the legacy ID for the assistant-selection flow.

--- a/internal/app/app_dialogs_registry.go
+++ b/internal/app/app_dialogs_registry.go
@@ -15,6 +15,7 @@ var appDialogIDList = []string{
 	DialogAddProject,
 	DialogCreateWorkspace,
 	DialogDeleteWorkspace,
+	DialogRenameWorkspace,
 	DialogTrustScripts,
 	DialogRemoveProject,
 	DialogSelectAssistant,

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -168,6 +168,25 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 			}
 		}
 
+	case DialogRenameWorkspace:
+		if workspace != nil && result.Value != "" {
+			name := validation.SanitizeInput(result.Value)
+			if err := validation.ValidateWorkspaceName(name); err != nil {
+				return func() tea.Msg {
+					return messages.Error{Err: err, Context: errorContext(errorServiceDialog, "validating workspace name")}
+				}
+			}
+			ws := workspace
+			proj := project
+			return func() tea.Msg {
+				return messages.RenameWorkspace{
+					Project:   proj,
+					Workspace: ws,
+					NewName:   name,
+				}
+			}
+		}
+
 	case DialogTrustScripts:
 		if workspace != nil {
 			return a.trustRepoScriptsAndRunSetupAsync(workspace, trustScriptsHash)

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -233,6 +233,8 @@ func (a *App) updateWorkspaceLifecycleMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		*cmds = append(*cmds, a.handleCreateWorkspace(msg)...)
 	case messages.DeleteWorkspace:
 		*cmds = append(*cmds, a.handleDeleteWorkspace(msg)...)
+	case messages.RenameWorkspace:
+		*cmds = append(*cmds, a.handleRenameWorkspace(msg)...)
 	case messages.AddProject:
 		*cmds = append(*cmds, a.addProject(msg.Path))
 	case messages.RemoveProject:
@@ -278,6 +280,8 @@ func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		a.handleShowCreateWorkspaceDialog(msg)
 	case messages.ShowDeleteWorkspaceDialog:
 		a.handleShowDeleteWorkspaceDialog(msg)
+	case messages.ShowRenameWorkspaceDialog:
+		a.handleShowRenameWorkspaceDialog(msg)
 	case messages.ShowTrustScriptsDialog:
 		a.handleShowTrustScriptsDialog(msg)
 	case messages.ShowRemoveProjectDialog:

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -70,6 +70,31 @@ func (a *App) handleShowDeleteWorkspaceDialog(msg messages.ShowDeleteWorkspaceDi
 	a.presentDialog(a.dialog)
 }
 
+// handleShowRenameWorkspaceDialog shows the rename workspace input dialog,
+// prefilled with the workspace's current name for editing.
+func (a *App) handleShowRenameWorkspaceDialog(msg messages.ShowRenameWorkspaceDialog) {
+	if msg.Workspace == nil {
+		return
+	}
+	a.dialogProject = msg.Project
+	a.dialogWorkspace = msg.Workspace
+	a.dialog = common.NewInputDialog(DialogRenameWorkspace, "Rename Workspace", "Enter new workspace name...")
+	a.dialog.SetInputValidate(func(s string) string {
+		s = validation.SanitizeInput(s)
+		if s == "" {
+			return "" // Don't show error for empty input
+		}
+		if err := validation.ValidateWorkspaceName(s); err != nil {
+			return err.Error()
+		}
+		return ""
+	})
+	a.presentDialog(a.dialog)
+	// Prefill after presentDialog: Show() resets the input to empty, so the
+	// current name must be set afterward to render ready-to-edit.
+	a.dialog.SetInputValue(msg.Workspace.Name)
+}
+
 // handleShowTrustScriptsDialog shows the repo script trust confirmation dialog.
 func (a *App) handleShowTrustScriptsDialog(msg messages.ShowTrustScriptsDialog) {
 	a.dialogWorkspace = msg.Workspace

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -36,6 +36,37 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 	return cmds
 }
 
+// handleRenameWorkspace handles the RenameWorkspace message: a Tier-1 label
+// rename. It updates only the workspace's display Name via the store — the git
+// branch, worktree, and workspace ID() are untouched — then reloads projects so
+// the dashboard and sidebar labels refresh.
+func (a *App) handleRenameWorkspace(msg messages.RenameWorkspace) []tea.Cmd {
+	if msg.Workspace == nil {
+		logging.Warn("RenameWorkspace received with nil workspace")
+		return nil
+	}
+	if a.workspaceService == nil || a.workspaceService.store == nil {
+		return nil
+	}
+	if err := a.workspaceService.store.Rename(msg.Workspace.ID(), msg.NewName); err != nil {
+		if cmd := common.ReportError(errorContext(errorServiceWorkspace, "renaming workspace"), err, ""); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
+	// Reflect the new label immediately on the in-memory active workspace so the
+	// header updates without waiting for the async reload.
+	if a.activeWorkspace != nil && a.activeWorkspace.Root == msg.Workspace.Root {
+		a.activeWorkspace.Name = msg.NewName
+	}
+	var cmds []tea.Cmd
+	if cmd := a.toast.ShowSuccess("Renamed workspace to " + msg.NewName); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	cmds = append(cmds, a.loadProjects())
+	return cmds
+}
+
 // handleWorkspaceCreatedWithWarning handles the WorkspaceCreatedWithWarning message.
 func (a *App) handleWorkspaceCreatedWithWarning(msg messages.WorkspaceCreatedWithWarning) []tea.Cmd {
 	var cmds []tea.Cmd

--- a/internal/app/app_tmux_sync_test.go
+++ b/internal/app/app_tmux_sync_test.go
@@ -51,6 +51,10 @@ func (s *blockingWorkspaceStore) Delete(id data.WorkspaceID) error {
 	return nil
 }
 
+func (s *blockingWorkspaceStore) Rename(id data.WorkspaceID, newName string) error {
+	return nil
+}
+
 func (s *blockingWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant
 }

--- a/internal/app/keybindings.go
+++ b/internal/app/keybindings.go
@@ -10,6 +10,7 @@ type KeyMap struct {
 	// Dashboard
 	Enter        key.Binding
 	Delete       key.Binding
+	Rename       key.Binding
 	ToggleFilter key.Binding
 	Refresh      key.Binding
 
@@ -42,6 +43,10 @@ func DefaultKeyMap() KeyMap {
 		Delete: key.NewBinding(
 			key.WithKeys("D"),
 			key.WithHelp("D", "delete"),
+		),
+		Rename: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "rename"),
 		),
 		ToggleFilter: key.NewBinding(
 			key.WithKeys("f"),

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -24,6 +24,7 @@ type WorkspaceStore interface {
 	UpsertFromDiscovery(workspace *data.Workspace) error
 	Save(workspace *data.Workspace) error
 	Delete(id data.WorkspaceID) error
+	Rename(id data.WorkspaceID, newName string) error
 	ResolvedDefaultAssistant() string
 }
 

--- a/internal/app/workspace_delete_isolation_test.go
+++ b/internal/app/workspace_delete_isolation_test.go
@@ -30,8 +30,9 @@ func (s *recordingWorkspaceStore) Save(ws *data.Workspace) error {
 	return nil
 }
 
-func (s *recordingWorkspaceStore) Delete(data.WorkspaceID) error    { return nil }
-func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
+func (s *recordingWorkspaceStore) Delete(data.WorkspaceID) error         { return nil }
+func (s *recordingWorkspaceStore) Rename(data.WorkspaceID, string) error { return nil }
+func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string      { return data.DefaultAssistant }
 
 func (s *recordingWorkspaceStore) saved() []string {
 	s.mu.Lock()

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -28,6 +28,7 @@ func (s *failingTombstoneWorkspaceStore) LoadMetadataFor(*data.Workspace) (bool,
 func (s *failingTombstoneWorkspaceStore) UpsertFromDiscovery(*data.Workspace) error { return nil }
 func (s *failingTombstoneWorkspaceStore) Save(*data.Workspace) error                { return nil }
 func (s *failingTombstoneWorkspaceStore) Delete(data.WorkspaceID) error             { return s.deleteErr }
+func (s *failingTombstoneWorkspaceStore) Rename(data.WorkspaceID, string) error     { return nil }
 
 func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -29,8 +29,9 @@ func (s *failingDeleteStore) Save(ws *data.Workspace) error {
 	s.saved = &cp
 	return s.saveErr
 }
-func (s *failingDeleteStore) Delete(data.WorkspaceID) error    { return s.deleteErr }
-func (s *failingDeleteStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
+func (s *failingDeleteStore) Delete(data.WorkspaceID) error         { return s.deleteErr }
+func (s *failingDeleteStore) Rename(data.WorkspaceID, string) error { return nil }
+func (s *failingDeleteStore) ResolvedDefaultAssistant() string      { return data.DefaultAssistant }
 
 // TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess proves a
 // metadata-delete failure is reported without using the generic failed-delete

--- a/internal/app/workspace_service_init_test.go
+++ b/internal/app/workspace_service_init_test.go
@@ -189,6 +189,8 @@ func (f *fakeAssistantStore) Save(*data.Workspace) error { panic("unexpected Sav
 
 func (f *fakeAssistantStore) Delete(data.WorkspaceID) error { panic("unexpected Delete") }
 
+func (f *fakeAssistantStore) Rename(data.WorkspaceID, string) error { panic("unexpected Rename") }
+
 // TestWorkspaceServiceResolvedDefaultAssistant covers every branch of the
 // nil-safe resolver: a nil receiver and a nil store both fall back to the package
 // default, while a wired store is consulted verbatim.

--- a/internal/data/rename_design_test.go
+++ b/internal/data/rename_design_test.go
@@ -1,32 +1,83 @@
 package data
 
 import (
+	"os"
 	"testing"
-
-	"github.com/andyrewlee/amux/internal/validation"
 )
 
-// renameWorkspaceLabelDesign is the proposed Tier-1 (label-only) rename gate,
-// declared here as a compile-checked design skeleton — it is NOT wired into the
-// store or the UI. It isolates the name-validation half of the future
-// (*WorkspaceStore).Rename method so the design's reuse of
-// validation.ValidateWorkspaceName can be exercised before the feature is built.
-//
-// See the "Workspace Rename Design (spike)" notes, kept with the maintainer's
-// planning notes, for the full two-tier design and the store API this stub
-// stands in for.
-func renameWorkspaceLabelDesign(name string) error {
-	return validation.ValidateWorkspaceName(name)
+// seedRenameWorkspace saves a single workspace into a fresh store and returns
+// the store plus the saved workspace's ID, so the rename tests below start from
+// a persisted record.
+func seedRenameWorkspace(t *testing.T, name string) (*WorkspaceStore, WorkspaceID) {
+	t.Helper()
+	store := NewWorkspaceStore(t.TempDir())
+	ws := &Workspace{
+		Name:       name,
+		Branch:     "feature-branch",
+		Base:       "origin/main",
+		Repo:       "/home/user/repo",
+		Root:       "/home/user/.amux/workspaces/feature",
+		Runtime:    RuntimeLocalWorktree,
+		Assistant:  "claude",
+		ScriptMode: "nonconcurrent",
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	return store, ws.ID()
 }
 
-// TestRenameWorkspaceLabelDesign_RejectsInvalidNames exercises the non-wired
-// Tier-1 validation gate: a valid label is accepted and every rule enforced by
-// validation.ValidateWorkspaceName rejects the corresponding label.
-func TestRenameWorkspaceLabelDesign_RejectsInvalidNames(t *testing.T) {
-	if err := renameWorkspaceLabelDesign("feature-2"); err != nil {
-		t.Fatalf("valid name should be accepted, got %v", err)
+// TestRenameWorkspaceLabelDesign_StoreIntegration is the wired Tier-1 test: a
+// label rename updates Name while ID() and the metadata file path are unchanged.
+// This pins the safety property that makes rename zero-churn — the ID derives
+// from Repo/Root only, so relabeling never relocates the record or touches any
+// ID-keyed tmux session / tag / worktree.
+func TestRenameWorkspaceLabelDesign_StoreIntegration(t *testing.T) {
+	store, id := seedRenameWorkspace(t, "old-name")
+	path := store.workspacePath(id)
+
+	if err := store.Rename(id, "new-name"); err != nil {
+		t.Fatalf("Rename() error = %v", err)
 	}
 
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() after rename error = %v", err)
+	}
+	if reloaded.Name != "new-name" {
+		t.Errorf("Name = %q, want %q", reloaded.Name, "new-name")
+	}
+	// The crux: renaming the label must NOT churn the ID, so the record stays at
+	// the same id-derived path.
+	if reloaded.ID() != id {
+		t.Errorf("ID changed by rename: got %q, want %q", reloaded.ID(), id)
+	}
+	if got := store.workspacePath(id); got != path {
+		t.Errorf("metadata path moved: got %q, want %q", got, path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("metadata file should still exist at original path: %v", err)
+	}
+	// The file did not move: exactly one workspace directory remains.
+	entries, err := os.ReadDir(store.root)
+	if err != nil {
+		t.Fatalf("ReadDir(store.root) error = %v", err)
+	}
+	dirs := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs++
+		}
+	}
+	if dirs != 1 {
+		t.Errorf("expected exactly 1 workspace dir after rename, got %d", dirs)
+	}
+}
+
+// TestRenameWorkspace_RejectsInvalidName asserts every rule enforced by
+// validation.ValidateWorkspaceName rejects the corresponding label through the
+// store, and that a rejected rename leaves the stored record untouched.
+func TestRenameWorkspace_RejectsInvalidName(t *testing.T) {
 	invalid := map[string]string{
 		"empty":            "",
 		"consecutive dots": "a..b",
@@ -35,17 +86,34 @@ func TestRenameWorkspaceLabelDesign_RejectsInvalidNames(t *testing.T) {
 		"leading dash":     "-nope",
 	}
 	for label, name := range invalid {
-		if err := renameWorkspaceLabelDesign(name); err == nil {
-			t.Errorf("%s: name %q should be rejected", label, name)
-		}
+		t.Run(label, func(t *testing.T) {
+			store, id := seedRenameWorkspace(t, "keep-me")
+			if err := store.Rename(id, name); err == nil {
+				t.Fatalf("Rename(%q) should be rejected", name)
+			}
+			reloaded, err := store.Load(id)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if reloaded.Name != "keep-me" {
+				t.Errorf("Name = %q, want unchanged %q", reloaded.Name, "keep-me")
+			}
+		})
 	}
 }
 
-// TestRenameWorkspaceLabelDesign_StoreIntegration is a placeholder for the real
-// Tier-1 test once (*WorkspaceStore).Rename is implemented: rename a saved
-// workspace, reload, and assert Name updated while ID() is unchanged and the
-// metadata file did not move. Skipped because the wired method does not exist
-// yet — this file is a design skeleton only.
-func TestRenameWorkspaceLabelDesign_StoreIntegration(t *testing.T) {
-	t.Skip("design skeleton: (*WorkspaceStore).Rename is not implemented yet")
+// TestRenameWorkspace_NoOpSameName asserts renaming to the current name is a
+// no-op that does not error.
+func TestRenameWorkspace_NoOpSameName(t *testing.T) {
+	store, id := seedRenameWorkspace(t, "same")
+	if err := store.Rename(id, "same"); err != nil {
+		t.Fatalf("Rename() to same name should be a no-op, got %v", err)
+	}
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if reloaded.Name != "same" {
+		t.Errorf("Name = %q, want %q", reloaded.Name, "same")
+	}
 }

--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/andyrewlee/amux/internal/fsatomic"
 
 	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/validation"
 )
 
 const workspaceFilename = "workspace.json"
@@ -223,6 +224,33 @@ func (s *WorkspaceStore) Save(ws *Workspace) error {
 		s.removeWorkspaceLockFile(oldID)
 	}
 	ws.storeID = id
+	return nil
+}
+
+// Rename updates a workspace's human-facing Name only. Repo/Root/Branch and
+// therefore ID() are unchanged, so no tmux session, tag, worktree, or in-memory
+// map keyed on the ID is affected (Tier-1 label rename). The newName is trimmed
+// and validated with the same rule as workspace creation, then the record is
+// saved in place atomically — because Repo/Root are untouched, ws.ID() == id and
+// Save takes its in-place branch (no flock migration, no old-record deletion).
+func (s *WorkspaceStore) Rename(id WorkspaceID, newName string) error {
+	newName = strings.TrimSpace(newName)
+	if err := validation.ValidateWorkspaceName(newName); err != nil {
+		return err
+	}
+	ws, err := s.Load(id)
+	if err != nil {
+		return fmt.Errorf("rename workspace %s: %w", id, err)
+	}
+	// No-op guard: renaming to the current name would only rewrite the file and
+	// emit a spurious watch event.
+	if ws.Name == newName {
+		return nil
+	}
+	ws.Name = newName
+	if err := s.Save(ws); err != nil {
+		return fmt.Errorf("rename workspace %s: %w", id, err)
+	}
 	return nil
 }
 

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -224,6 +224,12 @@ type ShowDeleteWorkspaceDialog struct {
 	Workspace *data.Workspace
 }
 
+// ShowRenameWorkspaceDialog requests showing the rename workspace input dialog
+type ShowRenameWorkspaceDialog struct {
+	Project   *data.Project
+	Workspace *data.Workspace
+}
+
 // ShowTrustScriptsDialog requests confirmation before trusting repo scripts.
 type ShowTrustScriptsDialog struct {
 	Workspace  *data.Workspace
@@ -247,6 +253,15 @@ type CreateWorkspace struct {
 type DeleteWorkspace struct {
 	Project   *data.Project
 	Workspace *data.Workspace
+}
+
+// RenameWorkspace requests renaming a workspace's display label (Tier-1). Only
+// the human Name changes; the git branch, worktree, and workspace ID are left
+// untouched.
+type RenameWorkspace struct {
+	Project   *data.Project
+	Workspace *data.Workspace
+	NewName   string
 }
 
 // RemoveProject requests removing a project from the registry

--- a/internal/ui/common/dialog.go
+++ b/internal/ui/common/dialog.go
@@ -139,6 +139,16 @@ func (d *Dialog) SetInputValidate(fn InputValidateFunc) *Dialog {
 	return d
 }
 
+// SetInputValue prefills the input field's current value so a dialog opened for
+// editing (e.g. rename) renders the existing value ready to edit. It affects
+// input dialogs only. Call it after Show(), which resets the input to empty.
+func (d *Dialog) SetInputValue(s string) {
+	if d == nil || d.dtype != DialogInput {
+		return
+	}
+	d.input.SetValue(s)
+}
+
 // transformInputMsg applies the input transform to key press and paste messages
 func (d *Dialog) transformInputMsg(msg tea.Msg) tea.Msg {
 	switch m := msg.(type) {

--- a/internal/ui/common/dialog_test.go
+++ b/internal/ui/common/dialog_test.go
@@ -442,3 +442,37 @@ func TestDialogConfirmClickNoWrappingMessage(t *testing.T) {
 		t.Fatalf("Expected Confirmed=false, got true")
 	}
 }
+
+func TestDialogSetInputValuePrefills(t *testing.T) {
+	d := NewInputDialog("rename", "Rename workspace", "Enter new name...")
+	// Show() resets the input to empty, so the prefill must land after it —
+	// mirroring how the rename dialog is wired (present, then prefill).
+	d.Show()
+	d.SetInputValue("existing-name")
+
+	if got := d.input.Value(); got != "existing-name" {
+		t.Fatalf("SetInputValue prefill = %q, want %q", got, "existing-name")
+	}
+
+	// Confirming emits the prefilled value as the DialogResult value.
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected a command from confirming the input dialog")
+	}
+	result, ok := cmd().(DialogResult)
+	if !ok {
+		t.Fatalf("expected DialogResult, got %T", cmd())
+	}
+	if result.Value != "existing-name" {
+		t.Fatalf("DialogResult.Value = %q, want %q", result.Value, "existing-name")
+	}
+}
+
+func TestDialogSetInputValueIgnoredForNonInput(t *testing.T) {
+	// A no-op on confirm dialogs: it must not panic or mutate anything.
+	d := NewConfirmDialog("confirm", "Title", "Message")
+	d.SetInputValue("ignored")
+	if got := d.input.Value(); got != "" {
+		t.Fatalf("confirm dialog input value = %q, want empty", got)
+	}
+}

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -290,6 +290,26 @@ func (m *Model) handleDelete() tea.Cmd {
 	return nil
 }
 
+// handleRename handles the rename key. Only workspace rows can be renamed
+// (Tier-1 label rename); projects have no rename action.
+func (m *Model) handleRename() tea.Cmd {
+	if m.cursor >= len(m.rows) {
+		return nil
+	}
+
+	row := m.rows[m.cursor]
+	if row.Type == RowWorkspace && row.Workspace != nil {
+		return func() tea.Msg {
+			return messages.ShowRenameWorkspaceDialog{
+				Project:   row.Project,
+				Workspace: row.Workspace,
+			}
+		}
+	}
+
+	return nil
+}
+
 // refresh requests a workspace rescan/import.
 func (m *Model) refresh() tea.Cmd {
 	return func() tea.Msg { return messages.RescanWorkspaces{} }

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -213,6 +213,7 @@ func (m *Model) helpLines(contentWidth int) []string {
 	if m.cursor >= 0 && m.cursor < len(m.rows) {
 		switch m.rows[m.cursor].Type {
 		case RowWorkspace:
+			items = append(items, m.helpItem("R", "rename"))
 			items = append(items, m.helpItem("D", "delete"))
 		case RowProject:
 			items = append(items, m.helpItem("D", "remove"))

--- a/internal/ui/dashboard/model_update.go
+++ b/internal/ui/dashboard/model_update.go
@@ -171,6 +171,8 @@ func (m *Model) handleNavKey(msg tea.KeyPressMsg, toolbarItems []toolbarItem) (*
 		return m, m.handleEnter()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("D"))):
 		return m, m.handleDelete()
+	case key.Matches(msg, key.NewBinding(key.WithKeys("R"))):
+		return m, m.handleRename()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
 		return m, m.refresh()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("G"))):


### PR DESCRIPTION
Workspace CRUD was missing exactly one verb — rename — forcing delete-and-recreate (destroying the worktree, branch, and live agent session) to fix a bad name. Ships Tier-1 (label-only): WorkspaceStore.Rename validates via ValidateWorkspaceName, Loads, no-op-guards, sets Name, atomic Save. Because Workspace.ID() derives from Repo+Root (Name ∉ ID, verified), a label rename causes ZERO session/tag/worktree/branch churn — the store test asserts ID() and the metadata path are unchanged after rename. Wiring: a Dialog.SetInputValue prefill setter, a dashboard R key mirroring delete's D, result validated → store.Rename → in-memory label update + ReportError on failure. Tier-2 (branch rename + worktree move) deferred (it would change ID() mid-session). All gates green incl. harness-golden + lint-ci-parity. (plan 027)