### PR TITLE
refactor: share dialog chrome across common dialogs

### DIFF
--- a/internal/ui/common/dialog_chrome.go
+++ b/internal/ui/common/dialog_chrome.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"charm.land/lipgloss/v2"
+)
+
+// dialogBorderStyle returns the shared bordered dialog chrome style used by
+// Dialog, SettingsDialog, and FilePicker: a rounded border in the primary
+// color with (1,2) padding, sized to the given content width.
+func dialogBorderStyle(width int) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary()).
+		Padding(1, 2).
+		Width(width)
+}
+
+// dialogFrameOffsets returns the frame size (border + padding) of the given
+// dialog style and the corresponding half-offsets used to align content
+// within that frame.
+func dialogFrameOffsets(style lipgloss.Style) (frameX, frameY, offsetX, offsetY int) {
+	frameX, frameY = style.GetFrameSize()
+	offsetX = frameX / 2
+	offsetY = frameY / 2
+	return frameX, frameY, offsetX, offsetY
+}
+
+// centerDialogBounds centers a dialog of the given content width/height
+// (plus frame) within a screen of screenW x screenH, clamping the resulting
+// position to be non-negative.
+func centerDialogBounds(screenW, screenH, contentW, frameX, frameY, contentHeight int) (x, y, w, h int) {
+	w = contentW + frameX
+	h = contentHeight + frameY
+	x = (screenW - w) / 2
+	y = (screenH - h) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	return x, y, w, h
+}

--- a/internal/ui/common/dialog_render.go
+++ b/internal/ui/common/dialog_render.go
@@ -88,18 +88,11 @@ func (d *Dialog) dialogContentWidth() int {
 }
 
 func (d *Dialog) dialogStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary()).
-		Padding(1, 2).
-		Width(d.dialogContentWidth())
+	return dialogBorderStyle(d.dialogContentWidth())
 }
 
 func (d *Dialog) dialogFrame() (frameX, frameY, offsetX, offsetY int) {
-	frameX, frameY = d.dialogStyle().GetFrameSize()
-	offsetX = frameX / 2
-	offsetY = frameY / 2
-	return frameX, frameY, offsetX, offsetY
+	return dialogFrameOffsets(d.dialogStyle())
 }
 
 // renderedLineCount returns the number of content-area lines after the dialog

--- a/internal/ui/common/filepicker_render.go
+++ b/internal/ui/common/filepicker_render.go
@@ -22,33 +22,16 @@ func (fp *FilePicker) View() string {
 const filePickerContentWidth = 55
 
 func (fp *FilePicker) dialogStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary()).
-		Padding(1, 2).
-		Width(filePickerContentWidth)
+	return dialogBorderStyle(filePickerContentWidth)
 }
 
 func (fp *FilePicker) dialogFrame() (frameX, frameY, offsetX, offsetY int) {
-	frameX, frameY = fp.dialogStyle().GetFrameSize()
-	offsetX = frameX / 2
-	offsetY = frameY / 2
-	return frameX, frameY, offsetX, offsetY
+	return dialogFrameOffsets(fp.dialogStyle())
 }
 
 func (fp *FilePicker) dialogBounds(contentHeight int) (x, y, w, h int) {
 	frameX, frameY, _, _ := fp.dialogFrame()
-	w = filePickerContentWidth + frameX
-	h = contentHeight + frameY
-	x = (fp.width - w) / 2
-	y = (fp.height - h) / 2
-	if x < 0 {
-		x = 0
-	}
-	if y < 0 {
-		y = 0
-	}
-	return x, y, w, h
+	return centerDialogBounds(fp.width, fp.height, filePickerContentWidth, frameX, frameY, contentHeight)
 }
 
 func (fp *FilePicker) renderLines() []string {

--- a/internal/ui/common/settings.go
+++ b/internal/ui/common/settings.go
@@ -422,9 +422,5 @@ func (s *SettingsDialog) dialogContentWidth() int {
 }
 
 func (s *SettingsDialog) dialogStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary()).
-		Padding(1, 2).
-		Width(s.dialogContentWidth())
+	return dialogBorderStyle(s.dialogContentWidth())
 }

--- a/internal/ui/common/settings_render.go
+++ b/internal/ui/common/settings_render.go
@@ -5,22 +5,12 @@ import (
 )
 
 func (s *SettingsDialog) dialogFrame() (frameX, frameY, offsetX, offsetY int) {
-	frameX, frameY = s.dialogStyle().GetFrameSize()
-	return frameX, frameY, frameX / 2, frameY / 2
+	return dialogFrameOffsets(s.dialogStyle())
 }
 
 func (s *SettingsDialog) dialogBounds(contentHeight int) (x, y, w, h int) {
-	contentWidth := s.dialogContentWidth()
 	frameX, frameY, _, _ := s.dialogFrame()
-	w, h = contentWidth+frameX, contentHeight+frameY
-	x, y = (s.width-w)/2, (s.height-h)/2
-	if x < 0 {
-		x = 0
-	}
-	if y < 0 {
-		y = 0
-	}
-	return x, y, w, h
+	return centerDialogBounds(s.width, s.height, s.dialogContentWidth(), frameX, frameY, contentHeight)
 }
 
 func (s *SettingsDialog) addHit(item settingsItem, index, y int) {


### PR DESCRIPTION
Implements plan 055 (TECHDEBT-01). Consolidates the duplicated `dialogStyle`/`dialogFrame`/`dialogBounds` across `Dialog`/`SettingsDialog`/`FilePicker` into shared package-level helpers in new `internal/ui/common/dialog_chrome.go`.

Reviewer re-ran on the branch: delegations byte-for-byte identical to originals; each dialog keeps its own width source; `Dialog`'s renderedLineCount/bounds model untouched. build + common tests + `make harness-golden` (byte-identical ×2) + check-file-length all green.