### PR TITLE
feat: commit workspace changes from the UI (git write-back, action 1)

### DIFF
--- a/internal/app/app_commit_workspace_test.go
+++ b/internal/app/app_commit_workspace_test.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+// TestHandleDialogResult_CommitWorkspaceInvokesCommitAll asserts a confirmed
+// commit dialog routes to git.CommitAll (via the seam) with the workspace Root
+// and the sanitized message, and yields a WorkspaceCommitted result.
+func TestHandleDialogResult_CommitWorkspaceInvokesCommitAll(t *testing.T) {
+	var gotRoot, gotMsg string
+	called := false
+	ws := &data.Workspace{Name: "feature", Root: "/tmp/ws", Branch: "feature"}
+	app := &App{
+		toast:           common.NewToastModel(),
+		dialogWorkspace: ws,
+		commitAllFn: func(_ context.Context, root, message string) error {
+			called = true
+			gotRoot = root
+			gotMsg = message
+			return nil
+		},
+	}
+
+	cmd := app.handleDialogResult(common.DialogResult{
+		ID:        DialogCommitWorkspace,
+		Confirmed: true,
+		Value:     "  wire commit-all  ",
+	})
+	if cmd == nil {
+		t.Fatal("expected a commit command from a confirmed commit dialog")
+	}
+	msg := cmd()
+
+	if !called {
+		t.Fatal("expected the CommitAll seam to be invoked")
+	}
+	if gotRoot != "/tmp/ws" {
+		t.Fatalf("commit ran in %q, want the workspace Root /tmp/ws", gotRoot)
+	}
+	if gotMsg != "wire commit-all" {
+		t.Fatalf("commit message = %q, want sanitized (trimmed) %q", gotMsg, "wire commit-all")
+	}
+	committed, ok := msg.(messages.WorkspaceCommitted)
+	if !ok {
+		t.Fatalf("expected messages.WorkspaceCommitted, got %T", msg)
+	}
+	if committed.Workspace != ws || committed.Err != nil {
+		t.Fatalf("unexpected WorkspaceCommitted: %+v", committed)
+	}
+}
+
+// TestHandleDialogResult_CommitWorkspaceCanceledDoesNotCommit asserts an
+// Esc/No dialog result never runs git.
+func TestHandleDialogResult_CommitWorkspaceCanceledDoesNotCommit(t *testing.T) {
+	called := false
+	app := &App{
+		toast:           common.NewToastModel(),
+		dialogWorkspace: &data.Workspace{Name: "feature", Root: "/tmp/ws"},
+		commitAllFn: func(context.Context, string, string) error {
+			called = true
+			return nil
+		},
+	}
+
+	cmd := app.handleDialogResult(common.DialogResult{
+		ID:        DialogCommitWorkspace,
+		Confirmed: false,
+		Value:     "ignored",
+	})
+	if cmd != nil {
+		t.Fatal("expected no command from a canceled commit dialog")
+	}
+	if called {
+		t.Fatal("canceled commit dialog must not invoke CommitAll")
+	}
+}
+
+// TestHandleWorkspaceCommitted_ErrorReportsAndSkipsRefresh asserts a failed
+// commit surfaces an error and does not silently succeed.
+func TestHandleWorkspaceCommitted_ErrorReports(t *testing.T) {
+	app := &App{toast: common.NewToastModel()}
+	cmd := app.handleWorkspaceCommitted(messages.WorkspaceCommitted{
+		Workspace: &data.Workspace{Root: "/tmp/ws"},
+		Err:       errors.New("boom"),
+	})
+	if cmd == nil {
+		t.Fatal("expected an error-reporting command")
+	}
+	// ReportError emits an Error message and an error Toast; assert the toast.
+	found := false
+	for _, m := range runCommandMessages(cmd) {
+		if toast, ok := m.(messages.Toast); ok && toast.Level == messages.ToastError {
+			found = true
+			if !strings.Contains(toast.Message, "boom") {
+				t.Fatalf("error toast missing cause: %q", toast.Message)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected an error toast from a failed commit")
+	}
+}
+
+// TestHandleWorkspaceCommitted_SuccessToastsAndRefreshes asserts a successful
+// commit shows a success toast and requests a status refresh.
+func TestHandleWorkspaceCommitted_SuccessToastsAndRefreshes(t *testing.T) {
+	app := &App{toast: common.NewToastModel()}
+	cmd := app.handleWorkspaceCommitted(messages.WorkspaceCommitted{
+		Workspace: &data.Workspace{Root: "/tmp/ws"},
+	})
+	if cmd == nil {
+		t.Fatal("expected a success command")
+	}
+	if view := ansi.Strip(app.toast.View()); !strings.Contains(view, "Committed changes") {
+		t.Fatalf("expected success toast, got %q", view)
+	}
+	// A gitStatus refresh is queued (nil gitStatus service yields a bare result
+	// message keyed to the workspace Root).
+	sawStatus := false
+	for _, m := range runCommandMessages(cmd) {
+		if res, ok := m.(messages.GitStatusResult); ok && res.Root == "/tmp/ws" {
+			sawStatus = true
+		}
+	}
+	if !sawStatus {
+		t.Fatal("expected a git-status refresh for the committed workspace")
+	}
+}

--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -27,6 +27,7 @@ const (
 	DialogAddProject      = "add_project"
 	DialogCreateWorkspace = "create_workspace"
 	DialogDeleteWorkspace = "delete_workspace"
+	DialogCommitWorkspace = "commit_workspace"
 	DialogTrustScripts    = "trust_scripts"
 	DialogRemoveProject   = "remove_project"
 	// DialogSelectAssistant is the legacy ID for the assistant-selection flow.
@@ -100,6 +101,11 @@ type App struct {
 	pendingWorkspaceProject *data.Project
 	pendingWorkspaceName    string
 	pendingWorkspaceBase    string
+
+	// commitAllFn is the git commit-all seam. Nil in production (falls back to
+	// git.CommitAll); tests install a fake to assert the dialog→commit wiring
+	// without a real repo.
+	commitAllFn func(context.Context, string, string) error
 
 	// Git status management
 	fileWatcher     *git.FileWatcher

--- a/internal/app/app_dialogs_registry.go
+++ b/internal/app/app_dialogs_registry.go
@@ -15,6 +15,7 @@ var appDialogIDList = []string{
 	DialogAddProject,
 	DialogCreateWorkspace,
 	DialogDeleteWorkspace,
+	DialogCommitWorkspace,
 	DialogTrustScripts,
 	DialogRemoveProject,
 	DialogSelectAssistant,

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -168,6 +168,13 @@ func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 			}
 		}
 
+	case DialogCommitWorkspace:
+		if workspace != nil {
+			// Message is the argv value of -m; sanitize control chars but never
+			// shell-interpolate. CommitAll rejects an empty message.
+			return a.commitWorkspaceAsync(workspace, validation.SanitizeInput(result.Value))
+		}
+
 	case DialogTrustScripts:
 		if workspace != nil {
 			return a.trustRepoScriptsAndRunSetupAsync(workspace, trustScriptsHash)

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -246,6 +246,10 @@ func (a *App) updateWorkspaceLifecycleMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		if cmd := a.handleWorkspaceDeleteFailed(msg); cmd != nil {
 			*cmds = append(*cmds, cmd)
 		}
+	case messages.WorkspaceCommitted:
+		if cmd := a.handleWorkspaceCommitted(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
 	case messages.FileWatcherEvent:
 		*cmds = append(*cmds, a.handleFileWatcherEvent(msg)...)
 	case messages.StateWatcherEvent:
@@ -278,6 +282,8 @@ func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		a.handleShowCreateWorkspaceDialog(msg)
 	case messages.ShowDeleteWorkspaceDialog:
 		a.handleShowDeleteWorkspaceDialog(msg)
+	case messages.ShowCommitWorkspaceDialog:
+		a.handleShowCommitWorkspaceDialog(msg)
 	case messages.ShowTrustScriptsDialog:
 		a.handleShowTrustScriptsDialog(msg)
 	case messages.ShowRemoveProjectDialog:

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -67,6 +68,30 @@ func (a *App) handleShowDeleteWorkspaceDialog(msg messages.ShowDeleteWorkspaceDi
 		"Delete Workspace",
 		fmt.Sprintf("Delete workspace '%s' and its branch?", msg.Workspace.Name),
 	)
+	a.presentDialog(a.dialog)
+}
+
+// handleShowCommitWorkspaceDialog shows the commit-message input dialog for a
+// workspace's changes. The message the user types is the confirmation gesture;
+// on confirm handleDialogResult stages and commits via git.CommitAll. Esc
+// cancels. Live validation mirrors the create-workspace dialog (sanitize, then
+// only flag a non-empty value); an empty message is refused by CommitAll.
+func (a *App) handleShowCommitWorkspaceDialog(msg messages.ShowCommitWorkspaceDialog) {
+	a.dialogWorkspace = msg.Workspace
+	a.dialog = common.NewInputDialog(DialogCommitWorkspace, "Commit changes", "Commit message...")
+	a.dialog.SetInputValidate(func(s string) string {
+		s = validation.SanitizeInput(s)
+		if s == "" {
+			return "" // Don't show an error for empty input; block on confirm.
+		}
+		// Defense-in-depth: the message is the argv value of -m so a leading '-'
+		// is never parsed as a flag, but keep the value shape consistent with
+		// ValidateBaseRef and warn the user before they commit.
+		if strings.HasPrefix(s, "-") {
+			return "commit message cannot start with '-'"
+		}
+		return ""
+	})
 	a.presentDialog(a.dialog)
 }
 

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -6,7 +6,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
 // loadProjects loads all registered projects and their workspaces.
@@ -24,6 +26,41 @@ func (a *App) rescanWorkspaces() tea.Cmd {
 		return nil
 	}
 	return a.workspaceService.RescanWorkspaces()
+}
+
+// commitWorkspaceAsync stages and commits every change in ws.Root with message,
+// off the UI goroutine, reporting the outcome as messages.WorkspaceCommitted.
+// The commit runs on ws's own branch through the hardened git.CommitAll; it
+// never merges, pushes, or checks out the base branch. commitAllFn is a seam so
+// tests can assert the wiring without touching a real repo.
+func (a *App) commitWorkspaceAsync(ws *data.Workspace, message string) tea.Cmd {
+	if ws == nil {
+		return nil
+	}
+	commit := a.commitAllFn
+	if commit == nil {
+		commit = git.CommitAll
+	}
+	ctx := a.ctx
+	root := ws.Root
+	return func() tea.Msg {
+		return messages.WorkspaceCommitted{Workspace: ws, Err: commit(ctx, root, message)}
+	}
+}
+
+// handleWorkspaceCommitted reports a commit-all outcome: on failure via
+// ReportError; on success a toast plus a full git-status refresh so the sidebar
+// diff/status view reflects the now-clean tree.
+func (a *App) handleWorkspaceCommitted(msg messages.WorkspaceCommitted) tea.Cmd {
+	if msg.Err != nil {
+		return common.ReportError("committing workspace changes", msg.Err, "Commit failed: "+msg.Err.Error())
+	}
+	var cmds []tea.Cmd
+	cmds = append(cmds, a.toast.ShowSuccess("Committed changes"))
+	if msg.Workspace != nil {
+		cmds = append(cmds, a.requestGitStatusFull(msg.Workspace.Root))
+	}
+	return common.SafeBatch(cmds...)
 }
 
 // requestGitStatus requests git status for a workspace using fast mode (skips line stats).

--- a/internal/git/writeback.go
+++ b/internal/git/writeback.go
@@ -1,0 +1,54 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// commitTimeout bounds the stage+commit pass. The 5s defaultGitTimeout is fine
+// for a small tree but too tight for a large staging pass; this follows the
+// worktreeTimeout precedent of overriding for multi-file ops. See Action 1 of
+// the write-back design (plans/design/026-git-writeback-design.md).
+const commitTimeout = 15 * time.Second
+
+// ErrEmptyCommitMessage is returned by CommitAll when the message is blank.
+// The UI must supply a non-empty message; commit-all never invents one.
+var ErrEmptyCommitMessage = errors.New("commit message cannot be empty")
+
+// CommitAll stages every change in workspaceRoot — tracked, untracked, and
+// deletions via `git add -A` — and commits them with message via
+// `git commit -m <message>`. Both git invocations run through the hardened
+// RunGitCtx, so they inherit filteredGitEnv, the hooks/fsmonitor neutralization
+// (hardenedGitArgs), the context timeout, and structured *Error on failure.
+//
+// message is passed as the argv value of -m and is never shell-interpolated, so
+// a message beginning with '-' cannot be reparsed as a git flag. An empty or
+// whitespace-only message is rejected with ErrEmptyCommitMessage.
+//
+// This is commit-only by design: no merge, push, force, amend, autostash, or
+// base-branch checkout. The commit lands on whatever branch workspaceRoot has
+// checked out. A clean tree is not special-cased here — `git commit` exits
+// non-zero on an empty index and that structured error is returned; callers
+// pre-check StatusResult.Clean before invoking to avoid the raw git error.
+func CommitAll(ctx context.Context, workspaceRoot, message string) error {
+	if strings.TrimSpace(message) == "" {
+		return ErrEmptyCommitMessage
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, commitTimeout)
+	defer cancel()
+
+	if _, err := RunGitCtx(ctx, workspaceRoot, "add", "-A"); err != nil {
+		return fmt.Errorf("staging changes: %w", err)
+	}
+	if _, err := RunGitCtx(ctx, workspaceRoot, "commit", "-m", message); err != nil {
+		return fmt.Errorf("committing changes: %w", err)
+	}
+	return nil
+}

--- a/internal/git/writeback_design_test.go
+++ b/internal/git/writeback_design_test.go
@@ -3,10 +3,14 @@ package git
 // This file is a compile-checked API skeleton for the design spike
 // "Minimal safe git write-back surface (commit / merge from the UI)", which
 // lives with the maintainer's planning notes under plans/design/. It declares
-// the proposed v1 write-back signatures as unexported stubs so their shapes are
-// validated by the Go compiler, without shipping any wired production code:
-// nothing here is exported, keybound, or invoked. Delete or promote these once
-// the feature is actually built.
+// the still-unbuilt v1 write-back signatures as unexported stubs so their shapes
+// are validated by the Go compiler, without shipping any wired production code:
+// nothing here is exported, keybound, or invoked. Delete or promote each stub
+// once its feature is actually built.
+//
+// Action 1 (commit-all) has shipped: it is the exported git.CommitAll in
+// writeback.go, so its design stub has been removed. The merge/abort stubs below
+// remain skeletons pending plan 026.
 
 import (
 	"context"
@@ -18,14 +22,6 @@ import (
 // It exists only so the skeleton has observable, testable behavior; the real
 // implementation replaces these stubs entirely.
 var errWritebackDesignNotImplemented = errors.New("git write-back: not implemented (design skeleton)")
-
-// commitAllDesign is the proposed CommitAll: stage everything in workspaceRoot
-// (git add -A) and commit it with message (git commit -m <message>). See
-// Action 1 in the design doc.
-func commitAllDesign(ctx context.Context, workspaceRoot, message string) error {
-	_, _, _ = ctx, workspaceRoot, message
-	return errWritebackDesignNotImplemented
-}
 
 // mergeWorkspaceBranchDesign is the proposed MergeWorkspaceBranch: merge branch
 // into the branch already checked out in repoPath (git merge --no-ff -- <branch>).
@@ -45,7 +41,6 @@ func abortMergeDesign(ctx context.Context, repoPath string) error {
 // Compile-time signature guards: if the proposed API shape drifts, the build
 // breaks here before any test runs.
 var (
-	_ func(context.Context, string, string) error = commitAllDesign
 	_ func(context.Context, string, string) error = mergeWorkspaceBranchDesign
 	_ func(context.Context, string) error         = abortMergeDesign
 )
@@ -56,9 +51,6 @@ var (
 func TestWritebackDesignAPISkeleton(t *testing.T) {
 	ctx := context.Background()
 
-	if err := commitAllDesign(ctx, "/ws", "msg"); !errors.Is(err, errWritebackDesignNotImplemented) {
-		t.Fatalf("commitAllDesign: got %v, want not-implemented sentinel", err)
-	}
 	if err := mergeWorkspaceBranchDesign(ctx, "/repo", "branch"); !errors.Is(err, errWritebackDesignNotImplemented) {
 		t.Fatalf("mergeWorkspaceBranchDesign: got %v, want not-implemented sentinel", err)
 	}

--- a/internal/git/writeback_test.go
+++ b/internal/git/writeback_test.go
@@ -1,0 +1,125 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCommitAllCreatesCommit stages a dirty tree and commits it, asserting the
+// commit lands with the given message and the working tree ends clean. It runs
+// against a real temp repo built by testutil.InitRepo.
+func TestCommitAllCreatesCommit(t *testing.T) {
+	skipIfNoGit(t)
+	root := initRepo(t)
+
+	// Dirty the tree: a tracked modification plus a brand-new untracked file, so
+	// `add -A` must pick up both.
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "new.txt"), []byte("brand new\n"), 0o600); err != nil {
+		t.Fatalf("write new.txt: %v", err)
+	}
+
+	const msg = "wire up commit-all"
+	if err := CommitAll(context.Background(), root, msg); err != nil {
+		t.Fatalf("CommitAll: unexpected error: %v", err)
+	}
+
+	// The newest commit carries the message.
+	if got := runGit(t, root, "log", "-1", "--pretty=%s"); got != msg {
+		t.Fatalf("commit subject = %q, want %q", got, msg)
+	}
+	// Both files are now committed and the tree is clean.
+	if got := runGit(t, root, "status", "--porcelain"); got != "" {
+		t.Fatalf("working tree not clean after CommitAll: %q", got)
+	}
+	// The untracked file was staged and committed, not left behind.
+	tracked := runGit(t, root, "ls-files", "new.txt")
+	if strings.TrimSpace(tracked) != "new.txt" {
+		t.Fatalf("new.txt not tracked after CommitAll: ls-files = %q", tracked)
+	}
+}
+
+// TestCommitAllEmptyMessageRejected asserts a blank message is refused before
+// any git runs, so no commit is created.
+func TestCommitAllEmptyMessageRejected(t *testing.T) {
+	skipIfNoGit(t)
+	root := initRepo(t)
+
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	before := runGit(t, root, "rev-parse", "HEAD")
+
+	for _, msg := range []string{"", "   ", "\t\n"} {
+		err := CommitAll(context.Background(), root, msg)
+		if !errors.Is(err, ErrEmptyCommitMessage) {
+			t.Fatalf("CommitAll(%q): got %v, want ErrEmptyCommitMessage", msg, err)
+		}
+	}
+
+	// HEAD is unchanged: rejection happened before any git invocation, and the
+	// dirty change is still uncommitted.
+	if after := runGit(t, root, "rev-parse", "HEAD"); after != before {
+		t.Fatalf("HEAD moved after rejected commit: %q -> %q", before, after)
+	}
+	if got := runGit(t, root, "status", "--porcelain"); got == "" {
+		t.Fatalf("expected the tree to still be dirty after a rejected commit")
+	}
+}
+
+// TestCommitAllCleanTreeReturnsError documents the clean-tree contract: CommitAll
+// does not special-case an empty index, so `git commit` exits non-zero and the
+// structured git error surfaces. The UI pre-checks StatusResult.Clean to avoid
+// reaching this path; this test pins the fallback behavior.
+func TestCommitAllCleanTreeReturnsError(t *testing.T) {
+	skipIfNoGit(t)
+	root := initRepo(t) // initRepo leaves a clean tree with one commit.
+
+	before := runGit(t, root, "rev-parse", "HEAD")
+
+	err := CommitAll(context.Background(), root, "nothing to do")
+	if err == nil {
+		t.Fatalf("CommitAll on a clean tree: expected an error, got nil")
+	}
+	// Empty-message sentinel must not be what a clean tree returns.
+	if errors.Is(err, ErrEmptyCommitMessage) {
+		t.Fatalf("clean tree returned ErrEmptyCommitMessage, want a git error")
+	}
+
+	if after := runGit(t, root, "rev-parse", "HEAD"); after != before {
+		t.Fatalf("HEAD moved on a clean-tree commit: %q -> %q", before, after)
+	}
+}
+
+// TestCommitAllMessageNotShellInterpolated commits a message containing shell
+// metacharacters and a leading dash, then reads it back verbatim. Because the
+// message is the argv value of -m (never a shell string and never parsed as a
+// flag), it round-trips exactly.
+func TestCommitAllMessageNotShellInterpolated(t *testing.T) {
+	skipIfNoGit(t)
+	root := initRepo(t)
+
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	const msg = "--not-a-flag $(touch pwned) `id` && echo hi"
+	if err := CommitAll(context.Background(), root, msg); err != nil {
+		t.Fatalf("CommitAll: unexpected error: %v", err)
+	}
+
+	if got := runGit(t, root, "log", "-1", "--pretty=%s"); got != msg {
+		t.Fatalf("commit subject = %q, want verbatim %q", got, msg)
+	}
+	// The $(touch pwned) substring must not have run.
+	if _, err := os.Stat(filepath.Join(root, "pwned")); !os.IsNotExist(err) {
+		t.Fatalf("shell metacharacters were interpreted: pwned exists (err=%v)", err)
+	}
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -230,6 +230,20 @@ type ShowTrustScriptsDialog struct {
 	ConfigHash string
 }
 
+// ShowCommitWorkspaceDialog requests showing the commit-message input dialog
+// for a workspace's changes (git commit-all).
+type ShowCommitWorkspaceDialog struct {
+	Workspace *data.Workspace
+}
+
+// WorkspaceCommitted is sent when a commit-all attempt finishes. Err is non-nil
+// on failure (surfaced via ReportError); on success the sidebar diff/status view
+// is refreshed for the workspace.
+type WorkspaceCommitted struct {
+	Workspace *data.Workspace
+	Err       error
+}
+
 // ShowRemoveProjectDialog requests showing the remove project confirmation
 type ShowRemoveProjectDialog struct {
 	Project *data.Project

--- a/internal/ui/sidebar/model_input.go
+++ b/internal/ui/sidebar/model_input.go
@@ -87,6 +87,8 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			cmds = append(cmds, m.openCurrentItem())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("g"))):
 			cmds = append(cmds, m.refreshStatus())
+		case key.Matches(msg, key.NewBinding(key.WithKeys("c"))):
+			cmds = append(cmds, m.commitWorkspace())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("/"))):
 			// Enter filter mode
 			m.filterMode = true
@@ -181,6 +183,26 @@ func (m *Model) moveCursor(delta int) {
 
 	if newCursor >= 0 && newCursor < len(m.displayItems) {
 		m.cursor = newCursor
+	}
+}
+
+// commitWorkspace opens the commit-all dialog for the focused workspace. It
+// pre-checks the tree per the write-back design: a nil or clean status has
+// nothing to commit (git commit on an empty index errors), so it shows a note
+// instead of opening the dialog. Otherwise it emits ShowCommitWorkspaceDialog;
+// the actual git.CommitAll runs only after the user confirms with a message.
+func (m *Model) commitWorkspace() tea.Cmd {
+	if m.workspace == nil {
+		return nil
+	}
+	if m.gitStatus == nil || m.gitStatus.Clean {
+		return func() tea.Msg {
+			return messages.Toast{Message: "Nothing to commit", Level: messages.ToastInfo}
+		}
+	}
+	ws := m.workspace
+	return func() tea.Msg {
+		return messages.ShowCommitWorkspaceDialog{Workspace: ws}
 	}
 }
 

--- a/internal/ui/sidebar/model_input_test.go
+++ b/internal/ui/sidebar/model_input_test.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
 )
@@ -212,6 +213,53 @@ func TestInputClickOutsideRowsIsNoOp(t *testing.T) {
 	}
 	if m.cursor != before {
 		t.Fatalf("expected cursor unchanged on out-of-range click, got %d (was %d)", m.cursor, before)
+	}
+}
+
+func TestInputCommitKeyOpensDialogForFocusedWorkspace(t *testing.T) {
+	m := newInputModel(t) // dirty two-section status
+	ws := &data.Workspace{Name: "feature", Root: "/tmp/ws", Branch: "feature"}
+	m.SetWorkspace(ws)
+
+	_, cmd := m.Update(keyPress('c'))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from commit key on a dirty tree")
+	}
+	msg := cmd()
+	show, ok := msg.(messages.ShowCommitWorkspaceDialog)
+	if !ok {
+		t.Fatalf("expected messages.ShowCommitWorkspaceDialog, got %T", msg)
+	}
+	if show.Workspace != ws {
+		t.Fatalf("ShowCommitWorkspaceDialog carried wrong workspace: %+v", show.Workspace)
+	}
+}
+
+func TestInputCommitKeyCleanTreeShowsNote(t *testing.T) {
+	m := New()
+	m.SetSize(80, 20)
+	m.Focus()
+	m.SetWorkspace(&data.Workspace{Name: "feature", Root: "/tmp/ws"})
+	m.SetGitStatus(&git.StatusResult{Clean: true})
+
+	_, cmd := m.Update(keyPress('c'))
+	if cmd == nil {
+		t.Fatal("expected a note cmd when committing a clean tree")
+	}
+	toast, ok := cmd().(messages.Toast)
+	if !ok {
+		t.Fatalf("expected messages.Toast for a clean tree, got %T", cmd())
+	}
+	if toast.Message != "Nothing to commit" {
+		t.Fatalf("unexpected clean-tree toast: %q", toast.Message)
+	}
+}
+
+func TestInputCommitKeyNoWorkspaceIsNoOp(t *testing.T) {
+	m := newInputModel(t) // dirty status but no workspace set
+	_, cmd := m.Update(keyPress('c'))
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for commit key with no workspace, got a cmd emitting %T", cmd())
 	}
 }
 

--- a/internal/ui/sidebar/model_view.go
+++ b/internal/ui/sidebar/model_view.go
@@ -189,6 +189,7 @@ func (m *Model) helpLines(contentWidth int) []string {
 		m.helpItem("k/↑", "up"),
 		m.helpItem("j/↓", "down"),
 		m.helpItem("enter/o", "open"),
+		m.helpItem("c", "commit"),
 		m.helpItem("/", "filter"),
 		m.helpItem("g", "refresh"),
 	}


### PR DESCRIPTION
The README promises 'merge changes back when done' but amux had no production git write verb — review inside amux, then leave to act. Ships the smallest safe slice: git.CommitAll(ctx, root, message) = add -A then commit -m via the hardened RunGitCtx, message passed as a distinct argv element (TestCommitAllMessageNotShellInterpolated commits '$(touch pwned)' and proves pwned is never created), empty message rejected, 15s timeout. A sidebar c key opens a commit-message dialog → CommitAll with ReportError on failure; clean tree shows 'Nothing to commit'. NO merge/push/force/amend/autostash/base-checkout (those are plan 026). Design commitAllDesign stub promoted; merge/abort stubs kept for 026. Real-temp-repo tests + seam-based UI wiring tests; harness-golden + lint-ci-parity green. (plan 025)