### PR TITLE
Workspace process lifecycle: transactional delete, orphan reaper, and delete-deadlock fix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,7 +85,7 @@ The table is hand-maintained; keep it in sync when adding or moving a package.
 | `internal/update` | Self-update: version check, download, verify, install | `updater.go` |
 | `internal/config` | Configuration: assistants, UI settings, resolved paths | `config.go` |
 | `internal/supervisor` | Named background workers with restart/backoff and error surfacing | `supervisor.go` |
-| `internal/process` | Cross-platform process-group teardown (kill agent process trees) | `treekill_unix.go` |
+| `internal/process` | Workspace process lifecycle: group teardown, script runner, durable service registry, enumeration/attribution, orphan reaping | `treekill_unix.go`, `registry.go`, `teardown.go` |
 | `internal/safego` | Panic-safe goroutine helpers with a pluggable panic handler | `safego.go` |
 | `internal/pprofhttp` | Opt-in pprof HTTP server wiring with explicit mux and timeouts | `server.go` |
 | `internal/perf` | Opt-in counters/timers for the harness and perf baselines | `perf.go` |

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	golang.org/x/term v0.44.0
 )
 
+require golang.org/x/sys v0.46.0
+
 require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
@@ -34,5 +36,4 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 )

--- a/internal/app/MESSAGE_FLOW.md
+++ b/internal/app/MESSAGE_FLOW.md
@@ -91,11 +91,17 @@ settle it (see `TestLifecycleCreateWhileProjectsLoading`).
    (`app_input_workspace.go`): marks the workspace `deleting`
    (`lifecycle.markDeleting`), shows the dashboard spinner, and enqueues the
    async `workspaceService.DeleteWorkspace` cmd. Sessions are NOT killed here:
-   a rejected/failed delete must leave live agents intact.
-2. The service validates (primary-checkout guard, repo/path checks), writes a
-   durable delete tombstone, removes the worktree under the per-repo git lock,
-   kills the workspace's tmux sessions only after worktree removal succeeded,
-   deletes the branch (failure is a warning), then deletes metadata.
+   a delete rejected by validation must leave live agents intact.
+2. The service validates (primary-checkout guard, repo/path checks), stops
+   managed scripts, kills the workspace's tmux sessions, kills orphaned
+   service process groups still referencing the worktree and verifies none
+   survive (`teardownWorkspaceProcessesForDelete` — a failure here aborts the
+   delete before anything touches the worktree), writes a durable delete
+   tombstone, removes the worktree under the per-repo git lock, deletes the
+   branch (failure is a warning), then deletes metadata. Teardown running
+   BEFORE removal is deliberate: a post-validation failure has already lost
+   its sessions (recoverable), while removing a worktree under live writers
+   orphans service stacks to PID 1 with a deleted cwd (which is not).
 3. `messages.WorkspaceDeleted` → `handleWorkspaceDeleted`: settles the phase,
    drops the workspace from the active set, navigates home when it was the
    active workspace, clears its dirty marker, and reloads projects.

--- a/internal/app/app_commit_workspace_test.go
+++ b/internal/app/app_commit_workspace_test.go
@@ -114,9 +114,14 @@ func TestHandleWorkspaceCommitted_ErrorReports(t *testing.T) {
 // TestHandleWorkspaceCommitted_SuccessToastsAndRefreshes asserts a successful
 // commit shows a success toast and requests a status refresh.
 func TestHandleWorkspaceCommitted_SuccessToastsAndRefreshes(t *testing.T) {
-	app := &App{toast: common.NewToastModel()}
+	// The refresh request needs a live service and an existing root: a
+	// vanished root (or absent service) now yields no result message at all,
+	// so a nil Status can never poison downstream caches.
+	root := t.TempDir()
+	stub := &fileWatcherGitStatusStub{}
+	app := &App{toast: common.NewToastModel(), gitStatus: stub}
 	cmd := app.handleWorkspaceCommitted(messages.WorkspaceCommitted{
-		Workspace: &data.Workspace{Root: "/tmp/ws"},
+		Workspace: &data.Workspace{Root: root},
 	})
 	if cmd == nil {
 		t.Fatal("expected a success command")
@@ -124,11 +129,9 @@ func TestHandleWorkspaceCommitted_SuccessToastsAndRefreshes(t *testing.T) {
 	if view := ansi.Strip(app.toast.View()); !strings.Contains(view, "Committed changes") {
 		t.Fatalf("expected success toast, got %q", view)
 	}
-	// A gitStatus refresh is queued (nil gitStatus service yields a bare result
-	// message keyed to the workspace Root).
 	sawStatus := false
 	for _, m := range runCommandMessages(cmd) {
-		if res, ok := m.(messages.GitStatusResult); ok && res.Root == "/tmp/ws" {
+		if res, ok := m.(messages.GitStatusResult); ok && res.Root == root && res.Status != nil {
 			sawStatus = true
 		}
 	}

--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -12,6 +12,7 @@ import (
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/supervisor"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/center"
@@ -53,6 +54,10 @@ type App struct {
 	gitStatus        GitStatusService
 	tmuxService      TmuxOps
 	updateService    UpdateService
+	// serviceRegistry durably tracks managed service process groups so they
+	// survive amux restarts as stoppable entities; the orphan reaper and the
+	// script runner share it. Nil in tests that construct App directly.
+	serviceRegistry *process.ServiceRegistry
 
 	// Limits
 	maxAttachedAgentTabs int
@@ -100,6 +105,12 @@ type App struct {
 
 	// Overlays
 	toast *common.ToastModel
+	// System-overload banner state, fed by the service reaper's periodic
+	// load sample (see handleServiceReapResult). When the machine is
+	// drowning, amux says so instead of surfacing mysterious tmux/git
+	// timeouts.
+	systemOverloaded  bool
+	systemLoadPerCore float64
 
 	// Dialog context
 	dialogProject          *data.Project

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -116,6 +116,11 @@ func New(version, commit, date string) (*App, error) {
 	registry := data.NewRegistry(cfg.Paths.RegistryPath)
 	workspaces := data.NewWorkspaceStore(cfg.Paths.MetadataRoot)
 	scripts := process.NewScriptRunner(cfg.PortStart, cfg.PortRangeSize)
+	// Track script-started service groups durably so a later amux process can
+	// still stop them — the in-memory running map alone is how service stacks
+	// used to outlive amux as untracked orphans.
+	serviceRegistry := process.NewServiceRegistry(cfg.Paths.ServiceRegistryPath)
+	scripts.AttachServiceRegistry(serviceRegistry)
 	workspaceService := newWorkspaceService(registry, workspaces, scripts, cfg.Paths.WorkspacesRoot)
 
 	// Create status manager (used for synchronous status caching only).
@@ -203,9 +208,12 @@ func New(version, commit, date string) (*App, error) {
 	// so it can skip workspaces that are being deleted (used by the rescan guard).
 	workspaceService.deleteInFlight = app.isWorkspaceDeleteInFlight
 	workspaceService.deleteInFlightGuard = app.runUnlessWorkspaceDeleteInFlight
-	// Let the delete path tear down workspace tmux sessions after worktree
-	// removal succeeds, without killing live sessions for failed deletes.
+	// Let the delete path tear down workspace tmux sessions and orphaned
+	// service groups BEFORE worktree removal, so nothing is left running out
+	// of a directory that is about to disappear.
 	workspaceService.killWorkspaceSessions = app.killWorkspaceSessionsSync
+	workspaceService.teardownProcesses = process.TeardownWorkspaceProcesses
+	app.serviceRegistry = serviceRegistry
 
 	return app, nil
 }
@@ -221,6 +229,10 @@ func (a *App) Init() tea.Cmd {
 		a.startGitStatusTicker(),
 		a.startPTYWatchdog(),
 		a.startOrphanGCTicker(),
+		// One-shot startup pass: reap service stacks orphaned while amux was
+		// not running (a crash, a kill, a prune interrupted mid-teardown) and
+		// reconcile the durable service registry before anything trusts it.
+		a.reapOrphanedServiceProcesses(),
 		a.startTmuxActivityTicker(),
 		a.triggerTmuxActivityScan(),
 		a.startTmuxSyncTicker(),

--- a/internal/app/app_input_dispatch.go
+++ b/internal/app/app_input_dispatch.go
@@ -32,12 +32,15 @@ import (
 //	                       OrphanGCTick, PTYWatchdogTick, tmuxActivityTick/
 //	                       Result, tmuxAvailableResult, TmuxSyncTick,
 //	                       tmuxTabsSyncResult, tmuxTabs/SidebarDiscoverResult,
-//	                       orphanGCResult, staleDetachedAgentGCResult
-//	                       → app_tmux*.go
+//	                       orphanGCResult, staleDetachedAgentGCResult,
+//	                       serviceReapResult
+//	                       → app_tmux*.go, app_service_reaper.go
 //	updateWorkspaceLifecycleMsg  ProjectsLoaded, WorkspaceActivated/Created/
 //	                       CreatedWithWarning/CreateFailed/SetupComplete,
 //	                       CreateWorkspace, DeleteWorkspace, WorkspaceDeleted/
-//	                       DeleteFailed, AddProject/RemoveProject/ProjectRemoved,
+//	                       DeleteFailed, RenameWorkspace, ToggleWorkspacePin,
+//	                       workspacePinPersistFailed,
+//	                       AddProject/RemoveProject/ProjectRemoved,
 //	                       RefreshDashboard, RescanWorkspaces, GitStatusResult,
 //	                       FileWatcherEvent, StateWatcherEvent
 //	                       → app_input_messages_workspace.go, app_input_workspace.go
@@ -200,6 +203,10 @@ func (a *App) updateTmuxMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		a.handleOrphanGCResult(msg)
 	case staleDetachedAgentGCResult:
 		a.handleStaleDetachedAgentGCResult(msg)
+	case serviceReapResult:
+		if cmd := a.handleServiceReapResult(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
 	case sessionCountResult:
 		a.handleSessionCountResult(msg)
 	default:
@@ -242,6 +249,12 @@ func (a *App) updateWorkspaceLifecycleMsg(msg tea.Msg, cmds *[]tea.Cmd) bool {
 		*cmds = append(*cmds, a.handleDeleteWorkspace(msg)...)
 	case messages.RenameWorkspace:
 		*cmds = append(*cmds, a.handleRenameWorkspace(msg)...)
+	case messages.ToggleWorkspacePin:
+		*cmds = append(*cmds, a.handleToggleWorkspacePin(msg)...)
+	case workspacePinPersistFailed:
+		if cmd := a.handleWorkspacePinPersistFailed(msg); cmd != nil {
+			*cmds = append(*cmds, cmd)
+		}
 	case messages.AddProject:
 		*cmds = append(*cmds, a.addProject(msg.Path))
 	case messages.RemoveProject:

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -47,7 +47,15 @@ func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
 		cmds = append(cmds, countCmd)
 	}
 	a.eachWorkspace(func(ws *data.Workspace, _ *data.Project) {
-		cmds = append(cmds, a.requestGitStatus(ws.Root))
+		// The active workspace stays on the short-TTL path; every other
+		// workspace's status only decorates dashboard rows, so serve those
+		// from the background cache instead of fanning out one git
+		// subprocess per workspace on every project reload.
+		if a.activeWorkspace != nil && a.activeWorkspace.Root == ws.Root {
+			cmds = append(cmds, a.requestGitStatus(ws.Root))
+			return
+		}
+		cmds = append(cmds, a.requestGitStatusBackground(ws.Root))
 	})
 	return cmds
 }

--- a/internal/app/app_input_pty_file_watcher_test.go
+++ b/internal/app/app_input_pty_file_watcher_test.go
@@ -23,6 +23,10 @@ func (s *fileWatcherGitStatusStub) GetCached(root string) *git.StatusResult {
 	return s.cacheByRoot[root]
 }
 
+func (s *fileWatcherGitStatusStub) GetCachedBackground(root string) *git.StatusResult {
+	return s.GetCached(root)
+}
+
 func (s *fileWatcherGitStatusStub) UpdateCache(root string, status *git.StatusResult) {
 	if s.cacheByRoot == nil {
 		s.cacheByRoot = make(map[string]*git.StatusResult)
@@ -45,9 +49,11 @@ func (s *fileWatcherGitStatusStub) RefreshFast(root string) (*git.StatusResult, 
 }
 
 func TestHandleFileWatcherEvent_ActiveWorkspaceRequestsFullStatus(t *testing.T) {
+	// The status request skips roots that are gone from disk, so the
+	// workspace root must actually exist.
 	active := &data.Workspace{
 		Repo: "/tmp/repo",
-		Root: "/tmp/repo/ws-active",
+		Root: t.TempDir(),
 	}
 	stub := &fileWatcherGitStatusStub{}
 	app := &App{
@@ -89,9 +95,9 @@ func TestHandleFileWatcherEvent_ActiveWorkspaceRequestsFullStatus(t *testing.T) 
 func TestHandleFileWatcherEvent_InactiveWorkspaceRequestsFastStatus(t *testing.T) {
 	active := &data.Workspace{
 		Repo: "/tmp/repo",
-		Root: "/tmp/repo/ws-active",
+		Root: t.TempDir(),
 	}
-	otherRoot := "/tmp/repo/ws-other"
+	otherRoot := t.TempDir()
 	stub := &fileWatcherGitStatusStub{}
 	app := &App{
 		gitStatus:       stub,
@@ -132,7 +138,7 @@ func TestHandleFileWatcherEvent_InactiveWorkspaceRequestsFastStatus(t *testing.T
 func TestHandleGitStatusTick_ActiveWorkspaceCacheMissRequestsFullStatus(t *testing.T) {
 	active := &data.Workspace{
 		Repo: "/tmp/repo",
-		Root: "/tmp/repo/ws-active",
+		Root: t.TempDir(),
 	}
 	stub := &fileWatcherGitStatusStub{}
 	app := &App{

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -25,10 +25,11 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		return nil
 	}
 	// Do NOT kill the workspace's tmux sessions here. All real delete validation
-	// (primary-checkout guard, repo/path checks, worktree removal) runs later in
-	// the async DeleteWorkspace cmd; killing up-front means a rejected or failed
-	// delete still destroys live agent sessions and scrollback. The kill now runs
-	// only on the confirmed-success path in handleWorkspaceDeleted.
+	// (primary-checkout guard, repo/path checks) runs later in the async
+	// DeleteWorkspace cmd; killing before validation means a rejected delete
+	// still destroys live agent sessions and scrollback. Once validation passes,
+	// the service kills sessions and orphaned service groups BEFORE removing the
+	// worktree, so nothing keeps running out of a deleted directory.
 	if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, true); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
@@ -65,6 +66,65 @@ func (a *App) handleRenameWorkspace(msg messages.RenameWorkspace) []tea.Cmd {
 	}
 	cmds = append(cmds, a.loadProjects())
 	return cmds
+}
+
+// workspacePinPersistFailed reverts an optimistic pin toggle whose store
+// write failed.
+type workspacePinPersistFailed struct {
+	Workspace *data.Workspace
+	Pinned    bool
+	Err       error
+}
+
+// handleToggleWorkspacePin flips a workspace's pinned flag. The in-memory
+// flip happens immediately on the Update goroutine — the dashboard row holds
+// this same Workspace pointer, so the badge updates on the next frame and a
+// second P press before persistence lands toggles back instead of re-applying
+// the stale value. The disk write runs in a tea.Cmd (store IO must not block
+// the update loop) and reverts the flip on failure.
+func (a *App) handleToggleWorkspacePin(msg messages.ToggleWorkspacePin) []tea.Cmd {
+	if msg.Workspace == nil {
+		logging.Warn("ToggleWorkspacePin received with nil workspace")
+		return nil
+	}
+	if a.workspaceService == nil || a.workspaceService.store == nil {
+		return nil
+	}
+	ws := msg.Workspace
+	pinned := !ws.Pinned
+	ws.Pinned = pinned
+	if a.activeWorkspace != nil && a.activeWorkspace.Root == ws.Root {
+		a.activeWorkspace.Pinned = pinned
+	}
+	var cmds []tea.Cmd
+	verb := "Pinned"
+	if !pinned {
+		verb = "Unpinned"
+	}
+	if cmd := a.toast.ShowSuccess(verb + " workspace " + ws.Name); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	store := a.workspaceService.store
+	id := ws.ID()
+	cmds = append(cmds, func() tea.Msg {
+		if err := store.SetPinned(id, pinned); err != nil {
+			return workspacePinPersistFailed{Workspace: ws, Pinned: pinned, Err: err}
+		}
+		return nil
+	})
+	return cmds
+}
+
+// handleWorkspacePinPersistFailed rolls back the optimistic flip and surfaces
+// the store error.
+func (a *App) handleWorkspacePinPersistFailed(msg workspacePinPersistFailed) tea.Cmd {
+	if msg.Workspace != nil {
+		msg.Workspace.Pinned = !msg.Pinned
+		if a.activeWorkspace != nil && a.activeWorkspace.Root == msg.Workspace.Root {
+			a.activeWorkspace.Pinned = !msg.Pinned
+		}
+	}
+	return common.ReportError(errorContext(errorServiceWorkspace, "pinning workspace"), msg.Err, "")
 }
 
 // handleWorkspaceCreatedWithWarning handles the WorkspaceCreatedWithWarning message.

--- a/internal/app/app_operations.go
+++ b/internal/app/app_operations.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"os"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -68,11 +69,25 @@ func (a *App) handleWorkspaceCommitted(msg messages.WorkspaceCommitted) tea.Cmd 
 	return common.SafeBatch(cmds...)
 }
 
+// gitStatusRootGone reports whether the workspace root no longer exists, in
+// which case spawning git is pure waste: the command would run against a
+// deleted or prune-staged directory until its timeout, every refresh cycle,
+// for every vanished workspace. Only a definite not-exist counts — a
+// transient EACCES/EIO must fall through to git rather than silently blank
+// real status.
+func gitStatusRootGone(root string) bool {
+	_, err := os.Stat(root)
+	return os.IsNotExist(err)
+}
+
 // requestGitStatus requests git status for a workspace using fast mode (skips line stats).
+// A vanished root produces NO result message — an Err-free result with a nil
+// Status would be cached by consumers (dashboard statusCache) and blank or
+// crash render paths that trust cached statuses to be non-nil.
 func (a *App) requestGitStatus(root string) tea.Cmd {
 	return func() tea.Msg {
-		if a.gitStatus == nil {
-			return messages.GitStatusResult{Root: root}
+		if a.gitStatus == nil || gitStatusRootGone(root) {
+			return nil
 		}
 		status, err := a.gitStatus.RefreshFast(root)
 		if err == nil {
@@ -85,8 +100,8 @@ func (a *App) requestGitStatus(root string) tea.Cmd {
 // requestGitStatusFull requests git status with full line stats (for sidebar display).
 func (a *App) requestGitStatusFull(root string) tea.Cmd {
 	return func() tea.Msg {
-		if a.gitStatus == nil {
-			return messages.GitStatusResult{Root: root}
+		if a.gitStatus == nil || gitStatusRootGone(root) {
+			return nil
 		}
 		status, err := a.gitStatus.Refresh(root)
 		if err == nil {
@@ -94,6 +109,21 @@ func (a *App) requestGitStatusFull(root string) tea.Cmd {
 		}
 		return messages.GitStatusResult{Root: root, Status: status, Err: err}
 	}
+}
+
+// requestGitStatusBackground requests git status for a non-active workspace:
+// a background-TTL cache hit is served without spawning git, so repeated
+// project reloads do not fan out one git subprocess per workspace. Explicit
+// invalidation (watcher events, commits) bypasses the TTL as usual.
+func (a *App) requestGitStatusBackground(root string) tea.Cmd {
+	if a.gitStatus != nil {
+		if cached := a.gitStatus.GetCachedBackground(root); cached != nil {
+			return func() tea.Msg {
+				return messages.GitStatusResult{Root: root, Status: cached}
+			}
+		}
+	}
+	return a.requestGitStatus(root)
 }
 
 // requestGitStatusCached requests git status using cache if available.

--- a/internal/app/app_service_reaper.go
+++ b/internal/app/app_service_reaper.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/process"
+)
+
+// serviceReapResult reports one reaper pass over orphaned service processes,
+// plus the resource observations the pass gathers from the same snapshot: the
+// per-workspace workload ledger and the system load.
+type serviceReapResult struct {
+	Killed []process.ProcessInfo
+	// Stats maps workspace root -> live workload attributed to it.
+	Stats map[string]process.WorkspaceStats
+	// LoadPerCore is the 1-minute load average per CPU core (0 when the
+	// platform cannot report it). It is sampled even when Err is set — the
+	// overload banner must keep working precisely when the heavy ps snapshot
+	// starts failing, which is what genuine overload looks like.
+	LoadPerCore float64
+	Err         error
+}
+
+// reapOrphanedServiceProcesses returns a Cmd that kills service process
+// groups left behind by workspaces that no longer exist: their root is gone
+// from disk or staged as .amux-prune-*. Groups tied to a live workspace are
+// never touched (see process.FindWorkspaceOrphans) — reaping must never break
+// the detach-and-reattach contract for sessions the user still owns. The
+// pass also reconciles the durable service registry against live processes.
+func (a *App) reapOrphanedServiceProcesses() tea.Cmd {
+	if a.config == nil || a.config.Paths == nil || a.config.Paths.WorkspacesRoot == "" {
+		return nil
+	}
+	workspacesRoot := a.config.Paths.WorkspacesRoot
+	registry := a.serviceRegistry
+	// Collect the known roots on the Update goroutine; the closure below runs
+	// off it and must not touch a.projects.
+	var roots []string
+	a.eachWorkspace(func(ws *data.Workspace, _ *data.Project) {
+		roots = append(roots, ws.Root)
+	})
+	return func() tea.Msg {
+		// Load first: a cheap syscall that must not depend on ps succeeding.
+		load, err := process.LoadPerCore()
+		if err != nil {
+			load = 0
+		}
+		snap, err := process.Snapshot()
+		if err != nil {
+			if errors.Is(err, errors.ErrUnsupported) {
+				return nil // no process enumeration on this platform
+			}
+			return serviceReapResult{Err: err, LoadPerCore: load}
+		}
+		if registry != nil {
+			registry.Reconcile(snap)
+		}
+		orphans := process.FindWorkspaceOrphans(snap, workspacesRoot, process.PathExists)
+		killed := process.KillOrphanedGroups(orphans)
+		return serviceReapResult{
+			Killed:      killed,
+			Stats:       process.StatsByWorkspace(snap, roots),
+			LoadPerCore: load,
+		}
+	}
+}
+
+// Overload hysteresis thresholds, in 1-minute load average per core. Well
+// above the >1 "busy" line so the banner only appears when the machine is
+// genuinely drowning (the state where amux's own tmux/git timeouts start
+// failing and everything looks broken), and clears with a gap so it does not
+// flap.
+const (
+	overloadOnPerCore  = 4.0
+	overloadOffPerCore = 2.5
+)
+
+// handleServiceReapResult logs a reaper pass, publishes the workload ledger
+// to the dashboard, updates the system-overload banner state, and surfaces
+// non-trivial cleanup as a toast so accumulated orphans stop being invisible.
+func (a *App) handleServiceReapResult(msg serviceReapResult) tea.Cmd {
+	// Overload state updates even on failed passes — see serviceReapResult.
+	switch {
+	case msg.LoadPerCore >= overloadOnPerCore && !a.systemOverloaded:
+		a.systemOverloaded = true
+		logging.Warn("system overload detected: load per core %.1f", msg.LoadPerCore)
+	case msg.LoadPerCore > 0 && msg.LoadPerCore < overloadOffPerCore && a.systemOverloaded:
+		a.systemOverloaded = false
+		logging.Info("system overload cleared: load per core %.1f", msg.LoadPerCore)
+	}
+	a.systemLoadPerCore = msg.LoadPerCore
+	if msg.Err != nil {
+		logging.Warn("service reaper: %v", msg.Err)
+		return nil
+	}
+	if a.dashboard != nil {
+		a.dashboard.SetResourceStats(msg.Stats)
+	}
+	if len(msg.Killed) == 0 {
+		return nil
+	}
+	logging.Info(
+		"service reaper: killed %d orphaned service group(s): %s",
+		len(msg.Killed), process.DescribeGroups(msg.Killed),
+	)
+	if a.toast == nil {
+		return nil
+	}
+	return a.toast.ShowInfo(fmt.Sprintf("Cleaned up %d orphaned service process group(s)", len(msg.Killed)))
+}

--- a/internal/app/app_tmux_gc.go
+++ b/internal/app/app_tmux_gc.go
@@ -293,6 +293,9 @@ func (a *App) handleOrphanGCTick() []tea.Cmd {
 	if gcCmd := a.gcOrphanedTmuxSessions(); gcCmd != nil {
 		cmds = append(cmds, gcCmd)
 	}
+	if reapCmd := a.reapOrphanedServiceProcesses(); reapCmd != nil {
+		cmds = append(cmds, reapCmd)
+	}
 	cmds = append(cmds, a.startOrphanGCTicker())
 	return cmds
 }

--- a/internal/app/app_tmux_sync_test.go
+++ b/internal/app/app_tmux_sync_test.go
@@ -59,6 +59,10 @@ func (s *blockingWorkspaceStore) SetEnv(id data.WorkspaceID, env map[string]stri
 	return nil
 }
 
+func (s *blockingWorkspaceStore) SetPinned(id data.WorkspaceID, pinned bool) error {
+	return nil
+}
+
 func (s *blockingWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant
 }

--- a/internal/app/app_view_overlays.go
+++ b/internal/app/app_view_overlays.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -9,12 +10,28 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/andyrewlee/amux/internal/perf"
+	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/compositor"
 )
 
 // composeOverlays adds overlay layers (dialogs, toasts, help, etc.) to the canvas.
 func (a *App) composeOverlays(canvas *lipgloss.Canvas) {
 	prefixOverlayHeight := 0
+
+	// System-overload banner: when the machine is drowning, name the real
+	// problem up top instead of letting it surface as mysterious tmux/git
+	// timeouts and multi-second input lag.
+	if a.systemOverloaded {
+		banner := a.renderOverloadBanner()
+		if banner != "" {
+			bannerWidth := lipgloss.Width(banner)
+			x := (a.width - bannerWidth) / 2
+			if x < 0 {
+				x = 0
+			}
+			canvas.Compose(compositor.NewStringDrawable(banner, x, 0))
+		}
+	}
 
 	// Dialog overlay
 	if a.dialog != nil && a.dialog.Visible() {
@@ -92,6 +109,24 @@ func (a *App) composeOverlays(canvas *lipgloss.Canvas) {
 		errDrawable := compositor.NewStringDrawable(errView, x, y)
 		canvas.Compose(errDrawable)
 	}
+}
+
+// renderOverloadBanner renders the one-line system-overload notice.
+func (a *App) renderOverloadBanner() string {
+	if a.width <= 0 {
+		return ""
+	}
+	msg := " System under heavy load — amux may respond slowly "
+	if a.systemLoadPerCore > 0 {
+		msg = " System under heavy load (" +
+			strconv.FormatFloat(a.systemLoadPerCore, 'f', 1, 64) +
+			"× cores) — amux may respond slowly "
+	}
+	style := lipgloss.NewStyle().
+		Foreground(common.ColorBackground()).
+		Background(common.ColorWarning()).
+		Bold(true)
+	return style.Render(clampLines(msg, a.width, 1))
 }
 
 // renderErrorOverlay returns the error overlay content.

--- a/internal/app/service_git.go
+++ b/internal/app/service_git.go
@@ -19,6 +19,13 @@ func (s *gitStatusService) GetCached(root string) *git.StatusResult {
 	return s.manager.GetCached(root)
 }
 
+func (s *gitStatusService) GetCachedBackground(root string) *git.StatusResult {
+	if s == nil || s.manager == nil {
+		return nil
+	}
+	return s.manager.GetCachedBackground(root)
+}
+
 func (s *gitStatusService) UpdateCache(root string, status *git.StatusResult) {
 	if s == nil || s.manager == nil {
 		return

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -26,12 +26,16 @@ type WorkspaceStore interface {
 	Delete(id data.WorkspaceID) error
 	Rename(id data.WorkspaceID, newName string) error
 	SetEnv(id data.WorkspaceID, env map[string]string) error
+	SetPinned(id data.WorkspaceID, pinned bool) error
 	ResolvedDefaultAssistant() string
 }
 
 // GitStatusService provides cached status reads and fresh refreshes.
 type GitStatusService interface {
 	GetCached(root string) *git.StatusResult
+	// GetCachedBackground reads the cache under the longer background TTL,
+	// for workspaces that are not active (dashboard decoration only).
+	GetCachedBackground(root string) *git.StatusResult
 	UpdateCache(root string, status *git.StatusResult)
 	Invalidate(root string)
 	Refresh(root string) (*git.StatusResult, error)

--- a/internal/app/workspace_delete_isolation_test.go
+++ b/internal/app/workspace_delete_isolation_test.go
@@ -35,7 +35,8 @@ func (s *recordingWorkspaceStore) Rename(data.WorkspaceID, string) error { retur
 func (s *recordingWorkspaceStore) SetEnv(data.WorkspaceID, map[string]string) error {
 	return nil
 }
-func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
+func (s *recordingWorkspaceStore) SetPinned(data.WorkspaceID, bool) error { return nil }
+func (s *recordingWorkspaceStore) ResolvedDefaultAssistant() string       { return data.DefaultAssistant }
 
 func (s *recordingWorkspaceStore) saved() []string {
 	s.mu.Lock()

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -32,6 +32,7 @@ func (s *failingTombstoneWorkspaceStore) Rename(data.WorkspaceID, string) error 
 func (s *failingTombstoneWorkspaceStore) SetEnv(data.WorkspaceID, map[string]string) error {
 	return nil
 }
+func (s *failingTombstoneWorkspaceStore) SetPinned(data.WorkspaceID, bool) error { return nil }
 
 func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
 	return data.DefaultAssistant

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -312,11 +312,23 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("stop_scripts", err)
 		}
 
-		// Validation passed, so this delete will proceed. Write a durable tombstone
-		// FIRST so that if the process quits/crashes between here and the metadata
-		// removal, startup recovery can finish the delete rather than surfacing a
-		// dir-less ghost workspace. store.Delete removes the whole metadata dir,
-		// clearing the tombstone on success.
+		// Kill the workspace's tmux sessions BEFORE removing the worktree, then
+		// kill any orphaned service groups still running out of it and verify
+		// none survive. Removing a worktree under live writers is how service
+		// stacks end up orphaned to PID 1 with a deleted cwd, unstoppable by
+		// path-based tooling. The trade-off is deliberate: a delete that fails
+		// after this point has already lost its sessions, which is recoverable;
+		// silently orphaned stacks are not.
+		s.killWorkspaceSessionsForDelete(wsID)
+		if failMsg := s.teardownWorkspaceProcessesForDelete(ws, wsID, fail); failMsg != nil {
+			return failMsg
+		}
+
+		// Validation and teardown passed, so this delete will proceed. Write a
+		// durable tombstone FIRST so that if the process quits/crashes between
+		// here and the metadata removal, startup recovery can finish the delete
+		// rather than surfacing a dir-less ghost workspace. store.Delete removes
+		// the whole metadata dir, clearing the tombstone on success.
 		s.markDeleteTombstone(ws.ID())
 
 		warning, failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail)
@@ -359,24 +371,6 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 	}
 }
 
-func (s *workspaceService) stopWorkspaceScriptsForDelete(ws *data.Workspace) error {
-	if s == nil || s.scripts == nil {
-		return nil
-	}
-	return s.scripts.Stop(ws)
-}
-
-func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) {
-	if s != nil && s.killWorkspaceSessions != nil {
-		s.killWorkspaceSessions(wsID)
-	}
-}
-
-func workspacePathGone(path string) bool {
-	_, err := os.Stat(path)
-	return os.IsNotExist(err)
-}
-
 func (s *workspaceService) archiveDeletedWorkspaceMetadata(ws *data.Workspace) error {
 	if s == nil || s.store == nil || ws == nil {
 		return nil
@@ -408,10 +402,9 @@ func (s *workspaceService) removeWorktreeAndBranchLocked(
 		}
 	}
 
-	// The worktree removal has succeeded or an owned stale path was cleaned up.
-	// Tear down any remaining workspace tmux sessions before metadata deletion,
-	// but never kill sessions for a delete that failed and left the workspace.
-	s.killWorkspaceSessionsForDelete(wsID)
+	// Sessions and orphaned service groups were already torn down before the
+	// worktree removal (see DeleteWorkspace), so nothing here can still hold
+	// the removed path.
 
 	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
 		logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
@@ -428,14 +421,10 @@ func (s *workspaceService) handleStaleRemoveError(
 	fail func(stage string, err error) tea.Msg,
 ) tea.Msg {
 	if !git.IsUnregisteredWorkspacePathError(err) {
-		if workspacePathGone(ws.Root) {
-			s.killWorkspaceSessionsForDelete(wsID)
-		}
 		return fail("remove_worktree", err)
 	}
 	if _, statErr := os.Stat(ws.Root); statErr != nil {
 		if os.IsNotExist(statErr) {
-			s.killWorkspaceSessionsForDelete(wsID)
 			return fail("remove_worktree", err)
 		}
 		return fail("remove_worktree", errors.Join(err, statErr))

--- a/internal/app/workspace_service_delete_kill_order_test.go
+++ b/internal/app/workspace_service_delete_kill_order_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/andyrewlee/amux/internal/process"
 )
 
-func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
+func TestDeleteWorkspace_KillsSessionsAndTearsDownBeforeWorktreeRemoval(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -22,7 +22,7 @@ func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 	}
 
 	order := 0
-	killOrder, removeOrder := -1, -1
+	killOrder, teardownOrder, removeOrder := -1, -1, -1
 	mock := &mockGitOps{
 		removeWorkspace: func(repoPath, workspacePath string) error {
 			order++
@@ -37,6 +37,14 @@ func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 		order++
 		killOrder = order
 	}
+	svc.teardownProcesses = func(root string) (process.TeardownResult, error) {
+		order++
+		teardownOrder = order
+		if root != workspacePath {
+			t.Fatalf("teardown root = %q, want %q", root, workspacePath)
+		}
+		return process.TeardownResult{}, nil
+	}
 
 	project := data.NewProject(projectPath)
 	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
@@ -45,14 +53,47 @@ func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 	if _, ok := msg.(messages.WorkspaceDeleted); !ok {
 		t.Fatalf("expected WorkspaceDeleted, got %T", msg)
 	}
-	if killOrder == -1 {
-		t.Fatal("expected workspace tmux sessions to be killed during delete")
+	if killOrder == -1 || teardownOrder == -1 || removeOrder == -1 {
+		t.Fatalf("expected kill, teardown, and removal to all run (kill=%d teardown=%d remove=%d)", killOrder, teardownOrder, removeOrder)
 	}
-	if removeOrder == -1 {
-		t.Fatal("expected the worktree to be removed during delete")
+	if !(killOrder < teardownOrder && teardownOrder < removeOrder) {
+		t.Fatalf("expected kill (%d) → teardown (%d) → worktree removal (%d)", killOrder, teardownOrder, removeOrder)
 	}
-	if killOrder <= removeOrder {
-		t.Fatalf("expected kill (order %d) after worktree removal (order %d)", killOrder, removeOrder)
+}
+
+func TestDeleteWorkspace_TeardownFailureAbortsDelete(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	mock := &mockGitOps{
+		removeWorkspace: func(repoPath, workspacePath string) error {
+			t.Fatal("worktree removal must not run when process teardown fails")
+			return nil
+		},
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = mock
+	svc.killWorkspaceSessions = func(wsID string) {}
+	svc.teardownProcesses = func(root string) (process.TeardownResult, error) {
+		return process.TeardownResult{}, errors.New("survivors remain")
+	}
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	failed, ok := msg.(messages.WorkspaceDeleteFailed)
+	if !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+	if failed.Err == nil {
+		t.Fatal("expected the teardown error to be surfaced")
 	}
 }
 
@@ -124,7 +165,7 @@ func TestDeleteWorkspace_StopsScriptsBeforeWorktreeRemoval(t *testing.T) {
 	}
 }
 
-func TestDeleteWorkspace_DoesNotKillSessionsWhenWorktreeRemovalFails(t *testing.T) {
+func TestDeleteWorkspace_KillsSessionsEvenWhenWorktreeRemovalFails(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -141,12 +182,50 @@ func TestDeleteWorkspace_DoesNotKillSessionsWhenWorktreeRemovalFails(t *testing.
 
 	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
 	svc.gitOps = mock
+	killed := false
 	svc.killWorkspaceSessions = func(wsID string) {
-		t.Fatal("failed delete must not kill workspace tmux sessions")
+		killed = true
 	}
 
 	project := data.NewProject(projectPath)
 	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+	// Sessions die before worktree removal is attempted; a post-validation
+	// failure cannot resurrect them. This is the deliberate trade-off that
+	// keeps service stacks from running out of half-deleted worktrees.
+	if !killed {
+		t.Fatal("expected sessions killed before the failed worktree removal")
+	}
+}
+
+func TestDeleteWorkspace_ValidationFailureDoesNotKillSessions(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	otherRepo := filepath.Join(tmp, "other-repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = &mockGitOps{}
+	svc.killWorkspaceSessions = func(wsID string) {
+		t.Fatal("a delete rejected by validation must not kill workspace tmux sessions")
+	}
+	svc.teardownProcesses = func(root string) (process.TeardownResult, error) {
+		t.Fatal("a delete rejected by validation must not tear down processes")
+		return process.TeardownResult{}, nil
+	}
+
+	project := data.NewProject(projectPath)
+	// Workspace repo mismatching the project path fails validate_repo_match
+	// before any destructive step.
+	ws := data.NewWorkspace("feature", "feature", "main", otherRepo, workspacePath)
 
 	msg := svc.DeleteWorkspace(project, ws)()
 	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -34,7 +34,8 @@ func (s *failingDeleteStore) Rename(data.WorkspaceID, string) error { return nil
 func (s *failingDeleteStore) SetEnv(data.WorkspaceID, map[string]string) error {
 	return nil
 }
-func (s *failingDeleteStore) ResolvedDefaultAssistant() string { return data.DefaultAssistant }
+func (s *failingDeleteStore) SetPinned(data.WorkspaceID, bool) error { return nil }
+func (s *failingDeleteStore) ResolvedDefaultAssistant() string       { return data.DefaultAssistant }
 
 // TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess proves a
 // metadata-delete failure is reported without using the generic failed-delete

--- a/internal/app/workspace_service_delete_teardown.go
+++ b/internal/app/workspace_service_delete_teardown.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/process"
+)
+
+// This file holds the pre-removal teardown steps of workspace delete: stop
+// managed scripts, kill the workspace's tmux sessions, then kill and verify
+// orphaned service groups. Split out of workspace_service.go for the repo's
+// 500-line file cap.
+
+func (s *workspaceService) stopWorkspaceScriptsForDelete(ws *data.Workspace) error {
+	if s == nil || s.scripts == nil {
+		return nil
+	}
+	return s.scripts.Stop(ws)
+}
+
+func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) {
+	if s != nil && s.killWorkspaceSessions != nil {
+		s.killWorkspaceSessions(wsID)
+	}
+}
+
+// teardownWorkspaceProcessesForDelete kills orphaned service process groups
+// still referencing the workspace root and refuses the delete when any
+// survive. It runs after the session kill, so surviving groups are exactly
+// the ones that would otherwise be orphaned by the worktree removal.
+func (s *workspaceService) teardownWorkspaceProcessesForDelete(
+	ws *data.Workspace, wsID string, fail func(stage string, err error) tea.Msg,
+) tea.Msg {
+	if s == nil || s.teardownProcesses == nil {
+		return nil
+	}
+	res, err := s.teardownProcesses(ws.Root)
+	if len(res.Killed) > 0 {
+		logging.Info(
+			"workspace delete tore down %d orphaned service group(s) workspace_id=%s: %s",
+			len(res.Killed), wsID, process.DescribeGroups(res.Killed),
+		)
+	}
+	if err != nil {
+		return fail("teardown_processes", err)
+	}
+	return nil
+}

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -51,9 +51,15 @@ type workspaceService struct {
 	deleteInFlightGuard func(wsID string, fn func()) bool
 	// killWorkspaceSessions synchronously tears down a workspace's tmux sessions.
 	// Wired in app_init; nil in directly-constructed services (a no-op). Called
-	// only after worktree removal succeeds, so failed deletes leave live sessions
-	// intact.
+	// before worktree removal so no session process can hold or repopulate the
+	// worktree while it is being deleted.
 	killWorkspaceSessions func(wsID string)
+	// teardownProcesses kills orphaned service process groups still referencing
+	// the workspace root and fails when any survive, making the delete
+	// transactional: stop services → kill sessions → kill survivors → verify →
+	// only then remove the worktree. Wired to process.TeardownWorkspaceProcesses
+	// in app_init; nil in directly-constructed services (a no-op).
+	teardownProcesses func(root string) (process.TeardownResult, error)
 	// repoGitLocks serializes git worktree/branch mutations per repository (keyed
 	// by normalized project path) so concurrent create/delete of workspaces in the
 	// same repo do not contend on .git locks (index.lock / packed-refs).

--- a/internal/app/workspace_service_init_test.go
+++ b/internal/app/workspace_service_init_test.go
@@ -195,6 +195,10 @@ func (f *fakeAssistantStore) SetEnv(data.WorkspaceID, map[string]string) error {
 	panic("unexpected SetEnv")
 }
 
+func (f *fakeAssistantStore) SetPinned(data.WorkspaceID, bool) error {
+	panic("unexpected SetPinned")
+}
+
 // TestWorkspaceServiceResolvedDefaultAssistant covers every branch of the
 // nil-safe resolver: a nil receiver and a nil store both fall back to the package
 // default, while a wired store is consulted verbatim.

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -9,11 +9,12 @@ const WorkspacesRootEnvVar = "AMUX_WORKSPACES_ROOT"
 
 // Paths holds all the file system paths used by the application
 type Paths struct {
-	Home           string // ~/.amux
-	WorkspacesRoot string // ~/.amux/workspaces
-	RegistryPath   string // ~/.amux/projects.json
-	MetadataRoot   string // ~/.amux/workspaces-metadata
-	ConfigPath     string // ~/.amux/config.json
+	Home                string // ~/.amux
+	WorkspacesRoot      string // ~/.amux/workspaces
+	RegistryPath        string // ~/.amux/projects.json
+	MetadataRoot        string // ~/.amux/workspaces-metadata
+	ConfigPath          string // ~/.amux/config.json
+	ServiceRegistryPath string // ~/.amux/service-registry.json
 }
 
 // DefaultPaths returns the default paths configuration
@@ -26,11 +27,12 @@ func DefaultPaths() (*Paths, error) {
 	amuxHome := filepath.Join(home, ".amux")
 
 	return &Paths{
-		Home:           amuxHome,
-		WorkspacesRoot: filepath.Join(amuxHome, "workspaces"),
-		RegistryPath:   filepath.Join(amuxHome, "projects.json"),
-		MetadataRoot:   filepath.Join(amuxHome, "workspaces-metadata"),
-		ConfigPath:     filepath.Join(amuxHome, "config.json"),
+		Home:                amuxHome,
+		WorkspacesRoot:      filepath.Join(amuxHome, "workspaces"),
+		RegistryPath:        filepath.Join(amuxHome, "projects.json"),
+		MetadataRoot:        filepath.Join(amuxHome, "workspaces-metadata"),
+		ConfigPath:          filepath.Join(amuxHome, "config.json"),
+		ServiceRegistryPath: filepath.Join(amuxHome, "service-registry.json"),
 	}, nil
 }
 

--- a/internal/data/workspace.go
+++ b/internal/data/workspace.go
@@ -78,6 +78,11 @@ type Workspace struct {
 	// Lifecycle
 	Archived   bool      `json:"archived"`
 	ArchivedAt time.Time `json:"archived_at,omitempty"`
+	// Pinned marks a workspace as deliberately long-running: lifecycle
+	// automation (suspend policies, cleanup suggestions) must leave it alone,
+	// and the dashboard badges it so "still running on purpose" is visibly
+	// different from "forgotten".
+	Pinned bool `json:"pinned,omitempty"`
 }
 
 // WorkspaceID is a unique identifier based on repo+root hash

--- a/internal/data/workspace_store.go
+++ b/internal/data/workspace_store.go
@@ -155,6 +155,7 @@ func (s *WorkspaceStore) load(id WorkspaceID, applyDefaults bool) (*Workspace, e
 		ActiveTabIndex: raw.ActiveTabIndex,
 		Archived:       raw.Archived,
 		ArchivedAt:     parseCreated(raw.ArchivedAt),
+		Pinned:         raw.Pinned,
 	}
 	ws.storeID = id
 

--- a/internal/data/workspace_store_pin.go
+++ b/internal/data/workspace_store_pin.go
@@ -1,0 +1,23 @@
+package data
+
+import "fmt"
+
+// SetPinned updates a workspace's pinned flag and persists it. Like SetEnv
+// and Rename (the Tier-1 single-field-update shape), it loads the workspace
+// fresh from disk before mutating and saving in place, so a caller holding a
+// possibly-stale in-memory Workspace cannot clobber a field another in-flight
+// operation changed concurrently.
+func (s *WorkspaceStore) SetPinned(id WorkspaceID, pinned bool) error {
+	ws, err := s.Load(id)
+	if err != nil {
+		return fmt.Errorf("set pinned for workspace %s: %w", id, err)
+	}
+	if ws.Pinned == pinned {
+		return nil
+	}
+	ws.Pinned = pinned
+	if err := s.Save(ws); err != nil {
+		return fmt.Errorf("set pinned for workspace %s: %w", id, err)
+	}
+	return nil
+}

--- a/internal/data/workspace_store_pin_test.go
+++ b/internal/data/workspace_store_pin_test.go
@@ -1,0 +1,45 @@
+package data
+
+import "testing"
+
+func TestSetPinnedPersistsAndGuardsNoOp(t *testing.T) {
+	store := NewWorkspaceStore(t.TempDir())
+	ws := NewWorkspace("feature", "feature", "main", "/repo", "/repo-ws/feature")
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := store.SetPinned(ws.ID(), true); err != nil {
+		t.Fatalf("SetPinned: %v", err)
+	}
+	loaded, err := store.Load(ws.ID())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !loaded.Pinned {
+		t.Fatal("expected workspace to be pinned after SetPinned(true)")
+	}
+
+	// Same-value write is a no-op (mirrors Rename/SetEnv guards).
+	if err := store.SetPinned(ws.ID(), true); err != nil {
+		t.Fatalf("SetPinned no-op: %v", err)
+	}
+
+	if err := store.SetPinned(ws.ID(), false); err != nil {
+		t.Fatalf("SetPinned(false): %v", err)
+	}
+	loaded, err = store.Load(ws.ID())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Pinned {
+		t.Fatal("expected workspace to be unpinned after SetPinned(false)")
+	}
+}
+
+func TestSetPinnedMissingWorkspaceErrors(t *testing.T) {
+	store := NewWorkspaceStore(t.TempDir())
+	if err := store.SetPinned(WorkspaceID("nope"), true); err == nil {
+		t.Fatal("expected error for unknown workspace")
+	}
+}

--- a/internal/data/workspace_store_serial.go
+++ b/internal/data/workspace_store_serial.go
@@ -25,6 +25,7 @@ type workspaceJSON struct {
 	Env            map[string]string `json:"env"`
 	OpenTabs       []TabInfo         `json:"open_tabs,omitempty"`
 	ActiveTabIndex int               `json:"active_tab_index"`
+	Pinned         bool              `json:"pinned,omitempty"`
 }
 
 // parseCreated parses a created timestamp from either time.Time format or string format

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -19,7 +19,7 @@ func GetBaseBranch(repoPath string) (string, error) {
 	candidates := []string{"main", "master", "develop", "dev"}
 
 	for _, branch := range candidates {
-		_, err := RunGitCtx(context.Background(), repoPath, "rev-parse", "--verify", branch)
+		_, err := RunGitCtx(WithRefreshSlot(context.Background()), repoPath, "rev-parse", "--verify", branch)
 		if err == nil {
 			return branch, nil
 		}
@@ -28,25 +28,25 @@ func GetBaseBranch(repoPath string) (string, error) {
 	// Try remote tracking branches for common candidates
 	for _, branch := range candidates {
 		remote := "origin/" + branch
-		_, err := RunGitCtx(context.Background(), repoPath, "rev-parse", "--verify", remote)
+		_, err := RunGitCtx(WithRefreshSlot(context.Background()), repoPath, "rev-parse", "--verify", remote)
 		if err == nil {
 			return remote, nil
 		}
 	}
 
 	// Try to get the default branch from remote
-	output, err := RunGitCtx(context.Background(), repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	output, err := RunGitCtx(WithRefreshSlot(context.Background()), repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err == nil {
 		// Output is like "refs/remotes/origin/main" or "refs/remotes/origin/feature/foo"
 		branch := strings.TrimPrefix(output, "refs/remotes/origin/")
 		// Verify the branch exists locally
-		_, err := RunGitCtx(context.Background(), repoPath, "rev-parse", "--verify", branch)
+		_, err := RunGitCtx(WithRefreshSlot(context.Background()), repoPath, "rev-parse", "--verify", branch)
 		if err == nil {
 			return branch, nil
 		}
 		// Try remote tracking branch for symbolic-ref result
 		remote := "origin/" + branch
-		_, err = RunGitCtx(context.Background(), repoPath, "rev-parse", "--verify", remote)
+		_, err = RunGitCtx(WithRefreshSlot(context.Background()), repoPath, "rev-parse", "--verify", remote)
 		if err == nil {
 			return remote, nil
 		}
@@ -64,7 +64,7 @@ func GetBranchFileDiff(repoPath, path string) (*DiffResult, error) {
 	mergeBase := resolveMergeBase(repoPath, base)
 
 	args := []string{"diff", "--no-color", "--no-ext-diff", "-U3", mergeBase + "...HEAD", "--", path}
-	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), branchDiffTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, args...)
 	if err != nil {
@@ -82,7 +82,7 @@ func GetBranchFileDiff(repoPath, path string) (*DiffResult, error) {
 // GetBranchFileDiff and BranchChangesVsBase so the two stay consistent about
 // which commit "vs base" means.
 func resolveMergeBase(repoPath, base string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), branchDiffTimeout)
 	defer cancel()
 	mergeBase, err := RunGitCtx(ctx, repoPath, "merge-base", base, "HEAD")
 	if err != nil {
@@ -103,7 +103,7 @@ func BranchChangesVsBase(repoPath string) ([]Change, error) {
 	}
 	mergeBase := resolveMergeBase(repoPath, base)
 
-	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), branchDiffTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, "diff", "--no-color", "--name-status", mergeBase+"...HEAD")
 	if err != nil {
@@ -156,7 +156,7 @@ func AheadBehind(repoPath string) (ahead, behind int, err error) {
 		return 0, 0, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), branchDiffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), branchDiffTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, "rev-list", "--left-right", "--count", base+"...HEAD")
 	if err != nil {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -69,7 +69,7 @@ func GetFileDiff(repoPath, path string, mode DiffMode) (*DiffResult, error) {
 		args = []string{"diff", "--no-color", "--no-ext-diff", "--no-textconv", "-U3", "--", path}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), diffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), diffTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, args...)
 	if err != nil {
@@ -87,7 +87,7 @@ func GetUntrackedFileContent(repoPath, path string) (*DiffResult, error) {
 	fullPath := repoPath + "/" + path
 
 	// Use RunGitAllowFailureCtx since --no-index returns exit code 1 when differences exist
-	ctx, cancel := context.WithTimeout(context.Background(), diffTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), diffTimeout)
 	defer cancel()
 	output, err := RunGitAllowFailureCtx(ctx, repoPath, "diff", "--no-index", "--no-color", "--", "/dev/null", fullPath)
 	if err != nil {

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -271,7 +271,63 @@ func isAmbiguousWindowsAllowFailureCanceledExit(
 	return !killedByContext && errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1
 }
 
+// gitSubprocessLimit bounds concurrent REFRESH git subprocesses — the
+// status/diff reads that fan out per workspace on timers and project loads.
+// Those used to spawn one git per workspace at once; on a loaded machine they
+// pile up, each runs to its timeout, and amux itself becomes a top CPU
+// consumer. Only spawns whose context carries the refresh-slot marker
+// contend: user-initiated mutations (worktree add/remove, commit, branch
+// delete) and other one-off commands never queue behind a background refresh
+// storm. Each subprocess holds a slot only for its own run, so nested spawns
+// inside one refresh (status → numstat) cannot deadlock the pool. Queued
+// commands wait inside their own deadline, so under overload they fail fast
+// instead of stacking.
+const gitSubprocessLimit = 4
+
+var gitSubprocessSlots = make(chan struct{}, gitSubprocessLimit)
+
+type refreshSlotKey struct{}
+
+// WithRefreshSlot marks ctx so git subprocesses spawned under it contend for
+// the bounded refresh pool. Status/diff read paths set it; see
+// gitSubprocessLimit.
+func WithRefreshSlot(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, refreshSlotKey{}, struct{}{})
+}
+
+func wantsRefreshSlot(ctx context.Context) bool {
+	return ctx != nil && ctx.Value(refreshSlotKey{}) != nil
+}
+
+// acquireGitSlot blocks until a subprocess slot frees up or ctx expires,
+// reporting whether the slot was acquired.
+func acquireGitSlot(ctx context.Context) bool {
+	if ctx == nil {
+		gitSubprocessSlots <- struct{}{}
+		return true
+	}
+	select {
+	case gitSubprocessSlots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func releaseGitSlot() {
+	<-gitSubprocessSlots
+}
+
 func runGitCommand(ctx context.Context, cmd *exec.Cmd) (bool, error) {
+	if wantsRefreshSlot(ctx) {
+		if !acquireGitSlot(ctx) {
+			return false, ctx.Err()
+		}
+		defer releaseGitSlot()
+	}
 	if ctx == nil {
 		return false, cmd.Run()
 	}

--- a/internal/git/operations_semaphore_test.go
+++ b/internal/git/operations_semaphore_test.go
@@ -1,0 +1,53 @@
+package git
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAcquireGitSlotRespectsContext(t *testing.T) {
+	// Fill every slot so the next acquire must wait.
+	for range gitSubprocessLimit {
+		if !acquireGitSlot(context.Background()) {
+			t.Fatal("expected free slot")
+		}
+	}
+	t.Cleanup(func() {
+		for range gitSubprocessLimit {
+			releaseGitSlot()
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if acquireGitSlot(ctx) {
+		releaseGitSlot()
+		t.Fatal("expected acquire to fail once all slots are held and ctx expires")
+	}
+
+	// Freeing a slot lets a waiting acquire through again.
+	releaseGitSlot()
+	if !acquireGitSlot(context.Background()) {
+		t.Fatal("expected acquire after release")
+	}
+}
+
+func TestStatusManagerBackgroundTTL(t *testing.T) {
+	m := NewStatusManager()
+	m.SetCacheTTL(1 * time.Millisecond)
+	status := &StatusResult{}
+	m.UpdateCache("/ws", status)
+	time.Sleep(5 * time.Millisecond)
+
+	if m.GetCached("/ws") != nil {
+		t.Fatal("expected short-TTL cache to expire")
+	}
+	if m.GetCachedBackground("/ws") != status {
+		t.Fatal("expected background TTL to still serve the entry")
+	}
+	m.Invalidate("/ws")
+	if m.GetCachedBackground("/ws") != nil {
+		t.Fatal("expected explicit invalidation to bypass the background TTL")
+	}
+}

--- a/internal/git/status.go
+++ b/internal/git/status.go
@@ -62,7 +62,7 @@ type StatusResult struct {
 // TotalDeleted will be zero and HasLineStats will be false. Use this on hot paths
 // where only Clean/change lists matter.
 func GetStatusFast(repoPath string) (*StatusResult, error) {
-	output, err := RunGitRawCtx(context.Background(), repoPath,
+	output, err := RunGitRawCtx(WithRefreshSlot(context.Background()), repoPath,
 		"--no-optional-locks", "status", "--porcelain=v1", "-z", "-u")
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func GetStatusFast(repoPath string) (*StatusResult, error) {
 // GetStatus returns the git status for a repository using porcelain v1 -z format
 // This format handles spaces, unicode, and special characters in paths correctly
 func GetStatus(repoPath string) (*StatusResult, error) {
-	output, err := RunGitRawCtx(context.Background(), repoPath, "--no-optional-locks", "status", "--porcelain=v1", "-z", "-u")
+	output, err := RunGitRawCtx(WithRefreshSlot(context.Background()), repoPath, "--no-optional-locks", "status", "--porcelain=v1", "-z", "-u")
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func getDiffNumstat(repoPath string, staged bool) (added, deleted int, err error
 	if staged {
 		args = []string{"--no-optional-locks", "diff", "--cached", "--numstat"}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), diffNumstatTimeout)
+	ctx, cancel := context.WithTimeout(WithRefreshSlot(context.Background()), diffNumstatTimeout)
 	defer cancel()
 	output, err := RunGitCtx(ctx, repoPath, args...)
 	if err != nil {

--- a/internal/git/status_manager.go
+++ b/internal/git/status_manager.go
@@ -25,13 +25,19 @@ type StatusManager struct {
 
 	// Configuration
 	cacheTTL time.Duration
+	// backgroundTTL is the much longer freshness window used for workspaces
+	// that are not active: their status only decorates dashboard rows, so
+	// re-spawning git for every workspace on every project reload is waste
+	// that compounds badly on a loaded machine.
+	backgroundTTL time.Duration
 }
 
 // NewStatusManager creates a new status manager
 func NewStatusManager() *StatusManager {
 	return &StatusManager{
-		cache:    make(map[string]*StatusCache),
-		cacheTTL: 5 * time.Second,
+		cache:         make(map[string]*StatusCache),
+		cacheTTL:      5 * time.Second,
+		backgroundTTL: 60 * time.Second,
 	}
 }
 
@@ -41,6 +47,19 @@ func (m *StatusManager) GetCached(root string) *StatusResult {
 	defer m.mu.RUnlock()
 
 	if cache, ok := m.cache[root]; ok && !cache.IsExpired(m.cacheTTL) {
+		return cache.Status
+	}
+	return nil
+}
+
+// GetCachedBackground returns the cached status under the background TTL, or
+// nil if not cached/expired. Explicit invalidation (file-watcher events,
+// commits) still forces a refresh regardless of TTL.
+func (m *StatusManager) GetCachedBackground(root string) *StatusResult {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if cache, ok := m.cache[root]; ok && !cache.IsExpired(m.backgroundTTL) {
 		return cache.Status
 	}
 	return nil

--- a/internal/git/workspace_cleanup_fsm.go
+++ b/internal/git/workspace_cleanup_fsm.go
@@ -108,16 +108,30 @@ func cleanupValidateStageStep(r *workspaceCleanupRun) (workspaceCleanupPhase, er
 	if !workspaceAlive {
 		return cleanupPhaseUnregister, nil
 	}
-	if stageErr == nil {
-		// Both the staged cleanup dir and the workspace path exist: ambiguous.
-		return cleanupPhaseDone, fmt.Errorf("workspace path %s exists while pending cleanup remains at %s", r.workspacePath, r.state.CleanupPath)
-	}
-	// Stage is gone but the workspace lives: only recoverable workspaces may
-	// proceed (they get re-staged by the remove phase).
+	// The workspace path is alive. Decide whether it is the workspace this
+	// cleanup owns (fingerprint match) or an unrelated stray that some
+	// background process recreated at the original path after staging — e.g. a
+	// package manager or watcher writing `<ws>/apps/...`, the exact shape that
+	// used to deadlock the delete forever ("workspace path X exists while
+	// pending cleanup remains at Y" on every retry).
 	canRecover, err := canRecoverPendingCleanupWorkspace(r.ctx, r.workspacePath, r.state)
 	if err != nil {
 		return cleanupPhaseDone, err
 	}
+	if stageErr == nil {
+		// Both the staged dir and a live path exist. This is a genuine
+		// ambiguity only when the live path IS this workspace re-created while
+		// cleanup was pending (staging should have moved it away) — refuse
+		// that. When the live path is instead an unrelated stray, the staged
+		// worktree is still ours to remove; proceed and leave the stray
+		// untouched rather than deadlocking.
+		if canRecover {
+			return cleanupPhaseDone, fmt.Errorf("workspace path %s exists while pending cleanup remains at %s", r.workspacePath, r.state.CleanupPath)
+		}
+		return cleanupPhaseUnregister, nil
+	}
+	// Stage is gone but the workspace lives: only recoverable workspaces may
+	// proceed (they get re-staged by the remove phase).
 	if !canRecover {
 		return cleanupPhaseDone, fmt.Errorf("workspace path %s exists while pending cleanup remains at %s", r.workspacePath, r.state.CleanupPath)
 	}

--- a/internal/git/workspace_cleanup_test.go
+++ b/internal/git/workspace_cleanup_test.go
@@ -170,7 +170,15 @@ func TestRemoveWorkspaceRecoversNoFingerprintMarkerWhenRetryMetadataRemains(t *t
 	}
 }
 
-func TestRemoveWorkspaceRejectsReappearedLivePathWhileStagedCleanupExists(t *testing.T) {
+// TestRemoveWorkspaceFinishesCleanupWhenUnrelatedStrayReappears covers the
+// real-world deadlock: after a workspace was staged for cleanup, a background
+// process (a package manager, a file watcher) recreates an unrelated stray at
+// the original path (e.g. `<ws>/apps/...`). The stray is not the recoverable
+// workspace — no git fingerprint match — so it must NOT block the delete.
+// The staged worktree (the thing actually marked for deletion) is removed and
+// the marker cleared, while the stray content is left untouched. Previously
+// this deadlocked forever with "pending cleanup remains".
+func TestRemoveWorkspaceFinishesCleanupWhenUnrelatedStrayReappears(t *testing.T) {
 	origRemoveWorkspacePathCtx := removeWorkspacePathCtx
 	origUnregisterWorktreeCtx := unregisterWorktreeCtx
 	defer func() {
@@ -184,7 +192,8 @@ func TestRemoveWorkspaceRejectsReappearedLivePathWhileStagedCleanupExists(t *tes
 	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
 		t.Fatalf("MkdirAll(workspacePath) error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspacePath, "replacement.txt"), []byte("replacement"), 0o644); err != nil {
+	strayFile := filepath.Join(workspacePath, "replacement.txt")
+	if err := os.WriteFile(strayFile, []byte("replacement"), 0o644); err != nil {
 		t.Fatalf("WriteFile(replacement.txt) error = %v", err)
 	}
 	if err := os.MkdirAll(stagedPath, 0o755); err != nil {
@@ -198,21 +207,35 @@ func TestRemoveWorkspaceRejectsReappearedLivePathWhileStagedCleanupExists(t *tes
 		t.Fatalf("writeWorkspaceCleanupState() error = %v", err)
 	}
 
+	// Real capability shape: repo present, worktree admin already gone, so
+	// unregister is a clean no-op and cleanup can finalize.
 	unregisterWorktreeCtx = func(context.Context, string, string) error {
-		t.Fatal("expected reappeared live path to be rejected before unregister")
 		return nil
 	}
-	removeWorkspacePathCtx = func(context.Context, string) error {
-		t.Fatal("expected reappeared live path to be rejected before staged cleanup delete")
-		return nil
+	var removedPaths []string
+	removeWorkspacePathCtx = func(_ context.Context, path string) error {
+		removedPaths = append(removedPaths, path)
+		return os.RemoveAll(path)
 	}
 
-	err := RemoveWorkspace("/tmp/repo", workspacePath)
-	if err == nil {
-		t.Fatal("expected RemoveWorkspace() to reject reappeared live path during pending cleanup")
+	if err := RemoveWorkspace("/tmp/repo", workspacePath); err != nil {
+		t.Fatalf("expected cleanup to finish past an unrelated stray, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "pending cleanup remains") {
-		t.Fatalf("expected pending cleanup conflict, got %v", err)
+	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected staged path removed, err=%v", err)
+	}
+	if _, err := os.Stat(prunedWorkspaceRetryMarkerPath(workspacePath)); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup marker cleared, err=%v", err)
+	}
+	// The stray content must be preserved — cleanup only removes the staged
+	// worktree, never whatever reappeared at the original path.
+	if _, err := os.Stat(strayFile); err != nil {
+		t.Fatalf("expected stray content preserved, err=%v", err)
+	}
+	for _, p := range removedPaths {
+		if p == workspacePath {
+			t.Fatal("cleanup must not remove the reappeared workspace path itself")
+		}
 	}
 }
 

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -230,6 +230,13 @@ type ShowRenameWorkspaceDialog struct {
 	Workspace *data.Workspace
 }
 
+// ToggleWorkspacePin flips a workspace's pinned flag: pinned workspaces are
+// deliberately long-running and exempt from lifecycle automation.
+type ToggleWorkspacePin struct {
+	Project   *data.Project
+	Workspace *data.Workspace
+}
+
 // ShowWorkspaceEnvDialog requests showing the workspace environment-variable
 // editor for the given workspace.
 type ShowWorkspaceEnvDialog struct {

--- a/internal/process/doc.go
+++ b/internal/process/doc.go
@@ -1,4 +1,9 @@
-// Package process provides cross-platform process-group teardown: it kills a
-// process together with its descendants (KillProcessGroup) so agent process
-// trees do not survive the tmux session that launched them.
+// Package process owns the lifecycle of OS processes around workspaces:
+// cross-platform process-group teardown (KillProcessGroup) so agent process
+// trees do not survive the tmux session that launched them, script running
+// with port allocation (ScriptRunner), a durable registry of managed service
+// groups so they stay stoppable across amux restarts (ServiceRegistry),
+// process enumeration/attribution for workspaces (Snapshot, OrphanedGroups,
+// StatsForWorkspace), and reaping of service stacks orphaned by deleted or
+// prune-staged worktrees (FindWorkspaceOrphans).
 package process

--- a/internal/process/enumerate.go
+++ b/internal/process/enumerate.go
@@ -1,0 +1,215 @@
+package process
+
+import (
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProcessInfo describes one live process observed by Snapshot.
+type ProcessInfo struct {
+	PID     int
+	PGID    int
+	PPID    int
+	CPU     float64 // instantaneous %CPU as reported by ps
+	Command string
+	// StartedAt is the process start time (zero when unparseable). Together
+	// with PID/PGID it identifies a process across snapshots: a recycled PID
+	// has a different start time.
+	StartedAt time.Time
+}
+
+// lstartLayout parses ps's `lstart` column under LC_ALL=C, whitespace-
+// normalized ("Sun Jul 13 13:00:00 2026" or "Sun Jul  3 ..." → "Jul 3").
+const lstartLayout = "Mon Jan 2 15:04:05 2006"
+
+// parsePSLines parses `ps -axo pid=,pgid=,ppid=,pcpu=,lstart=,command=`
+// output: four numeric columns, five start-time tokens, then the raw command
+// line (which may itself contain spaces). Unparseable lines are skipped
+// rather than failing the snapshot — ps output can interleave kernel tasks
+// with no command.
+func parsePSLines(out string) []ProcessInfo {
+	lines := strings.Split(out, "\n")
+	procs := make([]ProcessInfo, 0, len(lines))
+	for _, line := range lines {
+		var cols [9]string
+		rest := line
+		ok := true
+		for i := range cols {
+			rest = strings.TrimLeft(rest, " \t")
+			cut := strings.IndexAny(rest, " \t")
+			if cut < 0 {
+				ok = false
+				break
+			}
+			cols[i], rest = rest[:cut], rest[cut:]
+		}
+		command := strings.TrimSpace(rest)
+		if !ok || command == "" {
+			continue
+		}
+		pid, err1 := strconv.Atoi(cols[0])
+		pgid, err2 := strconv.Atoi(cols[1])
+		ppid, err3 := strconv.Atoi(cols[2])
+		cpu, err4 := strconv.ParseFloat(strings.TrimSuffix(cols[3], "%"), 64)
+		if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+			continue
+		}
+		// A zero StartedAt (bad lstart) degrades identity checks, never the
+		// snapshot itself.
+		startedAt, _ := time.ParseInLocation(lstartLayout, strings.Join(cols[4:9], " "), time.Local)
+		procs = append(procs, ProcessInfo{
+			PID: pid, PGID: pgid, PPID: ppid, CPU: cpu,
+			Command: command, StartedAt: startedAt,
+		})
+	}
+	return procs
+}
+
+// Descendants returns the transitive children of rootPID within snap,
+// excluding rootPID itself. Order is stable (by PID).
+func Descendants(snap []ProcessInfo, rootPID int) []ProcessInfo {
+	children := make(map[int][]ProcessInfo, len(snap))
+	for _, p := range snap {
+		children[p.PPID] = append(children[p.PPID], p)
+	}
+	var out []ProcessInfo
+	queue := []int{rootPID}
+	seen := map[int]bool{rootPID: true}
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		for _, child := range children[pid] {
+			if seen[child.PID] {
+				continue
+			}
+			seen[child.PID] = true
+			out = append(out, child)
+			queue = append(queue, child.PID)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PID < out[j].PID })
+	return out
+}
+
+// ReferencingPath returns the processes whose command line references path
+// itself or a location under it. The match is boundary-aware so /a/b does not
+// match /a/bc.
+func ReferencingPath(snap []ProcessInfo, path string) []ProcessInfo {
+	path = strings.TrimRight(path, "/")
+	if path == "" {
+		return nil
+	}
+	var out []ProcessInfo
+	for _, p := range snap {
+		if commandReferencesPath(p.Command, path) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// pathBoundaryChars terminate a path embedded in a command line. Both the
+// matcher (commandReferencesPath) and the extractor (referencedWorkspaceRoots
+// in reaper.go) MUST use this same set: if they disagree, a process can
+// "reference" a root that extraction never finds, or vice versa, and orphans
+// are silently skipped.
+const pathBoundaryChars = " \t\"';:"
+
+func commandReferencesPath(command, path string) bool {
+	for rest := command; ; {
+		idx := strings.Index(rest, path)
+		if idx < 0 {
+			return false
+		}
+		boundary := idx + len(path)
+		if boundary >= len(rest) {
+			return true
+		}
+		if c := rest[boundary]; c == '/' || strings.IndexByte(pathBoundaryChars, c) >= 0 {
+			return true
+		}
+		rest = rest[boundary:]
+	}
+}
+
+// sessionCommands are interactive processes that legitimately hold a
+// workspace's directory: multiplexers, editors, IDE processes, and agent
+// clients. Teardown and reaping must never treat these as managed services —
+// killing a user's shell, editor, or running agent breaks the
+// detach/reattach contract.
+var sessionCommands = map[string]bool{
+	"tmux": true, "ssh": true, "mosh-client": true,
+	"vim": true, "nvim": true, "vi": true, "emacs": true, "nano": true,
+	"less": true, "more": true, "man": true,
+	"claude": true, "codex": true, "amux": true, "gemini": true, "aider": true,
+	"code": true, "cursor": true, "zed": true, "subl": true, "electron": true,
+}
+
+var shellCommands = map[string]bool{
+	"sh": true, "bash": true, "zsh": true, "fish": true, "dash": true,
+	"tcsh": true, "csh": true, "ksh": true,
+}
+
+// IsSessionCommand reports whether a command line looks like an interactive
+// session process rather than a managed service workload. Shells need the
+// finer split: a login/interactive shell ("-zsh", "zsh -l", tmux's
+// "sh -lc ...; exec zsh -l" bootstrap) is a session, while "sh -c <cmd>" is a
+// service wrapper — it is exactly how managed dev-server stacks are spawned.
+// macOS app bundles (any ".app/" executable — editors, GUI apps launched from
+// launchd with PPID 1) are always sessions. Ambiguous shell invocations
+// default to session (never kill on doubt).
+func IsSessionCommand(command string) bool {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return false
+	}
+	if strings.HasPrefix(fields[0], "-") { // login shells report as "-zsh"
+		return true
+	}
+	// macOS app bundle executables ("Visual Studio Code.app/...") contain
+	// spaces, so check the whole command line rather than argv0. Erring
+	// toward "session" is the safe direction for a never-kill guard.
+	if strings.Contains(command, ".app/") {
+		return true
+	}
+	name := strings.ToLower(filepath.Base(fields[0]))
+	if sessionCommands[name] {
+		return true
+	}
+	if !shellCommands[name] {
+		return false
+	}
+	if len(fields) == 1 {
+		return true
+	}
+	flags := fields[1]
+	if !strings.HasPrefix(flags, "-") {
+		return true
+	}
+	if strings.Contains(flags, "l") || strings.Contains(flags, "i") {
+		return true
+	}
+	return !strings.Contains(flags, "c")
+}
+
+// GroupLeaders reduces procs to one representative per process group: the
+// group leader when present, otherwise the lowest-PID member. Killing by
+// group via these representatives covers every listed process exactly once.
+func GroupLeaders(procs []ProcessInfo) []ProcessInfo {
+	byGroup := make(map[int]ProcessInfo)
+	for _, p := range procs {
+		cur, ok := byGroup[p.PGID]
+		if !ok || p.PID == p.PGID || (cur.PID != cur.PGID && p.PID < cur.PID) {
+			byGroup[p.PGID] = p
+		}
+	}
+	out := make([]ProcessInfo, 0, len(byGroup))
+	for _, p := range byGroup {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PGID < out[j].PGID })
+	return out
+}

--- a/internal/process/enumerate_test.go
+++ b/internal/process/enumerate_test.go
@@ -1,0 +1,148 @@
+package process
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestParsePSLines(t *testing.T) {
+	out := "  100  100    1  0.0 Sun Jul 13 12:00:00 2026 sh -c pnpm run dev\n" +
+		"  101  100  100 46.3 Sun Jul  6 07:05:09 2026 node /ws/ando/app/node_modules/.bin/ts-node-dev server.ts\n" +
+		"garbage line\n" +
+		"  102  102    1  1.5 Sun Jul 13 12:00:00 2026 5 numeric-argv0-command\n" +
+		"\n"
+	procs := parsePSLines(out)
+	if len(procs) != 3 {
+		t.Fatalf("expected 3 processes, got %d: %+v", len(procs), procs)
+	}
+	if procs[0].PID != 100 || procs[0].PGID != 100 || procs[0].PPID != 1 || procs[0].Command != "sh -c pnpm run dev" {
+		t.Errorf("unexpected first process: %+v", procs[0])
+	}
+	want := time.Date(2026, 7, 13, 12, 0, 0, 0, time.Local)
+	if !procs[0].StartedAt.Equal(want) {
+		t.Errorf("expected start time %v, got %v", want, procs[0].StartedAt)
+	}
+	if procs[1].CPU != 46.3 {
+		t.Errorf("expected CPU 46.3, got %v", procs[1].CPU)
+	}
+	// Space-padded single-digit day must parse too.
+	if procs[1].StartedAt.IsZero() {
+		t.Errorf("space-padded lstart failed to parse: %+v", procs[1])
+	}
+	if procs[2].Command != "5 numeric-argv0-command" {
+		t.Errorf("numeric argv0 mis-parsed: %+v", procs[2])
+	}
+}
+
+func TestDescendants(t *testing.T) {
+	snap := []ProcessInfo{
+		{PID: 1, PPID: 0},
+		{PID: 10, PPID: 1},
+		{PID: 20, PPID: 10},
+		{PID: 21, PPID: 10},
+		{PID: 30, PPID: 20},
+		{PID: 40, PPID: 1},
+	}
+	got := Descendants(snap, 10)
+	want := []int{20, 21, 30}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %+v", want, got)
+	}
+	for i, pid := range want {
+		if got[i].PID != pid {
+			t.Errorf("descendant %d: expected pid %d, got %d", i, pid, got[i].PID)
+		}
+	}
+	if len(Descendants(snap, 999)) != 0 {
+		t.Error("unknown root should have no descendants")
+	}
+}
+
+func TestReferencingPathBoundaries(t *testing.T) {
+	snap := []ProcessInfo{
+		{PID: 1, Command: "node /ws/app/node_modules/.bin/vite"},
+		{PID: 2, Command: "node /ws/app-other/server.js"},
+		{PID: 3, Command: "vim /ws/app"},
+		{PID: 4, Command: "sh -c cd /ws/app; pnpm dev"},
+		{PID: 5, Command: "unrelated"},
+	}
+	got := ReferencingPath(snap, "/ws/app")
+	if len(got) != 3 {
+		t.Fatalf("expected pids 1,3,4 — got %+v", got)
+	}
+	for _, p := range got {
+		if p.PID == 2 || p.PID == 5 {
+			t.Errorf("pid %d should not match", p.PID)
+		}
+	}
+	// Trailing slash on the query must not change matching.
+	if len(ReferencingPath(snap, "/ws/app/")) != 3 {
+		t.Error("trailing slash changed match results")
+	}
+}
+
+func TestIsSessionCommand(t *testing.T) {
+	session := []string{
+		"-zsh", "/bin/zsh -l", "sh -lc unset TMUX; exec /bin/zsh -l",
+		"tmux -L amux -f /dev/null new-session",
+		"claude --dangerously-skip-permissions", "nvim .", "./amux",
+		// macOS app bundles and editors are always sessions, even with a
+		// workspace path in argv.
+		"/Applications/Visual Studio Code.app/Contents/MacOS/Electron /ws/app",
+		"code /ws/app",
+	}
+	for _, cmd := range session {
+		if !IsSessionCommand(cmd) {
+			t.Errorf("expected session command: %q", cmd)
+		}
+	}
+	services := []string{
+		"node /ws/app/node_modules/.bin/ts-node-dev server.ts",
+		"/opt/homebrew/bin/esbuild --service=0.23.1 --ping",
+		"pnpm dlx convex dev",
+		"sh -c pnpm run dev", // the ScriptRunner wrapper shape
+		"",
+	}
+	for _, cmd := range services {
+		if IsSessionCommand(cmd) {
+			t.Errorf("expected service command: %q", cmd)
+		}
+	}
+}
+
+func TestGroupLeaders(t *testing.T) {
+	procs := []ProcessInfo{
+		{PID: 12, PGID: 10},
+		{PID: 10, PGID: 10}, // leader listed second on purpose
+		{PID: 22, PGID: 20},
+		{PID: 21, PGID: 20}, // no leader present: lowest PID wins
+	}
+	got := GroupLeaders(procs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 groups, got %+v", got)
+	}
+	if got[0].PID != 10 {
+		t.Errorf("group 10: expected leader pid 10, got %d", got[0].PID)
+	}
+	if got[1].PID != 21 {
+		t.Errorf("group 20: expected lowest pid 21, got %d", got[1].PID)
+	}
+}
+
+func TestSnapshotSeesSelf(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Snapshot unsupported on windows")
+	}
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	for _, p := range snap {
+		if p.PID == os.Getpid() {
+			return
+		}
+	}
+	t.Error("snapshot does not contain the current process")
+}

--- a/internal/process/enumerate_unix.go
+++ b/internal/process/enumerate_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// snapshotTimeout bounds the ps invocation: under heavy system load (the
+// exact condition teardown/reaping runs in) a stuck ps must not wedge the
+// caller.
+const snapshotTimeout = 10 * time.Second
+
+// Snapshot lists live processes (pid, pgid, ppid, cpu, start time, command
+// line) via ps. Processes the current user cannot signal may appear; kills on
+// them fail benignly later rather than being filtered here. LC_ALL=C pins the
+// lstart column to the layout parsePSLines expects.
+func Snapshot() ([]ProcessInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), snapshotTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ps", "-axo", "pid=,pgid=,ppid=,pcpu=,lstart=,command=")
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ps snapshot: %w", err)
+	}
+	return parsePSLines(string(out)), nil
+}

--- a/internal/process/enumerate_windows.go
+++ b/internal/process/enumerate_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package process
+
+import "errors"
+
+// Snapshot is not implemented on Windows: there is no pgid-based service
+// lifecycle there (see treekill_windows.go), so teardown and reaping degrade
+// to the tmux-session and script-runner paths only.
+func Snapshot() ([]ProcessInfo, error) {
+	return nil, errors.ErrUnsupported
+}

--- a/internal/process/loadavg.go
+++ b/internal/process/loadavg.go
@@ -1,0 +1,19 @@
+package process
+
+import "runtime"
+
+// LoadPerCore returns the 1-minute load average divided by the CPU count —
+// values well above 1 mean more runnable threads than cores. Used to detect
+// the "machine is drowning" state so the UI can say so instead of surfacing
+// mysterious timeouts. Unsupported platforms return an error.
+func LoadPerCore() (float64, error) {
+	load, err := loadAverage1m()
+	if err != nil {
+		return 0, err
+	}
+	cores := runtime.NumCPU()
+	if cores < 1 {
+		cores = 1
+	}
+	return load / float64(cores), nil
+}

--- a/internal/process/loadavg_darwin.go
+++ b/internal/process/loadavg_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package process
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// loadAverage1m reads the 1-minute load average from vm.loadavg. The sysctl
+// returns struct loadavg { fixpt_t ldavg[3]; long fscale; }: three uint32
+// fixed-point samples, 4 bytes of alignment padding, then an int64 scale.
+func loadAverage1m() (float64, error) {
+	raw, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return 0, err
+	}
+	if len(raw) < 24 {
+		return 0, fmt.Errorf("vm.loadavg: unexpected %d-byte payload", len(raw))
+	}
+	ldavg := binary.LittleEndian.Uint32(raw[0:4])
+	fscale := int64(binary.LittleEndian.Uint64(raw[16:24]))
+	if fscale <= 0 {
+		return 0, fmt.Errorf("vm.loadavg: invalid fscale %d", fscale)
+	}
+	return float64(ldavg) / float64(fscale), nil
+}

--- a/internal/process/loadavg_linux.go
+++ b/internal/process/loadavg_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package process
+
+import "golang.org/x/sys/unix"
+
+// loadAverage1m reads the 1-minute load average via sysinfo(2), whose Loads
+// values are fixed-point with a 16-bit fractional part (SI_LOAD_SHIFT).
+func loadAverage1m() (float64, error) {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return 0, err
+	}
+	return float64(info.Loads[0]) / float64(1<<16), nil
+}

--- a/internal/process/loadavg_other.go
+++ b/internal/process/loadavg_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package process
+
+import "errors"
+
+func loadAverage1m() (float64, error) {
+	return 0, errors.ErrUnsupported
+}

--- a/internal/process/reaper.go
+++ b/internal/process/reaper.go
@@ -1,0 +1,81 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// pruneStagedMarker appears in the basename of worktrees staged for removal
+// by internal/git's cleanup (".<base>.amux-prune-<ts>-<attempt>"). Processes
+// still referencing such a path are running out of a directory amux is in the
+// middle of deleting — definitively amux's garbage.
+const pruneStagedMarker = ".amux-prune-"
+
+// FindWorkspaceOrphans returns orphaned service group leaders whose command
+// lines reference a workspace root under baseDir that is either staged for
+// prune or no longer on disk (exists reports path liveness; pass os.Stat
+// semantics in production, a fake in tests). Only definitively dead roots
+// qualify — groups referencing a live workspace are never returned, so this
+// can safely drive automatic reaping without violating the never-kill-
+// ambiguous rule.
+func FindWorkspaceOrphans(snap []ProcessInfo, baseDir string, exists func(string) bool) []ProcessInfo {
+	baseDir = strings.TrimRight(baseDir, "/")
+	if baseDir == "" {
+		return nil
+	}
+	roots := make(map[string]bool)
+	for _, p := range snap {
+		for _, root := range referencedWorkspaceRoots(p.Command, baseDir) {
+			roots[root] = true
+		}
+	}
+	seen := make(map[int]bool)
+	var out []ProcessInfo
+	for root := range roots {
+		staged := strings.Contains(filepath.Base(root), pruneStagedMarker)
+		if !staged && exists(root) {
+			continue
+		}
+		for _, leader := range OrphanedGroups(snap, root) {
+			if seen[leader.PGID] {
+				continue
+			}
+			seen[leader.PGID] = true
+			out = append(out, leader)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PGID < out[j].PGID })
+	return out
+}
+
+// PathExists is the production exists callback for FindWorkspaceOrphans.
+func PathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// referencedWorkspaceRoots extracts the workspace roots (baseDir/<project>/
+// <workspace>) named anywhere in a command line. Deeper references (a script
+// inside node_modules) resolve to their containing root.
+func referencedWorkspaceRoots(command, baseDir string) []string {
+	var roots []string
+	prefix := baseDir + "/"
+	for rest := command; ; {
+		idx := strings.Index(rest, prefix)
+		if idx < 0 {
+			return roots
+		}
+		tail := rest[idx+len(prefix):]
+		end := strings.IndexAny(tail, " \t\"';:")
+		if end < 0 {
+			end = len(tail)
+		}
+		parts := strings.SplitN(tail[:end], "/", 3)
+		if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+			roots = append(roots, filepath.Join(baseDir, parts[0], parts[1]))
+		}
+		rest = tail
+	}
+}

--- a/internal/process/registry.go
+++ b/internal/process/registry.go
@@ -1,0 +1,153 @@
+package process
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/fsatomic"
+)
+
+// ServiceRecord is the durable identity of one managed service process group:
+// enough to find and stop it from a later amux process, without the worktree
+// directory existing. StartedAt (with PID/PGID) is the identity: a recycled
+// PID has a different start time, and it survives the shell's exec
+// optimization (`sh -c cmd` replaces its own image, changing the command line
+// ps reports, but never the start time).
+type ServiceRecord struct {
+	WorkspaceRoot string    `json:"workspace_root"`
+	PID           int       `json:"pid"`
+	PGID          int       `json:"pgid"`
+	Command       string    `json:"command"`
+	StartedAt     time.Time `json:"started_at"`
+}
+
+// startTimeTolerance absorbs the skew between Record's time.Now() (taken just
+// after spawn) and the kernel's process start time as ps reports it.
+const startTimeTolerance = 10 * time.Second
+
+// Matches reports whether the record still identifies a live process in snap:
+// same PID and process group, plus identity. When both start times are known
+// they decide alone — command lines change across exec, and an equal generic
+// command ("sh -c pnpm run dev") on a recycled PID must NOT match. Only when
+// a start time is missing does the command-line comparison decide.
+func (r ServiceRecord) Matches(snap []ProcessInfo) bool {
+	for _, p := range snap {
+		if p.PID != r.PID {
+			continue
+		}
+		if p.PGID != r.PGID {
+			return false
+		}
+		if !r.StartedAt.IsZero() && !p.StartedAt.IsZero() {
+			delta := p.StartedAt.Sub(r.StartedAt)
+			if delta < 0 {
+				delta = -delta
+			}
+			return delta <= startTimeTolerance
+		}
+		return p.Command == r.Command
+	}
+	return false
+}
+
+// ServiceRegistry persists ServiceRecords to a single JSON file so managed
+// services survive amux restarts as known, stoppable entities instead of
+// untracked orphans. All mutations rewrite the file atomically; a missing or
+// corrupt file degrades to an empty registry (never blocks startup).
+type ServiceRegistry struct {
+	mu      sync.Mutex
+	path    string
+	records map[string]ServiceRecord // workspace key -> record
+}
+
+// NewServiceRegistry loads (or lazily creates) the registry at path.
+func NewServiceRegistry(path string) *ServiceRegistry {
+	reg := &ServiceRegistry{path: path, records: make(map[string]ServiceRecord)}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return reg
+	}
+	var records map[string]ServiceRecord
+	if json.Unmarshal(data, &records) == nil && records != nil {
+		reg.records = records
+	}
+	return reg
+}
+
+// Record stores rec under its workspace root, replacing any prior entry.
+func (g *ServiceRegistry) Record(rec ServiceRecord) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.records[rec.WorkspaceRoot] = rec
+	return g.persistLocked()
+}
+
+// Clear removes the entry for workspaceRoot when it refers to pid (pid 0
+// clears unconditionally). A mismatched pid is left alone so a stale clear
+// cannot drop a newer service's record.
+func (g *ServiceRegistry) Clear(workspaceRoot string, pid int) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	rec, ok := g.records[workspaceRoot]
+	if !ok || (pid != 0 && rec.PID != pid) {
+		return nil
+	}
+	delete(g.records, workspaceRoot)
+	return g.persistLocked()
+}
+
+// Get returns the record for workspaceRoot, if any.
+func (g *ServiceRegistry) Get(workspaceRoot string) (ServiceRecord, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	rec, ok := g.records[workspaceRoot]
+	return rec, ok
+}
+
+// Records returns a copy of all entries.
+func (g *ServiceRegistry) Records() []ServiceRecord {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]ServiceRecord, 0, len(g.records))
+	for _, rec := range g.records {
+		out = append(out, rec)
+	}
+	return out
+}
+
+// reconcileGrace protects records younger than this from being dropped by a
+// non-matching reconcile: the snapshot is taken before Reconcile runs, so a
+// service recorded while ps was executing is legitimately absent from it.
+const reconcileGrace = 2 * time.Minute
+
+// Reconcile drops entries whose process no longer matches its recorded
+// identity and returns the records that are still live (including
+// grace-period keeps). Call it at startup with a fresh Snapshot before
+// trusting the registry for stops.
+func (g *ServiceRegistry) Reconcile(snap []ProcessInfo) []ServiceRecord {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	live := make([]ServiceRecord, 0, len(g.records))
+	changed := false
+	for key, rec := range g.records {
+		if rec.Matches(snap) || time.Since(rec.StartedAt) < reconcileGrace {
+			live = append(live, rec)
+			continue
+		}
+		delete(g.records, key)
+		changed = true
+	}
+	if changed {
+		if err := g.persistLocked(); err != nil {
+			slog.Debug("service registry reconcile persist failed", "error", err)
+		}
+	}
+	return live
+}
+
+func (g *ServiceRegistry) persistLocked() error {
+	return fsatomic.WriteJSON(g.path, g.records)
+}

--- a/internal/process/registry_test.go
+++ b/internal/process/registry_test.go
@@ -1,0 +1,154 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testRecord(root string, pid int) ServiceRecord {
+	return ServiceRecord{
+		WorkspaceRoot: root,
+		PID:           pid,
+		PGID:          pid,
+		Command:       "sh -c pnpm run dev",
+		StartedAt:     time.Now(),
+	}
+}
+
+func TestServiceRegistryPersistsAcrossInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-registry.json")
+	reg := NewServiceRegistry(path)
+	if err := reg.Record(testRecord("/ws/a", 123)); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	reloaded := NewServiceRegistry(path)
+	rec, ok := reloaded.Get("/ws/a")
+	if !ok || rec.PID != 123 || rec.Command != "sh -c pnpm run dev" {
+		t.Fatalf("expected persisted record, got %+v ok=%v", rec, ok)
+	}
+}
+
+func TestServiceRegistryClearGuardsPID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-registry.json")
+	reg := NewServiceRegistry(path)
+	if err := reg.Record(testRecord("/ws/a", 123)); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// A stale clear (older pid) must not drop the newer record.
+	if err := reg.Clear("/ws/a", 999); err != nil {
+		t.Fatalf("Clear mismatched: %v", err)
+	}
+	if _, ok := reg.Get("/ws/a"); !ok {
+		t.Fatal("mismatched-pid clear dropped the record")
+	}
+
+	if err := reg.Clear("/ws/a", 123); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, ok := reg.Get("/ws/a"); ok {
+		t.Fatal("matching clear left the record behind")
+	}
+}
+
+func TestServiceRegistryCorruptFileDegradesToEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-registry.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reg := NewServiceRegistry(path)
+	if got := reg.Records(); len(got) != 0 {
+		t.Fatalf("expected empty registry, got %+v", got)
+	}
+	// And it must still accept writes.
+	if err := reg.Record(testRecord("/ws/a", 1)); err != nil {
+		t.Fatalf("Record after corrupt load: %v", err)
+	}
+}
+
+func TestServiceRecordMatches(t *testing.T) {
+	rec := testRecord("/ws/a", 100)
+	live := []ProcessInfo{{PID: 100, PGID: 100, Command: "sh -c pnpm run dev"}}
+	if !rec.Matches(live) {
+		t.Error("expected identity match")
+	}
+	recycled := []ProcessInfo{{PID: 100, PGID: 100, Command: "totally different"}}
+	if rec.Matches(recycled) {
+		t.Error("recycled PID with different command must not match")
+	}
+	regrouped := []ProcessInfo{{PID: 100, PGID: 42, Command: "sh -c pnpm run dev"}}
+	if rec.Matches(regrouped) {
+		t.Error("changed process group must not match")
+	}
+	if rec.Matches(nil) {
+		t.Error("dead process must not match")
+	}
+}
+
+func TestServiceRecordMatchesByStartTime(t *testing.T) {
+	rec := testRecord("/ws/a", 100)
+	// The shell's exec optimization replaces the command line but never the
+	// start time: identity must hold on start time alone.
+	execReplaced := []ProcessInfo{{
+		PID: 100, PGID: 100,
+		Command:   "node /ws/a/node_modules/.bin/dev-server",
+		StartedAt: rec.StartedAt.Add(2 * time.Second),
+	}}
+	if !rec.Matches(execReplaced) {
+		t.Error("exec-replaced command with matching start time must match")
+	}
+	// A recycled PID running the identical generic command must NOT match:
+	// start time is the identity when both sides know it.
+	recycledSameCommand := []ProcessInfo{{
+		PID: 100, PGID: 100,
+		Command:   rec.Command,
+		StartedAt: rec.StartedAt.Add(time.Hour),
+	}}
+	if rec.Matches(recycledSameCommand) {
+		t.Error("recycled PID with same command but different start time must not match")
+	}
+}
+
+func TestServiceRegistryReconcileDropsDead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "service-registry.json")
+	reg := NewServiceRegistry(path)
+	if err := reg.Record(testRecord("/ws/live", 100)); err != nil {
+		t.Fatal(err)
+	}
+	// Old enough to be outside the reconcile grace window.
+	dead := testRecord("/ws/dead", 200)
+	dead.StartedAt = time.Now().Add(-time.Hour)
+	if err := reg.Record(dead); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := []ProcessInfo{{PID: 100, PGID: 100, Command: "sh -c pnpm run dev"}}
+	live := reg.Reconcile(snap)
+	if len(live) != 1 || live[0].WorkspaceRoot != "/ws/live" {
+		t.Fatalf("expected only /ws/live to survive, got %+v", live)
+	}
+	// The drop must be durable.
+	reloaded := NewServiceRegistry(path)
+	if _, ok := reloaded.Get("/ws/dead"); ok {
+		t.Error("dead record survived reconcile on disk")
+	}
+}
+
+func TestServiceRegistryReconcileGraceKeepsFreshRecords(t *testing.T) {
+	// A record created while the snapshot was being taken is legitimately
+	// absent from it and must not be dropped.
+	reg := NewServiceRegistry(filepath.Join(t.TempDir(), "service-registry.json"))
+	if err := reg.Record(testRecord("/ws/fresh", 300)); err != nil {
+		t.Fatal(err)
+	}
+	live := reg.Reconcile(nil)
+	if len(live) != 1 || live[0].WorkspaceRoot != "/ws/fresh" {
+		t.Fatalf("expected fresh record kept through reconcile, got %+v", live)
+	}
+	if _, ok := reg.Get("/ws/fresh"); !ok {
+		t.Error("fresh record dropped by reconcile despite grace window")
+	}
+}

--- a/internal/process/scripts.go
+++ b/internal/process/scripts.go
@@ -91,34 +91,51 @@ func isBenignStopError(err error) bool {
 		strings.Contains(msg, "no such process")
 }
 
-func (r *ScriptRunner) clearRunningEntry(key string) {
+// clearRunningEntry removes the tracking for exactly the entry the caller
+// stopped. The compare against the current map entry is load-bearing: a Stop
+// racing finishRunningEntry plus an immediate RunScript restart must not
+// untrack (or de-register) the NEW service that replaced the stopped one.
+func (r *ScriptRunner) clearRunningEntry(key string, expected *runningScript) {
 	var releaseRoot string
+	cleared := false
 	r.mu.Lock()
-	current := r.running[key]
-	delete(r.running, key)
-	if pending, ok := r.pendingRelease[key]; ok && pending.running == current {
-		releaseRoot = pending.root
-		delete(r.pendingRelease, key)
+	if current, ok := r.running[key]; ok && current == expected {
+		delete(r.running, key)
+		cleared = true
+		if pending, ok := r.pendingRelease[key]; ok && pending.running == expected {
+			releaseRoot = pending.root
+			delete(r.pendingRelease, key)
+		}
 	}
+	reg := r.registry
 	r.mu.Unlock()
 	if releaseRoot != "" && r.portAllocator != nil {
 		r.portAllocator.ReleasePort(releaseRoot)
+	}
+	if cleared {
+		clearRegistryEntry(reg, key, expected)
 	}
 }
 
 func (r *ScriptRunner) finishRunningEntry(key string, running *runningScript) {
 	var releaseRoot string
+	cleared := false
 	r.mu.Lock()
 	if current, ok := r.running[key]; ok && current == running {
 		delete(r.running, key)
+		cleared = true
 		if pending, ok := r.pendingRelease[key]; ok && pending.running == running {
 			releaseRoot = pending.root
 			delete(r.pendingRelease, key)
 		}
 	}
+	reg := r.registry
 	r.mu.Unlock()
 	if releaseRoot != "" && r.portAllocator != nil {
 		r.portAllocator.ReleasePort(releaseRoot)
+	}
+	if cleared {
+		clearRegistryEntry(reg, key, running)
 	}
 }
 
@@ -138,6 +155,11 @@ type ScriptRunner struct {
 	pendingRelease   map[string]pendingPortRelease
 	killProcessGroup func(pid int, opts KillOptions) error
 	trust            *ScriptTrust // per-user approval registry for repo-supplied scripts
+	// registry, when attached, records each started script's process-group
+	// identity durably so a later amux process can still stop it. The running
+	// map alone dies with this process — exactly how service stacks used to
+	// outlive amux as untracked orphans.
+	registry *ServiceRegistry
 }
 
 type runningScript struct {
@@ -341,6 +363,19 @@ func (r *ScriptRunner) RunScript(ws *data.Workspace, scriptType ScriptType) (*ex
 	key := scriptWorkspaceKey(ws)
 	r.setRunningEntry(key, running)
 
+	if reg := r.serviceRegistry(); reg != nil {
+		record := ServiceRecord{
+			WorkspaceRoot: key,
+			PID:           cmd.Process.Pid,
+			PGID:          cmd.Process.Pid, // SetProcessGroup makes the child its own group leader
+			Command:       "sh -c " + cmdStr,
+			StartedAt:     time.Now(),
+		}
+		if err := reg.Record(record); err != nil {
+			slog.Debug("service registry record failed", "error", err)
+		}
+	}
+
 	// Monitor in background
 	safego.Go("process.script_wait", func() {
 		defer close(running.done)
@@ -383,49 +418,6 @@ func (r *ScriptRunner) TrustRepoScriptsIfHash(repoPath, expectedHash string) err
 		return ErrScriptsChangedSincePrompt
 	}
 	return r.trust.Trust(repoPath, raw)
-}
-
-// Stop stops the running script for a workspace
-func (r *ScriptRunner) Stop(ws *data.Workspace) error {
-	if err := validateScriptWorkspace(ws); err != nil {
-		return err
-	}
-
-	key := scriptWorkspaceKey(ws)
-	r.mu.Lock()
-	running, ok := r.running[key]
-	r.mu.Unlock()
-
-	if !ok {
-		return nil
-	}
-
-	if running.cmd != nil && running.cmd.Process != nil {
-		pid := running.cmd.Process.Pid
-		err := r.killProcessGroup(pid, KillOptions{})
-		if err != nil {
-			if isBenignStopError(err) {
-				r.clearRunningEntry(key)
-				return nil
-			}
-			return err
-		}
-		if running.done == nil {
-			r.clearRunningEntry(key)
-			return nil
-		}
-		// Wait briefly for the background cmd.Wait monitor to observe exit,
-		// then escalate to SIGKILL if needed.
-		select {
-		case <-running.done:
-			r.clearRunningEntry(key)
-		case <-time.After(scriptStopTimeout):
-			_ = ForceKillProcess(pid)
-			r.clearRunningEntry(key)
-		}
-	}
-
-	return nil
 }
 
 // IsRunning checks if a script is running for a workspace

--- a/internal/process/scripts_registry.go
+++ b/internal/process/scripts_registry.go
@@ -1,0 +1,123 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+// This file holds the ScriptRunner's durable-registry integration and the
+// stop paths that use it: recording started scripts, clearing records, and
+// stopping services recorded by an earlier amux process. Split out of
+// scripts.go for the repo's 500-line file cap.
+
+// AttachServiceRegistry enables durable process-group tracking for scripts
+// started by this runner.
+func (r *ScriptRunner) AttachServiceRegistry(reg *ServiceRegistry) {
+	r.mu.Lock()
+	r.registry = reg
+	r.mu.Unlock()
+}
+
+func (r *ScriptRunner) serviceRegistry() *ServiceRegistry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.registry
+}
+
+// clearRegistryEntry drops the durable record for an entry this runner just
+// stopped tracking. The PID guard keeps a stale clear from erasing a newer
+// service's record; an entry with no resolvable PID is left for Reconcile to
+// collect rather than cleared blind.
+func clearRegistryEntry(reg *ServiceRegistry, key string, entry *runningScript) {
+	if reg == nil || entry == nil || entry.cmd == nil || entry.cmd.Process == nil {
+		return
+	}
+	if err := reg.Clear(key, entry.cmd.Process.Pid); err != nil {
+		slog.Debug("service registry clear failed", "error", err)
+	}
+}
+
+// Stop stops the running script for a workspace
+func (r *ScriptRunner) Stop(ws *data.Workspace) error {
+	if err := validateScriptWorkspace(ws); err != nil {
+		return err
+	}
+
+	key := scriptWorkspaceKey(ws)
+	r.mu.Lock()
+	running, ok := r.running[key]
+	r.mu.Unlock()
+
+	if !ok {
+		return r.stopFromRegistry(key)
+	}
+
+	if running.cmd != nil && running.cmd.Process != nil {
+		pid := running.cmd.Process.Pid
+		err := r.killProcessGroup(pid, KillOptions{})
+		if err != nil {
+			if isBenignStopError(err) {
+				r.clearRunningEntry(key, running)
+				return nil
+			}
+			return err
+		}
+		if running.done == nil {
+			r.clearRunningEntry(key, running)
+			return nil
+		}
+		// Wait briefly for the background cmd.Wait monitor to observe exit,
+		// then escalate to SIGKILL if needed.
+		select {
+		case <-running.done:
+			r.clearRunningEntry(key, running)
+		case <-time.After(scriptStopTimeout):
+			_ = ForceKillProcess(pid)
+			r.clearRunningEntry(key, running)
+		}
+	}
+
+	return nil
+}
+
+// stopFromRegistry stops a service this process never started: a durable
+// record left by an earlier amux instance. The record is trusted only when
+// the live process still matches its recorded identity (same PID, group, and
+// command line), so a recycled PID can never be killed by mistake. A dead or
+// mismatched record is dropped instead.
+func (r *ScriptRunner) stopFromRegistry(key string) error {
+	reg := r.serviceRegistry()
+	if reg == nil {
+		return nil
+	}
+	rec, ok := reg.Get(key)
+	if !ok {
+		return nil
+	}
+	snap, err := Snapshot()
+	if err != nil {
+		if errors.Is(err, errors.ErrUnsupported) {
+			// No enumeration on this platform: leave the record alone (never
+			// kill unverified, never clear a possibly-live service's record).
+			return nil
+		}
+		return fmt.Errorf("stop recorded service: %w", err)
+	}
+	if !rec.Matches(snap) {
+		if err := reg.Clear(key, rec.PID); err != nil {
+			slog.Debug("service registry clear failed", "error", err)
+		}
+		return nil
+	}
+	if err := r.killProcessGroup(rec.PID, KillOptions{}); err != nil && !isBenignStopError(err) {
+		return err
+	}
+	if err := reg.Clear(key, rec.PID); err != nil {
+		slog.Debug("service registry clear failed", "error", err)
+	}
+	return nil
+}

--- a/internal/process/teardown.go
+++ b/internal/process/teardown.go
@@ -1,0 +1,256 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// teardownGracePeriod gives service stacks (dev servers with children of
+// their own) longer than the 200ms treekill default to exit cleanly before
+// SIGKILL.
+const teardownGracePeriod = 2 * time.Second
+
+// OrphanedGroups returns the process groups that qualify as orphaned service
+// workloads for path: some member's command line references the path, no
+// member is an interactive session process, and the group leader's ancestry
+// reaches the root of the process tree (PID <= 1, covering both init and
+// subreaper-managed orphans) without passing through a session process. A
+// parent missing from the snapshot is ambiguous and disqualifies the group —
+// never kill on doubt. The session guard is load-bearing: a user's shell,
+// agent client, or editor must never qualify, even when it holds the path
+// (see IsSessionCommand).
+func OrphanedGroups(snap []ProcessInfo, path string) []ProcessInfo {
+	referencing := ReferencingPath(snap, path)
+	if len(referencing) == 0 {
+		return nil
+	}
+	candidates := make(map[int]bool, len(referencing))
+	for _, p := range referencing {
+		candidates[p.PGID] = true
+	}
+	byPID := make(map[int]ProcessInfo, len(snap))
+	for _, p := range snap {
+		byPID[p.PID] = p
+	}
+	members := make(map[int][]ProcessInfo)
+	for _, p := range snap {
+		if candidates[p.PGID] {
+			members[p.PGID] = append(members[p.PGID], p)
+		}
+	}
+	var leaders []ProcessInfo
+	for _, procs := range members {
+		disqualified := false
+		for _, p := range procs {
+			if IsSessionCommand(p.Command) {
+				disqualified = true
+				break
+			}
+		}
+		if disqualified {
+			continue
+		}
+		leader := GroupLeaders(procs)[0]
+		if !ancestryReachesRootWithoutSession(leader, byPID) {
+			continue
+		}
+		leaders = append(leaders, leader)
+	}
+	sort.Slice(leaders, func(i, j int) bool { return leaders[i].PGID < leaders[j].PGID })
+	return leaders
+}
+
+// ancestryReachesRootWithoutSession walks p's parent chain. True means the
+// chain hits PID <= 1 (init, launchd, or a numbered subreaper's own root)
+// with every intermediate ancestor being a non-session process — the group
+// has no live session owning it. A missing ancestor or a cycle is ambiguous
+// and returns false.
+func ancestryReachesRootWithoutSession(p ProcessInfo, byPID map[int]ProcessInfo) bool {
+	seen := map[int]bool{p.PID: true}
+	cur := p
+	for {
+		if cur.PPID <= 1 {
+			return true
+		}
+		parent, ok := byPID[cur.PPID]
+		if !ok || seen[parent.PID] {
+			return false
+		}
+		if IsSessionCommand(parent.Command) {
+			return false
+		}
+		seen[parent.PID] = true
+		cur = parent
+	}
+}
+
+// TeardownResult reports what a workspace teardown did. A non-nil error from
+// TeardownWorkspaceProcesses means qualifying groups survived; the error text
+// carries their description.
+type TeardownResult struct {
+	// Killed are the group leaders that were terminated, one entry per group.
+	Killed []ProcessInfo
+}
+
+// TeardownWorkspaceProcesses kills orphaned service process groups that
+// reference the workspace root, then re-verifies. It returns an error when
+// qualifying groups survive the kill passes, so callers can refuse to proceed
+// with worktree removal instead of silently orphaning live writers. A nil
+// error with empty Killed means there was nothing to tear down. Platforms
+// without process enumeration (Windows) degrade to a no-op: session and
+// script teardown still run, only the orphan sweep is skipped.
+//
+// It deliberately does NOT touch processes still attached to a live session
+// (a tmux pane, a shell, an agent): those are the caller's to stop first —
+// tmux.KillSession already kills pane process groups.
+//
+// Known limitation: attribution is by command line, so a process whose argv
+// never names the workspace path (started with a relative command and only
+// its cwd inside the worktree) is invisible to both the kill and the verify
+// pass. The durable ServiceRegistry covers the managed-script case; fully
+// closing the gap needs cwd-based attribution.
+func TeardownWorkspaceProcesses(root string) (TeardownResult, error) {
+	var res TeardownResult
+	killedPGIDs := make(map[int]bool)
+	// Two passes: killing a session's shell reparents its background jobs
+	// asynchronously, so groups can become qualifying orphans between the
+	// first snapshot and the verify snapshot. The second pass catches exactly
+	// those; anything still alive after it is a genuine failure.
+	for pass := 0; pass < 2; pass++ {
+		snap, err := Snapshot()
+		if err != nil {
+			if errors.Is(err, errors.ErrUnsupported) {
+				return res, nil
+			}
+			return res, fmt.Errorf("teardown snapshot: %w", err)
+		}
+		targets := OrphanedGroups(snap, root)
+		if len(targets) == 0 {
+			return res, nil
+		}
+		killGroups(targets, func(leader ProcessInfo) {
+			if !killedPGIDs[leader.PGID] {
+				killedPGIDs[leader.PGID] = true
+				res.Killed = append(res.Killed, leader)
+			}
+		})
+	}
+	snap, err := Snapshot()
+	if err != nil {
+		return res, fmt.Errorf("teardown verify snapshot: %w", err)
+	}
+	if survivors := OrphanedGroups(snap, root); len(survivors) > 0 {
+		return res, fmt.Errorf("workspace processes survived teardown: %s", DescribeGroups(survivors))
+	}
+	return res, nil
+}
+
+// killGroups terminates the given group leaders concurrently — each kill
+// waits up to teardownGracePeriod before SIGKILL, so sequential kills would
+// cost gracePeriod × N on the caller's (synchronous delete) path. onKilled
+// runs serially for each leader that was actually signaled. Each kill
+// re-verifies the leader still belongs to its snapshotted process group, so
+// a PID recycled since the snapshot is never signaled.
+func killGroups(targets []ProcessInfo, onKilled func(ProcessInfo)) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, leader := range targets {
+		wg.Add(1)
+		go func(leader ProcessInfo) {
+			defer wg.Done()
+			if !processGroupMatches(leader.PID, leader.PGID) {
+				return
+			}
+			if err := KillProcessGroup(leader.PID, KillOptions{GracePeriod: teardownGracePeriod}); err != nil && !isBenignStopError(err) {
+				return
+			}
+			mu.Lock()
+			onKilled(leader)
+			mu.Unlock()
+		}(leader)
+	}
+	wg.Wait()
+}
+
+// KillOrphanedGroups terminates the given orphaned group leaders (as returned
+// by OrphanedGroups/FindWorkspaceOrphans against a recent snapshot) and
+// returns the ones that were actually signaled. Kills run concurrently and
+// re-verify group identity first — see killGroups.
+func KillOrphanedGroups(targets []ProcessInfo) []ProcessInfo {
+	var killed []ProcessInfo
+	killGroups(targets, func(leader ProcessInfo) {
+		killed = append(killed, leader)
+	})
+	return killed
+}
+
+// WorkspaceStats aggregates the live workload attributable to one workspace.
+type WorkspaceStats struct {
+	// Procs is the number of processes in groups referencing the workspace.
+	Procs int
+	// CPU is those processes' summed instantaneous %CPU (100 = one core).
+	CPU float64
+}
+
+// StatsByWorkspace sums, for every root, the process groups whose command
+// lines reference it — the same attribution the teardown/reaper paths use,
+// but without any orphan or session filtering: this is a resource ledger, not
+// a kill list. One shared pass over the snapshot serves all roots.
+func StatsByWorkspace(snap []ProcessInfo, roots []string) map[string]WorkspaceStats {
+	stats := make(map[string]WorkspaceStats)
+	if len(roots) == 0 {
+		return stats
+	}
+	trimmed := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if r := strings.TrimRight(root, "/"); r != "" {
+			trimmed = append(trimmed, r)
+		}
+	}
+	// pgid -> set of roots any member references.
+	groupRoots := make(map[int]map[string]bool)
+	for _, p := range snap {
+		for _, root := range trimmed {
+			if commandReferencesPath(p.Command, root) {
+				if groupRoots[p.PGID] == nil {
+					groupRoots[p.PGID] = make(map[string]bool, 1)
+				}
+				groupRoots[p.PGID][root] = true
+			}
+		}
+	}
+	if len(groupRoots) == 0 {
+		return stats
+	}
+	for _, p := range snap {
+		for root := range groupRoots[p.PGID] {
+			s := stats[root]
+			s.Procs++
+			s.CPU += p.CPU
+			stats[root] = s
+		}
+	}
+	return stats
+}
+
+// StatsForWorkspace is the single-root form of StatsByWorkspace.
+func StatsForWorkspace(snap []ProcessInfo, root string) WorkspaceStats {
+	return StatsByWorkspace(snap, []string{root})[strings.TrimRight(root, "/")]
+}
+
+// DescribeGroups renders group leaders compactly for logs and error messages.
+func DescribeGroups(leaders []ProcessInfo) string {
+	parts := make([]string, 0, len(leaders))
+	for _, l := range leaders {
+		cmd := l.Command
+		if len(cmd) > 80 {
+			cmd = cmd[:77] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("pgid %d (%s)", l.PGID, cmd))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/process/teardown_test.go
+++ b/internal/process/teardown_test.go
@@ -1,0 +1,134 @@
+package process
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOrphanedGroups(t *testing.T) {
+	root := "/base/proj/ws"
+	snap := []ProcessInfo{
+		// Qualifying orphan: leader reparented to PID 1, member references root.
+		{PID: 100, PGID: 100, PPID: 1, Command: "fnm exec pnpm dlx convex dev"},
+		{PID: 101, PGID: 100, PPID: 100, Command: "node " + root + "/node_modules/.bin/convex dev"},
+		// Live stack: leader still has a real parent (its shell) — not orphaned.
+		{PID: 200, PGID: 200, PPID: 50, Command: "node " + root + "/node_modules/.bin/vite"},
+		// Group containing a session command must never qualify.
+		{PID: 300, PGID: 300, PPID: 1, Command: "-zsh"},
+		{PID: 301, PGID: 300, PPID: 300, Command: "tail -f " + root + "/log.txt"},
+		// Orphaned group referencing a different workspace.
+		{PID: 400, PGID: 400, PPID: 1, Command: "node /base/proj/other/server.js"},
+	}
+	got := OrphanedGroups(snap, root)
+	if len(got) != 1 || got[0].PGID != 100 {
+		t.Fatalf("expected only pgid 100, got %+v", got)
+	}
+}
+
+func TestOrphanedGroupsLeaderReferencesButChildDoesNot(t *testing.T) {
+	root := "/base/proj/ws"
+	snap := []ProcessInfo{
+		{PID: 100, PGID: 100, PPID: 1, Command: "sh -c cd " + root + " && pnpm dev"},
+		{PID: 101, PGID: 100, PPID: 100, Command: "node dev-server"},
+	}
+	got := OrphanedGroups(snap, root)
+	if len(got) != 1 || got[0].PID != 100 {
+		t.Fatalf("expected leader pid 100, got %+v", got)
+	}
+}
+
+func TestOrphanedGroupsSubreaperAncestry(t *testing.T) {
+	root := "/base/proj/ws"
+	snap := []ProcessInfo{
+		// Linux user-session subreaper: orphans reparent to systemd --user
+		// (PPID != 1) — the group is still orphaned because the ancestry
+		// reaches the tree root without passing a session process.
+		{PID: 500, PGID: 500, PPID: 1, Command: "/usr/lib/systemd/systemd --user"},
+		{PID: 510, PGID: 510, PPID: 500, Command: "node " + root + "/server.js"},
+		// Same shape but the parent chain passes through an interactive
+		// shell: a user's own foreground stack, never orphaned.
+		{PID: 600, PGID: 600, PPID: 1, Command: "-zsh"},
+		{PID: 610, PGID: 610, PPID: 600, Command: "node " + root + "/other.js"},
+	}
+	got := OrphanedGroups(snap, root)
+	if len(got) != 1 || got[0].PGID != 510 {
+		t.Fatalf("expected only the subreaper-parented pgid 510, got %+v", got)
+	}
+}
+
+func TestOrphanedGroupsSparesAppBundles(t *testing.T) {
+	root := "/base/proj/ws"
+	snap := []ProcessInfo{
+		// A Dock-launched editor (PPID 1 on macOS) with the workspace path in
+		// argv must never qualify: .app/ bundles are session processes.
+		{PID: 700, PGID: 700, PPID: 1, Command: "/Applications/Visual Studio Code.app/Contents/MacOS/Electron " + root},
+	}
+	if got := OrphanedGroups(snap, root); len(got) != 0 {
+		t.Fatalf("app bundle must never be treated as an orphaned service, got %+v", got)
+	}
+}
+
+func TestDescribeGroupsTruncates(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	desc := DescribeGroups([]ProcessInfo{{PGID: 7, Command: long}})
+	if len(desc) > 120 || !strings.Contains(desc, "pgid 7") {
+		t.Errorf("unexpected description: %q", desc)
+	}
+}
+
+func TestFindWorkspaceOrphans(t *testing.T) {
+	base := "/base"
+	deadRoot := base + "/proj/gone"
+	stagedRoot := base + "/proj/.ws.amux-prune-123-0"
+	liveRoot := base + "/proj/alive"
+	snap := []ProcessInfo{
+		// Orphan referencing a deleted workspace root → reap.
+		{PID: 100, PGID: 100, PPID: 1, Command: "node " + deadRoot + "/server.js"},
+		// Orphan referencing a prune-staged path → reap even though the staged dir exists.
+		{PID: 200, PGID: 200, PPID: 1, Command: "node " + stagedRoot + "/node_modules/.bin/trigger dev"},
+		// Orphan referencing a live workspace → never reaped automatically.
+		{PID: 300, PGID: 300, PPID: 1, Command: "node " + liveRoot + "/server.js"},
+		// Non-orphan referencing a dead root (still has a parent) → left alone.
+		{PID: 400, PGID: 400, PPID: 50, Command: "node " + deadRoot + "/other.js"},
+	}
+	exists := func(path string) bool { return path == liveRoot || path == stagedRoot }
+	got := FindWorkspaceOrphans(snap, base, exists)
+	if len(got) != 2 {
+		t.Fatalf("expected pgids 100 and 200, got %+v", got)
+	}
+	if got[0].PGID != 100 || got[1].PGID != 200 {
+		t.Errorf("unexpected orphans: %+v", got)
+	}
+}
+
+func TestStatsForWorkspace(t *testing.T) {
+	root := "/base/proj/ws"
+	snap := []ProcessInfo{
+		// Group 100: leader doesn't reference root, child does — whole group counts.
+		{PID: 100, PGID: 100, PPID: 1, CPU: 1.0, Command: "fnm exec pnpm run dev"},
+		{PID: 101, PGID: 100, PPID: 100, CPU: 46.5, Command: "node " + root + "/node_modules/.bin/vite"},
+		// Unrelated group.
+		{PID: 200, PGID: 200, PPID: 1, CPU: 90.0, Command: "node /elsewhere/server.js"},
+	}
+	stats := StatsForWorkspace(snap, root)
+	if stats.Procs != 2 {
+		t.Errorf("expected 2 procs, got %d", stats.Procs)
+	}
+	if stats.CPU != 47.5 {
+		t.Errorf("expected 47.5 CPU, got %v", stats.CPU)
+	}
+	if empty := StatsForWorkspace(snap, "/base/proj/none"); empty.Procs != 0 || empty.CPU != 0 {
+		t.Errorf("expected zero stats, got %+v", empty)
+	}
+}
+
+func TestReferencedWorkspaceRoots(t *testing.T) {
+	cmd := "node /base/p1/ws1/node_modules/.bin/x --flag /base/p2/ws2 other"
+	roots := referencedWorkspaceRoots(cmd, "/base")
+	if len(roots) != 2 || roots[0] != "/base/p1/ws1" || roots[1] != "/base/p2/ws2" {
+		t.Fatalf("unexpected roots: %v", roots)
+	}
+	if got := referencedWorkspaceRoots("no paths here", "/base"); len(got) != 0 {
+		t.Errorf("expected no roots, got %v", got)
+	}
+}

--- a/internal/process/treekill_unix.go
+++ b/internal/process/treekill_unix.go
@@ -70,6 +70,15 @@ func ForceKillProcess(pid int) error {
 	return syscall.Kill(-pid, syscall.SIGKILL)
 }
 
+// processGroupMatches reports whether pid still belongs to the expected
+// process group. Kill paths that derived a target from an earlier snapshot
+// use it as a cheap identity re-check: a PID recycled since the snapshot
+// almost never lands in the same group.
+func processGroupMatches(pid, expectedPGID int) bool {
+	pgid, err := syscall.Getpgid(pid)
+	return err == nil && pgid == expectedPGID
+}
+
 // SetProcessGroup configures a command to run in its own process group.
 func SetProcessGroup(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {

--- a/internal/process/treekill_windows.go
+++ b/internal/process/treekill_windows.go
@@ -54,3 +54,11 @@ func ForceKillProcess(pid int) error {
 func SetProcessGroup(cmd *exec.Cmd) {
 	_ = cmd
 }
+
+// processGroupMatches cannot be verified without Unix process groups; the
+// kill paths that use it never run on Windows (Snapshot is unsupported), so
+// answering true keeps the shared code simple.
+func processGroupMatches(pid, expectedPGID int) bool {
+	_, _ = pid, expectedPGID
+	return true
+}

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -310,6 +310,27 @@ func (m *Model) handleRename() tea.Cmd {
 	return nil
 }
 
+// handlePin toggles the pinned flag on the selected workspace row. Pinned
+// workspaces are deliberately long-running; lifecycle automation leaves them
+// alone. Only workspace rows can be pinned.
+func (m *Model) handlePin() tea.Cmd {
+	if m.cursor >= len(m.rows) {
+		return nil
+	}
+
+	row := m.rows[m.cursor]
+	if row.Type == RowWorkspace && row.Workspace != nil {
+		return func() tea.Msg {
+			return messages.ToggleWorkspacePin{
+				Project:   row.Project,
+				Workspace: row.Workspace,
+			}
+		}
+	}
+
+	return nil
+}
+
 // refresh requests a workspace rescan/import.
 func (m *Model) refresh() tea.Cmd {
 	return func() tea.Msg { return messages.RescanWorkspaces{} }

--- a/internal/ui/dashboard/dashboard_render.go
+++ b/internal/ui/dashboard/dashboard_render.go
@@ -51,7 +51,7 @@ func (m *Model) renderRow(row Row, selected bool) string {
 				m.agentStates[row.ActivityWorkspaceID] == activity.StateDone &&
 				!m.doneAcked[row.ActivityWorkspaceID] {
 				done = true
-			} else if s, ok := m.statusCache[main.Root]; ok && !s.Clean {
+			} else if s, ok := m.statusCache[main.Root]; ok && s != nil && !s.Clean {
 				dirty = true
 			}
 		}
@@ -125,13 +125,23 @@ func (m *Model) renderRow(row Row, selected bool) string {
 			m.agentStates[row.ActivityWorkspaceID] == activity.StateDone &&
 			!m.doneAcked[row.ActivityWorkspaceID] {
 			done = true
-		} else if s, ok := m.statusCache[row.Workspace.Root]; ok && !s.Clean {
+		} else if s, ok := m.statusCache[row.Workspace.Root]; ok && s != nil && !s.Clean {
 			dirty = true
 		}
 		if statusText != "" {
 			status = " " + statusText
 		} else if done {
 			status = " " + m.styles.StatusPending.Render("done")
+		}
+		// Annotate heavy workloads (pre-rendered in SetResourceStats) so a
+		// forgotten dev stack is visible without leaving the dashboard. The
+		// pin badge rides the status suffix rather than the name so name
+		// truncation can never trim it off.
+		if label, ok := m.resourceLabels[row.Workspace.Root]; ok {
+			status += " " + m.styles.StatusPending.Render(label)
+		}
+		if row.Workspace.Pinned {
+			status += " " + m.styles.StatusPending.Render(common.Icons.Pin)
 		}
 
 		// Determine row style based on selection and active state
@@ -214,6 +224,7 @@ func (m *Model) helpLines(contentWidth int) []string {
 		switch m.rows[m.cursor].Type {
 		case RowWorkspace:
 			items = append(items, m.helpItem("R", "rename"))
+			items = append(items, m.helpItem("P", "pin"))
 			items = append(items, m.helpItem("D", "delete"))
 		case RowProject:
 			items = append(items, m.helpItem("D", "remove"))

--- a/internal/ui/dashboard/dashboard_render_test.go
+++ b/internal/ui/dashboard/dashboard_render_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -268,4 +269,25 @@ func TestDashboardHelpLineCountClampsContentWidth(t *testing.T) {
 			t.Fatalf("width %d: expected positive help line count, got %d", width, got)
 		}
 	}
+}
+
+// TestNilStatusResultNeverPanicsRender pins the launch crash where a
+// GitStatusResult carrying a nil Status (no error) was cached and then
+// dereferenced by renderRow. The update must drop nil statuses, and the
+// render must survive a poisoned cache regardless.
+func TestNilStatusResultNeverPanicsRender(t *testing.T) {
+	m := New()
+	m.SetSize(60, 20)
+	m.SetProjects([]data.Project{makeProject()})
+
+	// Nil status through the normal update path must not be cached.
+	m.Update(messages.GitStatusResult{Root: "/repo/.amux/workspaces/feature", Status: nil})
+	if _, ok := m.statusCache["/repo/.amux/workspaces/feature"]; ok {
+		t.Fatal("nil status must not enter the status cache")
+	}
+
+	// Defense in depth: even a directly poisoned cache must render.
+	m.statusCache["/repo/.amux/workspaces/feature"] = nil
+	m.statusCache["/repo"] = nil
+	_ = m.View()
 }

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -8,6 +9,7 @@ import (
 	"github.com/andyrewlee/amux/internal/app/activity"
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/git"
+	"github.com/andyrewlee/amux/internal/process"
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
@@ -72,6 +74,12 @@ type Model struct {
 	rows        []Row
 	activeRoot  string // Currently active workspace root
 	statusCache map[string]*git.StatusResult
+	// resourceLabels maps workspace root -> pre-rendered workload annotation
+	// (e.g. "1.2c"), derived once per reaper tick in SetResourceStats. Rows
+	// annotate heavy workloads so a forgotten dev stack burning CPU is
+	// visible at a glance; renderRow only does a map lookup, keeping the
+	// per-frame render path allocation-free for data that changes every 60s.
+	resourceLabels map[string]string
 
 	// UI state
 	cursor          int
@@ -109,6 +117,7 @@ func New() *Model {
 		projects:           []data.Project{},
 		rows:               []Row{},
 		statusCache:        make(map[string]*git.StatusResult),
+		resourceLabels:     make(map[string]string),
 		creatingWorkspaces: make(map[string]*data.Workspace),
 		deletingWorkspaces: make(map[string]bool),
 		activeWorkspaceIDs: make(map[string]bool),
@@ -117,6 +126,23 @@ func New() *Model {
 		focused:            true,
 		styles:             common.DefaultStyles(),
 	}
+}
+
+// resourceLabelThreshold is the %CPU (100 = one core) above which a
+// workspace's workload is annotated on its row. Lighter workloads stay
+// silent to keep rows quiet.
+const resourceLabelThreshold = 50.0
+
+// SetResourceStats replaces the per-workspace workload ledger, pre-rendering
+// the row annotations so the render path only looks them up.
+func (m *Model) SetResourceStats(stats map[string]process.WorkspaceStats) {
+	labels := make(map[string]string, len(stats))
+	for root, s := range stats {
+		if s.CPU >= resourceLabelThreshold {
+			labels[root] = fmt.Sprintf("%.1fc", s.CPU/100)
+		}
+	}
+	m.resourceLabels = labels
 }
 
 // SetActiveWorkspaces updates the set of workspaces with active agents.

--- a/internal/ui/dashboard/model_update.go
+++ b/internal/ui/dashboard/model_update.go
@@ -95,7 +95,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		m.SetProjects(msg.Projects)
 
 	case messages.GitStatusResult:
-		if msg.Err == nil {
+		// A nil Status must never enter the cache: renderRow dereferences
+		// cached entries (s.Clean) and trusts them to be non-nil.
+		if msg.Err == nil && msg.Status != nil {
 			m.statusCache[msg.Root] = msg.Status
 		}
 
@@ -173,6 +175,8 @@ func (m *Model) handleNavKey(msg tea.KeyPressMsg, toolbarItems []toolbarItem) (*
 		return m, m.handleDelete()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("R"))):
 		return m, m.handleRename()
+	case key.Matches(msg, key.NewBinding(key.WithKeys("P"))):
+		return m, m.handlePin()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
 		return m, m.refresh()
 	case key.Matches(msg, key.NewBinding(key.WithKeys("G"))):

--- a/internal/ui/theme/icons.go
+++ b/internal/ui/theme/icons.go
@@ -14,6 +14,7 @@ var Icons = struct {
 	Delete string
 	Edit   string
 	Close  string
+	Pin    string
 
 	// Navigation
 	Cursor      string
@@ -47,6 +48,7 @@ var Icons = struct {
 	Delete: "×",
 	Edit:   "~",
 	Close:  "×",
+	Pin:    "⚲",
 
 	// Navigation
 	Cursor:      ">",


### PR DESCRIPTION
Hardens the lifecycle of workspace processes end-to-end, plus two user-facing bug fixes surfaced while testing (a launch render-crash and a permanent delete deadlock). Six thematic commits:

1. **Process primitives** (`internal/process`) — ps-backed enumeration with start-time identity (survives PID reuse and the `sh -c` exec optimization), a durable `ServiceRegistry` so script-started stacks stay stoppable across restarts, orphan attribution/teardown that spares session processes (shells, editors, agent clients, `.app` bundles) and reaches orphans through Linux subreapers, plus a per-workspace workload ledger and per-core load.
2. **Transactional delete + reaper + overload banner** — kill sessions and orphaned service groups *before* worktree removal (removing under live writers is what orphaned stacks to PID 1 with a deleted cwd); wire the registry + orphan reaper (GC tick + startup); a system-overload banner fed by load sampled independently of the ps snapshot so it works precisely when the machine is drowning.
3. **Git refresh discipline** — a 4-slot semaphore scoped to status/diff/branch *refresh* reads only (mutations never queue behind a refresh storm); a background cache tier for non-active workspaces; skip spawning git against a vanished root, returning no result rather than a nil status.
4. **Resource ledger, pin flag, nil-status render safety** — dashboard workload annotations (pre-rendered off the frame path), a persisted `pin` flag (`P`) for deliberately long-running workspaces, and nil-guards so a poisoned status cache can't panic `renderRow` (the launch crash).
5. **Cleanup-deadlock fix** — a delete no longer deadlocks forever when a background process recreates a stray at a staged worktree path; the FSM distinguishes a real re-created workspace (git fingerprint) from a stray and finishes the cleanup, leaving the stray untouched.
6. **Docs** — ARCHITECTURE process row and MESSAGE_FLOW delete ordering.

## Testing
- `make devcheck`, `make lint-strict-new`, `make verify-loop` green
- `make perf-check` passes on a quiet machine (was over threshold only under heavy local load)
- New unit coverage for enumeration/registry/teardown, the git refresh semaphore + background TTL, pin persistence, nil-status render safety, and the cleanup-deadlock case

## Known follow-up (not in this PR)
Workspace identity can drift when `data.NormalizePath`'s symlink resolution changes with a path's existence, orphaning metadata so a deleted workspace can resurface. Fixing it needs a metadata-dir migration, so it's deliberately scoped out.