### PR TITLE
chore: pin ultraviolet in dependabot; fix env + linting docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "github.com/charmbracelet/ultraviolet"
     groups:
       # The Charm stack moves fast and spans two module prefixes; batch it
       # into a single PR so updates don't arrive piecemeal.

--- a/LINTING.md
+++ b/LINTING.md
@@ -13,7 +13,8 @@ make devcheck
 This runs:
 
 - `go vet ./...`
-- `go test ./...`
+- `go test` on all packages except `internal/tmux`, `internal/e2e`, and
+  `internal/app` (those run separately via a real-tmux skip check)
 - `golangci-lint run`
 - file length guard (`*.go` files must be <= 500 lines)
 
@@ -105,7 +106,7 @@ Focus areas:
 - correctness and safety (`errcheck`, `govet`, `staticcheck`, `unused`, `errorlint`)
 - mechanical consistency (`gofumpt`, `gofmt`, `goimports`, `copyloopvar`)
 - dependency and output discipline (`depguard`, `forbidigo`)
-- hygiene (`nolintlint`, `misspell`, `unconvert`, `ineffassign`, `gosimple`, `whitespace`)
+- hygiene (`nolintlint`, `misspell`, `unconvert`, `ineffassign`, `whitespace`) — the simplification checks formerly provided by a standalone S-series linter are folded into `staticcheck` under the pinned golangci-lint (see `.golangci-version`), not a separate linter
 - test helper quality (`thelper`)
 
 ## `nolint` Policy

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Create `.amux/workspaces.json` in your project to define commands that amux runs
 - `run` — the command started for a workspace's run script.
 - `archive` — the command run when a workspace is archived.
 
+### Environment available to workspace scripts
+
+`setup-workspace`, `run`, and `archive` scripts run with these variables set, in addition to your normal shell environment:
+
+| Variable | Meaning |
+|----------|---------|
+| `AMUX_WORKSPACE_NAME` | The workspace name |
+| `AMUX_WORKSPACE_ROOT` | The workspace worktree path |
+| `AMUX_WORKSPACE_BRANCH` | The workspace's git branch |
+| `ROOT_WORKSPACE_PATH` | The source repository root (also shown in the example above) |
+| `AMUX_PORT` | An allocated per-workspace port — bind dev servers here to avoid collisions across parallel workspaces |
+| `AMUX_PORT_RANGE` | The `start-end` port range allocated to this workspace |
+
 Because these commands come from the repository, amux runs them only after you trust the repo. The first time a repo's `.amux/workspaces.json` would run (and every time its contents change), amux records the approved content of the file; until then those project-supplied scripts are skipped and you are notified, rather than executing arbitrary commands chosen by the repo's author. Editing `.amux/workspaces.json` invalidates the approval, so changed commands are re-gated until you trust the file again. (Run/archive scripts you enter yourself in the amux UI are your own input and are never gated.)
 
 Workspace metadata is stored in `~/.amux/workspaces-metadata/<workspace-id>/workspace.json`, and local worktree directories live under `~/.amux/workspaces/<project>/<workspace>`. Trusted-repo approvals are recorded in `~/.amux/trusted-scripts.json`.


### PR DESCRIPTION
Implements plan 052 (DEPS-03 + DOCS-01 + DOCS-02).

- `.github/dependabot.yml`: ignore `github.com/charmbracelet/ultraviolet` so the weekly charm-group PR can't bump it independently of bubbletea. Still moves transitively via bubbletea's MVS.
- `README.md`: 'Environment available to workspace scripts' table (6 vars incl. `AMUX_PORT`), matching `internal/process/env.go`.
- `LINTING.md`: drop `gosimple` (folded into staticcheck under pinned v2.12.2); correct the `go test ./...` claim.

Docs/config only; `make devcheck` exit 0.