### PR TITLE
refactor: consolidate shellQuote into internal/shellutil

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,5 +92,6 @@ The table is hand-maintained; keep it in sync when adding or moving a package.
 | `internal/logging` | File-based logger; the output channel for internal packages | `logger.go` |
 | `internal/messages` | Shared Bubble Tea message vocabulary between pump and panes | `messages.go` |
 | `internal/validation` | Input/path guards (assistant, base ref, project path, workspace) | `validation.go` |
+| `internal/shellutil` | Shared shell-quoting primitive (POSIX single-quote escaping) | `shellutil.go` |
 | `internal/testutil` | Shared test polling helpers (deadline/poll loops with consistent failure messaging) | `wait.go` |
 | `internal/e2e` | PTY-driven end-to-end tests exercising the real binary | (tests) |

--- a/internal/pty/shell.go
+++ b/internal/pty/shell.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/andyrewlee/amux/internal/shellutil"
 )
 
 const defaultLoginShell = "/bin/bash"
@@ -27,9 +29,5 @@ func LoginShellCommand(shell string) (string, error) {
 	if !filepath.IsAbs(shell) {
 		return "", fmt.Errorf("SHELL must be an absolute path: %q", shell)
 	}
-	return "exec " + shellQuote(shell) + " -l", nil
-}
-
-func shellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	return "exec " + shellutil.ShellQuote(shell) + " -l", nil
 }

--- a/internal/shellutil/shellutil.go
+++ b/internal/shellutil/shellutil.go
@@ -1,0 +1,12 @@
+// Package shellutil holds small, security-sensitive shell helpers shared across
+// packages so their behavior can't drift between copies.
+package shellutil
+
+import "strings"
+
+// ShellQuote wraps value in single quotes for safe use as one POSIX shell word,
+// escaping embedded single quotes using the standard close-quote, backslash-quote,
+// open-quote idiom. An empty string becomes two adjacent single-quote characters.
+func ShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/internal/shellutil/shellutil_test.go
+++ b/internal/shellutil/shellutil_test.go
@@ -1,0 +1,51 @@
+package shellutil
+
+import "testing"
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "''",
+		},
+		{
+			name:     "plain word",
+			input:    "hello",
+			expected: "'hello'",
+		},
+		{
+			name:     "embedded single quote",
+			input:    "it's",
+			expected: "'it'\\''s'",
+		},
+		{
+			name:     "multiple embedded single quotes",
+			input:    "'''",
+			expected: "''\\'''\\'''\\'''",
+		},
+		{
+			name:     "spaces and shell metacharacters stay literal",
+			input:    "hello world $HOME `whoami` & | ; > <",
+			expected: "'hello world $HOME `whoami` & | ; > <'",
+		},
+		{
+			name:     "path-like value",
+			input:    "/usr/local/bin/amux",
+			expected: "'/usr/local/bin/amux'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShellQuote(tt.input)
+			if result != tt.expected {
+				t.Errorf("ShellQuote(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tmux/command.go
+++ b/internal/tmux/command.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/andyrewlee/amux/internal/shellutil"
 )
 
 // ClientCommandParams holds the parameters for building a tmux client command.
@@ -26,14 +28,14 @@ func NewClientCommand(sessionName string, p ClientCommandParams) string {
 
 func clientCommand(sessionName, workDir, command string, opts Options, tags SessionTags, detachExisting bool) string {
 	base := tmuxBase(opts)
-	session := shellQuote(sessionName)
-	optionTgt := shellQuote(exactSessionOptionTarget(sessionName))
-	sessionTgt := shellQuote(sessionTarget(sessionName))
-	dir := shellQuote(workDir)
+	session := shellutil.ShellQuote(sessionName)
+	optionTgt := shellutil.ShellQuote(exactSessionOptionTarget(sessionName))
+	sessionTgt := shellutil.ShellQuote(sessionTarget(sessionName))
+	dir := shellutil.ShellQuote(workDir)
 	// Strip tmux-specific vars inside managed panes so `tmux` commands do not
 	// accidentally target the AMUX control server.
 	command = "unset TMUX TMUX_PANE; " + command
-	cmd := shellQuote(command)
+	cmd := shellutil.ShellQuote(command)
 
 	// Ensure the session/server exists without attaching yet. tmux computes
 	// client features at attach time, so the server option below must be set
@@ -58,7 +60,7 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 		settings.WriteString(fmt.Sprintf("%s set-option -t %s mouse off 2>/dev/null; ", base, optionTgt))
 	}
 	if opts.DefaultTerminal != "" {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s default-terminal %s 2>/dev/null; ", base, optionTgt, shellQuote(opts.DefaultTerminal)))
+		settings.WriteString(fmt.Sprintf("%s set-option -t %s default-terminal %s 2>/dev/null; ", base, optionTgt, shellutil.ShellQuote(opts.DefaultTerminal)))
 	}
 	// Ensure activity timestamps update for window_activity-based tracking.
 	settings.WriteString(fmt.Sprintf("%s set-option -t %s -w monitor-activity on 2>/dev/null; ", base, optionTgt))
@@ -91,7 +93,7 @@ func appendSessionTags(settings *strings.Builder, base, session string, tags Ses
 	}
 	for _, e := range entries {
 		if e.value != "" {
-			settings.WriteString(fmt.Sprintf("%s set-option -t %s %s %s 2>/dev/null; ", base, session, e.key, shellQuote(e.value)))
+			settings.WriteString(fmt.Sprintf("%s set-option -t %s %s %s 2>/dev/null; ", base, session, e.key, shellutil.ShellQuote(e.value)))
 		}
 	}
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/process"
+	"github.com/andyrewlee/amux/internal/shellutil"
 )
 
 type Options struct {
@@ -163,10 +164,10 @@ func SessionStateFor(sessionName string, opts Options) (SessionState, error) {
 func tmuxBase(opts Options) string {
 	base := "tmux"
 	if opts.ServerName != "" {
-		base = fmt.Sprintf("%s -L %s", base, shellQuote(opts.ServerName))
+		base = fmt.Sprintf("%s -L %s", base, shellutil.ShellQuote(opts.ServerName))
 	}
 	if opts.ConfigPath != "" {
-		base = fmt.Sprintf("%s -f %s", base, shellQuote(opts.ConfigPath))
+		base = fmt.Sprintf("%s -f %s", base, shellutil.ShellQuote(opts.ConfigPath))
 	}
 	return base
 }
@@ -490,11 +491,4 @@ func parseOutputLines(output []byte) []string {
 		}
 	}
 	return result
-}
-
-func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -85,28 +85,6 @@ func TestSanitize(t *testing.T) {
 	}
 }
 
-func TestShellQuote(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"", "''"},
-		{"hello", "'hello'"},
-		{"hello world", "'hello world'"},
-		{"it's", "'it'\\''s'"},
-		{"path/to/file", "'path/to/file'"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := shellQuote(tt.input)
-			if result != tt.expected {
-				t.Errorf("shellQuote(%q) = %q, want %q", tt.input, result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestDefaultOptions(t *testing.T) {
 	opts := DefaultOptions()
 

--- a/internal/update/install.go
+++ b/internal/update/install.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/andyrewlee/amux/internal/shellutil"
 )
 
 // renameFile is a seam for tests to inject rename failures.
@@ -206,7 +208,7 @@ func InstallBinary(newBinaryPath, currentBinaryPath string) error {
 		if restoreErr := renameFile(backupPath, currentBinaryPath); restoreErr != nil {
 			return fmt.Errorf(
 				"installing new binary: %w; restoring backup also failed: %w (your previous binary is at %s — restore it manually with: mv %s %s)",
-				err, restoreErr, backupPath, shellQuote(backupPath), shellQuote(currentBinaryPath),
+				err, restoreErr, backupPath, shellutil.ShellQuote(backupPath), shellutil.ShellQuote(currentBinaryPath),
 			)
 		}
 		return fmt.Errorf("installing new binary: %w (previous binary restored)", err)
@@ -232,10 +234,6 @@ func uniqueUpgradeTempPath(dir, pattern string) (string, error) {
 		return "", err
 	}
 	return name, nil
-}
-
-func shellQuote(path string) string {
-	return "'" + strings.ReplaceAll(path, "'", "'\\''") + "'"
 }
 
 // copyFile copies a file from src to dst, preserving executable permissions.

--- a/internal/update/install_test.go
+++ b/internal/update/install_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/andyrewlee/amux/internal/shellutil"
 )
 
 func TestInstallBinary(t *testing.T) {
@@ -312,7 +314,7 @@ func TestInstallBinarySwapFailsRestoreFails(t *testing.T) {
 	if !strings.Contains(err.Error(), backupPath) {
 		t.Errorf("Expected error to name backup path %q, got: %v", backupPath, err)
 	}
-	wantHint := "mv " + shellQuote(backupPath) + " " + shellQuote(destPath)
+	wantHint := "mv " + shellutil.ShellQuote(backupPath) + " " + shellutil.ShellQuote(destPath)
 	if !strings.Contains(err.Error(), wantHint) {
 		t.Errorf("Expected error to include quoted manual recovery hint %q, got: %v", wantHint, err)
 	}


### PR DESCRIPTION
Implements plan 054 (TECHDEBT-02). Replaces the three duplicate `shellQuote` copies (update/install.go, pty/shell.go, tmux/tmux.go — plus additional call sites in tmux/command.go) with a single tested `internal/shellutil.ShellQuote`. Behavior byte-identical (incl. `""`→`''`). ARCHITECTURE.md row added (required by the package-table guard test).

Reviewer re-ran: build + tmux/update/pty/shellutil tests green; `grep -rn 'func shellQuote' internal/` returns nothing; command.go call sites verified byte-identical.