### PR TITLE
fix: disable repo gpg.program and textconv on hardened git

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -62,11 +62,11 @@ func GetFileDiff(repoPath, path string, mode DiffMode) (*DiffResult, error) {
 
 	switch mode {
 	case DiffModeStaged:
-		args = []string{"diff", "--cached", "--no-color", "--no-ext-diff", "-U3", "--", path}
+		args = []string{"diff", "--cached", "--no-color", "--no-ext-diff", "--no-textconv", "-U3", "--", path}
 	case DiffModeUnstaged:
-		args = []string{"diff", "--no-color", "--no-ext-diff", "-U3", "--", path}
+		args = []string{"diff", "--no-color", "--no-ext-diff", "--no-textconv", "-U3", "--", path}
 	default:
-		args = []string{"diff", "--no-color", "--no-ext-diff", "-U3", "--", path}
+		args = []string{"diff", "--no-color", "--no-ext-diff", "--no-textconv", "-U3", "--", path}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), diffTimeout)

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -259,4 +260,82 @@ func TestDiffResult_HunkCount(t *testing.T) {
 	if result.HunkCount() != 3 {
 		t.Errorf("HunkCount() = %d, want 3", result.HunkCount())
 	}
+}
+
+// TestGetFileDiff_NoTextconv proves GetFileDiff passes --no-textconv (not just
+// that the flag appears in source): a repo-local diff driver is configured via
+// .gitattributes + git config, and the fixture script writes a sentinel string
+// that would show up in the diff content if textconv ran. It must not, for
+// every DiffMode arm (staged, unstaged, and the default fallthrough used by
+// DiffModeBoth/DiffModeBranch).
+func TestGetFileDiff_NoTextconv(t *testing.T) {
+	skipIfNoGit(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("sh textconv script is unix-specific")
+	}
+	repo := initRepo(t)
+
+	scriptPath := filepath.Join(repo, "fake-textconv.sh")
+	script := "#!/bin/sh\necho TEXTCONV_RAN\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake-textconv.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gitattributes"), []byte("*.dat diff=faketextconv\n"), 0o600); err != nil {
+		t.Fatalf("write .gitattributes: %v", err)
+	}
+	runGit(t, repo, "config", "diff.faketextconv.textconv", scriptPath)
+
+	if err := os.WriteFile(filepath.Join(repo, "file.dat"), []byte("ORIGINAL_CONTENT\n"), 0o600); err != nil {
+		t.Fatalf("write file.dat: %v", err)
+	}
+	runGit(t, repo, "add", "file.dat", ".gitattributes")
+	runGit(t, repo, "commit", "-m", "add tracked diff-attributed file")
+
+	assertNoTextconv := func(t *testing.T, result *DiffResult, err error, wantSubstr string) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("GetFileDiff() error = %v", err)
+		}
+		if result.Error != "" {
+			t.Fatalf("Error = %q, want empty", result.Error)
+		}
+		if strings.Contains(result.Content, "TEXTCONV_RAN") {
+			t.Fatalf("diff content used textconv output (textconv was not suppressed): %q", result.Content)
+		}
+		if !strings.Contains(result.Content, wantSubstr) {
+			t.Fatalf("diff content missing raw content %q: %q", wantSubstr, result.Content)
+		}
+	}
+
+	t.Run("unstaged", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(repo, "file.dat"), []byte("CHANGED_CONTENT\n"), 0o600); err != nil {
+			t.Fatalf("write file.dat: %v", err)
+		}
+		result, err := GetFileDiff(repo, "file.dat", DiffModeUnstaged)
+		assertNoTextconv(t, result, err, "CHANGED_CONTENT")
+	})
+
+	t.Run("staged", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(repo, "file.dat"), []byte("STAGED_CONTENT\n"), 0o600); err != nil {
+			t.Fatalf("write file.dat: %v", err)
+		}
+		runGit(t, repo, "add", "file.dat")
+		result, err := GetFileDiff(repo, "file.dat", DiffModeStaged)
+		assertNoTextconv(t, result, err, "STAGED_CONTENT")
+
+		// Reset back to the committed original so subsequent subtests diff
+		// against a known unstaged baseline.
+		runGit(t, repo, "reset", "file.dat")
+		if err := os.WriteFile(filepath.Join(repo, "file.dat"), []byte("ORIGINAL_CONTENT\n"), 0o600); err != nil {
+			t.Fatalf("restore file.dat: %v", err)
+		}
+	})
+
+	t.Run("default mode (DiffModeBoth) suppresses textconv too", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(repo, "file.dat"), []byte("BOTH_MODE_CONTENT\n"), 0o600); err != nil {
+			t.Fatalf("write file.dat: %v", err)
+		}
+		result, err := GetFileDiff(repo, "file.dat", DiffModeBoth)
+		assertNoTextconv(t, result, err, "BOTH_MODE_CONTENT")
+	})
 }

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -23,19 +23,35 @@ var runGitCommandAfterWaitHook func()
 var allowRepoGitHooks = os.Getenv("AMUX_ALLOW_GIT_HOOKS") == "1"
 
 // hardenedGitArgs prepends config flags that neutralize repo-controlled code
-// execution: post-checkout/pre-* hooks and core.fsmonitor (both of which name
-// programs git will execute). amux runs git in repositories it does not
-// control, and a repo delivered with a populated .git (hooks or
-// core.fsmonitor in .git/config) must not auto-run its code just because amux
-// touched it. It is a no-op when the user opted in via AMUX_ALLOW_GIT_HOOKS=1.
+// execution on exactly three vectors: post-checkout/pre-* hooks
+// (core.hooksPath), core.fsmonitor, and gpg-signing on commit
+// (commit.gpgsign, which would otherwise run a repo-configured
+// gpg.program). amux runs git in repositories it does not control, and a
+// repo delivered with a populated .git (hooks, core.fsmonitor, or
+// commit.gpgsign+gpg.program in .git/config) must not auto-run its code just
+// because amux touched it. It is a no-op when the user opted in via
+// AMUX_ALLOW_GIT_HOOKS=1 — opting into repo hooks is opting into repo trust,
+// so signing is restored too.
+//
+// NOT neutralized: repo .gitattributes clean/smudge/process filter drivers
+// and diff/merge textconv/external-diff drivers named in-tree. Diff/browse
+// read paths pass --no-ext-diff/--no-textconv per call site instead (see
+// diff.go); there is no single git-wide flag to disable all attribute-driven
+// filter drivers, so that vector is a documented residual — see the
+// Maintenance notes in plans/045-sec-git-hardening-completeness.md.
 func hardenedGitArgs(args []string) []string {
 	if allowRepoGitHooks {
 		return args
 	}
 	// core.hooksPath= (empty value) points git's hook lookup at an empty path
 	// so no repo hook is found or run; core.fsmonitor=false disables any
-	// repo-configured fsmonitor program.
-	prefix := []string{"-c", "core.hooksPath=", "-c", "core.fsmonitor=false"}
+	// repo-configured fsmonitor program; commit.gpgsign=false stops `git
+	// commit` from invoking a repo-configured gpg.program.
+	prefix := []string{
+		"-c", "core.hooksPath=",
+		"-c", "core.fsmonitor=false",
+		"-c", "commit.gpgsign=false",
+	}
 	return append(prefix, args...)
 }
 

--- a/internal/git/operations_hardening_test.go
+++ b/internal/git/operations_hardening_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 )
 
-// These tests cover the hook/fsmonitor hardening applied by hardenedGitArgs:
-// amux-internal git runs must not execute repo-controlled programs (hooks,
-// core.fsmonitor) unless the user opted in via AMUX_ALLOW_GIT_HOOKS=1.
-// They live in their own file to respect the 500-line file-length lint gate
-// on operations_test.go.
+// These tests cover the hook/fsmonitor/gpg-sign hardening applied by
+// hardenedGitArgs: amux-internal git runs must not execute repo-controlled
+// programs (hooks, core.fsmonitor, gpg.program via commit.gpgsign) unless the
+// user opted in via AMUX_ALLOW_GIT_HOOKS=1. They live in their own file to
+// respect the 500-line file-length lint gate on operations_test.go.
 
 func TestHardenedGitArgs(t *testing.T) {
 	t.Run("default prepends hardening flags", func(t *testing.T) {
@@ -26,12 +26,29 @@ func TestHardenedGitArgs(t *testing.T) {
 		original := append([]string(nil), args...)
 
 		got := hardenedGitArgs(args)
-		want := []string{"-c", "core.hooksPath=", "-c", "core.fsmonitor=false", "status", "--porcelain"}
+		want := []string{
+			"-c", "core.hooksPath=",
+			"-c", "core.fsmonitor=false",
+			"-c", "commit.gpgsign=false",
+			"status", "--porcelain",
+		}
 		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 			t.Fatalf("hardenedGitArgs() = %q, want %q", got, want)
 		}
 		if strings.Join(args, "\x00") != strings.Join(original, "\x00") {
 			t.Fatalf("hardenedGitArgs() mutated input args: %q, want %q", args, original)
+		}
+	})
+
+	t.Run("default includes commit.gpgsign=false", func(t *testing.T) {
+		prev := allowRepoGitHooks
+		allowRepoGitHooks = false
+		t.Cleanup(func() { allowRepoGitHooks = prev })
+
+		got := hardenedGitArgs([]string{"commit", "-m", "msg"})
+		joined := strings.Join(got, "\x00")
+		if !strings.Contains(joined, "-c\x00commit.gpgsign=false") {
+			t.Fatalf("hardenedGitArgs(commit) = %q, want it to contain -c commit.gpgsign=false", got)
 		}
 	})
 
@@ -44,6 +61,18 @@ func TestHardenedGitArgs(t *testing.T) {
 		got := hardenedGitArgs(args)
 		if strings.Join(got, "\x00") != strings.Join(args, "\x00") {
 			t.Fatalf("hardenedGitArgs() = %q, want unchanged %q", got, args)
+		}
+	})
+
+	t.Run("opt-in also restores gpg-signing (no commit.gpgsign override)", func(t *testing.T) {
+		prev := allowRepoGitHooks
+		allowRepoGitHooks = true
+		t.Cleanup(func() { allowRepoGitHooks = prev })
+
+		got := hardenedGitArgs([]string{"commit", "-m", "msg"})
+		joined := strings.Join(got, "\x00")
+		if strings.Contains(joined, "commit.gpgsign") {
+			t.Fatalf("hardenedGitArgs(commit) under opt-in = %q, want no commit.gpgsign override at all", got)
 		}
 	})
 }
@@ -100,6 +129,75 @@ func TestInternalGitRunDoesNotRunRepoHook(t *testing.T) {
 		}
 		if _, err := os.Stat(sentinel); err != nil {
 			t.Fatalf("expected post-checkout hook to run under opt-in; sentinel stat err = %v", err)
+		}
+	})
+}
+
+// writeGpgProgramSentinel repo-locally configures commit.gpgsign=true and
+// gpg.program to point at a script that creates a sentinel file when
+// invoked (then exits non-zero, so a real signing attempt fails cleanly
+// instead of hanging or fabricating a signature). Returns the sentinel path.
+func writeGpgProgramSentinel(t *testing.T, repo string) string {
+	t.Helper()
+	sentinel := filepath.Join(repo, "GPG_RAN")
+	scriptPath := filepath.Join(repo, "fake-gpg.sh")
+	script := "#!/bin/sh\n: > '" + sentinel + "'\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake-gpg.sh) error = %v", err)
+	}
+	runGit(t, repo, "config", "commit.gpgsign", "true")
+	runGit(t, repo, "config", "gpg.program", scriptPath)
+	return sentinel
+}
+
+func TestInternalGitCommitDoesNotRunRepoGpgProgram(t *testing.T) {
+	skipIfNoGit(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("sh gpg-program script is unix-specific")
+	}
+
+	t.Run("default suppresses repo gpg.program on commit", func(t *testing.T) {
+		prev := allowRepoGitHooks
+		allowRepoGitHooks = false
+		t.Cleanup(func() { allowRepoGitHooks = prev })
+
+		repo := initRepo(t)
+		sentinel := writeGpgProgramSentinel(t, repo)
+
+		if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("x\n"), 0o600); err != nil {
+			t.Fatalf("write file.txt: %v", err)
+		}
+		if _, err := RunGitCtx(context.Background(), repo, "add", "-A"); err != nil {
+			t.Fatalf("RunGitCtx(add) error = %v", err)
+		}
+		if _, err := RunGitCtx(context.Background(), repo, "commit", "-m", "no sign"); err != nil {
+			t.Fatalf("RunGitCtx(commit) error = %v", err)
+		}
+		if _, err := os.Stat(sentinel); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected repo gpg.program to be suppressed; sentinel stat err = %v", err)
+		}
+	})
+
+	t.Run("opt-in re-enables repo gpg.program on commit", func(t *testing.T) {
+		prev := allowRepoGitHooks
+		allowRepoGitHooks = true
+		t.Cleanup(func() { allowRepoGitHooks = prev })
+
+		repo := initRepo(t)
+		sentinel := writeGpgProgramSentinel(t, repo)
+
+		if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("x\n"), 0o600); err != nil {
+			t.Fatalf("write file.txt: %v", err)
+		}
+		if _, err := RunGitCtx(context.Background(), repo, "add", "-A"); err != nil {
+			t.Fatalf("RunGitCtx(add) error = %v", err)
+		}
+		// The fake gpg program exits non-zero, so the commit itself fails under
+		// opt-in — we only assert it was invoked (sentinel created), proving
+		// commit.gpgsign is not force-disabled when the user opted in.
+		_, _ = RunGitCtx(context.Background(), repo, "commit", "-m", "sign attempt")
+		if _, err := os.Stat(sentinel); err != nil {
+			t.Fatalf("expected repo gpg.program to run under opt-in; sentinel stat err = %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Implements plan 045 (SEC-01). `hardenedGitArgs` only neutralized hooks/fsmonitor while its doc claimed full repo-config exec neutralization. Adds `-c commit.gpgsign=false` (stops `git commit` invoking a repo `gpg.program` on the new CommitAll path) and `--no-textconv` to `GetFileDiff`; corrects the doc to enumerate coverage and record the `.gitattributes` filter-driver residual (no single git flag; deferred). `AMUX_ALLOW_GIT_HOOKS=1` opt-out restores signing too.

Reviewer re-ran: `internal/git` tests green incl. new behavioral sentinel tests proving a repo-local gpg.program/textconv is NOT invoked by default and IS under the opt-out. `make devcheck` exit 0.