### PR TITLE
feat: surface branch-vs-base diff and ahead/behind

### DIFF
--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -103,6 +103,18 @@ func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case sidebar.BranchChangesLoaded, sidebar.AheadBehindLoaded:
+		// Branch-vs-base list / ahead-behind badge fetch results: route back
+		// into the sidebar regardless of which of its tabs is active (see
+		// TabbedSidebar.Update's special-case for these two types).
+		if a.sidebar != nil {
+			newSidebar, cmd := a.sidebar.Update(msg)
+			a.sidebar = newSidebar
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+
 	case messages.Error:
 		if cmd := a.handleErrorMessage(msg); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -143,7 +143,9 @@ func (a *App) rebindActiveSelection() []tea.Cmd {
 			}
 		}
 		if a.sidebar != nil {
-			a.sidebar.SetWorkspace(ws)
+			if cmd := a.sidebar.SetWorkspace(ws); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		}
 		if a.sidebarTerminal != nil {
 			a.sidebarTerminal.SetWorkspacePreview(ws)
@@ -300,7 +302,9 @@ func (a *App) handleWorkspaceActivated(msg messages.WorkspaceActivated) []tea.Cm
 	a.centerBtnFocused = false
 	a.centerBtnIndex = 0
 	a.center.SetWorkspace(msg.Workspace)
-	a.sidebar.SetWorkspace(msg.Workspace)
+	if cmd := a.sidebar.SetWorkspace(msg.Workspace); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	a.sidebarTerminal.SetWorkspacePreview(msg.Workspace)
 	// Discover shared tmux tabs first; restore/sync happens below.
 	if discoverCmd := a.discoverWorkspaceTabsFromTmux(msg.Workspace); discoverCmd != nil {

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -59,6 +59,11 @@ func (a *App) handleWorkspaceCommitted(msg messages.WorkspaceCommitted) tea.Cmd 
 	cmds = append(cmds, a.toast.ShowSuccess("Committed changes"))
 	if msg.Workspace != nil {
 		cmds = append(cmds, a.requestGitStatusFull(msg.Workspace.Root))
+		// A commit moves HEAD, which changes how far ahead of base it is; refresh
+		// the sidebar's ahead/behind badge so it doesn't show a stale count.
+		if a.sidebar != nil {
+			cmds = append(cmds, a.sidebar.RefreshAheadBehind())
+		}
 	}
 	return common.SafeBatch(cmds...)
 }

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -3,6 +3,8 @@ package git
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -59,16 +61,10 @@ func GetBranchFileDiff(repoPath, path string) (*DiffResult, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
-	mergeBase, err := RunGitCtx(ctx, repoPath, "merge-base", base, "HEAD")
-	cancel()
-	if err != nil {
-		mergeBase = base
-	}
+	mergeBase := resolveMergeBase(repoPath, base)
 
 	args := []string{"diff", "--no-color", "--no-ext-diff", "-U3", mergeBase + "...HEAD", "--", path}
-	ctx, cancel = context.WithTimeout(context.Background(), branchDiffTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, args...)
 	if err != nil {
@@ -79,4 +75,108 @@ func GetBranchFileDiff(repoPath, path string) (*DiffResult, error) {
 	}
 
 	return parseDiff(path, output), nil
+}
+
+// resolveMergeBase returns merge-base(base, HEAD), falling back to base
+// itself if the merge-base lookup fails (e.g. unrelated histories). Shared by
+// GetBranchFileDiff and BranchChangesVsBase so the two stay consistent about
+// which commit "vs base" means.
+func resolveMergeBase(repoPath, base string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	defer cancel()
+	mergeBase, err := RunGitCtx(ctx, repoPath, "merge-base", base, "HEAD")
+	if err != nil {
+		return base
+	}
+	return mergeBase
+}
+
+// BranchChangesVsBase lists every file that differs between HEAD and
+// merge-base(base, HEAD) — i.e. everything committed on this branch that
+// hasn't landed on base yet. It reuses the same base/merge-base resolution as
+// GetBranchFileDiff (GetBaseBranch, then resolveMergeBase) so "vs base" means
+// the same thing in both places. Read-only: no fetch, merge, or checkout.
+func BranchChangesVsBase(repoPath string) ([]Change, error) {
+	base, err := GetBaseBranch(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	mergeBase := resolveMergeBase(repoPath, base)
+
+	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	defer cancel()
+	output, err := RunGitCtx(ctx, repoPath, "diff", "--no-color", "--name-status", mergeBase+"...HEAD")
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNameStatus(output), nil
+}
+
+// parseNameStatus parses `git diff --name-status` output (one "CODE\tpath" or
+// "CODE\toldpath\tnewpath" line per change) into Changes, reusing the same
+// status-code mapping as working-tree status parsing.
+func parseNameStatus(output string) []Change {
+	if output == "" {
+		return nil
+	}
+	var changes []Change
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 2 {
+			continue
+		}
+		code := parts[0]
+		change := Change{Kind: statusCodeToKind(code[0])}
+		if (code[0] == 'R' || code[0] == 'C') && len(parts) >= 3 {
+			change.OldPath = parts[1]
+			change.Path = parts[2]
+		} else {
+			change.Path = parts[1]
+		}
+		changes = append(changes, change)
+	}
+	sortChanges(changes)
+	return changes
+}
+
+// AheadBehind reports how many commits HEAD is ahead of and behind the
+// workspace's base branch, using the same base resolution as
+// GetBranchFileDiff/BranchChangesVsBase (GetBaseBranch) so all three agree on
+// what "base" means for a workspace. Read-only. When no base branch can be
+// determined (e.g. no candidate/remote branch exists), the GetBaseBranch
+// error is returned unchanged so callers can tell "nothing to compare
+// against" apart from a real git failure.
+func AheadBehind(repoPath string) (ahead, behind int, err error) {
+	base, err := GetBaseBranch(repoPath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	defer cancel()
+	output, err := RunGitCtx(ctx, repoPath, "rev-list", "--left-right", "--count", base+"...HEAD")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// --left-right --count <base>...HEAD prints "leftCount rightCount": left
+	// is commits reachable from base but not HEAD (behind), right is commits
+	// reachable from HEAD but not base (ahead).
+	fields := strings.Fields(output)
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("git rev-list --left-right --count: unexpected output %q", output)
+	}
+	behind, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("git rev-list --left-right --count: %w", err)
+	}
+	ahead, err = strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("git rev-list --left-right --count: %w", err)
+	}
+	return ahead, behind, nil
 }

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -286,6 +287,189 @@ func TestGetBranchFileDiff(t *testing.T) {
 		}
 		if result != nil {
 			t.Errorf("GetBranchFileDiff() result = %+v, want nil on error", result)
+		}
+		if !strings.Contains(err.Error(), "unable to determine default branch") {
+			t.Errorf("error = %q, want it to mention default branch", err.Error())
+		}
+	})
+}
+
+func TestBranchChangesVsBase(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("lists added, modified, and deleted files vs base", func(t *testing.T) {
+		repo := initRepo(t)
+		writeFile(t, repo, "modified.go", "package main\n")
+		writeFile(t, repo, "removed.go", "package doomed\n\nfunc DoNotKeep() int { return 1 }\n")
+		runGit(t, repo, "add", "modified.go", "removed.go")
+		runGit(t, repo, "commit", "-m", "seed files")
+
+		runGit(t, repo, "checkout", "-b", "feature")
+		writeFile(t, repo, "modified.go", "package main\n\nfunc main() {}\n")
+		runGit(t, repo, "rm", "removed.go")
+		// Content deliberately dissimilar from removed.go so git's rename
+		// detection doesn't collapse this add+delete pair into a rename.
+		writeFile(t, repo, "added.go", "package brandnew\n\ntype Widget struct{ Count int }\n")
+		runGit(t, repo, "add", "modified.go", "added.go")
+		runGit(t, repo, "commit", "-m", "change files")
+
+		changes, err := BranchChangesVsBase(repo)
+		if err != nil {
+			t.Fatalf("BranchChangesVsBase() unexpected error: %v", err)
+		}
+		if len(changes) != 3 {
+			t.Fatalf("BranchChangesVsBase() returned %d changes, want 3: %+v", len(changes), changes)
+		}
+
+		byPath := make(map[string]Change, len(changes))
+		for _, c := range changes {
+			byPath[c.Path] = c
+		}
+
+		if c, ok := byPath["added.go"]; !ok || c.Kind != ChangeAdded {
+			t.Errorf("added.go = %+v, want ChangeAdded present", c)
+		}
+		if c, ok := byPath["modified.go"]; !ok || c.Kind != ChangeModified {
+			t.Errorf("modified.go = %+v, want ChangeModified present", c)
+		}
+		if c, ok := byPath["removed.go"]; !ok || c.Kind != ChangeDeleted {
+			t.Errorf("removed.go = %+v, want ChangeDeleted present", c)
+		}
+
+		// Sorted lexicographically, mirroring status parsing.
+		for i := 1; i < len(changes); i++ {
+			if changes[i-1].Path > changes[i].Path {
+				t.Errorf("changes not sorted: %q before %q", changes[i-1].Path, changes[i].Path)
+			}
+		}
+	})
+
+	t.Run("returns no changes for a branch with nothing ahead of base", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "checkout", "-b", "feature")
+
+		changes, err := BranchChangesVsBase(repo)
+		if err != nil {
+			t.Fatalf("BranchChangesVsBase() unexpected error: %v", err)
+		}
+		if len(changes) != 0 {
+			t.Errorf("BranchChangesVsBase() = %+v, want no changes", changes)
+		}
+	})
+
+	t.Run("propagates base-branch resolution error", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "branch", "-m", "main", "work")
+
+		changes, err := BranchChangesVsBase(repo)
+		if err == nil {
+			t.Fatalf("BranchChangesVsBase() error = nil, want error from base resolution (changes=%+v)", changes)
+		}
+		if changes != nil {
+			t.Errorf("BranchChangesVsBase() changes = %+v, want nil on error", changes)
+		}
+		if !strings.Contains(err.Error(), "unable to determine default branch") {
+			t.Errorf("error = %q, want it to mention default branch", err.Error())
+		}
+	})
+}
+
+func TestAheadBehind(t *testing.T) {
+	skipIfNoGit(t)
+
+	t.Run("counts commits ahead of base", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "checkout", "-b", "feature")
+		for i := 0; i < 3; i++ {
+			writeFile(t, repo, "file.txt", strings.Repeat("x", i+1))
+			runGit(t, repo, "add", "file.txt")
+			runGit(t, repo, "commit", "-m", "commit "+strconv.Itoa(i))
+		}
+
+		ahead, behind, err := AheadBehind(repo)
+		if err != nil {
+			t.Fatalf("AheadBehind() unexpected error: %v", err)
+		}
+		if ahead != 3 {
+			t.Errorf("ahead = %d, want 3", ahead)
+		}
+		if behind != 0 {
+			t.Errorf("behind = %d, want 0", behind)
+		}
+	})
+
+	t.Run("counts commits behind base", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "checkout", "-b", "feature")
+		// Base (main) picks up two commits the feature branch never sees.
+		runGit(t, repo, "checkout", "main")
+		for i := 0; i < 2; i++ {
+			writeFile(t, repo, "base.txt", strings.Repeat("y", i+1))
+			runGit(t, repo, "add", "base.txt")
+			runGit(t, repo, "commit", "-m", "base commit "+strconv.Itoa(i))
+		}
+		runGit(t, repo, "checkout", "feature")
+
+		ahead, behind, err := AheadBehind(repo)
+		if err != nil {
+			t.Fatalf("AheadBehind() unexpected error: %v", err)
+		}
+		if ahead != 0 {
+			t.Errorf("ahead = %d, want 0", ahead)
+		}
+		if behind != 2 {
+			t.Errorf("behind = %d, want 2", behind)
+		}
+	})
+
+	t.Run("counts both ahead and behind when diverged", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "checkout", "-b", "feature")
+		writeFile(t, repo, "feature.txt", "one\n")
+		runGit(t, repo, "add", "feature.txt")
+		runGit(t, repo, "commit", "-m", "feature commit")
+
+		runGit(t, repo, "checkout", "main")
+		writeFile(t, repo, "base.txt", "one\n")
+		runGit(t, repo, "add", "base.txt")
+		runGit(t, repo, "commit", "-m", "base commit")
+		runGit(t, repo, "checkout", "feature")
+
+		ahead, behind, err := AheadBehind(repo)
+		if err != nil {
+			t.Fatalf("AheadBehind() unexpected error: %v", err)
+		}
+		if ahead != 1 {
+			t.Errorf("ahead = %d, want 1", ahead)
+		}
+		if behind != 1 {
+			t.Errorf("behind = %d, want 1", behind)
+		}
+	})
+
+	t.Run("zero commits ahead or behind on a clean checkout of base", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "checkout", "-b", "feature")
+
+		ahead, behind, err := AheadBehind(repo)
+		if err != nil {
+			t.Fatalf("AheadBehind() unexpected error: %v", err)
+		}
+		if ahead != 0 || behind != 0 {
+			t.Errorf("ahead, behind = %d, %d, want 0, 0", ahead, behind)
+		}
+	})
+
+	t.Run("propagates base-branch resolution error", func(t *testing.T) {
+		repo := initRepo(t)
+		runGit(t, repo, "branch", "-m", "main", "work")
+
+		ahead, behind, err := AheadBehind(repo)
+		if err == nil {
+			t.Fatalf("AheadBehind() error = nil, want error from base resolution (ahead=%d behind=%d)", ahead, behind)
+		}
+		if ahead != 0 || behind != 0 {
+			t.Errorf("AheadBehind() ahead, behind = %d, %d, want 0, 0 on error", ahead, behind)
 		}
 		if !strings.Contains(err.Error(), "unable to determine default branch") {
 			t.Errorf("error = %q, want it to mention default branch", err.Error())

--- a/internal/ui/sidebar/branch.go
+++ b/internal/ui/sidebar/branch.go
@@ -1,0 +1,148 @@
+package sidebar
+
+import (
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/git"
+)
+
+// BranchChangesLoaded carries the result of an async BranchChangesVsBase
+// fetch triggered by toggling branch mode on. It is routed back into the
+// sidebar explicitly by internal/app (see app_input.go), since Bubbletea has
+// no generic message broadcast.
+type BranchChangesLoaded struct {
+	Root    string
+	LoadID  int
+	Changes []git.Change
+	Err     error
+}
+
+// AheadBehindLoaded carries the result of an async AheadBehind fetch,
+// triggered on workspace switch, manual refresh ("g"), and after a commit.
+type AheadBehindLoaded struct {
+	Root   string
+	LoadID int
+	Ahead  int
+	Behind int
+	Err    error
+}
+
+// loadBranchChanges returns a command that fetches BranchChangesVsBase for
+// the current workspace. Bumps branchLoadID so a stale result (e.g. from a
+// rapid toggle-off/toggle-on) is dropped on arrival.
+func (m *Model) loadBranchChanges() tea.Cmd {
+	if m.workspace == nil {
+		return nil
+	}
+	root := m.workspace.Root
+	m.branchLoadID++
+	loadID := m.branchLoadID
+	return func() tea.Msg {
+		changes, err := git.BranchChangesVsBase(root)
+		return BranchChangesLoaded{Root: root, LoadID: loadID, Changes: changes, Err: err}
+	}
+}
+
+// refreshAheadBehind returns a command that fetches AheadBehind for the
+// current workspace. Bumps aheadBehindLoadID so a stale result is dropped.
+func (m *Model) refreshAheadBehind() tea.Cmd {
+	if m.workspace == nil {
+		return nil
+	}
+	root := m.workspace.Root
+	m.aheadBehindLoadID++
+	loadID := m.aheadBehindLoadID
+	return func() tea.Msg {
+		ahead, behind, err := git.AheadBehind(root)
+		return AheadBehindLoaded{Root: root, LoadID: loadID, Ahead: ahead, Behind: behind, Err: err}
+	}
+}
+
+// handleBranchChangesLoaded applies a BranchChangesLoaded result, dropping it
+// if it's stale (superseded by a newer toggle or a workspace switch).
+func (m *Model) handleBranchChangesLoaded(msg BranchChangesLoaded) {
+	if msg.LoadID != m.branchLoadID {
+		return
+	}
+	if m.workspace == nil || msg.Root != m.workspace.Root {
+		return
+	}
+	m.branchLoading = false
+	m.branchErr = msg.Err
+	m.branchChanges = msg.Changes
+	if m.branchMode {
+		m.rebuildDisplayList()
+	}
+}
+
+// handleAheadBehindLoaded applies an AheadBehindLoaded result, dropping it if
+// it's stale.
+func (m *Model) handleAheadBehindLoaded(msg AheadBehindLoaded) {
+	if msg.LoadID != m.aheadBehindLoadID {
+		return
+	}
+	if m.workspace == nil || msg.Root != m.workspace.Root {
+		return
+	}
+	m.aheadBehindErr = msg.Err
+	if msg.Err == nil {
+		m.ahead = msg.Ahead
+		m.behind = msg.Behind
+	}
+}
+
+// toggleBranchMode flips branch mode. Turning it on (re-)triggers a fetch;
+// turning it off just falls back to the staged/unstaged/untracked list built
+// from the already-loaded gitStatus — no fetch needed.
+func (m *Model) toggleBranchMode() tea.Cmd {
+	m.branchMode = !m.branchMode
+	var cmd tea.Cmd
+	if m.branchMode {
+		m.branchLoading = true
+		m.branchErr = nil
+		cmd = m.loadBranchChanges()
+	}
+	m.rebuildDisplayList()
+	return cmd
+}
+
+// rebuildBranchDisplayList populates displayItems from branchChanges,
+// honoring the same filter query as the staged/unstaged/untracked lists.
+func (m *Model) rebuildBranchDisplayList() {
+	if len(m.branchChanges) == 0 {
+		return
+	}
+
+	matchesFilter := func(c *git.Change) bool {
+		if m.filterQuery == "" {
+			return true
+		}
+		return strings.Contains(strings.ToLower(c.Path), strings.ToLower(m.filterQuery))
+	}
+
+	count := 0
+	for i := range m.branchChanges {
+		if matchesFilter(&m.branchChanges[i]) {
+			count++
+		}
+	}
+	if count == 0 {
+		return
+	}
+
+	m.displayItems = append(m.displayItems, displayItem{
+		isHeader: true,
+		header:   "Vs base (" + strconv.Itoa(count) + ")",
+	})
+	for i := range m.branchChanges {
+		if matchesFilter(&m.branchChanges[i]) {
+			m.displayItems = append(m.displayItems, displayItem{
+				change: &m.branchChanges[i],
+				mode:   git.DiffModeBranch,
+			})
+		}
+	}
+}

--- a/internal/ui/sidebar/branch_test.go
+++ b/internal/ui/sidebar/branch_test.go
@@ -1,0 +1,322 @@
+package sidebar
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/testutil"
+)
+
+// newFeatureWorkspaceRepo builds a temp repo on "main" with one commit ahead
+// on "feature" (checked out), and returns a *data.Workspace pointed at it —
+// the fixture the branch-mode fetch commands (loadBranchChanges,
+// refreshAheadBehind) exercise end-to-end against a real git repo.
+func newFeatureWorkspaceRepo(t *testing.T) (*data.Workspace, string) {
+	t.Helper()
+	repo := testutil.InitRepo(t)
+	testutil.RunGit(t, repo, "checkout", "-b", "feature")
+	if err := os.WriteFile(repo+"/widget.go", []byte("package widget\n"), 0o600); err != nil {
+		t.Fatalf("write widget.go: %v", err)
+	}
+	testutil.RunGit(t, repo, "add", "widget.go")
+	testutil.RunGit(t, repo, "commit", "-m", "add widget")
+	ws := data.NewWorkspace("feature", "feature", "main", repo, repo)
+	return ws, repo
+}
+
+func TestToggleBranchModeFetchesAndPopulatesDisplayItems(t *testing.T) {
+	ws, _ := newFeatureWorkspaceRepo(t)
+
+	m := New()
+	m.SetSize(60, 20)
+	m.SetWorkspace(ws)
+
+	cmd := m.toggleBranchMode()
+	if !m.branchMode {
+		t.Fatal("toggleBranchMode() should turn branch mode on")
+	}
+	if !m.branchLoading {
+		t.Fatal("toggleBranchMode() should mark branchLoading while the fetch is in flight")
+	}
+	if cmd == nil {
+		t.Fatal("toggleBranchMode() should return a fetch command when turning on")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(BranchChangesLoaded)
+	if !ok {
+		t.Fatalf("fetch command produced %T, want BranchChangesLoaded", msg)
+	}
+	if loaded.Err != nil {
+		t.Fatalf("BranchChangesLoaded.Err = %v, want nil", loaded.Err)
+	}
+	if len(loaded.Changes) != 1 || loaded.Changes[0].Path != "widget.go" {
+		t.Fatalf("BranchChangesLoaded.Changes = %+v, want [widget.go]", loaded.Changes)
+	}
+
+	newModel, followUpCmd := m.Update(loaded)
+	m = newModel
+	if followUpCmd != nil {
+		t.Errorf("Update(BranchChangesLoaded) returned a command, want nil")
+	}
+	if m.branchLoading {
+		t.Error("branchLoading should be false once the result lands")
+	}
+
+	var fileItems int
+	for _, item := range m.displayItems {
+		if item.isHeader {
+			continue
+		}
+		fileItems++
+		if item.mode != git.DiffModeBranch {
+			t.Errorf("displayItem.mode = %v, want DiffModeBranch", item.mode)
+		}
+		if item.change.Path != "widget.go" {
+			t.Errorf("displayItem.change.Path = %q, want widget.go", item.change.Path)
+		}
+	}
+	if fileItems != 1 {
+		t.Fatalf("displayItems has %d file rows, want 1: %+v", fileItems, m.displayItems)
+	}
+
+	// Toggling off should fall back to the working-tree list without
+	// disturbing the fetched branch data.
+	if cmd := m.toggleBranchMode(); cmd != nil {
+		t.Error("toggling branch mode off should not issue a fetch")
+	}
+	if m.branchMode {
+		t.Error("branch mode should be off")
+	}
+}
+
+func TestToggleBranchModeOffRestoresWorkingTreeList(t *testing.T) {
+	m := New()
+	m.SetSize(60, 20)
+	m.SetWorkspace(data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo"))
+	m.SetGitStatus(&git.StatusResult{
+		Unstaged: []git.Change{{Path: "a.go", Kind: git.ChangeModified}},
+	})
+
+	// Force branch mode on synthetically (skip the real fetch) then back off.
+	m.branchMode = true
+	m.branchChanges = []git.Change{{Path: "b.go", Kind: git.ChangeAdded}}
+	m.rebuildDisplayList()
+
+	m.toggleBranchMode()
+	if m.branchMode {
+		t.Fatal("expected branch mode to toggle off")
+	}
+
+	var paths []string
+	for _, item := range m.displayItems {
+		if !item.isHeader {
+			paths = append(paths, item.change.Path)
+		}
+	}
+	if len(paths) != 1 || paths[0] != "a.go" {
+		t.Fatalf("displayItems after toggling off = %v, want [a.go] (working tree)", paths)
+	}
+}
+
+func TestRebuildBranchDisplayListRespectsFilter(t *testing.T) {
+	m := New()
+	m.branchMode = true
+	// Pre-sorted, mirroring what BranchChangesVsBase returns in production
+	// (rebuildBranchDisplayList itself doesn't sort — it trusts its input).
+	m.branchChanges = []git.Change{
+		{Path: "cmd/main.go", Kind: git.ChangeModified},
+		{Path: "internal/bar.go", Kind: git.ChangeAdded},
+		{Path: "internal/foo.go", Kind: git.ChangeModified},
+	}
+	m.filterQuery = "internal"
+
+	m.rebuildDisplayList()
+
+	if !m.displayItems[0].isHeader || m.displayItems[0].header != "Vs base (2)" {
+		t.Fatalf("expected header 'Vs base (2)', got %+v", m.displayItems[0])
+	}
+	var paths []string
+	for _, item := range m.displayItems {
+		if !item.isHeader {
+			paths = append(paths, item.change.Path)
+		}
+	}
+	if len(paths) != 2 || paths[0] != "internal/bar.go" || paths[1] != "internal/foo.go" {
+		t.Fatalf("filtered branch paths = %v, want [internal/bar.go internal/foo.go]", paths)
+	}
+}
+
+func TestHandleBranchChangesLoadedDropsStaleResults(t *testing.T) {
+	m := New()
+	m.SetWorkspace(data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo"))
+	m.branchMode = true
+	m.branchLoading = true
+	m.branchLoadID = 2 // a newer toggle already bumped this past the in-flight fetch's ID
+
+	m.handleBranchChangesLoaded(BranchChangesLoaded{
+		Root:    "/tmp/repo",
+		LoadID:  1, // stale
+		Changes: []git.Change{{Path: "stale.go", Kind: git.ChangeModified}},
+	})
+	if !m.branchLoading || m.branchChanges != nil {
+		t.Fatalf("stale LoadID result should be dropped, got loading=%v changes=%+v", m.branchLoading, m.branchChanges)
+	}
+
+	m.handleBranchChangesLoaded(BranchChangesLoaded{
+		Root:    "/some/other/repo",
+		LoadID:  2,
+		Changes: []git.Change{{Path: "other.go", Kind: git.ChangeModified}},
+	})
+	if !m.branchLoading || m.branchChanges != nil {
+		t.Fatalf("result for a different workspace root should be dropped, got loading=%v changes=%+v", m.branchLoading, m.branchChanges)
+	}
+
+	m.handleBranchChangesLoaded(BranchChangesLoaded{
+		Root:    "/tmp/repo",
+		LoadID:  2,
+		Changes: []git.Change{{Path: "current.go", Kind: git.ChangeModified}},
+	})
+	if m.branchLoading {
+		t.Error("matching LoadID/Root should clear branchLoading")
+	}
+	if len(m.branchChanges) != 1 || m.branchChanges[0].Path != "current.go" {
+		t.Fatalf("branchChanges = %+v, want [current.go]", m.branchChanges)
+	}
+}
+
+func TestHandleAheadBehindLoadedUpdatesAndDropsStale(t *testing.T) {
+	m := New()
+	m.SetWorkspace(data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo"))
+	m.aheadBehindLoadID = 3
+
+	m.handleAheadBehindLoaded(AheadBehindLoaded{Root: "/tmp/repo", LoadID: 2, Ahead: 5, Behind: 5})
+	if m.ahead != 0 || m.behind != 0 {
+		t.Fatalf("stale LoadID should be dropped, got ahead=%d behind=%d", m.ahead, m.behind)
+	}
+
+	m.handleAheadBehindLoaded(AheadBehindLoaded{Root: "/tmp/repo", LoadID: 3, Ahead: 2, Behind: 1})
+	if m.ahead != 2 || m.behind != 1 {
+		t.Fatalf("ahead, behind = %d, %d, want 2, 1", m.ahead, m.behind)
+	}
+
+	wantErr := errors.New("boom")
+	m.aheadBehindLoadID = 4
+	m.handleAheadBehindLoaded(AheadBehindLoaded{Root: "/tmp/repo", LoadID: 4, Err: wantErr})
+	if m.aheadBehindErr == nil {
+		t.Fatal("expected aheadBehindErr to be set")
+	}
+	// An error result must not clobber the last-known good counts.
+	if m.ahead != 2 || m.behind != 1 {
+		t.Fatalf("ahead, behind after error = %d, %d, want unchanged 2, 1", m.ahead, m.behind)
+	}
+}
+
+func TestSetWorkspaceResetsBranchStateAndFetchesAheadBehind(t *testing.T) {
+	ws, repo := newFeatureWorkspaceRepo(t)
+
+	m := New()
+	m.SetWorkspace(data.NewWorkspace("other", "other", "main", "/tmp/other", "/tmp/other"))
+	m.branchMode = true
+	m.branchChanges = []git.Change{{Path: "leftover.go"}}
+	m.ahead, m.behind = 9, 9
+
+	cmd := m.SetWorkspace(ws)
+	if m.branchMode {
+		t.Error("SetWorkspace should turn branch mode off for the new workspace")
+	}
+	if m.branchChanges != nil {
+		t.Error("SetWorkspace should clear stale branchChanges")
+	}
+	if m.ahead != 0 || m.behind != 0 {
+		t.Errorf("SetWorkspace should zero ahead/behind pending the new fetch, got %d/%d", m.ahead, m.behind)
+	}
+	if cmd == nil {
+		t.Fatal("SetWorkspace should return an ahead/behind fetch command for a genuinely new workspace")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(AheadBehindLoaded)
+	if !ok {
+		t.Fatalf("fetch command produced %T, want AheadBehindLoaded", msg)
+	}
+	if loaded.Root != repo {
+		t.Errorf("AheadBehindLoaded.Root = %q, want %q", loaded.Root, repo)
+	}
+	if loaded.Err != nil {
+		t.Fatalf("AheadBehindLoaded.Err = %v, want nil", loaded.Err)
+	}
+	if loaded.Ahead != 1 || loaded.Behind != 0 {
+		t.Errorf("ahead, behind = %d, %d, want 1, 0", loaded.Ahead, loaded.Behind)
+	}
+}
+
+func TestSetWorkspaceNilOrRebindReturnsNilCmd(t *testing.T) {
+	m := New()
+	if cmd := m.SetWorkspace(nil); cmd != nil {
+		t.Error("SetWorkspace(nil) should return a nil command")
+	}
+
+	ws := data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo")
+	if cmd := m.SetWorkspace(ws); cmd == nil {
+		t.Fatal("SetWorkspace with a new workspace should return a non-nil command")
+	}
+	// Re-setting the identical workspace (same canonical Root/Repo identity)
+	// is a metadata rebind, not a switch, so it must not re-fetch.
+	if cmd := m.SetWorkspace(ws); cmd != nil {
+		t.Error("SetWorkspace with the identical *data.Workspace pointer should not re-fetch")
+	}
+}
+
+func TestRenderAheadBehindBadge(t *testing.T) {
+	m := New()
+	m.SetWorkspace(data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo"))
+
+	if got := m.renderAheadBehindBadge(); got != "" {
+		t.Fatalf("badge with ahead=behind=0 = %q, want empty", got)
+	}
+
+	m.ahead, m.behind = 2, 0
+	if got := m.renderAheadBehindBadge(); !strings.Contains(got, "2") {
+		t.Fatalf("badge = %q, want it to mention ahead count 2", got)
+	}
+
+	m.aheadBehindErr = errors.New("boom")
+	if got := m.renderAheadBehindBadge(); got != "" {
+		t.Fatalf("badge after error = %q, want empty (hide rather than show stale/wrong data)", got)
+	}
+}
+
+func TestRenderBranchSectionStates(t *testing.T) {
+	m := New()
+	m.SetSize(60, 20)
+	m.SetWorkspace(data.NewWorkspace("ws", "ws", "main", "/tmp/repo", "/tmp/repo"))
+	m.branchMode = true
+
+	m.branchLoading = true
+	if got := m.renderBranchSection(); !strings.Contains(got, "Loading") {
+		t.Fatalf("loading state = %q, want it to mention Loading", got)
+	}
+
+	m.branchLoading = false
+	m.branchErr = errors.New("git exploded")
+	if got := m.renderBranchSection(); !strings.Contains(got, "git exploded") {
+		t.Fatalf("error state = %q, want it to surface the error", got)
+	}
+
+	m.branchErr = nil
+	m.branchChanges = nil
+	if got := m.renderBranchSection(); !strings.Contains(got, "No commits ahead of base") {
+		t.Fatalf("empty state = %q, want the no-commits message", got)
+	}
+
+	m.branchChanges = []git.Change{{Path: "widget.go", Kind: git.ChangeModified}}
+	m.rebuildDisplayList()
+	if got := m.renderBranchSection(); !strings.Contains(got, "widget.go") {
+		t.Fatalf("populated state = %q, want it to list widget.go", got)
+	}
+}

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -21,7 +21,8 @@ type displayItem struct {
 }
 
 // Model is the Bubbletea model for the sidebar pane
-// (rendering lives in model_view.go, input in model_input.go).
+// (rendering lives in model_view.go, input in model_input.go; branch-mode
+// fetch/render helpers live in branch.go).
 type Model struct {
 	// State
 	workspace    *data.Workspace
@@ -35,7 +36,25 @@ type Model struct {
 	filterQuery string
 	filterInput textinput.Model
 
-	// Display list (flattened from grouped status)
+	// Branch mode: when true, displayItems lists files changed vs base
+	// (BranchChangesVsBase) instead of working-tree status, feeding the
+	// existing DiffModeBranch diff viewer. Additive to staged/unstaged/
+	// untracked — toggled independently, off by default.
+	branchMode    bool
+	branchChanges []git.Change
+	branchLoading bool
+	branchErr     error
+	branchLoadID  int // guards a stale toggle-triggered fetch from clobbering a newer one
+
+	// Ahead/behind vs base (git.AheadBehind), refreshed on workspace switch
+	// and manual refresh; rendered as a badge regardless of branchMode.
+	ahead             int
+	behind            int
+	aheadBehindErr    error
+	aheadBehindLoadID int // guards a stale refresh from clobbering a newer one
+
+	// Display list (flattened from grouped status, or from branchChanges when
+	// branchMode is active)
 	displayItems []displayItem
 
 	// Layout
@@ -59,9 +78,16 @@ func New() *Model {
 	}
 }
 
-// rebuildDisplayList rebuilds the flat display list from grouped status.
+// rebuildDisplayList rebuilds the flat display list from grouped status, or
+// from branchChanges when branch mode is active (see branch.go).
 func (m *Model) rebuildDisplayList() {
 	m.displayItems = nil
+
+	if m.branchMode {
+		m.rebuildBranchDisplayList()
+		m.clampCursorToDisplayItems()
+		return
+	}
 
 	if m.gitStatus == nil || m.gitStatus.Clean {
 		return
@@ -143,6 +169,12 @@ func (m *Model) rebuildDisplayList() {
 		}
 	}
 
+	m.clampCursorToDisplayItems()
+}
+
+// clampCursorToDisplayItems keeps the cursor in bounds and off section
+// headers after displayItems changes shape (rebuild, filter, mode toggle).
+func (m *Model) clampCursorToDisplayItems() {
 	// Reset cursor if it's out of bounds
 	if m.cursor >= len(m.displayItems) {
 		m.cursor = len(m.displayItems) - 1
@@ -161,7 +193,7 @@ func (m *Model) rebuildDisplayList() {
 }
 
 func (m *Model) listHeaderLines() int {
-	if m.gitStatus == nil || m.gitStatus.Clean {
+	if !m.branchMode && (m.gitStatus == nil || m.gitStatus.Clean) {
 		return 0
 	}
 	header := 0

--- a/internal/ui/sidebar/model_input.go
+++ b/internal/ui/sidebar/model_input.go
@@ -40,6 +40,14 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case BranchChangesLoaded:
+		m.handleBranchChangesLoaded(msg)
+		return m, nil
+
+	case AheadBehindLoaded:
+		m.handleAheadBehindLoaded(msg)
+		return m, nil
+
 	case tea.MouseWheelMsg:
 		if !m.focused {
 			return m, nil
@@ -86,9 +94,11 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("enter", "space", "o"))):
 			cmds = append(cmds, m.openCurrentItem())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("g"))):
-			cmds = append(cmds, m.refreshStatus())
+			cmds = append(cmds, m.refreshStatus(), m.refreshAheadBehind())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("c"))):
 			cmds = append(cmds, m.commitWorkspace())
+		case key.Matches(msg, key.NewBinding(key.WithKeys("b"))):
+			cmds = append(cmds, m.toggleBranchMode())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("/"))):
 			// Enter filter mode
 			m.filterMode = true
@@ -125,7 +135,7 @@ func (m *Model) openCurrentItem() tea.Cmd {
 }
 
 func (m *Model) rowIndexAt(screenY int) (int, bool) {
-	if m.gitStatus == nil || m.gitStatus.Clean {
+	if !m.branchMode && (m.gitStatus == nil || m.gitStatus.Clean) {
 		return -1, false
 	}
 	if len(m.displayItems) == 0 {

--- a/internal/ui/sidebar/model_lifecycle.go
+++ b/internal/ui/sidebar/model_lifecycle.go
@@ -49,12 +49,14 @@ func (m *Model) Focused() bool {
 	return m.focused
 }
 
-// SetWorkspace sets the active workspace.
-func (m *Model) SetWorkspace(ws *data.Workspace) {
+// SetWorkspace sets the active workspace. It returns a command that fetches
+// the ahead/behind badge for the new workspace (nil when ws is nil or this is
+// just a pointer rebind of the same workspace).
+func (m *Model) SetWorkspace(ws *data.Workspace) tea.Cmd {
 	if sameWorkspaceByCanonicalPaths(m.workspace, ws) {
 		// Rebind pointer for metadata freshness without resetting UI state.
 		m.workspace = ws
-		return
+		return nil
 	}
 	m.workspace = ws
 	m.cursor = 0
@@ -67,7 +69,17 @@ func (m *Model) SetWorkspace(ws *data.Workspace) {
 		m.filterMode = false
 		m.filterInput.Blur()
 	}
+	// Branch-mode data (list + ahead/behind) belongs to the previous
+	// workspace; drop it rather than showing stale results under the new one.
+	m.branchMode = false
+	m.branchChanges = nil
+	m.branchErr = nil
+	m.branchLoading = false
+	m.ahead = 0
+	m.behind = 0
+	m.aheadBehindErr = nil
 	m.rebuildDisplayList()
+	return m.refreshAheadBehind()
 }
 
 // FilterActive reports whether the Changes view is currently in filter-input

--- a/internal/ui/sidebar/model_view.go
+++ b/internal/ui/sidebar/model_view.go
@@ -50,18 +50,23 @@ func (m *Model) View() string {
 	return result
 }
 
-// renderChanges renders the git changes with grouped display
+// renderChanges renders the git changes with grouped display, or the
+// branch-vs-base list when branch mode is active (see branch.go).
 func (m *Model) renderChanges() string {
-	if m.gitStatus == nil {
+	if !m.branchMode && m.gitStatus == nil {
 		return m.styles.Muted.Render("No status loaded")
 	}
 
 	var b strings.Builder
 
-	// Show branch info
+	// Show branch info + ahead/behind badge
 	if m.workspace != nil && m.workspace.Branch != "" {
 		b.WriteString(m.styles.Muted.Render("branch: "))
 		b.WriteString(m.styles.BranchName.Render(m.workspace.Branch))
+		if badge := m.renderAheadBehindBadge(); badge != "" {
+			b.WriteString(" ")
+			b.WriteString(badge)
+		}
 		b.WriteString("\n")
 	}
 
@@ -75,6 +80,10 @@ func (m *Model) renderChanges() string {
 		b.WriteString(m.styles.Muted.Render("filter: "))
 		b.WriteString(m.styles.BranchName.Render(m.filterQuery))
 		b.WriteString("\n")
+	}
+
+	if m.branchMode {
+		return b.String() + m.renderBranchSection()
 	}
 
 	if m.gitStatus.Clean {
@@ -99,7 +108,55 @@ func (m *Model) renderChanges() string {
 		}
 	}
 	b.WriteString("\n")
+	b.WriteString(m.renderDisplayItemRows())
 
+	return b.String()
+}
+
+// renderAheadBehindBadge renders the "↑N ↓M vs base" indicator, or "" when
+// there's nothing ahead/behind (mirrors the +/- line-stats convention above:
+// silent when zero) or the last AheadBehind fetch failed.
+func (m *Model) renderAheadBehindBadge() string {
+	if m.workspace == nil || m.aheadBehindErr != nil {
+		return ""
+	}
+	if m.ahead == 0 && m.behind == 0 {
+		return ""
+	}
+	var parts []string
+	if m.ahead > 0 {
+		parts = append(parts, m.styles.StatusAdded.Render("↑"+strconv.Itoa(m.ahead)))
+	}
+	if m.behind > 0 {
+		parts = append(parts, m.styles.StatusDeleted.Render("↓"+strconv.Itoa(m.behind)))
+	}
+	return strings.Join(parts, " ") + m.styles.Muted.Render(" vs base")
+}
+
+// renderBranchSection renders the branch-mode body: a loading/error/empty
+// state, or the summary line plus the shared displayItems rows.
+func (m *Model) renderBranchSection() string {
+	switch {
+	case m.branchLoading:
+		return "\n" + m.styles.Muted.Render("Loading changes vs base...")
+	case m.branchErr != nil:
+		return "\n" + m.styles.StatusDeleted.Render("Error: "+m.branchErr.Error())
+	case len(m.branchChanges) == 0:
+		return "\n" + m.styles.StatusClean.Render(common.Icons.Clean+" No commits ahead of base")
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.Muted.Render(strconv.Itoa(len(m.branchChanges)) + " changed vs base"))
+	b.WriteString("\n")
+	b.WriteString(m.renderDisplayItemRows())
+	return b.String()
+}
+
+// renderDisplayItemRows renders the scrollable list of displayItems (section
+// headers and file rows). Shared by the working-tree and branch-mode lists,
+// which differ only in how displayItems was populated.
+func (m *Model) renderDisplayItemRows() string {
+	var b strings.Builder
 	visibleHeight := m.visibleHeight()
 
 	// Adjust scroll
@@ -123,58 +180,59 @@ func (m *Model) renderChanges() string {
 			headerStyle := m.styles.SidebarHeader
 			b.WriteString(headerStyle.Render(item.header))
 			b.WriteString("\n")
-		} else {
-			// File entry
-			cursor := common.Icons.CursorEmpty + " "
-			if i == m.cursor {
-				cursor = common.Icons.Cursor + " "
-			}
-
-			// Status indicator with color
-			var statusStyle lipgloss.Style
-			switch item.change.Kind {
-			case git.ChangeModified:
-				statusStyle = m.styles.StatusModified
-			case git.ChangeAdded:
-				statusStyle = m.styles.StatusAdded
-			case git.ChangeDeleted:
-				statusStyle = m.styles.StatusDeleted
-			case git.ChangeRenamed:
-				statusStyle = m.styles.StatusRenamed
-			case git.ChangeUntracked:
-				statusStyle = m.styles.StatusUntracked
-			default:
-				statusStyle = m.styles.Muted
-			}
-
-			// Use single-char status code for consistent alignment
-			statusCode := item.change.KindString()
-
-			// Build the prefix (cursor + status code)
-			prefix := cursor + statusStyle.Render(statusCode) + " "
-			prefixWidth := lipgloss.Width(prefix)
-
-			// Calculate max path width, leaving room for prefix
-			maxPathWidth := m.width - prefixWidth
-			if maxPathWidth < 5 {
-				maxPathWidth = 5
-			}
-
-			// Truncate path from left to fit, showing end of path (most relevant part)
-			displayPath := item.change.Path
-			pathWidth := lipgloss.Width(displayPath)
-			if pathWidth > maxPathWidth {
-				// Remove characters from start until it fits
-				runes := []rune(displayPath)
-				for len(runes) > 4 && lipgloss.Width(string(runes)) > maxPathWidth-3 {
-					runes = runes[1:]
-				}
-				displayPath = "..." + string(runes)
-			}
-
-			line := prefix + m.styles.FilePath.Render(displayPath)
-			b.WriteString(line + "\n")
+			continue
 		}
+
+		// File entry
+		cursor := common.Icons.CursorEmpty + " "
+		if i == m.cursor {
+			cursor = common.Icons.Cursor + " "
+		}
+
+		// Status indicator with color
+		var statusStyle lipgloss.Style
+		switch item.change.Kind {
+		case git.ChangeModified:
+			statusStyle = m.styles.StatusModified
+		case git.ChangeAdded:
+			statusStyle = m.styles.StatusAdded
+		case git.ChangeDeleted:
+			statusStyle = m.styles.StatusDeleted
+		case git.ChangeRenamed:
+			statusStyle = m.styles.StatusRenamed
+		case git.ChangeUntracked:
+			statusStyle = m.styles.StatusUntracked
+		default:
+			statusStyle = m.styles.Muted
+		}
+
+		// Use single-char status code for consistent alignment
+		statusCode := item.change.KindString()
+
+		// Build the prefix (cursor + status code)
+		prefix := cursor + statusStyle.Render(statusCode) + " "
+		prefixWidth := lipgloss.Width(prefix)
+
+		// Calculate max path width, leaving room for prefix
+		maxPathWidth := m.width - prefixWidth
+		if maxPathWidth < 5 {
+			maxPathWidth = 5
+		}
+
+		// Truncate path from left to fit, showing end of path (most relevant part)
+		displayPath := item.change.Path
+		pathWidth := lipgloss.Width(displayPath)
+		if pathWidth > maxPathWidth {
+			// Remove characters from start until it fits
+			runes := []rune(displayPath)
+			for len(runes) > 4 && lipgloss.Width(string(runes)) > maxPathWidth-3 {
+				runes = runes[1:]
+			}
+			displayPath = "..." + string(runes)
+		}
+
+		line := prefix + m.styles.FilePath.Render(displayPath)
+		b.WriteString(line + "\n")
 	}
 
 	return b.String()
@@ -190,6 +248,7 @@ func (m *Model) helpLines(contentWidth int) []string {
 		m.helpItem("j/↓", "down"),
 		m.helpItem("enter/o", "open"),
 		m.helpItem("c", "commit"),
+		m.helpItem("b", "vs base"),
 		m.helpItem("/", "filter"),
 		m.helpItem("g", "refresh"),
 	}

--- a/internal/ui/sidebar/tabs.go
+++ b/internal/ui/sidebar/tabs.go
@@ -98,6 +98,16 @@ func (m *TabbedSidebar) Update(msg tea.Msg) (*TabbedSidebar, tea.Cmd) {
 
 	// Handle tab switching on mouse click
 	switch msg := msg.(type) {
+	case BranchChangesLoaded, AheadBehindLoaded:
+		// Route straight to the Changes model regardless of which tab is
+		// active: these are background fetches (workspace switch, "g"
+		// refresh, branch-mode toggle) that must land even if the user has
+		// since switched to the Project tab, or the ahead/behind badge and
+		// branch list would go stale until the next fetch.
+		var cmd tea.Cmd
+		m.changes, cmd = m.changes.Update(msg)
+		return m, cmd
+
 	case tea.MouseClickMsg:
 		if msg.Button == tea.MouseLeft && msg.Y == 0 {
 			// Check if click is in tab bar
@@ -372,16 +382,24 @@ func (m *TabbedSidebar) Focused() bool {
 	return m.focused
 }
 
-// SetWorkspace sets the active workspace
-func (m *TabbedSidebar) SetWorkspace(ws *data.Workspace) {
+// SetWorkspace sets the active workspace. It returns the Changes view's
+// ahead/behind refresh command (nil for a no-op rebind); see Model.SetWorkspace.
+func (m *TabbedSidebar) SetWorkspace(ws *data.Workspace) tea.Cmd {
 	m.workspace = ws
-	m.changes.SetWorkspace(ws)
+	cmd := m.changes.SetWorkspace(ws)
 	m.projectTree.SetWorkspace(ws)
+	return cmd
 }
 
 // SetGitStatus sets the git status (forwards to changes view)
 func (m *TabbedSidebar) SetGitStatus(status *git.StatusResult) {
 	m.changes.SetGitStatus(status)
+}
+
+// RefreshAheadBehind re-fetches the ahead/behind badge for the active
+// workspace (e.g. after a commit changes HEAD's distance from base).
+func (m *TabbedSidebar) RefreshAheadBehind() tea.Cmd {
+	return m.changes.refreshAheadBehind()
 }
 
 // ActiveTab returns the currently active tab


### PR DESCRIPTION
Implements plan 059 (DIR-02). Completes the read-side of the write-back loop: after committing, work no longer vanishes from review.

Git layer (read-only): `BranchChangesVsBase` (`--name-status merge-base...HEAD`) + `AheadBehind` (`rev-list --left-right --count`), sharing a new `resolveMergeBase` helper factored out of `GetBranchFileDiff` (behavior-preserving). No fetch/merge/push/checkout anywhere.
UI: a sidebar branch-mode toggle (`b`) lists committed-vs-base changes into the EXISTING DiffModeBranch viewer; an always-on ahead/behind badge, refreshed after a commit. Async fetches carry a monotonic LoadID + Root guard to drop stale results.

Reviewer re-ran: git/sidebar/diff/app tests green (incl. new branch tests); `make harness-golden` byte-identical (feature absent from harness presets); all files <500; git layer confirmed read-only; cache-cleaned lint clean.