### PR TITLE
feat: publish @amux_agent_state tmux tag

### DIFF
--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -166,7 +166,8 @@ amux stores per-session metadata as tmux session options (`@amux_*`). Read one
 with `tmux show-options -t <bare-name> -v <key>` (bare name, no `=` — see above)
 or read them all with `tmux show-options -t <bare-name>`. The keys, set at
 session creation (`appendSessionTags`, `internal/tmux/command.go`) and updated at
-runtime (`internal/tmux/tags.go`, `internal/ui/center/model_input_lifecycle.go`):
+runtime (`internal/tmux/tags.go`, `internal/ui/center/model_input_lifecycle.go`,
+`internal/app/app_tmux_activity_result.go`):
 
 | Key | Meaning | Value format |
 |-----|---------|--------------|
@@ -181,12 +182,20 @@ runtime (`internal/tmux/tags.go`, `internal/ui/center/model_input_lifecycle.go`)
 | `@amux_session_lease_ms` | ownership lease timestamp | Unix **milliseconds** |
 | `@amux_last_output_at` | last observed agent output | Unix **milliseconds** |
 | `@amux_last_input_at` | last input amux delivered | Unix **milliseconds** |
+| `@amux_agent_state` | semantic agent state (idle/working/done) | `idle` \| `working` \| `done` |
 
 Note the unit split: `@amux_created_at` is in seconds; the activity/lease
 timestamps are in milliseconds. amux parses these back with
 `activity.ParseLastOutputAtTag` (`internal/app/activity/fetch.go`). The owner and
 lease tags coordinate ownership between concurrent amux instances; an external
 orchestrator should treat them as read-only telemetry and not forge them.
+
+`@amux_agent_state` is amux's own idle/working/done classification (the same
+hysteresis that drives the working indicator and the bell-on-done), published
+per session so an external orchestrator does not have to re-derive it from the
+raw timestamp tags above. It is read-only telemetry, written best-effort and
+only when the state actually changes (not on every scan), so a missing or
+momentarily stale value should be tolerated the same way as the other tags.
 
 ## Option B: a minimal CLI (recorded, not recommended)
 

--- a/internal/app/app_tmux_activity_agent_state_tag_test.go
+++ b/internal/app/app_tmux_activity_agent_state_tag_test.go
@@ -1,0 +1,226 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/app/activity"
+	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+)
+
+// ---------------------------------------------------------------------------
+// sessionAgentStateChanges — pure coalescing logic (no tmux involved).
+// ---------------------------------------------------------------------------
+
+// TestSessionAgentStateChanges_CoalescesToRealTransitions proves that only
+// sessions whose classified AgentState actually changed this scan are
+// returned — an unchanged session must not appear, which is the coalescing
+// plan 057 requires to bound @amux_agent_state writes to real transitions
+// instead of firing on every ~5s scan tick.
+func TestSessionAgentStateChanges_CoalescesToRealTransitions(t *testing.T) {
+	now := time.Now()
+	prev := map[string]*activity.SessionState{
+		// "idle-to-working" intentionally absent: a nil prev state classifies
+		// as StateIdle (activity.ClassifyState's documented default).
+		"working-to-done": {Score: activity.ScoreThreshold, LastActiveAt: now},
+		"unchanged":       {Score: activity.ScoreThreshold},
+	}
+	updated := map[string]*activity.SessionState{
+		"idle-to-working": {Score: activity.ScoreThreshold},
+		"working-to-done": {Score: 0, LastWorkingAt: now},
+		"unchanged":       {Score: activity.ScoreThreshold},
+	}
+
+	changes := sessionAgentStateChanges(prev, updated, now)
+
+	got := make(map[string]activity.AgentState, len(changes))
+	for _, c := range changes {
+		got[c.sessionName] = c.state
+	}
+	if len(changes) != 2 {
+		t.Fatalf("expected exactly 2 coalesced changes, got %d: %#v", len(changes), changes)
+	}
+	if got["idle-to-working"] != activity.StateWorking {
+		t.Errorf("idle-to-working: got %v, want StateWorking", got["idle-to-working"])
+	}
+	if got["working-to-done"] != activity.StateDone {
+		t.Errorf("working-to-done: got %v, want StateDone", got["working-to-done"])
+	}
+	if _, ok := got["unchanged"]; ok {
+		t.Errorf("unchanged session must be coalesced out, but it appeared: %v", got["unchanged"])
+	}
+}
+
+// TestSessionAgentStateChanges_EmptyUpdatedYieldsNoChanges verifies the
+// zero-updates case produces no changes and does not panic on a nil map.
+func TestSessionAgentStateChanges_EmptyUpdatedYieldsNoChanges(t *testing.T) {
+	prev := map[string]*activity.SessionState{"a": {Score: activity.ScoreThreshold}}
+	changes := sessionAgentStateChanges(prev, nil, time.Now())
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes for empty updatedStates, got %#v", changes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// agentStateTagWriteCmd — the best-effort dispatch, via the setAgentStateTag
+// seam (mirrors the runTmuxCmd/runTmuxCmdCombined seam pattern in
+// internal/tmux, since SetSessionTagValue itself is a direct package call
+// with no interface to fake through).
+// ---------------------------------------------------------------------------
+
+type recordedAgentStateTagWrite struct {
+	sessionName string
+	key         string
+	value       string
+}
+
+func fakeSetAgentStateTag(t *testing.T, err error) *[]recordedAgentStateTagWrite {
+	t.Helper()
+	orig := setAgentStateTag
+	var recorded []recordedAgentStateTagWrite
+	setAgentStateTag = func(sessionName, key, value string, _ tmux.Options) error {
+		recorded = append(recorded, recordedAgentStateTagWrite{sessionName, key, value})
+		return err
+	}
+	t.Cleanup(func() { setAgentStateTag = orig })
+	return &recorded
+}
+
+// drainCmd runs cmd and recursively runs every leaf command inside any
+// resulting tea.BatchMsg, so best-effort side effects (like the tag write)
+// dispatched via common.SafeBatch actually fire during a test, the same way
+// the bubbletea runtime would eventually run them.
+func drainCmd(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if bm, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range bm {
+			drainCmd(c)
+		}
+	}
+}
+
+// TestAgentStateTagWriteCmd_NilForNoChanges verifies the no-churn guard: with
+// no coalesced changes, no command (and therefore no tmux call) is produced.
+func TestAgentStateTagWriteCmd_NilForNoChanges(t *testing.T) {
+	recorded := fakeSetAgentStateTag(t, nil)
+	if cmd := agentStateTagWriteCmd(nil, tmux.Options{}); cmd != nil {
+		t.Fatal("expected nil cmd for zero changes")
+	}
+	if len(*recorded) != 0 {
+		t.Fatalf("expected no tmux calls, got %#v", *recorded)
+	}
+}
+
+// TestAgentStateTagWriteCmd_WritesStateStringPerChangedSession is the pin
+// plan 057 asks for: a simulated state transition results in a
+// SetSessionTagValue call using tmux.TagAgentState and state.String(). The
+// write is also proven best-effort — a simulated tmux failure must not panic
+// or surface as an error message.
+func TestAgentStateTagWriteCmd_WritesStateStringPerChangedSession(t *testing.T) {
+	recorded := fakeSetAgentStateTag(t, errors.New("simulated tmux failure"))
+
+	changes := []agentStateTagChange{
+		{sessionName: "sess-a", state: activity.StateWorking},
+		{sessionName: "sess-b", state: activity.StateDone},
+	}
+	cmd := agentStateTagWriteCmd(changes, tmux.Options{ServerName: "test-server"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for non-empty changes")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("best-effort write must yield no message even on failure, got %#v", msg)
+	}
+
+	if len(*recorded) != 2 {
+		t.Fatalf("expected 2 recorded writes, got %d: %#v", len(*recorded), *recorded)
+	}
+	want := map[string]string{"sess-a": "working", "sess-b": "done"}
+	for _, w := range *recorded {
+		if w.key != tmux.TagAgentState {
+			t.Errorf("write for %s used key %q, want %q", w.sessionName, w.key, tmux.TagAgentState)
+		}
+		if w.value != want[w.sessionName] {
+			t.Errorf("write for %s: got value %q, want %q", w.sessionName, w.value, want[w.sessionName])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyTmuxActivityPayload wiring — proves the tag write is actually reachable
+// from the real activity-result handling path, not just a dangling helper.
+// ---------------------------------------------------------------------------
+
+// TestApplyTmuxActivityPayload_EmitsAgentStateTagOnTransition simulates a
+// session's first observation (idle -> working, since a brand-new session is
+// immediately classified active) and asserts the returned command, once
+// drained, issues exactly one @amux_agent_state write for that session.
+func TestApplyTmuxActivityPayload_EmitsAgentStateTagOnTransition(t *testing.T) {
+	recorded := fakeSetAgentStateTag(t, nil)
+
+	app := &App{
+		tmuxActivity: tmuxActivityState{
+			sessionStates:      map[string]*activity.SessionState{},
+			activeWorkspaceIDs: map[string]bool{},
+			agentStates:        map[string]activity.AgentState{},
+		},
+		dashboard: dashboard.New(),
+	}
+	app.tmuxActivity.settled = true
+
+	msg := tmuxActivityResult{
+		ActiveWorkspaceIDs: map[string]bool{},
+		AgentStates:        map[string]activity.AgentState{},
+		UpdatedStates: map[string]*activity.SessionState{
+			"sess-new": {Score: activity.ScoreThreshold},
+		},
+	}
+
+	drainCmd(app.applyTmuxActivityPayload(msg))
+
+	if len(*recorded) != 1 {
+		t.Fatalf("expected 1 recorded tag write, got %d: %#v", len(*recorded), *recorded)
+	}
+	got := (*recorded)[0]
+	if got.sessionName != "sess-new" || got.key != tmux.TagAgentState || got.value != "working" {
+		t.Fatalf("unexpected tag write: %#v", got)
+	}
+}
+
+// TestApplyTmuxActivityPayload_NoAgentStateTagWriteWhenUnchanged proves the
+// coalescing end to end: a session reported with the same classification as
+// last scan must not produce any @amux_agent_state write.
+func TestApplyTmuxActivityPayload_NoAgentStateTagWriteWhenUnchanged(t *testing.T) {
+	recorded := fakeSetAgentStateTag(t, nil)
+
+	app := &App{
+		tmuxActivity: tmuxActivityState{
+			sessionStates: map[string]*activity.SessionState{
+				"sess-steady": {Score: activity.ScoreThreshold},
+			},
+			activeWorkspaceIDs: map[string]bool{},
+			agentStates:        map[string]activity.AgentState{},
+		},
+		dashboard: dashboard.New(),
+	}
+	app.tmuxActivity.settled = true
+
+	msg := tmuxActivityResult{
+		ActiveWorkspaceIDs: map[string]bool{},
+		AgentStates:        map[string]activity.AgentState{},
+		UpdatedStates: map[string]*activity.SessionState{
+			"sess-steady": {Score: activity.ScoreThreshold},
+		},
+	}
+
+	drainCmd(app.applyTmuxActivityPayload(msg))
+
+	if len(*recorded) != 0 {
+		t.Fatalf("expected no tag write for an unchanged state (coalescing), got %#v", *recorded)
+	}
+}

--- a/internal/app/app_tmux_activity_result.go
+++ b/internal/app/app_tmux_activity_result.go
@@ -3,12 +3,14 @@ package app
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -122,6 +124,12 @@ func (a *App) applyTmuxActivityPayload(msg tmuxActivityResult) tea.Cmd {
 	if msg.ActiveWorkspaceIDs == nil {
 		msg.ActiveWorkspaceIDs = make(map[string]bool)
 	}
+	// Compute per-session @amux_agent_state transitions before merging: this
+	// reads a.tmuxActivity.sessionStates as it stood at the end of the previous
+	// scan (the "prev" side of the transition) against msg.UpdatedStates (the
+	// "next" side), which is keyed by session name and therefore gives a clean
+	// (session name, new state) pairing with no workspace-level ambiguity.
+	agentStateChanges := sessionAgentStateChanges(a.tmuxActivity.sessionStates, msg.UpdatedStates, time.Now())
 	// Merge updated hysteresis states back on the main thread.
 	for name, state := range msg.UpdatedStates {
 		a.tmuxActivity.sessionStates[name] = state
@@ -143,14 +151,67 @@ func (a *App) applyTmuxActivityPayload(msg tmuxActivityResult) tea.Cmd {
 	}
 	a.syncActiveWorkspacesToDashboard()
 	spinner := a.dashboard.StartSpinnerIfNeeded()
+	tagCmd := agentStateTagWriteCmd(agentStateChanges, a.tmuxOptions)
 	if doneCount > 0 && a.toast != nil {
 		msgText := "Agent finished"
 		if doneCount > 1 {
 			msgText = fmt.Sprintf("%d agents finished", doneCount)
 		}
-		return common.SafeBatch(a.toast.ShowInfo(msgText), spinner)
+		return common.SafeBatch(a.toast.ShowInfo(msgText), spinner, tagCmd)
 	}
-	return spinner
+	return common.SafeBatch(spinner, tagCmd)
+}
+
+// agentStateTagChange pairs a tmux session name with its newly classified
+// AgentState, used to coalesce @amux_agent_state tag writes to true state
+// transitions (see sessionAgentStateChanges).
+type agentStateTagChange struct {
+	sessionName string
+	state       activity.AgentState
+}
+
+// sessionAgentStateChanges classifies each session in updatedStates via
+// activity.ClassifyState (the same deterministic per-session classification
+// ClassifyWorkspaceStates and the dashboard indicators use) both before and
+// after this scan's update, and returns only the sessions whose classification
+// actually changed. This is the coalescing that keeps @amux_agent_state writes
+// bounded to real transitions instead of firing on every ~5s scan tick,
+// mirroring how the working->done toast (countWorkingToDone) only fires on
+// transition.
+func sessionAgentStateChanges(prevStates, updatedStates map[string]*activity.SessionState, now time.Time) []agentStateTagChange {
+	var changes []agentStateTagChange
+	for name, next := range updatedStates {
+		prevState := activity.ClassifyState(prevStates[name], now)
+		nextState := activity.ClassifyState(next, now)
+		if nextState != prevState {
+			changes = append(changes, agentStateTagChange{sessionName: name, state: nextState})
+		}
+	}
+	return changes
+}
+
+// setAgentStateTag is a seam over tmux.SetSessionTagValue so tests can assert
+// exactly which @amux_agent_state writes agentStateTagWriteCmd issues without a
+// live tmux server. Production always uses the real tmux.SetSessionTagValue.
+var setAgentStateTag = tmux.SetSessionTagValue
+
+// agentStateTagWriteCmd returns a best-effort command that publishes
+// @amux_agent_state for each changed session. Like the existing
+// @amux_last_output_at / @amux_last_input_at tag writes, failures are ignored
+// (external orchestrators tolerate a missing/stale tag) and the write happens
+// off the main Update-loop goroutine via the returned tea.Cmd — the session
+// names and target states were already resolved synchronously on the main
+// thread by sessionAgentStateChanges, so this closure touches no App state.
+func agentStateTagWriteCmd(changes []agentStateTagChange, opts tmux.Options) tea.Cmd {
+	if len(changes) == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		for _, change := range changes {
+			_ = setAgentStateTag(change.sessionName, tmux.TagAgentState, change.state.String(), opts)
+		}
+		return nil
+	}
 }
 
 // countWorkingToDone counts the number of workspaces that transitioned from

--- a/internal/tmux/tags.go
+++ b/internal/tmux/tags.go
@@ -23,6 +23,12 @@ const (
 	TagLastInputAt    = "@amux_last_input_at"
 	TagSessionOwner   = "@amux_session_owner"
 	TagSessionLeaseAt = "@amux_session_lease_ms"
+	// TagAgentState publishes the semantic per-session agent state
+	// ("idle"/"working"/"done", see activity.AgentState.String()) computed by
+	// the activity scan's hysteresis. Written best-effort on state transitions
+	// only (see app_tmux_activity_result.go); read-only telemetry for external
+	// orchestrators.
+	TagAgentState = "@amux_agent_state"
 )
 
 // SessionsWithTags returns sessions matching the provided tags, plus values for requested tag keys.

--- a/internal/tmux/tags_test.go
+++ b/internal/tmux/tags_test.go
@@ -366,6 +366,42 @@ func TestSetSessionTagValue_Roundtrip(t *testing.T) {
 	}
 }
 
+// TestTagAgentState_KeyPinned pins the @amux_agent_state tag key string. This
+// is part of the external orchestration contract (docs/ORCHESTRATION.md) — a
+// rename here must be a deliberate, documented breaking change, not an
+// incidental refactor.
+func TestTagAgentState_KeyPinned(t *testing.T) {
+	if TagAgentState != "@amux_agent_state" {
+		t.Fatalf("TagAgentState = %q, want %q", TagAgentState, "@amux_agent_state")
+	}
+}
+
+// TestSetSessionTagValue_AgentStateRoundtrip writes each documented
+// @amux_agent_state value (idle/working/done) through the same public
+// SetSessionTagValue path the activity scan's best-effort tag write uses, and
+// reads each back — proving the tag key/value pair actually round-trips
+// through tmux, not just that the Go constant string is correct.
+func TestSetSessionTagValue_AgentStateRoundtrip(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	createSession(t, opts, "sstv-agentstate", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	for _, want := range []string{"idle", "working", "done"} {
+		if err := SetSessionTagValue("sstv-agentstate", TagAgentState, want, opts); err != nil {
+			t.Fatalf("SetSessionTagValue(%q): %v", want, err)
+		}
+		got, err := SessionTagValue("sstv-agentstate", TagAgentState, opts)
+		if err != nil {
+			t.Fatalf("SessionTagValue: %v", err)
+		}
+		if got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	}
+}
+
 // TestSetSessionTagValues_MissingSessionIsNoError verifies the hasSession
 // pre-check short-circuits to nil (no spurious error) for a session that does
 // not exist, the "killed between create and tag" case.


### PR DESCRIPTION
Implements plan 057 (DIR-04). Publishes the already-computed per-session agent state (`idle`/`working`/`done`) as `@amux_agent_state` for external orchestrators, so they stop re-deriving it from raw timestamps.

Design: the plan's suggested bell locus keys states by workspace ID (ambiguous for multi-session workspaces), so this uses `UpdatedStates` (per-session, matching the existing per-session tags) classified via the existing `ClassifyState`. Change-detection is synchronous on the Update loop (reads pre-merge state); only the tmux I/O is deferred into a Cmd capturing value data — no App-state race. Coalesced to real transitions; best-effort. ORCHESTRATION.md documents it; key pinned in a test.

Reviewer re-ran: build + activity/tmux/app tests green (incl. real-tmux roundtrip); coalescing + best-effort verified.