### PR TITLE
test: cover default-assistant fallback and archived listing

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -260,3 +260,70 @@ func TestAssistantNamesOrder(t *testing.T) {
 		t.Fatalf("expected custom assistants to be sorted at end, got %v", got)
 	}
 }
+
+// TestCanonicalDefaultAssistantDirectMatch confirms the direct-match branch:
+// when the candidate normalizes to a name present in the assistants map, it
+// is returned as-is.
+func TestCanonicalDefaultAssistantDirectMatch(t *testing.T) {
+	assistants := map[string]AssistantConfig{
+		"claude": {Command: "claude"},
+		"codex":  {Command: "codex"},
+	}
+	if got := canonicalDefaultAssistant("claude", assistants); got != "claude" {
+		t.Fatalf("canonicalDefaultAssistant() = %q, want %q", got, "claude")
+	}
+}
+
+// TestCanonicalDefaultAssistantFallsBackToFallbackConstant covers the second
+// branch: the candidate is missing from the map, but fallbackDefaultAssistant
+// is present, so it wins over any other ordered entry. This branch is only
+// reachable by calling canonicalDefaultAssistant directly with a candidate
+// other than fallbackDefaultAssistant -- ResolvedDefaultAssistant always
+// passes fallbackDefaultAssistant as the candidate, so it can't isolate this
+// case from the direct-match branch above.
+func TestCanonicalDefaultAssistantFallsBackToFallbackConstant(t *testing.T) {
+	assistants := map[string]AssistantConfig{
+		fallbackDefaultAssistant: {Command: fallbackDefaultAssistant},
+		"codex":                  {Command: "codex"},
+	}
+	if got := canonicalDefaultAssistant("unknown-agent", assistants); got != fallbackDefaultAssistant {
+		t.Fatalf("canonicalDefaultAssistant() = %q, want %q", got, fallbackDefaultAssistant)
+	}
+}
+
+// TestResolvedDefaultAssistantFallsBackToFirstOrdered covers the third
+// branch: fallbackDefaultAssistant itself is absent from the map, so
+// resolution falls through to the first name in preferred display order.
+func TestResolvedDefaultAssistantFallsBackToFirstOrdered(t *testing.T) {
+	assistants := map[string]AssistantConfig{
+		"codex":  {Command: "codex"},
+		"gemini": {Command: "gemini"},
+	}
+	cfg := &Config{Assistants: assistants}
+
+	want := orderedAssistantNames(assistants)
+	if len(want) == 0 {
+		t.Fatal("orderedAssistantNames() returned no names; test fixture invalid")
+	}
+	if got := cfg.ResolvedDefaultAssistant(); got != want[0] {
+		t.Fatalf("ResolvedDefaultAssistant() = %q, want %q", got, want[0])
+	}
+	if got := cfg.ResolvedDefaultAssistant(); got == fallbackDefaultAssistant {
+		t.Fatalf("ResolvedDefaultAssistant() = %q, should not equal omitted fallback %q", got, fallbackDefaultAssistant)
+	}
+}
+
+// TestResolvedDefaultAssistantFallsBackToFallbackConstantWhenAssistantsEmpty
+// covers the final branch: an empty/nil assistants map has no candidates at
+// all, so resolution returns the fallbackDefaultAssistant constant verbatim.
+func TestResolvedDefaultAssistantFallsBackToFallbackConstantWhenAssistantsEmpty(t *testing.T) {
+	cfg := &Config{Assistants: nil}
+	if got := cfg.ResolvedDefaultAssistant(); got != fallbackDefaultAssistant {
+		t.Fatalf("ResolvedDefaultAssistant() = %q, want %q", got, fallbackDefaultAssistant)
+	}
+
+	cfg = &Config{Assistants: map[string]AssistantConfig{}}
+	if got := cfg.ResolvedDefaultAssistant(); got != fallbackDefaultAssistant {
+		t.Fatalf("ResolvedDefaultAssistant() with empty map = %q, want %q", got, fallbackDefaultAssistant)
+	}
+}

--- a/internal/data/workspace_store_advanced_test.go
+++ b/internal/data/workspace_store_advanced_test.go
@@ -226,6 +226,53 @@ func TestWorkspaceStore_ListByRepo_NormalizesSymlinks(t *testing.T) {
 	}
 }
 
+// TestWorkspaceStore_ListByRepoIncludingArchived_IncludesArchived asserts the
+// inverse of TestWorkspaceStore_ListByRepo_SkipsArchived: ListByRepo excludes
+// archived workspaces, but ListByRepoIncludingArchived (used by the
+// load/reattach path) returns both live and archived workspaces for the repo.
+func TestWorkspaceStore_ListByRepoIncludingArchived_IncludesArchived(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(root)
+
+	repo := "/home/user/repo"
+
+	active := &Workspace{Name: "active", Repo: repo, Root: "/path/to/active"}
+	archived := &Workspace{Name: "old", Repo: repo, Root: "/path/to/old", Archived: true}
+
+	if err := store.Save(active); err != nil {
+		t.Fatalf("Save(active) error = %v", err)
+	}
+	if err := store.Save(archived); err != nil {
+		t.Fatalf("Save(archived) error = %v", err)
+	}
+
+	liveOnly, err := store.ListByRepo(repo)
+	if err != nil {
+		t.Fatalf("ListByRepo() error = %v", err)
+	}
+	if len(liveOnly) != 1 {
+		t.Fatalf("expected 1 workspace from ListByRepo, got %d", len(liveOnly))
+	}
+	if liveOnly[0].Name != "active" {
+		t.Errorf("ListByRepo() returned %s, want active", liveOnly[0].Name)
+	}
+
+	both, err := store.ListByRepoIncludingArchived(repo)
+	if err != nil {
+		t.Fatalf("ListByRepoIncludingArchived() error = %v", err)
+	}
+	if len(both) != 2 {
+		t.Fatalf("expected 2 workspaces from ListByRepoIncludingArchived, got %d", len(both))
+	}
+	names := map[string]bool{}
+	for _, ws := range both {
+		names[ws.Name] = true
+	}
+	if !names["active"] || !names["old"] {
+		t.Errorf("ListByRepoIncludingArchived() = %v, want both active and old", names)
+	}
+}
+
 func TestWorkspaceStore_LoadRejectsInvalidWorkspaceID(t *testing.T) {
 	root := t.TempDir()
 	store := NewWorkspaceStore(root)


### PR DESCRIPTION
Implements plan 051 (TEST-03 + TEST-06). Test-only. Covers the `canonicalDefaultAssistant` fallback chain (config) and `ListByRepoIncludingArchived` archived-inclusion (data). Reviewer: diff is test-only; both packages green.