### PR TITLE
test: cover settings-tmux persist and rename/commit dialog guards

### DIFF
--- a/internal/app/app_input_messages_dialogs_rename_commit_test.go
+++ b/internal/app/app_input_messages_dialogs_rename_commit_test.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// TestHandleShowRenameWorkspaceDialog_PrefillsCurrentName guards the
+// load-bearing "prefill AFTER presentDialog" ordering in
+// handleShowRenameWorkspaceDialog: Show() resets the input to empty, so
+// SetInputValue must run after it or the dialog would render blank instead
+// of ready-to-edit. Uses the newDialogHarness/dialogView helpers defined in
+// app_input_messages_dialogs_show_test.go (same package).
+func TestHandleShowRenameWorkspaceDialog_PrefillsCurrentName(t *testing.T) {
+	h := newDialogHarness(t)
+	project := &data.Project{Name: "alpha", Path: "/repo/alpha"}
+	ws := &data.Workspace{Name: "old-name", Repo: "/repo/alpha", Root: "/repo/alpha/ws"}
+
+	h.app.handleShowRenameWorkspaceDialog(messages.ShowRenameWorkspaceDialog{
+		Project:   project,
+		Workspace: ws,
+	})
+
+	if h.app.dialogProject != project {
+		t.Fatal("expected dialogProject to be stored")
+	}
+	if h.app.dialogWorkspace != ws {
+		t.Fatal("expected dialogWorkspace to be stored")
+	}
+
+	view := dialogView(t, h.app.dialog)
+	if !strings.Contains(view, "Rename Workspace") {
+		t.Fatalf("expected rename title in view, got %q", view)
+	}
+	if !strings.Contains(view, "old-name") {
+		t.Fatalf("expected the rename dialog prefilled with the current workspace name, got %q", view)
+	}
+}
+
+// TestHandleShowRenameWorkspaceDialog_NilWorkspaceIsNoop confirms the
+// nil-workspace guard: no dialog is shown.
+func TestHandleShowRenameWorkspaceDialog_NilWorkspaceIsNoop(t *testing.T) {
+	h := newDialogHarness(t)
+
+	h.app.handleShowRenameWorkspaceDialog(messages.ShowRenameWorkspaceDialog{
+		Project:   &data.Project{Name: "alpha"},
+		Workspace: nil,
+	})
+
+	if h.app.dialog != nil {
+		t.Fatal("expected nil-workspace rename request to be a no-op")
+	}
+}
+
+// TestHandleShowRenameWorkspaceDialog_ValidatesReplacementName exercises the
+// validate closure (SanitizeInput then ValidateWorkspaceName): an invalid
+// replacement blocks Enter and surfaces an error, a valid one confirms.
+func TestHandleShowRenameWorkspaceDialog_ValidatesReplacementName(t *testing.T) {
+	h := newDialogHarness(t)
+	ws := &data.Workspace{Name: "old-name"}
+
+	h.app.handleShowRenameWorkspaceDialog(messages.ShowRenameWorkspaceDialog{Workspace: ws})
+
+	clearInput := func() {
+		// 20 backspaces safely over-clears regardless of current content
+		// length; backspacing an empty field is a no-op.
+		for i := 0; i < 20; i++ {
+			h.app.dialog, _ = h.app.dialog.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+		}
+	}
+	typeInto := func(s string) {
+		for _, r := range s {
+			h.app.dialog, _ = h.app.dialog.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		}
+	}
+
+	clearInput()
+	typeInto("bad..name")
+	rendered := ansi.Strip(h.app.dialog.View())
+	if !strings.Contains(rendered, "name") {
+		t.Fatalf("expected validation error for invalid replacement name, got %q", rendered)
+	}
+	if _, cmd := h.app.dialog.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+		t.Fatal("expected Enter to be blocked while the replacement name is invalid")
+	}
+
+	clearInput()
+	typeInto("feature-y")
+	res := confirmResult(t, h.app.dialog)
+	if !res.Confirmed || res.Value != "feature-y" {
+		t.Fatalf("expected confirmed result with value %q, got %+v", "feature-y", res)
+	}
+}
+
+// TestHandleShowCommitWorkspaceDialog_ValidatesLeadingDash covers the
+// commit-message dialog's live guard: a '-'-prefixed message is refused
+// (defense-in-depth against it being parsed as a `git commit -m` flag),
+// while a normal or empty message is accepted at the validate-closure level
+// (an empty message is refused later, by CommitAll on confirm).
+func TestHandleShowCommitWorkspaceDialog_ValidatesLeadingDash(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErrText bool
+	}{
+		{name: "empty message shows no error", input: "", wantErrText: false},
+		{name: "normal message shows no error", input: "fix bug", wantErrText: false},
+		{name: "leading dash rejected", input: "-oops", wantErrText: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newDialogHarness(t)
+			ws := &data.Workspace{Name: "feature-x", Repo: "/repo/alpha", Root: "/repo/alpha/ws"}
+
+			h.app.handleShowCommitWorkspaceDialog(messages.ShowCommitWorkspaceDialog{Workspace: ws})
+
+			if h.app.dialogWorkspace != ws {
+				t.Fatal("expected dialogWorkspace to be stored")
+			}
+			view := dialogView(t, h.app.dialog)
+			if !strings.Contains(view, "Commit changes") {
+				t.Fatalf("expected commit title in view, got %q", view)
+			}
+
+			for _, r := range tc.input {
+				h.app.dialog, _ = h.app.dialog.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+			}
+
+			rendered := ansi.Strip(h.app.dialog.View())
+			if tc.wantErrText {
+				if !strings.Contains(rendered, "cannot start with '-'") {
+					t.Fatalf("expected leading-dash validation error for %q, got %q", tc.input, rendered)
+				}
+				if _, cmd := h.app.dialog.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+					t.Fatalf("expected Enter to be blocked while invalid for %q", tc.input)
+				}
+				return
+			}
+			if strings.Contains(rendered, "cannot start with '-'") {
+				t.Fatalf("expected no validation error for %q, got %q", tc.input, rendered)
+			}
+			res := confirmResult(t, h.app.dialog)
+			if !res.Confirmed || res.Value != tc.input {
+				t.Fatalf("expected confirmed result with value %q, got %+v", tc.input, res)
+			}
+		})
+	}
+}

--- a/internal/app/app_input_messages_dialogs_settings_tmux_test.go
+++ b/internal/app/app_input_messages_dialogs_settings_tmux_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+// TestHandleSettingsResult_PersistsTmuxConfigEdit confirms an edited tmux
+// config-path field is written to config.UI.TmuxConfigPath and persisted to
+// disk via SaveUISettings on a non-canceled close -- the tmux counterpart to
+// TestHandleSettingsResult_PersistsAssistantCommandEdit in
+// app_input_messages_dialogs_test.go. The dialog exposes no direct tmux
+// setter (unlike AssistantCommands(), which returns a mutable map), so the
+// edit is driven the same way a real user would: Tab to focus the field,
+// then type into it (see settings_test.go's TestSettingsDialogEditsTmuxFields
+// for the same pattern one layer down, in internal/ui/common).
+func TestHandleSettingsResult_PersistsTmuxConfigEdit(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{Mode: HarnessCenter, Width: 120, Height: 40})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "amux-config.json")
+	h.app.config.Paths.ConfigPath = configPath
+	// Pin the theme to the same value PersistedUISettings resolves to for a
+	// not-yet-existing config file (the default, "gruvbox"), so this test's
+	// close is dirty for tmux only -- independent of whatever theme the
+	// machine running the test happens to have in its real ~/.amux/config.json.
+	h.app.config.UI.Theme = string(common.ThemeGruvbox)
+	h.app.handleShowSettingsDialog()
+
+	// Tab from Theme to the tmux server field, then to the config-path field,
+	// and type a new value there.
+	h.app.settingsDialog, _ = h.app.settingsDialog.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	h.app.settingsDialog, _ = h.app.settingsDialog.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	for _, r := range "/tmp/new-tmux.conf" {
+		h.app.settingsDialog, _ = h.app.settingsDialog.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+
+	cmd := h.app.handleSettingsResult(common.SettingsResult{})
+	if cmd != nil {
+		t.Fatal("expected no warning cmd when tmux save succeeds")
+	}
+
+	if got := h.app.config.UI.TmuxConfigPath; got != "/tmp/new-tmux.conf" {
+		t.Errorf("in-memory TmuxConfigPath = %q, want %q", got, "/tmp/new-tmux.conf")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config file to be written: %v", err)
+	}
+	if !strings.Contains(string(data), `"tmux_config": "/tmp/new-tmux.conf"`) {
+		t.Fatalf("expected persisted tmux config path in config, got %q", string(data))
+	}
+}
+
+// TestHandleSettingsResult_UnchangedTmuxSkipsSave confirms closing the
+// settings dialog without editing any tmux field does not write to disk,
+// mirroring TestHandleSettingsResult_UnchangedThemeSkipsSave's contract for
+// the tmux fields specifically.
+func TestHandleSettingsResult_UnchangedTmuxSkipsSave(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{Mode: HarnessCenter, Width: 120, Height: 40})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "amux-config.json")
+	h.app.config.Paths.ConfigPath = configPath
+	h.app.config.UI.Theme = string(common.ThemeGruvbox)
+	h.app.config.UI.TmuxServer = "existing-server"
+	h.app.handleShowSettingsDialog()
+
+	cmd := h.app.handleSettingsResult(common.SettingsResult{})
+	if cmd != nil {
+		t.Fatal("expected no cmd when closing settings without any tmux edit")
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected unchanged tmux close not to write config, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
Implements plan 049 (TEST-01/04/05). Test-only. Covers: `applySettingsTmux` change-detection (a tmux edit persists via SaveUISettings; unchanged skips), rename-dialog prefill ordering, and the commit-dialog `-`-prefix guard. New sibling test files (kept the plan-named files under the 500-line cap).

Reviewer: diff is test-only; app suite green; drives tmux fields via the same Update(KeyPressMsg) path as the settings_test exemplar.