### PR TITLE
fix: make the settings dialog height-aware and scrollable

### DIFF
--- a/internal/ui/common/settings.go
+++ b/internal/ui/common/settings.go
@@ -64,6 +64,13 @@ type SettingsDialog struct {
 	themes      []Theme
 	session     int
 
+	// scrollOffset is the first visible row of the scrollable body (the
+	// section between the fixed "Settings" header and the fixed "[Close]"
+	// footer). It is recomputed on every render (see composeVisibleLines in
+	// settings_scroll.go) so it always keeps the focused row in view,
+	// without requiring every navigation handler to update it explicitly.
+	scrollOffset int
+
 	// For mouse hit detection
 	hitRegions []settingsHitRegion
 
@@ -346,7 +353,12 @@ func (s *SettingsDialog) handlePrev() (*SettingsDialog, tea.Cmd) {
 }
 
 func (s *SettingsDialog) handleClick(msg tea.MouseClickMsg) tea.Cmd {
-	lines := s.renderLines()
+	// composeVisibleLines is what View() actually renders (a height-clamped,
+	// scroll-offset window of the body plus the always-visible footer), and
+	// it remaps s.hitRegions to match those on-screen coordinates. Using the
+	// raw, unclamped renderLines() here would let clicks resolve against
+	// rows that are currently scrolled out of view.
+	lines := s.composeVisibleLines()
 	contentHeight := len(lines)
 	if contentHeight == 0 {
 		return nil
@@ -381,7 +393,7 @@ func (s *SettingsDialog) View() string {
 	if !s.visible {
 		return ""
 	}
-	return s.dialogStyle().Render(strings.Join(s.renderLines(), "\n"))
+	return s.dialogStyle().Render(strings.Join(s.composeVisibleLines(), "\n"))
 }
 
 func (s *SettingsDialog) dialogContentWidth() int {

--- a/internal/ui/common/settings_scroll.go
+++ b/internal/ui/common/settings_scroll.go
@@ -1,0 +1,147 @@
+package common
+
+// settingsHeaderLines and settingsFooterLines encode a structural invariant
+// of renderLines() in settings_render.go: it always begins with exactly two
+// fixed lines ("Settings" + a blank) and always ends with exactly two fixed
+// lines (a blank + "[Close]"), regardless of which optional sections
+// (the update hint, the update affordance) are present. Everything between
+// those two fixed slices is the scrollable body.
+// TestSettingsRenderHeaderFooterInvariant guards this assumption.
+const (
+	settingsHeaderLines = 2
+	settingsFooterLines = 2
+)
+
+// composeVisibleLines returns the lines SettingsDialog actually renders: the
+// fixed header, a height-clamped and scroll-offset window of the body, and
+// the fixed footer ("[Close]" and its border are always shown, never
+// scrolled out of view). Modeled on the file picker's scrollOffset/
+// maxVisible viewport (internal/ui/common/filepicker.go).
+//
+// It also rewrites s.hitRegions -- populated as a side effect of
+// renderLines(), in full/unclamped coordinates -- into the coordinates of
+// the composed/visible lines, dropping hit regions for rows currently
+// scrolled out of view so clicks can't resolve against invisible rows.
+func (s *SettingsDialog) composeVisibleLines() []string {
+	full := s.renderLines()
+	fullHits := s.hitRegions
+
+	if len(full) < settingsHeaderLines+settingsFooterLines {
+		// Not enough content to have a meaningful header/body/footer split;
+		// this cannot happen with the current renderLines() implementation,
+		// but render unclamped rather than risk a slice panic.
+		return full
+	}
+
+	bodyLen := len(full) - settingsHeaderLines - settingsFooterLines
+	visibleBody := s.bodyWindowHeight(bodyLen)
+	offset := s.clampScrollOffset(fullHits, bodyLen, visibleBody)
+
+	lines := make([]string, 0, settingsHeaderLines+visibleBody+settingsFooterLines)
+	lines = append(lines, full[:settingsHeaderLines]...)
+	bodyStart := settingsHeaderLines + offset
+	lines = append(lines, full[bodyStart:bodyStart+visibleBody]...)
+	lines = append(lines, full[len(full)-settingsFooterLines:]...)
+
+	s.hitRegions = remapHitRegions(fullHits, len(full), offset, visibleBody)
+	return lines
+}
+
+// bodyWindowHeight returns how many body rows fit given the dialog's
+// assigned height. An unset height (0, as in tests that construct a dialog
+// and call renderLines()/View() without ever calling SetSize) is treated as
+// unbounded, so existing content-only assertions keep working without
+// requiring every test to size the dialog first.
+func (s *SettingsDialog) bodyWindowHeight(bodyLen int) int {
+	if bodyLen <= 0 {
+		return 0
+	}
+	if s.height <= 0 {
+		return bodyLen
+	}
+
+	_, frameY, _, _ := s.dialogFrame()
+	avail := s.height - frameY - settingsHeaderLines - settingsFooterLines
+	if avail < 1 {
+		avail = 1 // always show at least one body row alongside the footer
+	}
+	if avail > bodyLen {
+		avail = bodyLen
+	}
+	return avail
+}
+
+// clampScrollOffset adjusts (and persists into s.scrollOffset) the first
+// visible body row so the currently focused item's row stays inside the
+// visible window -- the same ensure-visible shape as the file picker's
+// ensureVisible, just evaluated fresh on every render instead of requiring
+// each navigation handler (handleNext, handlePrev, handleClick, ...) to
+// call it explicitly. If the focused item isn't part of the scrollable body
+// (settingsItemClose lives in the fixed footer), the offset is left as-is:
+// it keeps whatever position navigation last scrolled the body to.
+func (s *SettingsDialog) clampScrollOffset(fullHits []settingsHitRegion, bodyLen, visibleBody int) int {
+	if visibleBody >= bodyLen {
+		s.scrollOffset = 0
+		return 0
+	}
+
+	if idx := focusedBodyIndex(fullHits, s.focusedItem, s.themeCursor); idx >= 0 {
+		switch {
+		case idx < s.scrollOffset:
+			s.scrollOffset = idx
+		case idx >= s.scrollOffset+visibleBody:
+			s.scrollOffset = idx - visibleBody + 1
+		}
+	}
+
+	if maxOffset := bodyLen - visibleBody; s.scrollOffset > maxOffset {
+		s.scrollOffset = maxOffset
+	}
+	if s.scrollOffset < 0 {
+		s.scrollOffset = 0
+	}
+	return s.scrollOffset
+}
+
+// focusedBodyIndex finds the body-relative row (0-based, excluding the
+// header) of the currently focused item using the hit regions renderLines
+// already records for every focusable row. It returns -1 when the focused
+// item has no body row (settingsItemClose, rendered in the fixed footer).
+func focusedBodyIndex(hits []settingsHitRegion, focused settingsItem, themeCursor int) int {
+	for _, h := range hits {
+		if h.item != focused {
+			continue
+		}
+		if focused == settingsItemTheme && h.index != themeCursor {
+			continue
+		}
+		return h.region.Y - settingsHeaderLines
+	}
+	return -1
+}
+
+// remapHitRegions translates hit regions from renderLines' full, unclamped
+// coordinates into the coordinates of the composed/visible lines, dropping
+// any row currently scrolled out of the body window.
+func remapHitRegions(hits []settingsHitRegion, fullLen, offset, visibleBody int) []settingsHitRegion {
+	footerStart := fullLen - settingsFooterLines
+	out := make([]settingsHitRegion, 0, len(hits))
+	for _, h := range hits {
+		y := h.region.Y
+		switch {
+		case y < settingsHeaderLines:
+			// Header rows aren't focusable/clickable today, but keep the
+			// mapping total (identity) in case that changes.
+		case y >= footerStart:
+			h.region.Y = settingsHeaderLines + visibleBody + (y - footerStart)
+		default:
+			bodyIdx := y - settingsHeaderLines
+			if bodyIdx < offset || bodyIdx >= offset+visibleBody {
+				continue // scrolled out of view: not clickable
+			}
+			h.region.Y = settingsHeaderLines + (bodyIdx - offset)
+		}
+		out = append(out, h)
+	}
+	return out
+}

--- a/internal/ui/common/settings_scroll_test.go
+++ b/internal/ui/common/settings_scroll_test.go
@@ -1,0 +1,195 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestSettingsRenderHeaderFooterInvariant guards the structural assumption
+// composeVisibleLines relies on: renderLines() always starts with exactly
+// settingsHeaderLines fixed lines ("Settings" + a blank) and always ends
+// with exactly settingsFooterLines fixed lines (a blank + "[Close]"),
+// whether or not the optional update hint/affordance are present.
+func TestSettingsRenderHeaderFooterInvariant(t *testing.T) {
+	assertShape := func(t *testing.T, lines []string) {
+		t.Helper()
+		if len(lines) < settingsHeaderLines+settingsFooterLines {
+			t.Fatalf("renderLines() returned %d lines, want at least %d", len(lines), settingsHeaderLines+settingsFooterLines)
+		}
+		if !strings.Contains(lines[0], "Settings") {
+			t.Errorf("line 0 = %q, want the Settings title", lines[0])
+		}
+		if lines[1] != "" {
+			t.Errorf("line 1 = %q, want a blank header separator", lines[1])
+		}
+		last := lines[len(lines)-1]
+		if !strings.Contains(last, "[Close]") {
+			t.Errorf("last line = %q, want [Close]", last)
+		}
+		if lines[len(lines)-2] != "" {
+			t.Errorf("second-to-last line = %q, want a blank footer separator", lines[len(lines)-2])
+		}
+	}
+
+	d := NewSettingsDialog(ThemeAyuDark, "", "", "")
+	assertShape(t, d.renderLines())
+
+	// The update affordance adds a line to the body; the header/footer shape
+	// must not move.
+	d.SetUpdateInfo("v1", "v2", true)
+	assertShape(t, d.renderLines())
+
+	// The update hint also adds a body line.
+	d.SetUpdateInfo("v1", "", false)
+	d.SetUpdateHint("Installed via Homebrew - update with brew upgrade amux")
+	assertShape(t, d.renderLines())
+}
+
+// TestSettingsViewClampsBodyToHeight confirms View() never renders taller
+// than the dialog's assigned height once the body no longer fits, and that
+// [Close] plus the bottom border are still the final two rendered lines.
+func TestSettingsViewClampsBodyToHeight(t *testing.T) {
+	d := NewSettingsDialog(ThemeAyuDark, "", "", "")
+	const height = 15 // short enough that the 19-theme body must scroll
+	d.SetSize(120, height)
+	d.Show()
+
+	lines := d.composeVisibleLines()
+	_, frameY, _, _ := d.dialogFrame()
+	total := len(lines) + frameY
+	if total > height {
+		t.Fatalf("composed dialog height = %d, want <= assigned height %d", total, height)
+	}
+
+	if !strings.Contains(lines[len(lines)-1], "[Close]") {
+		t.Fatalf("expected last composed line to be [Close], got %q", lines[len(lines)-1])
+	}
+
+	view := d.View()
+	if !strings.Contains(view, "[Close]") {
+		t.Fatal("expected [Close] to be rendered by View()")
+	}
+	if !strings.Contains(view, "╰") {
+		t.Fatal("expected the dialog's bottom border to be rendered by View()")
+	}
+}
+
+// TestSettingsViewScrollsThemeCursorIntoView drives themeCursor to the last
+// theme (far past a short dialog's visible window) and confirms View()
+// scrolls the body so that theme's name is visible, while [Close] remains
+// visible throughout.
+func TestSettingsViewScrollsThemeCursorIntoView(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0), "", "", "")
+	if len(d.themes) < 8 {
+		t.Skip("need enough themes to force scrolling at a short height")
+	}
+	d.SetSize(120, 15)
+	d.Show()
+	d.focusedItem = settingsItemTheme
+
+	// Wrap backward from the first theme to the last: far below a 15-row
+	// dialog's visible window.
+	_, _ = d.handlePrev()
+
+	view := d.View()
+	lastTheme := d.themes[len(d.themes)-1].Name
+	if !strings.Contains(view, lastTheme) {
+		t.Fatalf("expected focused theme %q to be scrolled into view, got:\n%s", lastTheme, view)
+	}
+	if !strings.Contains(view, "[Close]") {
+		t.Fatal("expected [Close] to remain visible while the body is scrolled")
+	}
+}
+
+// TestSettingsScrollOffsetAdvancesAndRetreatsWithNavigation exercises the
+// up/down theme navigation (handleNext/handlePrev) at a height too short to
+// show every theme, confirming scrollOffset advances as focus moves past the
+// visible window and retreats back to 0 once focus returns to the top.
+func TestSettingsScrollOffsetAdvancesAndRetreatsWithNavigation(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0), "", "", "")
+	if len(d.themes) < 8 {
+		t.Skip("need enough themes to force scrolling at a short height")
+	}
+	d.SetSize(120, 15)
+	d.Show()
+
+	d.View() // establish baseline: cursor 0 is within the initial window
+	if d.scrollOffset != 0 {
+		t.Fatalf("initial scrollOffset = %d, want 0", d.scrollOffset)
+	}
+
+	for i := 0; i < len(d.themes)-1; i++ {
+		_, _ = d.handleNext()
+	}
+	d.View()
+	if d.scrollOffset == 0 {
+		t.Fatal("expected scrollOffset to advance once the focused theme scrolled past the visible window")
+	}
+
+	for i := 0; i < len(d.themes)-1; i++ {
+		_, _ = d.handlePrev()
+	}
+	d.View()
+	// Theme 0's row is body index 1 (body index 0 is the non-focusable
+	// "Theme" section label), so the minimal offset that keeps it visible
+	// while scrolling up from further down the list is 1, not 0.
+	if d.scrollOffset != 1 {
+		t.Fatalf("scrollOffset after returning to theme 0 = %d, want 1", d.scrollOffset)
+	}
+	if !strings.Contains(d.View(), d.themes[0].Name) {
+		t.Fatalf("expected theme 0 (%q) to be visible after returning to it", d.themes[0].Name)
+	}
+}
+
+// TestSettingsViewCloseAlwaysVisibleAtAnyHeight focuses Close directly
+// (bypassing the navigation handlers, the way handleSelect/handleClick
+// would leave it) across a range of heights and confirms [Close] and the
+// dialog's bottom border are always part of the rendered output.
+func TestSettingsViewCloseAlwaysVisibleAtAnyHeight(t *testing.T) {
+	for _, h := range []int{9, 10, 15, 20, 24, 36, 60} {
+		d := NewSettingsDialog(ThemeAyuDark, "", "", "")
+		d.SetSize(120, h)
+		d.Show()
+		d.focusedItem = settingsItemClose
+
+		view := d.View()
+		if !strings.Contains(view, "[Close]") {
+			t.Errorf("height=%d: expected [Close] visible, got:\n%s", h, view)
+		}
+		if !strings.Contains(view, "╰") {
+			t.Errorf("height=%d: expected the bottom border rune present, got:\n%s", h, view)
+		}
+	}
+}
+
+// TestSettingsClickOnCloseWorksWhenBodyIsScrolled exercises handleClick
+// through composeVisibleLines/remapHitRegions at a height short enough that
+// the body is scrolled, confirming a click on [Close] (always the last
+// composed line, in the fixed footer) still resolves correctly.
+func TestSettingsClickOnCloseWorksWhenBodyIsScrolled(t *testing.T) {
+	d := NewSettingsDialog(themeAt(t, 0), "", "", "")
+	d.SetSize(120, 15)
+	d.Show()
+
+	lines := d.composeVisibleLines()
+	contentHeight := len(lines)
+	dialogX, dialogY, _, _ := d.dialogBounds(contentHeight)
+	_, _, contentOffsetX, contentOffsetY := d.dialogFrame()
+
+	closeLocalY := len(lines) - 1
+	msg := tea.MouseClickMsg{
+		Button: tea.MouseLeft,
+		X:      dialogX + contentOffsetX,
+		Y:      dialogY + contentOffsetY + closeLocalY,
+	}
+
+	cmd := d.handleClick(msg)
+	if d.Visible() {
+		t.Fatal("clicking [Close] should hide the dialog")
+	}
+	if cmd == nil {
+		t.Fatal("expected a SettingsResult command from clicking [Close]")
+	}
+}


### PR DESCRIPTION
Implements plan 043 (prerequisite that unblocks plan 031).

The Settings dialog's `View()` joined all `renderLines()` with no height clamp, so at any terminal shorter than 36 rows `[Close]` and the bottom border clipped off. This makes `View()` height-aware: it renders the fixed header + a scroll-offset, height-clamped window of the body + the always-visible `[Close]` footer, scrolling the focused row into view. Modeled on the file picker's viewport. `handleClick` uses the same composed lines and remapped hit regions so clicks can't resolve against scrolled-out rows.

- **No golden change**: at the preset 120×36 the body already fit exactly, so the clamp is a no-op there and `overlay_settings.frame` is byte-identical; the fix only engages below 36 rows.
- Verified: 120×24 now shows `[Close]` + border unclipped (was clipped); 120×36 byte-identical.
- Gates (re-run by reviewer on the branch): build, `internal/ui/common`+`internal/app` tests, `make harness-golden` ×2 (deterministic), `-update` = 0 golden changes, `make lint-ci-parity`, `check-file-length` — all exit 0.

New: `internal/ui/common/settings_scroll.go` (compose/clamp/remap) + `settings_scroll_test.go` (scroll, ensure-visible, click-when-scrolled, header/footer-invariant tests).