### PR TITLE
fix: clamp SGR truecolor and blank last-column wide glyph

### DIFF
--- a/internal/ui/compositor/vtermlayer.go
+++ b/internal/ui/compositor/vtermlayer.go
@@ -108,6 +108,13 @@ func (l *VTermLayer) DrawAt(s uv.Screen, posX, posY, maxWidth, maxHeight int) {
 		for x := 0; x < width && x < len(row); x++ {
 			cell := row[x]
 
+			// A wide glyph landing on the last visible column can't render its
+			// second half; substitute a blank there instead of emitting a
+			// truncated wide cell. Mirrors canvas.go's DrawScreen guard.
+			if cell.Width == 2 && x+1 >= width {
+				cell = vterm.DefaultCell()
+			}
+
 			// For continuation cells (part of wide character), write an empty cell
 			// to clear any stale content at that position from previous renders.
 			if cell.Width == 0 {

--- a/internal/ui/compositor/vtermlayer_test.go
+++ b/internal/ui/compositor/vtermlayer_test.go
@@ -143,6 +143,33 @@ func TestVTermLayerClearsContinuationCells(t *testing.T) {
 	}
 }
 
+// TestVTermLayerBlanksWideGlyphOnLastColumn asserts DrawAt substitutes a
+// blank for a Width==2 cell that lands on the last visible column (e.g. after
+// a narrowing resize leaves a wide glyph at width-1), matching canvas.go's
+// DrawScreen guard (cell.Width == 2 && col+1 >= w).
+func TestVTermLayerBlanksWideGlyphOnLastColumn(t *testing.T) {
+	screen := [][]vterm.Cell{
+		{vterm.DefaultCell(), {Rune: '中', Width: 2}},
+	}
+	snap := &VTermSnapshot{
+		Screen: screen,
+		Width:  2,
+		Height: 1,
+	}
+	layer := NewVTermLayer(snap)
+
+	s := &bufferScreen{Buffer: uv.NewBuffer(2, 1)}
+	layer.Draw(s, s.Bounds())
+
+	cell := s.CellAt(1, 0)
+	if cell == nil {
+		t.Fatalf("expected cell to be written at last column")
+	}
+	if cell.Width != 1 || cell.Content != " " {
+		t.Fatalf("expected blank single-width cell at last column, got width=%d content=%q", cell.Width, cell.Content)
+	}
+}
+
 func TestVTermSnapshotHonorsCursorHideOutsideAltScreen(t *testing.T) {
 	term := vterm.New(10, 3)
 	term.Write([]byte("\x1b[?25l")) // hide cursor outside alt screen

--- a/internal/vterm/sgr.go
+++ b/internal/vterm/sgr.go
@@ -75,7 +75,7 @@ func (p *Parser) parseExtendedColor(i int, color *Color) int {
 			g := p.params[i+3]
 			b := p.params[i+4]
 			color.Type = ColorRGB
-			color.Value = uint32(r)<<16 | uint32(g)<<8 | uint32(b)
+			color.Value = clampColorComponent(r)<<16 | clampColorComponent(g)<<8 | clampColorComponent(b)
 			return i + 4
 		}
 	case 5: // 256 color
@@ -86,4 +86,19 @@ func (p *Parser) parseExtendedColor(i int, color *Color) int {
 		}
 	}
 	return i + 1
+}
+
+// clampColorComponent clamps a parsed SGR truecolor component to [0,255]
+// before it is packed into a Color.Value, mirroring the string-render path's
+// sgrColorComponent (internal/ui/compositor/canvas_drawable.go). Without this,
+// an out-of-range component (e.g. `\x1b[38;2;255;300;0m`) overflows into
+// adjacent channels when shifted and packed.
+func clampColorComponent(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if v > 255 {
+		return 255
+	}
+	return uint32(v)
 }

--- a/internal/vterm/vterm_test.go
+++ b/internal/vterm/vterm_test.go
@@ -199,6 +199,22 @@ func TestCSISemicolonParameterParsing(t *testing.T) {
 	}
 }
 
+func TestSGRTruecolorClampsOutOfRangeComponent(t *testing.T) {
+	t.Parallel()
+	vt := New(80, 24)
+
+	// A component above 255 must clamp instead of overflowing into the
+	// adjacent channel when packed into Color.Value.
+	vt.Write([]byte("\x1b[38;2;255;300;0m"))
+	if vt.CurrentStyle.Fg.Type != ColorRGB {
+		t.Errorf("Expected ColorRGB, got %v", vt.CurrentStyle.Fg.Type)
+	}
+	expected := uint32(255)<<16 | uint32(255)<<8 | uint32(0)
+	if vt.CurrentStyle.Fg.Value != expected {
+		t.Errorf("Expected clamped RGB value %#06x, got %#06x", expected, vt.CurrentStyle.Fg.Value)
+	}
+}
+
 func TestVersionBumpsOnCursorMoveAndAltScreenCursorHide(t *testing.T) {
 	t.Parallel()
 	vt := New(10, 5)


### PR DESCRIPTION
Implements plan 047 (VT-CORR-03 + VT-CORR-05). Two vterm render fixes, each aligning a path with its already-correct sibling:
- `internal/vterm/sgr.go`: clamp SGR truecolor r/g/b to [0,255] before packing (was overflowing into adjacent channels); mirrors `canvas_drawable.go`'s `sgrColorComponent`.
- `internal/ui/compositor/vtermlayer.go`: blank a `Width==2` glyph on the last column in `DrawAt`; mirrors `canvas.go`'s guard.

Reviewer re-ran: vterm+compositor tests ok, `make harness-golden` byte-identical, no golden touched. New edge-case tests in both packages.