### PR TITLE
fix: only feed scrollback when scroll region is top-anchored

### DIFF
--- a/internal/vterm/alt_screen_erase_overlap_test.go
+++ b/internal/vterm/alt_screen_erase_overlap_test.go
@@ -376,7 +376,21 @@ func TestResizeGrowReservesTrackedCaptureEndOffset(t *testing.T) {
 	}
 }
 
-func TestScrollUpCustomScrollRegionPreservesTrackedAltScreenCaptureReplacement(t *testing.T) {
+// TestScrollUpCustomScrollRegionSkipsTrackedAltScreenCaptureBookkeeping
+// covers a scroll region with a non-zero top margin (ScrollTop=1, i.e. row 0
+// is excluded, as a TUI would do to pin a status line) on the alt screen with
+// AllowAltScreenScrollback. Per plan 046 (only feed scrollback when the
+// scroll region is top-anchored), scrollUp must not treat a line scrolled off
+// a partial region's top margin as having reached the top of the physical
+// screen: it must not append to Scrollback and must not bump
+// altCapture.endOffset. Previously this test asserted the opposite (endOffset
+// became 1 and the scrolled-off "one" row was preserved) — that pinned the
+// bug this plan fixes. With the fix, the next captureScreenToScrollback finds
+// no tracked-frame overlap with the fully-redrawn screen (frameShiftOverlap
+// requires an exact suffix/prefix match, and "one" is gone from row 0) and
+// falls back to the same drop-and-replace path already covered by
+// TestAltScreenEraseNoOverlapWhenContentDiffers.
+func TestScrollUpCustomScrollRegionSkipsTrackedAltScreenCaptureBookkeeping(t *testing.T) {
 	t.Parallel()
 	vt := New(10, 4)
 	vt.AllowAltScreenScrollback = true
@@ -406,13 +420,13 @@ func TestScrollUpCustomScrollRegionPreservesTrackedAltScreenCaptureReplacement(t
 	vt.scrollUp(1)
 	vt.Screen[3] = makeLine("four")
 
-	if vt.altCapture.endOffset != 1 {
-		t.Fatalf("endOffset = %d, want 1 after region scroll", vt.altCapture.endOffset)
+	if vt.altCapture.endOffset != 0 {
+		t.Fatalf("endOffset = %d, want 0 (non-top-anchored region scroll must not feed capture bookkeeping)", vt.altCapture.endOffset)
 	}
 
 	vt.captureScreenToScrollback()
 
-	want := []string{"one", "status", "two", "three", "four"}
+	want := []string{"status", "two", "three", "four"}
 	if len(vt.Scrollback) != len(want) {
 		dumpScrollback(t, vt)
 		t.Fatalf("scrollback length = %d, want %d", len(vt.Scrollback), len(want))

--- a/internal/vterm/scroll.go
+++ b/internal/vterm/scroll.go
@@ -14,8 +14,11 @@ func (v *VTerm) scrollUp(n int) {
 		n = regionHeight
 	}
 
-	// Capture lines to scrollback (skip alt screen unless explicitly enabled)
-	if v.scrollbackEnabled() {
+	// Capture lines to scrollback (skip alt screen unless explicitly enabled;
+	// only a top-anchored region feeds scrollback per xterm/DEC semantics —
+	// lines scrolled off a partial region's top margin are discarded, not
+	// saved, since they never reached the top of the physical screen).
+	if v.scrollbackEnabled() && v.ScrollTop == 0 {
 		top := v.ScrollTop
 		bottom := top + n
 		if bottom > v.ScrollBottom {

--- a/internal/vterm/scroll_test.go
+++ b/internal/vterm/scroll_test.go
@@ -35,3 +35,73 @@ func TestScrollUpDoesNotAliasScreenRow(t *testing.T) {
 		}
 	}
 }
+
+// TestScrollUpTopAnchoredRegionFeedsScrollback verifies the default
+// full-screen region (ScrollTop == 0) still feeds scrollback exactly as
+// before: every line scrolled off the top of the physical screen is
+// preserved, in order.
+func TestScrollUpTopAnchoredRegionFeedsScrollback(t *testing.T) {
+	t.Parallel()
+
+	vt := New(8, 3)
+	// 5 lines through a 3-row screen with no trailing newline: 2 lines
+	// (L1, L2) scroll off into Scrollback, leaving L3-L5 on screen.
+	vt.Write([]byte("L1\r\nL2\r\nL3\r\nL4\r\nL5"))
+
+	if len(vt.Scrollback) != 2 {
+		t.Fatalf("scrollback len = %d, want 2", len(vt.Scrollback))
+	}
+	wantScrollback := []string{"L1", "L2"}
+	for i, want := range wantScrollback {
+		if got := lineText(vt.Scrollback[i]); got != want {
+			t.Errorf("Scrollback[%d] = %q, want %q", i, got, want)
+		}
+	}
+	wantScreen := []string{"L3", "L4", "L5"}
+	for y, want := range wantScreen {
+		if got := lineText(vt.Screen[y]); got != want {
+			t.Errorf("Screen[%d] = %q, want %q", y, got, want)
+		}
+	}
+}
+
+// TestScrollUpNonTopAnchoredRegionSkipsScrollback verifies that scrolling a
+// scroll region whose top margin is below row 0 (e.g. a TUI pinning a header
+// via CSI 2;4r) does NOT feed scrollback: those lines never reached the top
+// of the physical screen, so xterm/DEC semantics discard them. The in-region
+// shift and bottom blank-fill must still happen exactly as for a top-anchored
+// region.
+func TestScrollUpNonTopAnchoredRegionSkipsScrollback(t *testing.T) {
+	t.Parallel()
+
+	vt := New(8, 6)
+	// Region rows 2-4 (1-indexed): ScrollTop=1, ScrollBottom=4.
+	vt.Write([]byte("\x1b[2;4r"))
+	vt.Write([]byte("\x1b[2;1HR1\x1b[3;1HR2\x1b[4;1HR3"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("scrollback len before scroll = %d, want 0", len(vt.Scrollback))
+	}
+
+	// Cursor sits on the region's last row (index 3); CR+LF scrolls the
+	// region by one line.
+	vt.Write([]byte("\r\n"))
+
+	if len(vt.Scrollback) != 0 {
+		t.Fatalf("scrollback len after non-top-anchored scroll = %d, want 0 (R1 must be discarded, not saved)", len(vt.Scrollback))
+	}
+
+	wantRows := map[int]string{
+		0: "",   // above the region: untouched
+		1: "R2", // shifted up within the region
+		2: "R3", // shifted up within the region
+		3: "",   // bottom of region: blank-filled
+		4: "",   // below the region: untouched
+		5: "",   // below the region: untouched
+	}
+	for y, want := range wantRows {
+		if got := rowText(vt, y); got != want {
+			t.Errorf("row %d = %q, want %q", y, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implements plan 046 (VT-CORR-01). `scrollUp` fed scrolled-off lines into scrollback for ANY region; per xterm/DEC semantics only a top-anchored region (ScrollTop==0) should — lines scrolled off a partial region's top margin are discarded. Fix: gate the capture block on `v.ScrollTop == 0` (shift/blank-fill stay unconditional).

Reviewer verified: gate change exact; 2 new tests (top-anchored preserved, non-top-anchored skips); one pre-existing alt-capture test updated to assert the FIXED behavior (traced: it previously pinned the bug — endOffset 1→0, scrollback drops the wrongly-captured region-top line). All other alt-capture tests unchanged; `make harness-golden` byte-identical; `make devcheck` exit 0.