### PR TITLE
fix: re-mark workspace dirty when a debounced save fails

### DIFF
--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -25,7 +25,8 @@ import (
 //	                       → service_update.go
 //	updateTabMsg           OpenDiff, CloseTab, LaunchAgent, TabCreated/Closed/
 //	                       Detached/Reattached/StateChanged/SelectionChanged,
-//	                       persistDebounceMsg, center.TabInputFailed
+//	                       persistDebounceMsg, persistSaveFailedMsg,
+//	                       center.TabInputFailed
 //	                       → app_input_messages_center.go, app_persistence.go
 //	updateTmuxMsg          CleanupTmuxSessions, SpinnerTick, GitStatusTick,
 //	                       OrphanGCTick, PTYWatchdogTick, tmuxActivityTick/
@@ -151,6 +152,8 @@ func (a *App) updateTabMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		*cmds = append(*cmds, a.persistWorkspaceTabs(msg.WorkspaceID))
 	case persistDebounceMsg:
 		*cmds = append(*cmds, a.handlePersistDebounce(msg))
+	case persistSaveFailedMsg:
+		*cmds = append(*cmds, a.handlePersistSaveFailed(msg))
 	case center.TabInputFailed:
 		*cmds = append(*cmds, a.handleTabInputFailed(msg)...)
 	default:

--- a/internal/app/app_persistence.go
+++ b/internal/app/app_persistence.go
@@ -50,6 +50,17 @@ type persistDebounceMsg struct {
 	token persistToken
 }
 
+// persistSaveFailedMsg is returned by the debounced-save Cmd goroutine when one
+// or more workspace saves fail. a.lifecycle.dirty is App state and must be
+// mutated only on the Update loop (see workspaceLifecycleState.dirty's doc
+// comment: "Touched only from App.Update handlers (single writer)"), so the
+// goroutine cannot re-mark a workspace dirty itself. It reports the failure
+// via this message instead; handlePersistSaveFailed does the actual re-dirty
+// on the Update loop.
+type persistSaveFailedMsg struct {
+	workspaceIDs []string
+}
+
 // persistWorkspaceTabs marks a workspace dirty and schedules a debounced save.
 func (a *App) persistWorkspaceTabs(wsID string) tea.Cmd {
 	if wsID == "" {
@@ -128,6 +139,7 @@ func (a *App) handlePersistDebounce(msg persistDebounceMsg) tea.Cmd {
 	}
 	service := a.workspaceService
 	return func() tea.Msg {
+		var failedIDs []string
 		for _, snap := range snapshots {
 			wsID := string(snap.ID())
 			var saveErr error
@@ -139,12 +151,34 @@ func (a *App) handlePersistDebounce(msg persistDebounceMsg) tea.Cmd {
 			}
 			if saveErr != nil {
 				logging.Warn("Failed to save workspace tabs: %v", saveErr)
+				// Do not touch a.lifecycle.dirty here — this runs in a Cmd
+				// goroutine, not on the Update loop. Report the failure via a
+				// message so handlePersistSaveFailed can re-dirty safely.
+				failedIDs = append(failedIDs, wsID)
 			} else {
 				// Marker bookkeeping is intentionally outside delete-state guard.
 				// Delete safety is enforced by the guarded Save above.
 				a.markLocalWorkspaceSaveForID(wsID)
 			}
 		}
-		return nil
+		if len(failedIDs) == 0 {
+			return nil
+		}
+		return persistSaveFailedMsg{workspaceIDs: failedIDs}
 	}
+}
+
+// handlePersistSaveFailed re-marks workspaces dirty after their debounced save
+// failed, so the next debounce (or clean shutdown) retries the save. This is
+// the Update-loop counterpart to the persistSaveFailedMsg emitted from the
+// save goroutine above: persistWorkspaceTabs mutates a.lifecycle.dirty, and it
+// must only ever be called from here, not from that goroutine.
+func (a *App) handlePersistSaveFailed(msg persistSaveFailedMsg) tea.Cmd {
+	var cmds []tea.Cmd
+	for _, wsID := range msg.workspaceIDs {
+		if cmd := a.persistWorkspaceTabs(wsID); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return common.SafeBatch(cmds...)
 }

--- a/internal/app/app_persistence_test.go
+++ b/internal/app/app_persistence_test.go
@@ -271,3 +271,120 @@ func TestDeleteFailureRequeuesAndDebouncedPersistSavesWorkspace(t *testing.T) {
 		t.Fatal("expected workspace to be cleared from dirty set after save")
 	}
 }
+
+// TestHandlePersistDebounceReDirtiesWorkspaceOnSaveFailure proves a failed
+// debounced Save is not silently dropped: the save goroutine reports the
+// failure via persistSaveFailedMsg (it must not touch a.lifecycle.dirty
+// itself — that's App state, single-writer on the Update loop), and
+// handlePersistSaveFailed — the Update-loop handler for that message —
+// re-dirties the workspace so a later debounce or clean shutdown retries it.
+func TestHandlePersistDebounceReDirtiesWorkspaceOnSaveFailure(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	wsID := string(ws.ID())
+
+	store := &failingDeleteStore{saveErr: errors.New("disk full")}
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	c := center.New(nil)
+	c.SetWorkspace(ws)
+	c.AddTab(&center.Tab{
+		Name:      "agent",
+		Assistant: "claude",
+		Workspace: ws,
+	})
+
+	app := &App{
+		center:           c,
+		workspaceService: svc,
+		projects:         []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{*ws}}},
+		lifecycle: workspaceLifecycleState{
+			persistToken: 1,
+			dirty:        map[string]bool{wsID: true},
+			localSavesAt: make(map[string]localWorkspaceSaveMarker),
+		},
+	}
+
+	cmd := app.handlePersistDebounce(persistDebounceMsg{token: 1})
+	if cmd == nil {
+		t.Fatal("expected a save command for the dirty workspace")
+	}
+	// handlePersistDebounce clears the dirty marker synchronously at
+	// snapshot-collection time; the save itself (and any re-dirty on
+	// failure) happens later, when the returned Cmd runs.
+	if app.lifecycle.dirty[wsID] {
+		t.Fatal("expected dirty marker cleared at snapshot time, before save runs")
+	}
+
+	msg := cmd()
+	if store.saved == nil {
+		t.Fatal("expected Save to have been called")
+	}
+	failMsg, ok := msg.(persistSaveFailedMsg)
+	if !ok {
+		t.Fatalf("expected persistSaveFailedMsg on save failure, got %T", msg)
+	}
+	if len(failMsg.workspaceIDs) != 1 || failMsg.workspaceIDs[0] != wsID {
+		t.Fatalf("expected failed workspace IDs to be [%s], got %v", wsID, failMsg.workspaceIDs)
+	}
+
+	// The Update loop (not the save goroutine) performs the re-dirty.
+	reDirtyCmd := app.handlePersistSaveFailed(failMsg)
+	if reDirtyCmd == nil {
+		t.Fatal("expected a rescheduled debounce command after save failure")
+	}
+	if !app.lifecycle.dirty[wsID] {
+		t.Fatal("expected workspace to be re-dirtied after save failure")
+	}
+}
+
+// TestHandlePersistDebounceSuccessDoesNotReDirty is the control case for
+// TestHandlePersistDebounceReDirtiesWorkspaceOnSaveFailure: a successful save
+// must not emit persistSaveFailedMsg and must leave the workspace clean.
+func TestHandlePersistDebounceSuccessDoesNotReDirty(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	wsID := string(ws.ID())
+
+	storeRoot := t.TempDir()
+	store := data.NewWorkspaceStore(storeRoot)
+	svc := newWorkspaceService(nil, store, nil, "")
+
+	c := center.New(nil)
+	c.SetWorkspace(ws)
+	c.AddTab(&center.Tab{
+		Name:      "agent",
+		Assistant: "claude",
+		Workspace: ws,
+	})
+
+	app := &App{
+		center:           c,
+		workspaceService: svc,
+		projects:         []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{*ws}}},
+		lifecycle: workspaceLifecycleState{
+			persistToken: 1,
+			dirty:        map[string]bool{wsID: true},
+			localSavesAt: make(map[string]localWorkspaceSaveMarker),
+		},
+	}
+
+	cmd := app.handlePersistDebounce(persistDebounceMsg{token: 1})
+	if cmd == nil {
+		t.Fatal("expected a save command for the dirty workspace")
+	}
+
+	msg := cmd()
+	if msg != nil {
+		t.Fatalf("expected nil tea.Msg on successful save, got %T", msg)
+	}
+	if app.lifecycle.dirty[wsID] {
+		t.Fatal("expected workspace to remain clean after a successful save")
+	}
+
+	loaded, err := store.Load(ws.ID())
+	if err != nil {
+		t.Fatalf("load after persistence: %v", err)
+	}
+	if len(loaded.OpenTabs) == 0 {
+		t.Fatal("expected workspace tabs to be persisted")
+	}
+}


### PR DESCRIPTION
Implements plan 048 (APP-CORR-02). The debounced-save Cmd cleared the dirty marker up front then swallowed a Save error, silently dropping tab-state on a transient failure. The save goroutine now returns `persistSaveFailedMsg`; `handlePersistSaveFailed` re-dirties the failed workspaces on the Update loop (`a.lifecycle.dirty` is single-writer — the goroutine never touches it), so the next debounce/clean-shutdown retries.

Reviewer verified: concurrency-safe (goroutine→message→Update-loop re-dirty); tests cover failure (emits msg → re-dirty) and success (no re-dirty); build/app-test/vet/file-length/cache-cleaned-lint all green.