### PR TITLE
test: pin repo-local git identity in testutil.InitRepo

### DIFF
--- a/internal/testutil/gitrepo.go
+++ b/internal/testutil/gitrepo.go
@@ -61,6 +61,13 @@ func InitRepoWithBranch(t gitTB, branch string) string {
 	t.Helper()
 	root := t.TempDir()
 	RunGit(t, root, "init", "-b", branch)
+	// Pin a repo-local identity so any commit in this repo succeeds — including
+	// production code paths under test (e.g. git.CommitAll) that shell out with a
+	// clean env and cannot see RunGit's GIT_AUTHOR_*/GIT_COMMITTER_* injection.
+	// CI runners have no global git identity, so without this git aborts with
+	// "Author identity unknown".
+	RunGit(t, root, "config", "user.name", "Test")
+	RunGit(t, root, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("init\n"), 0o600); err != nil {
 		t.Fatalf("write README: %v", err)
 	}


### PR DESCRIPTION
Hotfix for main CI (`test` job red).

`git.CommitAll` (plan 025, #594) shells out with a clean env and cannot see `RunGit`'s `GIT_AUTHOR_*`/`GIT_COMMITTER_*` injection. On CI runners with no global git identity, its `git commit` aborts with "Author identity unknown", failing `TestCommitAllCreatesCommit` and `TestCommitAllMessageNotShellInterpolated`. It passed locally only because dev machines have a global identity (macOS git also auto-derives `user@host`).

Fix: set repo-local `user.name`/`user.email` in `testutil.InitRepo`, which git honors over auto-detection and which any commit in the temp repo reads from `.git/config`.

Reproduced locally under `user.useConfigOnly=true` (which disables auto-detection, matching the runner): **fails** without the fix (`no email was given and auto-detection is disabled`), **passes** with it. Full `internal/git` + `internal/testutil` + app consumer tests green.