### PR TITLE
style: fix goimports grouping in benchmark_style_test.go

### DIFF
--- a/internal/ui/compositor/benchmark_style_test.go
+++ b/internal/ui/compositor/benchmark_style_test.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/andyrewlee/amux/internal/vterm"
 	uv "github.com/charmbracelet/ultraviolet"
+
+	"github.com/andyrewlee/amux/internal/vterm"
 )
 
 func BenchmarkStyleDeltaANSI(b *testing.B) {


### PR DESCRIPTION
Hotfix for main CI. The #595 file split (benchmark_test.go → benchmark_style_test.go) grouped the local `internal/vterm` import with third-party `ultraviolet`; the pinned strict linter's goimports requires local-prefix imports in a trailing group. This splits them into stdlib / third-party / local.

- `make lint-ci-parity` → exit 0
- `.cache/bin/golangci-lint run internal/ui/compositor/...` → 0 issues