### PR TITLE
feat: edit per-workspace environment variables from the UI

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -90,6 +90,13 @@ type App struct {
 	settingsThemeDirty          bool
 	// Theme that was active when the settings dialog opened, restored on Esc.
 	settingsThemeOriginal common.ThemeID
+	// envDialog is the workspace environment-variable editor; envDialogWorkspace
+	// is the workspace it was opened for, read back in handleEnvDialogResult
+	// (mirroring dialogWorkspace's role for the generic Dialog, but tracked
+	// separately since a settings-style bespoke dialog isn't routed through
+	// a.dialogWorkspace).
+	envDialog          *common.EnvDialog
+	envDialogWorkspace *data.Workspace
 
 	// Overlays
 	toast *common.ToastModel

--- a/internal/app/app_input_dialogs.go
+++ b/internal/app/app_input_dialogs.go
@@ -94,6 +94,12 @@ func (a *App) handleSettingsDialogInput(msg tea.Msg, cmds *[]tea.Cmd) bool {
 	return consumed
 }
 
+func (a *App) handleEnvDialogInput(msg tea.Msg, cmds *[]tea.Cmd) bool {
+	var consumed bool
+	a.envDialog, consumed = handleOverlayInput(a.envDialog, msg, cmds, false)
+	return consumed
+}
+
 // handleDialogResult handles dialog completion
 func (a *App) handleDialogResult(result common.DialogResult) tea.Cmd {
 	project := a.dialogProject

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -41,7 +41,8 @@ import (
 //	                       RefreshDashboard, RescanWorkspaces, GitStatusResult,
 //	                       FileWatcherEvent, StateWatcherEvent
 //	                       → app_input_messages_workspace.go, app_input_workspace.go
-//	updateDialogShowMsg    Show* dialog requests, ThemePreview, SettingsResult
+//	updateDialogShowMsg    Show* dialog requests, ThemePreview, SettingsResult,
+//	                       EnvDialogResult
 //	                       → app_input_dialogs.go
 
 // handlePreSwitchInput runs the overlay/dialog guards that may consume a message
@@ -76,6 +77,9 @@ func (a *App) handlePreSwitchInput(msg tea.Msg, cmds *[]tea.Cmd) (tea.Cmd, bool)
 		return common.SafeBatch(*cmds...), true
 	}
 	if a.handleSettingsDialogInput(msg, cmds) {
+		return common.SafeBatch(*cmds...), true
+	}
+	if a.handleEnvDialogInput(msg, cmds) {
 		return common.SafeBatch(*cmds...), true
 	}
 	return nil, false
@@ -289,6 +293,8 @@ func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		a.handleShowDeleteWorkspaceDialog(msg)
 	case messages.ShowRenameWorkspaceDialog:
 		a.handleShowRenameWorkspaceDialog(msg)
+	case messages.ShowWorkspaceEnvDialog:
+		a.handleShowWorkspaceEnvDialog(msg)
 	case messages.ShowCommitWorkspaceDialog:
 		a.handleShowCommitWorkspaceDialog(msg)
 	case messages.ShowTrustScriptsDialog:
@@ -307,6 +313,10 @@ func (a *App) updateDialogShowMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		}
 	case common.SettingsResult:
 		if cmd := a.handleSettingsResult(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
+	case common.EnvDialogResult:
+		if cmd := a.handleEnvDialogResult(msg); cmd != nil {
 			*cmds = append(*cmds, cmd)
 		}
 	default:

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -98,6 +98,21 @@ func (a *App) handleShowRenameWorkspaceDialog(msg messages.ShowRenameWorkspaceDi
 	a.dialog.SetInputValue(msg.Workspace.Name)
 }
 
+// handleShowWorkspaceEnvDialog shows the workspace environment-variable
+// editor, seeded from a copy of the workspace's current Env with reserved
+// keys (process.IsReservedScriptEnvKey -- the AMUX_*/ROOT_* names env.go
+// injects) excluded up front, so they can never appear as an editable or
+// removable row. Mirrors handleShowRenameWorkspaceDialog's show-time setup.
+func (a *App) handleShowWorkspaceEnvDialog(msg messages.ShowWorkspaceEnvDialog) {
+	if msg.Workspace == nil {
+		return
+	}
+	a.envDialogWorkspace = msg.Workspace
+	a.envDialog = common.NewEnvDialog(filterReservedEnv(msg.Workspace.Env))
+	a.envDialog.SetSize(a.width, a.height)
+	a.envDialog.Show()
+}
+
 // handleShowCommitWorkspaceDialog shows the commit-message input dialog for a
 // workspace's changes. The message the user types is the confirmation gesture;
 // on confirm handleDialogResult stages and commits via git.CommitAll. Esc
@@ -408,4 +423,56 @@ func (a *App) handleSettingsResult(res common.SettingsResult) tea.Cmd {
 		}
 	}
 	return common.SafeBatch(saveCmd, assistantsSaveCmd)
+}
+
+// filterReservedEnv drops any reserved-key (process.IsReservedScriptEnvKey)
+// or blank-key entry from env, returning a fresh map. It is used both to seed
+// the env dialog (so a reserved key can never appear as an editable row) and,
+// defensively, again right before persisting the dialog's read-back map --
+// the one place that actually writes ws.Env -- so "reserved keys are never
+// written" holds even if a future change to EnvDialog ever let one slip
+// through the seed-time filter.
+func filterReservedEnv(env map[string]string) map[string]string {
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		if k == "" || process.IsReservedScriptEnvKey(k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// handleEnvDialogResult handles the workspace env dialog's close. On cancel,
+// every edit is discarded: no mutation, no persist, matching the settings
+// dialog's Esc contract (handleSettingsResult above). On confirm, the edited
+// map is filtered (see filterReservedEnv) and persisted via
+// WorkspaceStore.SetEnv -- the same load-fresh-then-save shape
+// handleRenameWorkspace's store.Rename call uses for its Tier-1 field update,
+// so a stale in-memory copy held for the dialog's lifetime cannot clobber a
+// field another in-flight operation changed concurrently.
+func (a *App) handleEnvDialogResult(res common.EnvDialogResult) tea.Cmd {
+	ws := a.envDialogWorkspace
+	a.envDialogWorkspace = nil
+	dialog := a.envDialog
+	a.envDialog = nil
+
+	if res.Canceled || ws == nil || dialog == nil {
+		return nil
+	}
+	env := filterReservedEnv(dialog.Env())
+
+	if a.workspaceService == nil || a.workspaceService.store == nil {
+		return nil
+	}
+	if err := a.workspaceService.store.SetEnv(ws.ID(), env); err != nil {
+		return common.ReportError(errorContext(errorServiceWorkspace, "saving workspace environment"), err, "")
+	}
+	// Reflect the change immediately on the in-memory active workspace, like
+	// handleRenameWorkspace does for Name, so the app's own view of the
+	// workspace does not go stale until the next reload.
+	if a.activeWorkspace != nil && a.activeWorkspace.Root == ws.Root {
+		a.activeWorkspace.Env = env
+	}
+	return a.toast.ShowSuccess("Updated environment for " + ws.Name)
 }

--- a/internal/app/app_input_mouse.go
+++ b/internal/app/app_input_mouse.go
@@ -145,6 +145,7 @@ func (a *App) routeMouseWheel(msg tea.MouseWheelMsg) tea.Cmd {
 	if (a.dialog != nil && a.dialog.Visible()) ||
 		(a.filePicker != nil && a.filePicker.Visible()) ||
 		(a.settingsDialog != nil && a.settingsDialog.Visible()) ||
+		(a.envDialog != nil && a.envDialog.Visible()) ||
 		a.err != nil ||
 		a.toastCoversPoint(msg.X, msg.Y) {
 		// Modal, error, and toast overlays should block background scrolling.

--- a/internal/app/app_input_workspace_env_test.go
+++ b/internal/app/app_input_workspace_env_test.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/common"
+)
+
+// newEnvTestHarness builds a harness App wired to a real, temp-dir-backed
+// WorkspaceStore (newAppShell attaches no services, so the harness has none
+// by default -- see harness.go), then seeds and saves ws into that store so
+// its ID resolves. It returns the harness, the concrete store (so tests can
+// Load back what was persisted without an unchecked type assertion on the
+// WorkspaceStore interface), and the saved workspace's ID.
+func newEnvTestHarness(t *testing.T, ws *data.Workspace) (*Harness, *data.WorkspaceStore, data.WorkspaceID) {
+	t.Helper()
+	h, err := NewHarness(HarnessOptions{Mode: HarnessCenter, Width: 120, Height: 40})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+	store := data.NewWorkspaceStore(t.TempDir())
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	h.app.workspaceService = newWorkspaceService(nil, store, nil, "")
+	return h, store, ws.ID()
+}
+
+func TestHandleShowWorkspaceEnvDialog_SeedsDialogExcludingReservedKeys(t *testing.T) {
+	ws := &data.Workspace{
+		Name: "feature",
+		Repo: "/repo/primary",
+		Root: "/repo/primary/ws",
+		Env: map[string]string{
+			"API_KEY":             "secret",
+			"AMUX_WORKSPACE_ROOT": "poison",
+		},
+	}
+	h, _, _ := newEnvTestHarness(t, ws)
+
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: ws})
+
+	if h.app.envDialog == nil || !h.app.envDialog.Visible() {
+		t.Fatal("expected envDialog to be shown")
+	}
+	if h.app.envDialogWorkspace != ws {
+		t.Fatalf("envDialogWorkspace = %#v, want %#v", h.app.envDialogWorkspace, ws)
+	}
+	got := h.app.envDialog.Env()
+	if got["API_KEY"] != "secret" {
+		t.Fatalf("expected API_KEY row, got %#v", got)
+	}
+	if _, ok := got["AMUX_WORKSPACE_ROOT"]; ok {
+		t.Fatalf("reserved key AMUX_WORKSPACE_ROOT must not be shown/editable, got %#v", got)
+	}
+}
+
+func TestHandleShowWorkspaceEnvDialog_NilWorkspaceIsNoop(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{Mode: HarnessCenter, Width: 120, Height: 40})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: nil})
+	if h.app.envDialog != nil {
+		t.Fatal("expected no dialog for a nil workspace")
+	}
+}
+
+func TestHandleEnvDialogResult_PersistsEditedEnvAndUpdatesActiveWorkspace(t *testing.T) {
+	ws := &data.Workspace{
+		Name: "feature",
+		Repo: "/repo/primary",
+		Root: "/repo/primary/ws",
+		Env:  map[string]string{"NODE_ENV": "dev"},
+	}
+	h, store, id := newEnvTestHarness(t, ws)
+	h.app.activeWorkspace = ws
+
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: ws})
+	// Edit NODE_ENV's value (cursor starts on row 0, the only row).
+	h.app.envDialog.Update(tea.KeyPressMsg{Code: 'X', Text: "X"})
+
+	cmd := h.app.handleEnvDialogResult(common.EnvDialogResult{})
+	if cmd == nil {
+		t.Fatal("expected a success-toast cmd")
+	}
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() after confirm error = %v", err)
+	}
+	if reloaded.Env["NODE_ENV"] != "devX" {
+		t.Fatalf("persisted NODE_ENV = %q, want %q", reloaded.Env["NODE_ENV"], "devX")
+	}
+
+	if h.app.activeWorkspace.Env["NODE_ENV"] != "devX" {
+		t.Fatalf("active workspace Env not updated in place: %#v", h.app.activeWorkspace.Env)
+	}
+	if h.app.envDialog != nil || h.app.envDialogWorkspace != nil {
+		t.Fatal("expected envDialog/envDialogWorkspace cleared after confirm")
+	}
+	if !strings.Contains(h.app.toast.View(), "feature") {
+		t.Fatalf("expected a success toast naming the workspace, got %q", h.app.toast.View())
+	}
+}
+
+func TestHandleEnvDialogResult_RemovedPairIsDeletedFromEnv(t *testing.T) {
+	ws := &data.Workspace{
+		Name: "feature",
+		Repo: "/repo/primary",
+		Root: "/repo/primary/ws",
+		Env:  map[string]string{"KEEP": "1", "DROP": "2"},
+	}
+	h, store, id := newEnvTestHarness(t, ws)
+
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: ws})
+	// Cursor starts on row 0, which is "DROP" (sorted before "KEEP").
+	h.app.envDialog.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	h.app.handleEnvDialogResult(common.EnvDialogResult{})
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, ok := reloaded.Env["DROP"]; ok {
+		t.Fatalf("expected DROP removed, got %#v", reloaded.Env)
+	}
+	if reloaded.Env["KEEP"] != "1" {
+		t.Fatalf("expected KEEP untouched, got %#v", reloaded.Env)
+	}
+}
+
+func TestHandleEnvDialogResult_CanceledDiscardsEditsWithoutPersisting(t *testing.T) {
+	ws := &data.Workspace{
+		Name: "feature",
+		Repo: "/repo/primary",
+		Root: "/repo/primary/ws",
+		Env:  map[string]string{"NODE_ENV": "dev"},
+	}
+	h, store, id := newEnvTestHarness(t, ws)
+
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: ws})
+	h.app.envDialog.Update(tea.KeyPressMsg{Code: 'X', Text: "X"})
+
+	cmd := h.app.handleEnvDialogResult(common.EnvDialogResult{Canceled: true})
+	if cmd != nil {
+		t.Fatalf("expected no cmd on cancel, got one that emits %T", cmd())
+	}
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if reloaded.Env["NODE_ENV"] != "dev" {
+		t.Fatalf("cancel must not persist: Env = %#v, want unchanged", reloaded.Env)
+	}
+	if h.app.envDialog != nil || h.app.envDialogWorkspace != nil {
+		t.Fatal("expected envDialog/envDialogWorkspace cleared after cancel")
+	}
+}
+
+func TestHandleEnvDialogResult_ReservedKeyNeverPersisted(t *testing.T) {
+	// Simulate a hand-edited workspace.json that smuggled a reserved key in
+	// (the dialog itself cannot produce one -- see the ui/common-level
+	// tests -- but the apply path re-checks defensively).
+	ws := &data.Workspace{
+		Name: "feature",
+		Repo: "/repo/primary",
+		Root: "/repo/primary/ws",
+		Env: map[string]string{
+			"CUSTOM_VAR":      "value",
+			"AMUX_PORT":       "9999",
+			"AMUX_PORT_RANGE": "9999-10000",
+		},
+	}
+	h, store, id := newEnvTestHarness(t, ws)
+
+	h.app.handleShowWorkspaceEnvDialog(messages.ShowWorkspaceEnvDialog{Workspace: ws})
+	h.app.handleEnvDialogResult(common.EnvDialogResult{})
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, ok := reloaded.Env["AMUX_PORT"]; ok {
+		t.Fatalf("reserved key AMUX_PORT must never be persisted, got %#v", reloaded.Env)
+	}
+	if _, ok := reloaded.Env["AMUX_PORT_RANGE"]; ok {
+		t.Fatalf("reserved key AMUX_PORT_RANGE must never be persisted, got %#v", reloaded.Env)
+	}
+	if reloaded.Env["CUSTOM_VAR"] != "value" {
+		t.Fatalf("expected CUSTOM_VAR preserved, got %#v", reloaded.Env)
+	}
+}
+
+func TestHandleEnvDialogResult_NoDialogIsNoop(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{Mode: HarnessCenter, Width: 120, Height: 40})
+	if err != nil {
+		t.Fatalf("NewHarness returned error: %v", err)
+	}
+	if cmd := h.app.handleEnvDialogResult(common.EnvDialogResult{}); cmd != nil {
+		t.Fatalf("expected nil cmd with no dialog open, got one that emits %T", cmd())
+	}
+}

--- a/internal/app/app_tmux_sync_test.go
+++ b/internal/app/app_tmux_sync_test.go
@@ -55,6 +55,10 @@ func (s *blockingWorkspaceStore) Rename(id data.WorkspaceID, newName string) err
 	return nil
 }
 
+func (s *blockingWorkspaceStore) SetEnv(id data.WorkspaceID, env map[string]string) error {
+	return nil
+}
+
 func (s *blockingWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant
 }

--- a/internal/app/app_ui.go
+++ b/internal/app/app_ui.go
@@ -140,6 +140,9 @@ func (a *App) updateLayout() {
 	if a.settingsDialog != nil {
 		a.settingsDialog.SetSize(a.width, a.height)
 	}
+	if a.envDialog != nil {
+		a.envDialog.SetSize(a.width, a.height)
+	}
 }
 
 func (a *App) setKeymapHintsEnabled(enabled bool) {

--- a/internal/app/app_view_overlays.go
+++ b/internal/app/app_view_overlays.go
@@ -43,6 +43,15 @@ func (a *App) composeOverlays(canvas *lipgloss.Canvas) {
 		canvas.Compose(settingsDrawable)
 	}
 
+	// Workspace env dialog overlay
+	if a.envDialog != nil && a.envDialog.Visible() {
+		envView := a.envDialog.View()
+		envWidth, envHeight := viewDimensions(envView)
+		x, y := a.centeredPosition(envWidth, envHeight)
+		envDrawable := compositor.NewStringDrawable(envView, x, y)
+		canvas.Compose(envDrawable)
+	}
+
 	// Prefix command palette
 	if a.prefixActive {
 		palette := a.renderPrefixPalette()
@@ -209,6 +218,7 @@ func (a *App) overlayVisible() bool {
 	return (a.dialog != nil && a.dialog.Visible()) ||
 		(a.filePicker != nil && a.filePicker.Visible()) ||
 		(a.settingsDialog != nil && a.settingsDialog.Visible()) ||
+		(a.envDialog != nil && a.envDialog.Visible()) ||
 		a.prefixActive ||
 		a.err != nil
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -25,6 +25,7 @@ type WorkspaceStore interface {
 	Save(workspace *data.Workspace) error
 	Delete(id data.WorkspaceID) error
 	Rename(id data.WorkspaceID, newName string) error
+	SetEnv(id data.WorkspaceID, env map[string]string) error
 	ResolvedDefaultAssistant() string
 }
 

--- a/internal/app/workspace_delete_isolation_test.go
+++ b/internal/app/workspace_delete_isolation_test.go
@@ -32,7 +32,10 @@ func (s *recordingWorkspaceStore) Save(ws *data.Workspace) error {
 
 func (s *recordingWorkspaceStore) Delete(data.WorkspaceID) error         { return nil }
 func (s *recordingWorkspaceStore) Rename(data.WorkspaceID, string) error { return nil }
-func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string      { return data.DefaultAssistant }
+func (s *recordingWorkspaceStore) SetEnv(data.WorkspaceID, map[string]string) error {
+	return nil
+}
+func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
 
 func (s *recordingWorkspaceStore) saved() []string {
 	s.mu.Lock()

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -29,6 +29,9 @@ func (s *failingTombstoneWorkspaceStore) UpsertFromDiscovery(*data.Workspace) er
 func (s *failingTombstoneWorkspaceStore) Save(*data.Workspace) error                { return nil }
 func (s *failingTombstoneWorkspaceStore) Delete(data.WorkspaceID) error             { return s.deleteErr }
 func (s *failingTombstoneWorkspaceStore) Rename(data.WorkspaceID, string) error     { return nil }
+func (s *failingTombstoneWorkspaceStore) SetEnv(data.WorkspaceID, map[string]string) error {
+	return nil
+}
 
 func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -31,7 +31,10 @@ func (s *failingDeleteStore) Save(ws *data.Workspace) error {
 }
 func (s *failingDeleteStore) Delete(data.WorkspaceID) error         { return s.deleteErr }
 func (s *failingDeleteStore) Rename(data.WorkspaceID, string) error { return nil }
-func (s *failingDeleteStore) ResolvedDefaultAssistant() string      { return data.DefaultAssistant }
+func (s *failingDeleteStore) SetEnv(data.WorkspaceID, map[string]string) error {
+	return nil
+}
+func (s *failingDeleteStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
 
 // TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess proves a
 // metadata-delete failure is reported without using the generic failed-delete

--- a/internal/app/workspace_service_init_test.go
+++ b/internal/app/workspace_service_init_test.go
@@ -191,6 +191,10 @@ func (f *fakeAssistantStore) Delete(data.WorkspaceID) error { panic("unexpected 
 
 func (f *fakeAssistantStore) Rename(data.WorkspaceID, string) error { panic("unexpected Rename") }
 
+func (f *fakeAssistantStore) SetEnv(data.WorkspaceID, map[string]string) error {
+	panic("unexpected SetEnv")
+}
+
 // TestWorkspaceServiceResolvedDefaultAssistant covers every branch of the
 // nil-safe resolver: a nil receiver and a nil store both fall back to the package
 // default, while a wired store is consulted verbatim.

--- a/internal/data/workspace_store_env.go
+++ b/internal/data/workspace_store_env.go
@@ -1,0 +1,35 @@
+package data
+
+import (
+	"fmt"
+	"maps"
+)
+
+// SetEnv updates a workspace's environment-variable map and persists it. Like
+// Rename (the same Tier-1 single-field-update shape, in workspace_store.go),
+// it loads the workspace fresh from disk before mutating and saving in place,
+// so a caller holding a possibly-stale in-memory Workspace (e.g. one captured
+// when a dialog opened) cannot clobber a field another in-flight operation
+// changed concurrently in the meantime. Split into its own file to keep
+// workspace_store.go under the repo's 500-line file cap.
+//
+// Reserved-key exclusion is the caller's responsibility: internal/process
+// already imports internal/data for data.Workspace, so this package importing
+// internal/process back to reuse its reserved-key list would cycle. See
+// process.IsReservedScriptEnvKey.
+func (s *WorkspaceStore) SetEnv(id WorkspaceID, env map[string]string) error {
+	ws, err := s.Load(id)
+	if err != nil {
+		return fmt.Errorf("set env for workspace %s: %w", id, err)
+	}
+	// No-op guard, mirroring Rename's same-name check: writing an identical
+	// map would only rewrite the file and emit a spurious watch event.
+	if maps.Equal(ws.Env, env) {
+		return nil
+	}
+	ws.Env = env
+	if err := s.Save(ws); err != nil {
+		return fmt.Errorf("set env for workspace %s: %w", id, err)
+	}
+	return nil
+}

--- a/internal/data/workspace_store_env_test.go
+++ b/internal/data/workspace_store_env_test.go
@@ -1,0 +1,104 @@
+package data
+
+import "testing"
+
+// seedEnvWorkspace saves a single workspace (optionally pre-seeded with Env)
+// into a fresh store and returns the store plus the saved workspace's ID,
+// mirroring seedRenameWorkspace in rename_design_test.go.
+func seedEnvWorkspace(t *testing.T, env map[string]string) (*WorkspaceStore, WorkspaceID) {
+	t.Helper()
+	store := NewWorkspaceStore(t.TempDir())
+	ws := &Workspace{
+		Name:       "feature",
+		Branch:     "feature-branch",
+		Base:       "origin/main",
+		Repo:       "/home/user/repo",
+		Root:       "/home/user/.amux/workspaces/feature",
+		Runtime:    RuntimeLocalWorktree,
+		Assistant:  "claude",
+		ScriptMode: "nonconcurrent",
+		Env:        env,
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	return store, ws.ID()
+}
+
+// TestWorkspaceStoreSetEnv_PersistsAndReloads is the wired persist-path test:
+// SetEnv updates the stored Env map and a fresh Load reflects it, mirroring
+// TestRenameWorkspaceLabelDesign_StoreIntegration's shape for the Name field.
+func TestWorkspaceStoreSetEnv_PersistsAndReloads(t *testing.T) {
+	store, id := seedEnvWorkspace(t, map[string]string{"OLD": "value"})
+
+	newEnv := map[string]string{"API_KEY": "secret", "NODE_ENV": "production"}
+	if err := store.SetEnv(id, newEnv); err != nil {
+		t.Fatalf("SetEnv() error = %v", err)
+	}
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() after SetEnv error = %v", err)
+	}
+	if len(reloaded.Env) != 2 || reloaded.Env["API_KEY"] != "secret" || reloaded.Env["NODE_ENV"] != "production" {
+		t.Fatalf("Env after SetEnv = %#v, want %#v", reloaded.Env, newEnv)
+	}
+	// The old key must be gone: SetEnv replaces the map wholesale (the app
+	// layer is responsible for merging edits before calling it).
+	if _, ok := reloaded.Env["OLD"]; ok {
+		t.Fatalf("expected OLD to be replaced, got %#v", reloaded.Env)
+	}
+	// ID must be unchanged (Repo/Root/Branch untouched, so no tmux/tag/worktree
+	// churn), the same invariant Rename pins.
+	if reloaded.ID() != id {
+		t.Errorf("ID changed by SetEnv: got %q, want %q", reloaded.ID(), id)
+	}
+}
+
+// TestWorkspaceStoreSetEnv_EmptyMapClearsEnv confirms SetEnv can clear every
+// custom var (removing the last pair via the dialog persists as an empty
+// map, not a no-op).
+func TestWorkspaceStoreSetEnv_EmptyMapClearsEnv(t *testing.T) {
+	store, id := seedEnvWorkspace(t, map[string]string{"FOO": "bar"})
+
+	if err := store.SetEnv(id, map[string]string{}); err != nil {
+		t.Fatalf("SetEnv() error = %v", err)
+	}
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(reloaded.Env) != 0 {
+		t.Fatalf("Env after clearing = %#v, want empty", reloaded.Env)
+	}
+}
+
+// TestWorkspaceStoreSetEnv_NoOpSameMapDoesNotError mirrors
+// TestRenameWorkspace_NoOpSameName: writing back an identical map is a
+// harmless no-op.
+func TestWorkspaceStoreSetEnv_NoOpSameMapDoesNotError(t *testing.T) {
+	store, id := seedEnvWorkspace(t, map[string]string{"FOO": "bar"})
+
+	if err := store.SetEnv(id, map[string]string{"FOO": "bar"}); err != nil {
+		t.Fatalf("SetEnv() with identical map should be a no-op, got %v", err)
+	}
+
+	reloaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if reloaded.Env["FOO"] != "bar" {
+		t.Fatalf("Env = %#v, want unchanged", reloaded.Env)
+	}
+}
+
+// TestWorkspaceStoreSetEnv_UnknownIDErrors confirms SetEnv surfaces the same
+// load error Rename would for a workspace ID with no metadata on disk, rather
+// than silently creating a new record.
+func TestWorkspaceStoreSetEnv_UnknownIDErrors(t *testing.T) {
+	store := NewWorkspaceStore(t.TempDir())
+	if err := store.SetEnv(WorkspaceID("does-not-exist"), map[string]string{"A": "1"}); err == nil {
+		t.Fatal("expected an error for an unknown workspace ID")
+	}
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -230,6 +230,12 @@ type ShowRenameWorkspaceDialog struct {
 	Workspace *data.Workspace
 }
 
+// ShowWorkspaceEnvDialog requests showing the workspace environment-variable
+// editor for the given workspace.
+type ShowWorkspaceEnvDialog struct {
+	Workspace *data.Workspace
+}
+
 // ShowTrustScriptsDialog requests confirmation before trusting repo scripts.
 type ShowTrustScriptsDialog struct {
 	Workspace  *data.Workspace

--- a/internal/process/env.go
+++ b/internal/process/env.go
@@ -89,6 +89,16 @@ func (b *EnvBuilder) BuildEnvMap(ws *data.Workspace) map[string]string {
 	return envMap
 }
 
+// IsReservedScriptEnvKey reports whether key is one of the reserved
+// AMUX_*/ROOT_* names BuildEnv/BuildEnvMap inject (see isReservedScriptEnvKey
+// below for the exact list). It is exported so callers outside this package
+// -- namely the workspace environment-variable editor -- can exclude reserved
+// keys before they are ever shown or persisted, without duplicating or
+// drifting from this list.
+func IsReservedScriptEnvKey(key string) bool {
+	return isReservedScriptEnvKey(key)
+}
+
 func isReservedScriptEnvKey(key string) bool {
 	switch key {
 	case "AMUX_WORKSPACE_NAME",

--- a/internal/process/env_test.go
+++ b/internal/process/env_test.go
@@ -216,6 +216,32 @@ func TestEnvBuilder_NilReceiver(t *testing.T) {
 	}
 }
 
+// TestIsReservedScriptEnvKey_MatchesUnexported pins the exported wrapper's
+// only contract: it must agree with isReservedScriptEnvKey for every name
+// BuildEnv actually injects, plus an arbitrary non-reserved name, so the
+// workspace env editor (internal/ui/common's EnvDialog, via internal/app)
+// cannot drift from the list this package enforces at injection time.
+func TestIsReservedScriptEnvKey_MatchesUnexported(t *testing.T) {
+	reserved := []string{
+		"AMUX_WORKSPACE_NAME",
+		"AMUX_WORKSPACE_ROOT",
+		"AMUX_WORKSPACE_BRANCH",
+		"ROOT_WORKSPACE_PATH",
+		"AMUX_PORT",
+		"AMUX_PORT_RANGE",
+	}
+	for _, key := range reserved {
+		if !IsReservedScriptEnvKey(key) {
+			t.Errorf("IsReservedScriptEnvKey(%q) = false, want true", key)
+		}
+	}
+	for _, key := range []string{"CUSTOM_VAR", "", "NODE_ENV"} {
+		if IsReservedScriptEnvKey(key) {
+			t.Errorf("IsReservedScriptEnvKey(%q) = true, want false", key)
+		}
+	}
+}
+
 func envSliceMap(env []string) map[string]string {
 	out := make(map[string]string, len(env))
 	for _, kv := range env {

--- a/internal/ui/common/env_dialog.go
+++ b/internal/ui/common/env_dialog.go
@@ -1,0 +1,225 @@
+package common
+
+import (
+	"sort"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// EnvDialogResult is sent when the workspace environment-variable dialog
+// closes. Canceled is true when the user dismissed via Esc, in which case the
+// caller must discard every edit (no mutation, no persist) -- the same
+// cancel contract SettingsResult uses.
+type EnvDialogResult struct {
+	Canceled bool
+}
+
+// EnvDialog is a modal dialog that edits a single workspace's
+// environment-variable map. It mirrors SettingsDialog's Assistants section
+// (handleAssistantFieldKey in settings_assistants.go): rows render as
+// "key: value", Up/Down move a row cursor, printable runes edit the focused
+// row's value, Backspace deletes the last rune of the focused value, and
+// Ctrl+D removes the focused pair outright.
+//
+// This widget is domain-agnostic on purpose (internal/ui/common imports
+// neither internal/data nor internal/process elsewhere): it just edits
+// whatever map[string]string it is given. Excluding reserved keys
+// (process.IsReservedScriptEnvKey) is the caller's job -- see
+// internal/app's handleShowWorkspaceEnvDialog, which filters ws.Env before
+// calling NewEnvDialog and filters again defensively before persisting.
+//
+// First-cut scope (plan 058's Design decision): only EDITING an existing
+// pair's value and REMOVING a pair are supported. Adding a brand-new key
+// needs a second input target inside a row (a name field, with its own
+// validation) -- a materially different widget than every other multi-row
+// editor in this package -- so "add" is deferred to a follow-up, the same
+// escape hatch plan 031 used for "add a new assistant".
+type EnvDialog struct {
+	visible bool
+	width   int
+
+	// keys is the display order. It is built once at construction (sorted,
+	// for a deterministic and testable row order) and only ever shrinks (on
+	// remove); it is never re-sorted, so removing a row does not reshuffle
+	// the rows around it.
+	keys   []string
+	values map[string]string
+	cursor int
+}
+
+// NewEnvDialog seeds the dialog from env, which is copied so later edits in
+// the dialog cannot alias the caller's map (mirroring SetAssistants).
+func NewEnvDialog(env map[string]string) *EnvDialog {
+	keys := make([]string, 0, len(env))
+	values := make(map[string]string, len(env))
+	for k, v := range env {
+		keys = append(keys, k)
+		values[k] = v
+	}
+	sort.Strings(keys)
+	return &EnvDialog{keys: keys, values: values}
+}
+
+func (d *EnvDialog) Show()            { d.visible = true }
+func (d *EnvDialog) Hide()            { d.visible = false }
+func (d *EnvDialog) Visible() bool    { return d.visible }
+func (d *EnvDialog) SetSize(w, _ int) { d.width = w }
+func (d *EnvDialog) Cursor() *tea.Cursor {
+	return nil
+}
+
+// Env returns the (possibly edited) map for read-back on close: a copy so the
+// caller cannot mutate the dialog's internal state through the returned map.
+// Removed pairs are simply absent (deleteFocusedPair drops them from both
+// keys and values), so there is no separate "removed" set to reconcile.
+func (d *EnvDialog) Env() map[string]string {
+	out := make(map[string]string, len(d.values))
+	for k, v := range d.values {
+		out[k] = v
+	}
+	return out
+}
+
+// Update handles input. Like SettingsDialog, Esc always cancels. While a row
+// is focused, only Up/Down/Ctrl+D/Backspace are structural; every other
+// printable rune (including j/k and space) is typed into the focused row's
+// value -- there is no "leave the field" key distinct from Enter here, since
+// (unlike Settings) this dialog has only one section to route around.
+func (d *EnvDialog) Update(msg tea.Msg) (*EnvDialog, tea.Cmd) {
+	if !d.visible {
+		return d, nil
+	}
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return d, nil
+	}
+
+	switch {
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("esc"))):
+		d.visible = false
+		return d, func() tea.Msg { return EnvDialogResult{Canceled: true} }
+
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("enter"))):
+		d.visible = false
+		return d, func() tea.Msg { return EnvDialogResult{} }
+
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("down"))):
+		d.moveCursor(1)
+		return d, nil
+
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("up"))):
+		d.moveCursor(-1)
+		return d, nil
+
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("ctrl+d"))):
+		d.deleteFocusedPair()
+		return d, nil
+
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("backspace"))):
+		d.deleteFocusedRune()
+		return d, nil
+	}
+
+	if keyMsg.Text != "" {
+		d.appendFocusedText(keyMsg.Text)
+	}
+	return d, nil
+}
+
+// moveCursor moves the row cursor by delta, wrapping within the row list
+// (mirroring moveAssistantCursor's theme-cursor-style wraparound).
+func (d *EnvDialog) moveCursor(delta int) {
+	n := len(d.keys)
+	if n == 0 {
+		return
+	}
+	d.cursor = ((d.cursor+delta)%n + n) % n
+}
+
+// focusedKey returns the key at cursor, or "" if the row list is empty or the
+// cursor is out of range.
+func (d *EnvDialog) focusedKey() (string, bool) {
+	if d.cursor < 0 || d.cursor >= len(d.keys) {
+		return "", false
+	}
+	return d.keys[d.cursor], true
+}
+
+// appendFocusedText appends filtered text to the focused row's value, reusing
+// the same printable-rune filter as the tmux fields and assistant commands.
+func (d *EnvDialog) appendFocusedText(txt string) {
+	k, ok := d.focusedKey()
+	if !ok {
+		return
+	}
+	d.values[k] += keepRunes(txt, isPrintableFieldRune)
+}
+
+// deleteFocusedRune removes the last rune from the focused row's value.
+func (d *EnvDialog) deleteFocusedRune() {
+	k, ok := d.focusedKey()
+	if !ok {
+		return
+	}
+	d.values[k] = trimLastRune(d.values[k])
+}
+
+// deleteFocusedPair removes the focused key/value pair outright (not just its
+// value) and clamps the cursor to stay within the now-shorter row list.
+func (d *EnvDialog) deleteFocusedPair() {
+	k, ok := d.focusedKey()
+	if !ok {
+		return
+	}
+	delete(d.values, k)
+	d.keys = append(d.keys[:d.cursor], d.keys[d.cursor+1:]...)
+	if d.cursor >= len(d.keys) {
+		d.cursor = len(d.keys) - 1
+	}
+	if d.cursor < 0 {
+		d.cursor = 0
+	}
+}
+
+func (d *EnvDialog) View() string {
+	if !d.visible {
+		return ""
+	}
+	return d.dialogStyle().Render(strings.Join(d.renderLines(), "\n"))
+}
+
+func (d *EnvDialog) dialogContentWidth() int {
+	if d.width > 0 {
+		return min(50, max(35, d.width-20))
+	}
+	return 40
+}
+
+func (d *EnvDialog) dialogStyle() lipgloss.Style {
+	return dialogBorderStyle(d.dialogContentWidth())
+}
+
+func (d *EnvDialog) renderLines() []string {
+	title := lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary())
+	muted := lipgloss.NewStyle().Foreground(ColorMuted())
+
+	lines := []string{title.Render("Workspace Environment"), ""}
+
+	if len(d.keys) == 0 {
+		lines = append(lines, muted.Render("No editable environment variables."))
+	}
+	for i, k := range d.keys {
+		style, prefix := muted, "  "
+		if i == d.cursor {
+			style = lipgloss.NewStyle().Foreground(ColorPrimary()).Bold(true)
+			prefix = Icons.Cursor + " "
+		}
+		lines = append(lines, prefix+style.Render(k+": "+d.values[k]))
+	}
+
+	lines = append(lines, "", muted.Render("up/down move  ctrl+d remove  enter save  esc cancel"))
+	return lines
+}

--- a/internal/ui/common/env_dialog_test.go
+++ b/internal/ui/common/env_dialog_test.go
@@ -1,0 +1,252 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// typeIntoEnvDialog drives d's real key router (Update) rather than poking
+// fields directly, mirroring settings_assistants_test.go's typeInto helper.
+func typeIntoEnvDialog(d *EnvDialog, s string) {
+	for _, r := range s {
+		d.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+}
+
+func TestNewEnvDialogSeedsSortedCopy(t *testing.T) {
+	env := map[string]string{"NODE_ENV": "production", "API_KEY": "secret"}
+	d := NewEnvDialog(env)
+
+	// Mutating the caller's map after construction must not affect the
+	// dialog's seeded copy.
+	env["API_KEY"] = "mutated"
+
+	got := d.Env()
+	if got["API_KEY"] != "secret" {
+		t.Fatalf("API_KEY = %q, want %q (dialog must copy env, not alias it)", got["API_KEY"], "secret")
+	}
+	if got["NODE_ENV"] != "production" {
+		t.Fatalf("NODE_ENV = %q, want %q", got["NODE_ENV"], "production")
+	}
+	if len(d.keys) != 2 || d.keys[0] != "API_KEY" || d.keys[1] != "NODE_ENV" {
+		t.Fatalf("keys = %#v, want sorted [API_KEY NODE_ENV]", d.keys)
+	}
+}
+
+func TestEnvDialogEnvReturnsCopyNotAlias(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"FOO": "bar"})
+	got := d.Env()
+	got["FOO"] = "mutated-by-caller"
+
+	if d.values["FOO"] != "bar" {
+		t.Fatalf("Env() mutation leaked into dialog state: values[FOO] = %q, want %q", d.values["FOO"], "bar")
+	}
+}
+
+func TestEnvDialogEditsFocusedValue(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"API_KEY": "", "NODE_ENV": "dev"})
+	d.Show()
+
+	// Cursor starts at row 0 (API_KEY, sorted first).
+	typeIntoEnvDialog(d, "sk-123")
+	if got := d.Env()["API_KEY"]; got != "sk-123" {
+		t.Fatalf("API_KEY = %q, want %q", got, "sk-123")
+	}
+
+	// Down moves to NODE_ENV; typing (including letters like j/k) edits its
+	// value, not list navigation -- mirrors the assistant-field contract.
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	typeIntoEnvDialog(d, "jk-prod")
+	if got := d.Env()["NODE_ENV"]; got != "devjk-prod" {
+		t.Fatalf("NODE_ENV = %q, want %q", got, "devjk-prod")
+	}
+	// The other row's value must be untouched.
+	if got := d.Env()["API_KEY"]; got != "sk-123" {
+		t.Fatalf("API_KEY changed unexpectedly: %q", got)
+	}
+
+	// Backspace trims the last rune of the focused (NODE_ENV) value.
+	d.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if got := d.Env()["NODE_ENV"]; got != "devjk-pro" {
+		t.Fatalf("NODE_ENV after backspace = %q, want %q", got, "devjk-pro")
+	}
+}
+
+func TestEnvDialogCursorWraps(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1", "B": "2"})
+	d.Show()
+
+	if d.cursor != 0 {
+		t.Fatalf("initial cursor = %d, want 0", d.cursor)
+	}
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if d.cursor != 1 {
+		t.Fatalf("cursor after Down = %d, want 1", d.cursor)
+	}
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if d.cursor != 0 {
+		t.Fatalf("cursor after wrapping Down = %d, want 0", d.cursor)
+	}
+	d.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if d.cursor != 1 {
+		t.Fatalf("cursor after wrapping Up = %d, want 1", d.cursor)
+	}
+}
+
+func TestEnvDialogCtrlDRemovesFocusedPairOnly(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1", "B": "2", "C": "3"})
+	d.Show()
+	// Cursor at row 0 = "A".
+
+	d.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	got := d.Env()
+	if _, ok := got["A"]; ok {
+		t.Fatalf("expected A removed, got %#v", got)
+	}
+	if got["B"] != "2" || got["C"] != "3" {
+		t.Fatalf("expected B and C untouched, got %#v", got)
+	}
+	if len(d.keys) != 2 {
+		t.Fatalf("keys = %#v, want 2 remaining rows", d.keys)
+	}
+}
+
+func TestEnvDialogRemoveLastRowClampsCursor(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1"})
+	d.Show()
+
+	d.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	if len(d.Env()) != 0 {
+		t.Fatalf("expected empty map after removing the only pair, got %#v", d.Env())
+	}
+	if d.cursor != 0 {
+		t.Fatalf("cursor after removing last row = %d, want 0", d.cursor)
+	}
+
+	// Further navigation/removal/typing on an empty roster must not panic.
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	typeIntoEnvDialog(d, "x")
+	if len(d.Env()) != 0 {
+		t.Fatalf("expected still-empty map, got %#v", d.Env())
+	}
+}
+
+func TestEnvDialogRemoveThenEditNextRow(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1", "B": "2"})
+	d.Show()
+
+	// Remove "A" (row 0); cursor clamps to the new row 0, which is now "B".
+	d.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	typeIntoEnvDialog(d, "x")
+
+	got := d.Env()
+	if got["B"] != "2x" {
+		t.Fatalf("B = %q, want %q (edit should land on the row now under the cursor)", got["B"], "2x")
+	}
+}
+
+func TestEnvDialogEscCancelsWithoutMutating(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1"})
+	d.Show()
+	typeIntoEnvDialog(d, "edited")
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if d.Visible() {
+		t.Fatal("esc should hide the dialog")
+	}
+	result, ok := cmd().(EnvDialogResult)
+	if !ok || !result.Canceled {
+		t.Fatalf("expected canceled EnvDialogResult, got %#v (ok=%v)", cmd(), ok)
+	}
+	// Esc reports canceled; the CALLER (internal/app) is responsible for
+	// discarding a.envDialog rather than reading Env() back on this path. The
+	// in-memory edit is still visible here (the widget itself does not revert
+	// it) -- asserting that documents the contract the app-layer test in
+	// internal/app pins: a canceled result must never reach the persist path.
+	if got := d.Env()["A"]; got != "1edited" {
+		t.Fatalf("Env() after cancel = %q, want the in-memory edit %q (caller must discard, not the widget)", got, "1edited")
+	}
+}
+
+func TestEnvDialogEnterConfirms(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1"})
+	d.Show()
+	typeIntoEnvDialog(d, "x")
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if d.Visible() {
+		t.Fatal("enter should hide the dialog")
+	}
+	result, ok := cmd().(EnvDialogResult)
+	if !ok || result.Canceled {
+		t.Fatalf("expected a confirmed EnvDialogResult, got %#v (ok=%v)", cmd(), ok)
+	}
+	if got := d.Env()["A"]; got != "1x" {
+		t.Fatalf("A = %q, want %q", got, "1x")
+	}
+}
+
+func TestEnvDialogEmptyRosterIsNoop(t *testing.T) {
+	d := NewEnvDialog(nil)
+	d.Show()
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	d.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	if len(d.Env()) != 0 {
+		t.Fatalf("expected no env vars for an empty roster, got %#v", d.Env())
+	}
+}
+
+func TestEnvDialogUpdateIgnoredWhenNotVisible(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1"})
+	// Note: Show() is never called.
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd != nil {
+		t.Fatal("expected nil cmd when the dialog is not visible")
+	}
+	if got := d.Env()["A"]; got != "1" {
+		t.Fatalf("A = %q, want unchanged %q", got, "1")
+	}
+}
+
+func TestEnvDialogRenderShowsRowsAndHighlightsCursor(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"API_KEY": "secret", "NODE_ENV": "dev"})
+	d.Show()
+	d.cursor = 1 // NODE_ENV
+
+	view := d.View()
+	if !strings.Contains(view, "Workspace Environment") {
+		t.Fatalf("expected a title, got:\n%s", view)
+	}
+	if !strings.Contains(view, "API_KEY: secret") {
+		t.Fatalf("expected API_KEY row, got:\n%s", view)
+	}
+	if !strings.Contains(view, "NODE_ENV: dev") {
+		t.Fatalf("expected NODE_ENV row, got:\n%s", view)
+	}
+}
+
+func TestEnvDialogViewEmptyWhenNotVisible(t *testing.T) {
+	d := NewEnvDialog(map[string]string{"A": "1"})
+	if got := d.View(); got != "" {
+		t.Fatalf("View() on a hidden dialog = %q, want empty", got)
+	}
+}
+
+func TestEnvDialogViewNoRowsShowsPlaceholder(t *testing.T) {
+	d := NewEnvDialog(nil)
+	d.Show()
+	view := d.View()
+	if !strings.Contains(view, "No editable environment variables.") {
+		t.Fatalf("expected empty-roster placeholder, got:\n%s", view)
+	}
+}

--- a/internal/ui/sidebar/model_input.go
+++ b/internal/ui/sidebar/model_input.go
@@ -99,6 +99,8 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			cmds = append(cmds, m.commitWorkspace())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("b"))):
 			cmds = append(cmds, m.toggleBranchMode())
+		case key.Matches(msg, key.NewBinding(key.WithKeys("e"))):
+			cmds = append(cmds, m.openEnvDialog())
 		case key.Matches(msg, key.NewBinding(key.WithKeys("/"))):
 			// Enter filter mode
 			m.filterMode = true
@@ -213,6 +215,20 @@ func (m *Model) commitWorkspace() tea.Cmd {
 	ws := m.workspace
 	return func() tea.Msg {
 		return messages.ShowCommitWorkspaceDialog{Workspace: ws}
+	}
+}
+
+// openEnvDialog opens the workspace environment-variable editor for the
+// focused workspace. Unlike commitWorkspace, it has no git-status
+// precondition -- env vars are independent of the working tree, so there is
+// nothing to pre-check before showing the dialog.
+func (m *Model) openEnvDialog() tea.Cmd {
+	if m.workspace == nil {
+		return nil
+	}
+	ws := m.workspace
+	return func() tea.Msg {
+		return messages.ShowWorkspaceEnvDialog{Workspace: ws}
 	}
 }
 

--- a/internal/ui/sidebar/model_input_test.go
+++ b/internal/ui/sidebar/model_input_test.go
@@ -263,6 +263,56 @@ func TestInputCommitKeyNoWorkspaceIsNoOp(t *testing.T) {
 	}
 }
 
+func TestInputEnvKeyOpensDialogForFocusedWorkspace(t *testing.T) {
+	m := newInputModel(t) // dirty two-section status
+	ws := &data.Workspace{Name: "feature", Root: "/tmp/ws", Branch: "feature"}
+	m.SetWorkspace(ws)
+
+	_, cmd := m.Update(keyPress('e'))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from env key")
+	}
+	msg := cmd()
+	show, ok := msg.(messages.ShowWorkspaceEnvDialog)
+	if !ok {
+		t.Fatalf("expected messages.ShowWorkspaceEnvDialog, got %T", msg)
+	}
+	if show.Workspace != ws {
+		t.Fatalf("ShowWorkspaceEnvDialog carried wrong workspace: %+v", show.Workspace)
+	}
+}
+
+func TestInputEnvKeyCleanTreeStillOpensDialog(t *testing.T) {
+	// Unlike the commit key, the env key has no git-status precondition: env
+	// vars are independent of the working tree.
+	m := New()
+	m.SetSize(80, 20)
+	m.Focus()
+	ws := &data.Workspace{Name: "feature", Root: "/tmp/ws"}
+	m.SetWorkspace(ws)
+	m.SetGitStatus(&git.StatusResult{Clean: true})
+
+	_, cmd := m.Update(keyPress('e'))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from env key on a clean tree")
+	}
+	show, ok := cmd().(messages.ShowWorkspaceEnvDialog)
+	if !ok {
+		t.Fatalf("expected messages.ShowWorkspaceEnvDialog, got %T", cmd())
+	}
+	if show.Workspace != ws {
+		t.Fatalf("ShowWorkspaceEnvDialog carried wrong workspace: %+v", show.Workspace)
+	}
+}
+
+func TestInputEnvKeyNoWorkspaceIsNoOp(t *testing.T) {
+	m := newInputModel(t) // dirty status but no workspace set
+	_, cmd := m.Update(keyPress('e'))
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for env key with no workspace, got a cmd emitting %T", cmd())
+	}
+}
+
 func TestInputIgnoredWhenUnfocused(t *testing.T) {
 	m := New()
 	m.SetSize(80, 20)

--- a/internal/ui/sidebar/model_view.go
+++ b/internal/ui/sidebar/model_view.go
@@ -249,6 +249,7 @@ func (m *Model) helpLines(contentWidth int) []string {
 		m.helpItem("enter/o", "open"),
 		m.helpItem("c", "commit"),
 		m.helpItem("b", "vs base"),
+		m.helpItem("e", "env"),
 		m.helpItem("/", "filter"),
 		m.helpItem("g", "refresh"),
 	}


### PR DESCRIPTION
Implements plan 058 (DIR-03). Adds a workspace env-variable editor (`e` in the sidebar Changes pane): `Workspace.Env` was persisted + injected but had no UI writer. Edit existing values + Ctrl+D remove a pair; "add new key" deferred (needs a materially different widget — per the plan's Design decision).

- Persist: new `WorkspaceStore.SetEnv` mirroring `Rename` (load-fresh + `maps.Equal` no-op guard, so a stale dialog copy can't clobber concurrent changes); split to `workspace_store_env.go` for the 500-cap.
- Reserved keys (`process.IsReservedScriptEnvKey`, newly exported) filtered at seed AND pre-persist (defense-in-depth) — in `internal/app`, preserving the `common`-doesn't-import-`data`/`process` layering.
- Esc discards (returns before SetEnv). Tested.

Reviewer: rebased onto current main (conflict with 059's sidebar keybinding resolved — both `b`/vs-base and `e`/env kept); build + data/common/sidebar/app tests green; harness-golden byte-identical (feature absent from harness presets); lint 0 issues; files <500.