### PR TITLE
fix: safely reconcile stale amux state

### DIFF
--- a/cmd/amux/tmux_socket_janitor.go
+++ b/cmd/amux/tmux_socket_janitor.go
@@ -3,11 +3,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/logging"
@@ -31,7 +33,7 @@ func cleanupStaleTestTmuxSockets() {
 				continue
 			}
 			name := entry.Name()
-			if !strings.HasPrefix(name, "amux-test-") && !strings.HasPrefix(name, "amux-e2e-check-") {
+			if !isTestTmuxSocketName(name) {
 				continue
 			}
 			info, err := entry.Info()
@@ -42,7 +44,7 @@ func cleanupStaleTestTmuxSockets() {
 				continue
 			}
 			socketPath := filepath.Join(dir, name)
-			if isLiveUnixSocket(socketPath) {
+			if !isStaleUnixSocket(socketPath) {
 				continue
 			}
 			if err := os.Remove(socketPath); err == nil {
@@ -53,6 +55,25 @@ func cleanupStaleTestTmuxSockets() {
 	if removed > 0 {
 		logging.Info("Removed %d stale tmux test sockets", removed)
 	}
+}
+
+func isTestTmuxSocketName(name string) bool {
+	for _, prefix := range []string{
+		"amux-test-",
+		"amux-e2e-",
+		"amux-gctest-",
+		"amux-ptytest-",
+		"amux-sidebar-test-",
+		"amux-closeloop-check-",
+		"amux-create-pipeline-",
+		"amux-pre-push-e2e-check-",
+		"amux-verify-loop-check-",
+	} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func tmuxSocketDirs() []string {
@@ -73,12 +94,18 @@ func tmuxSocketDirs() []string {
 	return out
 }
 
-func isLiveUnixSocket(path string) bool {
+func isStaleUnixSocket(path string) bool {
 	dialer := net.Dialer{Timeout: staleSocketDialTimeout}
 	conn, err := dialer.Dial("unix", path)
-	if err != nil {
+	if err == nil {
+		_ = conn.Close()
 		return false
 	}
-	_ = conn.Close()
-	return true
+	// Fail closed unless the kernel definitively says the socket has no listener
+	// (or disappeared during the scan). A timeout can be a busy live server.
+	return isDefinitivelyStaleSocketError(err)
+}
+
+func isDefinitivelyStaleSocketError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, os.ErrNotExist)
 }

--- a/cmd/amux/tmux_socket_janitor_test.go
+++ b/cmd/amux/tmux_socket_janitor_test.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -24,6 +26,31 @@ func shortSocketDir(t *testing.T) string {
 	tmuxSocketDirsFn = func() []string { return []string{dir} }
 	t.Cleanup(func() { tmuxSocketDirsFn = prev })
 	return dir
+}
+
+func TestIsTestTmuxSocketName(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want bool
+	}{
+		{name: "amux-e2e-123", want: true},
+		{name: "amux-gctest-123", want: true},
+		{name: "amux-ptytest-123", want: true},
+		{name: "amux-sidebar-test-123", want: true},
+		{name: "amux-closeloop-check-123", want: true},
+		{name: "amux-create-pipeline-123", want: true},
+		{name: "amux-pre-push-e2e-check-123", want: true},
+		{name: "amux-verify-loop-check-123", want: true},
+		{name: "amux", want: false},
+		{name: "amux-user-server", want: false},
+		{name: "default", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTestTmuxSocketName(tt.name); got != tt.want {
+				t.Fatalf("isTestTmuxSocketName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
 }
 
 // listenUnix creates a live unix socket at path and registers its cleanup.
@@ -87,6 +114,27 @@ func TestCleanupStaleTestTmuxSockets_KeepsLiveTestSocket(t *testing.T) {
 
 	if _, err := os.Stat(live); err != nil {
 		t.Fatalf("expected live test socket to be kept, stat err = %v", err)
+	}
+}
+
+func TestStaleSocketClassificationFailsClosed(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "refused is stale", err: syscall.ECONNREFUSED, want: true},
+		{name: "missing is stale", err: os.ErrNotExist, want: true},
+		{name: "timeout is unknown", err: context.DeadlineExceeded, want: false},
+		{name: "permission is unknown", err: os.ErrPermission, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := &net.OpError{Op: "dial", Net: "unix", Err: tt.err}
+			got := isDefinitivelyStaleSocketError(wrapped)
+			if got != tt.want {
+				t.Fatalf("stale classification for %v = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -181,7 +181,7 @@ func New(version, commit, date string) (*App, error) {
 	app.externalCritical = make(chan tea.Msg, externalCriticalBuffer)
 	app.ctx = ctx
 	app.tmuxOptions = tmuxOpts
-	app.instanceID = newInstanceID()
+	app.instanceID = newInstanceID(cfg.Paths.Home)
 	app.supervisor = supervisor.New(ctx)
 	app.installSupervisorErrorHandler()
 	// Route PTY messages through the app-level pump.

--- a/internal/app/app_input_messages_dialogs.go
+++ b/internal/app/app_input_messages_dialogs.go
@@ -232,7 +232,7 @@ func (a *App) handleShowRemoveProjectDialog(msg messages.ShowRemoveProjectDialog
 	a.dialog = common.NewConfirmDialog(
 		DialogRemoveProject,
 		"Remove Project",
-		fmt.Sprintf("Remove project '%s' from AMUX? This won't delete any files.", projectName),
+		fmt.Sprintf("Remove project '%s' from AMUX? Running agents and project scripts will stop; its repository and worktrees stay on disk.", projectName),
 	)
 	a.presentDialog(a.dialog)
 }

--- a/internal/app/app_input_messages_dialogs_show_test.go
+++ b/internal/app/app_input_messages_dialogs_show_test.go
@@ -295,6 +295,10 @@ func TestHandleShowRemoveProjectDialog_RendersProjectName(t *testing.T) {
 			if !strings.Contains(view, tc.wantName) {
 				t.Fatalf("expected %q in view, got %q", tc.wantName, view)
 			}
+			if tc.project != nil && (!strings.Contains(view, "Running agents and project scripts") ||
+				!strings.Contains(view, "repository and worktrees stay on disk")) {
+				t.Fatalf("expected workload and file-retention warning in view, got %q", view)
+			}
 
 			res := confirmResult(t, h.app.dialog)
 			if res.ID != DialogRemoveProject {

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -37,7 +37,8 @@ func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
 	if a.dashboard != nil {
 		a.dashboard.SetProjects(a.projects)
 	}
-	cmds = append(cmds, a.rebindActiveSelection()...)
+	cmds = append(cmds, a.rebindActiveSelectionForLoad(loadToken)...)
+	a.lifecycle.clearCreatedProjectLoadBarriersThrough(loadToken, loadedIdentities)
 	// Request git status for all workspaces
 	cmds = append(cmds, a.scanTmuxActivityNow())
 	if gcCmd := a.gcOrphanedTmuxSessions(); gcCmd != nil {
@@ -85,6 +86,10 @@ func projectLoadWorkspaceIdentities(projects []data.Project) map[string]bool {
 }
 
 func (a *App) rebindActiveSelection() []tea.Cmd {
+	return a.rebindActiveSelectionForLoad(0)
+}
+
+func (a *App) rebindActiveSelectionForLoad(loadToken projectsLoadToken) []tea.Cmd {
 	var cmds []tea.Cmd
 	if a.activeWorkspace != nil {
 		previous := a.activeWorkspace
@@ -95,6 +100,9 @@ func (a *App) rebindActiveSelection() []tea.Cmd {
 		}
 		if ws == nil {
 			if a.lifecycle.isDeletingWorkspace(wsID, previous.Root) {
+				return cmds
+			}
+			if a.lifecycle.shouldRetainCreatedWorkspace(wsID, previous.Root, loadToken) {
 				return cmds
 			}
 			a.goHome()

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -24,6 +24,7 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		logging.Warn("DeleteWorkspace rejected while workspace %s is in another lifecycle phase", msg.Workspace.ID())
 		return nil
 	}
+	a.lifecycle.clearCreatedProjectLoadBarrier(string(msg.Workspace.ID()), msg.Workspace.Root)
 	// Do NOT kill the workspace's tmux sessions here. All real delete validation
 	// (primary-checkout guard, repo/path checks, worktree removal) runs later in
 	// the async DeleteWorkspace cmd; killing up-front means a rejected or failed
@@ -77,8 +78,20 @@ func (a *App) handleWorkspaceCreatedWithWarning(msg messages.WorkspaceCreatedWit
 			cmds = append(cmds, cmd)
 		}
 	}
-	cmds = append(cmds, a.loadProjects())
+	cmds = append(cmds, a.loadProjectsAfterCreate(msg.Workspace))
 	return cmds
+}
+
+func (a *App) loadProjectsAfterCreate(ws *data.Workspace) tea.Cmd {
+	cmd := a.loadProjects()
+	if cmd != nil && ws != nil {
+		a.lifecycle.markCreatedUntilProjectsLoad(
+			string(ws.ID()),
+			ws.Root,
+			a.lifecycle.projectsLoadToken,
+		)
+	}
+	return cmd
 }
 
 // handleWorkspaceCreated handles the WorkspaceCreated message.
@@ -91,7 +104,7 @@ func (a *App) handleWorkspaceCreated(msg messages.WorkspaceCreated) []tea.Cmd {
 		}
 		cmds = append(cmds, a.runSetupAsync(msg.Workspace))
 	}
-	cmds = append(cmds, a.loadProjects())
+	cmds = append(cmds, a.loadProjectsAfterCreate(msg.Workspace))
 	return cmds
 }
 

--- a/internal/app/app_tmux_activity.go
+++ b/internal/app/app_tmux_activity.go
@@ -341,5 +341,14 @@ func (a *App) handleTmuxAvailableResult(msg tmuxAvailableResult) []tea.Cmd {
 			return nil
 		})
 	}
+	// Availability and project loading race during Init. Scheduling both cleanup
+	// passes here complements handleProjectsLoaded, so whichever result arrives
+	// second performs reconciliation immediately instead of waiting for a tick.
+	if gcCmd := a.gcStaleDetachedAgentSessions(); gcCmd != nil {
+		cmds = append(cmds, gcCmd)
+	}
+	if gcCmd := a.gcOrphanedTmuxSessions(); gcCmd != nil {
+		cmds = append(cmds, gcCmd)
+	}
 	return cmds
 }

--- a/internal/app/app_tmux_gc.go
+++ b/internal/app/app_tmux_gc.go
@@ -24,12 +24,13 @@ type orphanGCResult struct {
 // staleDetachedAgentGCResult is returned after attempting to clean up stale
 // detached agent sessions.
 type staleDetachedAgentGCResult struct {
-	Considered      int
-	Killed          int
-	SkippedAttached int
-	SkippedFresh    int
-	SkippedLivePane int
-	Err             error
+	Considered       int
+	Killed           int
+	SkippedAttached  int
+	SkippedLiveOwner int
+	SkippedFresh     int
+	SkippedLivePane  int
+	Err              error
 }
 
 // collectKnownWorkspaceIDs returns the set of workspace IDs currently tracked
@@ -65,11 +66,12 @@ func (a *App) gcOrphanedTmuxSessions() tea.Cmd {
 		if svc == nil {
 			return orphanGCResult{Err: errTmuxUnavailable}
 		}
+		now := time.Now()
 		byWorkspace, err := a.amuxSessionsByWorkspace(opts)
 		if err != nil {
 			return orphanGCResult{Err: err}
 		}
-		now := time.Now()
+		a.refreshOwnedSessionHeartbeats(byWorkspace, now, opts)
 		killed := a.killOrphanedSessions(byWorkspace, knownIDs, now, opts)
 		return orphanGCResult{Killed: killed}
 	}
@@ -87,19 +89,16 @@ func (a *App) gcStaleDetachedAgentSessions() tea.Cmd {
 		}
 
 		match := map[string]string{"@amux": "1", "@amux_type": "agent"}
-		if instanceID := strings.TrimSpace(a.instanceID); instanceID != "" {
-			// Detached-agent GC is instance-scoped so multiple amux instances do
-			// not race to kill each other's managed sessions.
-			match["@amux_instance"] = instanceID
-		}
 		rows, err := svc.SessionsWithTags(
 			match,
 			[]string{
+				"@amux_instance",
 				"@amux_created_at",
 				"session_activity",
 				tmux.TagLastOutputAt,
 				tmux.TagLastInputAt,
 				tmux.TagSessionLeaseAt,
+				tmux.TagSessionOwnerHeartbeatAt,
 			},
 			opts,
 		)
@@ -134,6 +133,9 @@ func (a *App) gcStaleDetachedAgentSessions() tea.Cmd {
 			if sessionName == "" {
 				continue
 			}
+			if !instancesShareState(row.Tags["@amux_instance"], a.instanceID) {
+				continue
+			}
 			result.Considered++
 
 			hasClients := false
@@ -149,6 +151,10 @@ func (a *App) gcStaleDetachedAgentSessions() tea.Cmd {
 			}
 			if hasClients {
 				result.SkippedAttached++
+				continue
+			}
+			if foreignSessionOwnerAlive(row.Tags, a.instanceID, now) {
+				result.SkippedLiveOwner++
 				continue
 			}
 
@@ -189,8 +195,10 @@ func (a *App) gcStaleDetachedAgentSessions() tea.Cmd {
 }
 
 type workspaceSession struct {
-	Name      string
-	CreatedAt int64
+	Name             string
+	CreatedAt        int64
+	InstanceID       string
+	OwnerHeartbeatAt time.Time
 }
 
 func (a *App) amuxSessionsByWorkspace(opts tmux.Options) (map[string][]workspaceSession, error) {
@@ -198,10 +206,13 @@ func (a *App) amuxSessionsByWorkspace(opts tmux.Options) (map[string][]workspace
 		return nil, errTmuxUnavailable
 	}
 	match := map[string]string{"@amux": "1"}
-	if a.instanceID != "" {
-		match["@amux_instance"] = a.instanceID
-	}
-	rows, err := a.tmuxService.SessionsWithTags(match, []string{"@amux_workspace", "@amux_created_at"}, opts)
+	rows, err := a.tmuxService.SessionsWithTags(match, []string{
+		"@amux_workspace",
+		"@amux_created_at",
+		"@amux_instance",
+		tmux.TagSessionLeaseAt,
+		tmux.TagSessionOwnerHeartbeatAt,
+	}, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -211,13 +222,61 @@ func (a *App) amuxSessionsByWorkspace(opts tmux.Options) (map[string][]workspace
 		if wsID == "" {
 			continue
 		}
+		rowInstanceID := strings.TrimSpace(row.Tags["@amux_instance"])
+		if !instancesShareState(rowInstanceID, a.instanceID) {
+			continue
+		}
 		var createdAt int64
 		if raw := strings.TrimSpace(row.Tags["@amux_created_at"]); raw != "" {
 			createdAt, _ = strconv.ParseInt(raw, 10, 64)
 		}
-		out[wsID] = append(out[wsID], workspaceSession{Name: row.Name, CreatedAt: createdAt})
+		out[wsID] = append(out[wsID], workspaceSession{
+			Name:             row.Name,
+			CreatedAt:        createdAt,
+			InstanceID:       rowInstanceID,
+			OwnerHeartbeatAt: sessionOwnerHeartbeatAt(row.Tags),
+		})
 	}
 	return out, nil
+}
+
+type sessionTagBatchSetter interface {
+	SetSessionTagValueForSessions(sessionNames []string, key, value string, opts tmux.Options) error
+}
+
+func (a *App) refreshOwnedSessionHeartbeats(byWorkspace map[string][]workspaceSession, now time.Time, opts tmux.Options) {
+	instanceID := strings.TrimSpace(a.instanceID)
+	if instanceID == "" || a.tmuxService == nil {
+		return
+	}
+	setter, ok := a.tmuxService.(sessionTagBatchSetter)
+	if !ok {
+		return
+	}
+	names := make([]string, 0)
+	for _, sessions := range byWorkspace {
+		for _, session := range sessions {
+			if session.InstanceID != instanceID || session.Name == "" {
+				continue
+			}
+			if !session.OwnerHeartbeatAt.IsZero() && !session.OwnerHeartbeatAt.After(now) &&
+				now.Sub(session.OwnerHeartbeatAt) < sessionOwnerHeartbeatInterval {
+				continue
+			}
+			names = append(names, session.Name)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	if err := setter.SetSessionTagValueForSessions(
+		names,
+		tmux.TagSessionOwnerHeartbeatAt,
+		strconv.FormatInt(now.UnixMilli(), 10),
+		opts,
+	); err != nil {
+		logging.Warn("session owner heartbeat refresh failed: %v", err)
+	}
 }
 
 func (a *App) killOrphanedSessions(byWorkspace map[string][]workspaceSession, knownIDs map[string]bool, now time.Time, opts tmux.Options) int {
@@ -231,6 +290,9 @@ func (a *App) killOrphanedSessions(byWorkspace map[string][]workspaceSession, kn
 		}
 		for _, ws := range sessions {
 			if ws.Name == "" {
+				continue
+			}
+			if foreignWorkspaceSessionOwnerAlive(ws, a.instanceID, now) {
 				continue
 			}
 			createdAt := ws.CreatedAt
@@ -252,6 +314,17 @@ func (a *App) killOrphanedSessions(byWorkspace map[string][]workspaceSession, kn
 			if hasClients {
 				continue
 			}
+			state, err := a.tmuxService.SessionStateFor(ws.Name, opts)
+			if err != nil {
+				// A detached session can still be running an agent, build, or proof.
+				// Missing metadata is not enough evidence to terminate that work;
+				// only collect sessions whose panes are confirmed dead.
+				logging.Warn("orphan GC: failed to check pane liveness for %s: %v", ws.Name, err)
+				continue
+			}
+			if state.Exists && state.HasLivePane {
+				continue
+			}
 			if err := a.tmuxService.KillSession(ws.Name, opts); err != nil {
 				logging.Warn("orphan GC: failed to kill session %s: %v", ws.Name, err)
 				continue
@@ -260,6 +333,41 @@ func (a *App) killOrphanedSessions(byWorkspace map[string][]workspaceSession, kn
 		}
 	}
 	return killed
+}
+
+func sessionOwnerHeartbeatAt(tags map[string]string) time.Time {
+	if heartbeat, ok := activity.ParseLastOutputAtTag(tags[tmux.TagSessionOwnerHeartbeatAt]); ok {
+		return heartbeat
+	}
+	// Compatibility fallback: current releases set the activity lease at
+	// create/reattach time, so a peer gets a safety window before the first
+	// dedicated owner heartbeat is written.
+	if lease, ok := activity.ParseLastOutputAtTag(tags[tmux.TagSessionLeaseAt]); ok {
+		return lease
+	}
+	return time.Time{}
+}
+
+func ownerHeartbeatAlive(heartbeatAt, now time.Time) bool {
+	if heartbeatAt.IsZero() {
+		return false
+	}
+	if heartbeatAt.After(now) {
+		return true // fail closed under clock skew
+	}
+	return now.Sub(heartbeatAt) <= sessionOwnerStaleAfter
+}
+
+func foreignWorkspaceSessionOwnerAlive(session workspaceSession, currentInstanceID string, now time.Time) bool {
+	owner := strings.TrimSpace(session.InstanceID)
+	current := strings.TrimSpace(currentInstanceID)
+	return owner != "" && owner != current && ownerHeartbeatAlive(session.OwnerHeartbeatAt, now)
+}
+
+func foreignSessionOwnerAlive(tags map[string]string, currentInstanceID string, now time.Time) bool {
+	owner := strings.TrimSpace(tags["@amux_instance"])
+	current := strings.TrimSpace(currentInstanceID)
+	return owner != "" && owner != current && ownerHeartbeatAlive(sessionOwnerHeartbeatAt(tags), now)
 }
 
 func isRecentOrphanSession(createdAt int64, now time.Time) bool {
@@ -304,10 +412,11 @@ func (a *App) handleStaleDetachedAgentGCResult(msg staleDetachedAgentGCResult) {
 	}
 	if msg.Killed > 0 {
 		logging.Info(
-			"detached agent GC: killed=%d considered=%d attached=%d fresh=%d live_pane=%d",
+			"detached agent GC: killed=%d considered=%d attached=%d live_owner=%d fresh=%d live_pane=%d",
 			msg.Killed,
 			msg.Considered,
 			msg.SkippedAttached,
+			msg.SkippedLiveOwner,
 			msg.SkippedFresh,
 			msg.SkippedLivePane,
 		)

--- a/internal/app/app_tmux_gc_detached_test.go
+++ b/internal/app/app_tmux_gc_detached_test.go
@@ -75,7 +75,7 @@ func TestGcStaleDetachedAgentSessions_RunsWhenFollower(t *testing.T) {
 	}
 	app := &App{
 		tmuxAvailable: true,
-		instanceID:    "instance-a",
+		instanceID:    "aaaaaaaaaaaaaaaa.1111111111111111",
 		tmuxActivity:  tmuxActivityState{ownershipSet: true, scannerOwner: false},
 		tmuxService:   ops,
 	}
@@ -97,19 +97,19 @@ func TestGcStaleDetachedAgentSessions_RunsWhenFollower(t *testing.T) {
 	if ops.lastMatch["@amux_type"] != "agent" {
 		t.Fatalf("expected @amux_type=agent, got %v", ops.lastMatch)
 	}
-	if ops.lastMatch["@amux_instance"] != "instance-a" {
-		t.Fatalf("expected instance-scoped match, got %v", ops.lastMatch)
+	if _, filtered := ops.lastMatch["@amux_instance"]; filtered {
+		t.Fatalf("expected ownership-aware GC to enumerate every instance, got %v", ops.lastMatch)
 	}
 }
 
-func TestGcStaleDetachedAgentSessions_FiltersByInstanceID(t *testing.T) {
+func TestGcStaleDetachedAgentSessions_EnumeratesEveryInstance(t *testing.T) {
 	ops := &detachedGCOps{
 		rows:      []tmux.SessionTagValues{},
 		allStates: map[string]tmux.SessionState{},
 	}
 	app := &App{
 		tmuxAvailable: true,
-		instanceID:    "instance-a",
+		instanceID:    "aaaaaaaaaaaaaaaa.1111111111111111",
 		tmuxService:   ops,
 	}
 	msg := app.gcStaleDetachedAgentSessions()()
@@ -126,18 +126,93 @@ func TestGcStaleDetachedAgentSessions_FiltersByInstanceID(t *testing.T) {
 	if ops.lastMatch["@amux_type"] != "agent" {
 		t.Fatalf("expected @amux_type=agent, got %v", ops.lastMatch)
 	}
-	if ops.lastMatch["@amux_instance"] != "instance-a" {
-		t.Fatalf("expected instance-scoped match, got %v", ops.lastMatch)
+	if _, filtered := ops.lastMatch["@amux_instance"]; filtered {
+		t.Fatalf("expected no instance filter, got %v", ops.lastMatch)
 	}
 }
 
 func TestGcStaleDetachedAgentSessions_RunsWhenOwnershipUnknown(t *testing.T) {
 	app := &App{
 		tmuxAvailable: true,
-		instanceID:    "instance-a",
+		instanceID:    "aaaaaaaaaaaaaaaa.1111111111111111",
 	}
 	if cmd := app.gcStaleDetachedAgentSessions(); cmd == nil {
 		t.Fatal("expected cmd when ownership is unknown")
+	}
+}
+
+func TestGcStaleDetachedAgentSessions_ProtectsOnlyLiveForeignOwner(t *testing.T) {
+	now := time.Now()
+	staleActivity := now.Add(-detachedAgentLivePaneStaleAfter - time.Hour)
+	for _, tt := range []struct {
+		name      string
+		heartbeat time.Time
+		wantKill  int
+		wantOwner int
+	}{
+		{name: "fresh owner", heartbeat: now, wantOwner: 1},
+		{name: "stale owner", heartbeat: now.Add(-sessionOwnerStaleAfter - time.Minute), wantKill: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &detachedGCOps{
+				rows: []tmux.SessionTagValues{{
+					Name: "foreign-agent",
+					Tags: map[string]string{
+						"@amux_instance":                "aaaaaaaaaaaaaaaa.2222222222222222",
+						tmux.TagSessionOwnerHeartbeatAt: strconv.FormatInt(tt.heartbeat.UnixMilli(), 10),
+						tmux.TagLastOutputAt:            strconv.FormatInt(staleActivity.UnixMilli(), 10),
+					},
+				}},
+				allStates: map[string]tmux.SessionState{
+					"foreign-agent": {Exists: true, HasLivePane: true},
+				},
+				clients: map[string]bool{"foreign-agent": false},
+			}
+			app := &App{
+				tmuxAvailable: true,
+				instanceID:    "aaaaaaaaaaaaaaaa.1111111111111111",
+				tmuxService:   ops,
+			}
+			msg := app.gcStaleDetachedAgentSessions()()
+			result, ok := msg.(staleDetachedAgentGCResult)
+			if !ok {
+				t.Fatalf("GC returned %T, want staleDetachedAgentGCResult", msg)
+			}
+			if result.Killed != tt.wantKill || result.SkippedLiveOwner != tt.wantOwner {
+				t.Fatalf("result = %+v, want killed=%d live_owner=%d", result, tt.wantKill, tt.wantOwner)
+			}
+		})
+	}
+}
+
+func TestGcStaleDetachedAgentSessions_IgnoresDifferentStateNamespace(t *testing.T) {
+	stale := time.Now().Add(-detachedAgentLivePaneStaleAfter - time.Hour)
+	ops := &detachedGCOps{
+		rows: []tmux.SessionTagValues{{
+			Name: "other-profile-agent",
+			Tags: map[string]string{
+				"@amux_instance":     "bbbbbbbbbbbbbbbb.2222222222222222",
+				tmux.TagLastOutputAt: strconv.FormatInt(stale.UnixMilli(), 10),
+			},
+		}},
+		allStates: map[string]tmux.SessionState{
+			"other-profile-agent": {Exists: true, HasLivePane: true},
+		},
+		clients: map[string]bool{"other-profile-agent": false},
+	}
+	app := &App{
+		tmuxAvailable: true,
+		instanceID:    "aaaaaaaaaaaaaaaa.1111111111111111",
+		tmuxService:   ops,
+	}
+
+	msg := app.gcStaleDetachedAgentSessions()()
+	result, ok := msg.(staleDetachedAgentGCResult)
+	if !ok {
+		t.Fatalf("GC returned %T, want staleDetachedAgentGCResult", msg)
+	}
+	if result.Considered != 0 || result.Killed != 0 || len(ops.killed) != 0 {
+		t.Fatalf("different namespace was considered for stale GC: result=%+v killed=%v", result, ops.killed)
 	}
 }
 

--- a/internal/app/app_tmux_gc_handlers_test.go
+++ b/internal/app/app_tmux_gc_handlers_test.go
@@ -127,6 +127,26 @@ func TestHandleOrphanGCTick_RunsBothGCAndRearmsTickerWhenReady(t *testing.T) {
 	}
 }
 
+func TestHandleTmuxAvailableResult_RunsStartupCleanupWhenProjectsReady(t *testing.T) {
+	app := &App{
+		projectsLoaded: true,
+		tmuxService:    tickGCOps{},
+	}
+
+	cmds := app.handleTmuxAvailableResult(tmuxAvailableResult{available: true})
+	if len(cmds) < 2 {
+		t.Fatalf("expected startup cleanup commands, got %d", len(cmds))
+	}
+	msg := cmds[len(cmds)-2]()
+	if _, ok := msg.(staleDetachedAgentGCResult); !ok {
+		t.Fatalf("penultimate startup command returned %T, want staleDetachedAgentGCResult", msg)
+	}
+	msg = cmds[len(cmds)-1]()
+	if _, ok := msg.(orphanGCResult); !ok {
+		t.Fatalf("last startup command returned %T, want orphanGCResult", msg)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // handleStaleDetachedAgentGCResult — logs the sweep outcome. We run it against
 // the real logging backend (pointed at a temp file) and read the emitted lines

--- a/internal/app/app_tmux_gc_safety_test.go
+++ b/internal/app/app_tmux_gc_safety_test.go
@@ -15,8 +15,12 @@ type gcOrphanOps struct {
 
 	sessionsWithTags  func(match map[string]string, keys []string, opts tmux.Options) ([]tmux.SessionTagValues, error)
 	sessionHasClients func(name string, opts tmux.Options) (bool, error)
+	sessionStateFor   func(name string, opts tmux.Options) (tmux.SessionState, error)
 	sessionCreatedAt  func(name string, opts tmux.Options) (int64, error)
 	killed            []string
+	heartbeatSessions []string
+	heartbeatKey      string
+	heartbeatValue    string
 }
 
 func (g *gcOrphanOps) SessionsWithTags(match map[string]string, keys []string, opts tmux.Options) ([]tmux.SessionTagValues, error) {
@@ -33,6 +37,13 @@ func (g *gcOrphanOps) SessionHasClients(name string, opts tmux.Options) (bool, e
 	return false, nil
 }
 
+func (g *gcOrphanOps) SessionStateFor(name string, opts tmux.Options) (tmux.SessionState, error) {
+	if g.sessionStateFor != nil {
+		return g.sessionStateFor(name, opts)
+	}
+	return tmux.SessionState{}, nil
+}
+
 func (g *gcOrphanOps) SessionCreatedAt(name string, opts tmux.Options) (int64, error) {
 	if g.sessionCreatedAt != nil {
 		return g.sessionCreatedAt(name, opts)
@@ -45,10 +56,18 @@ func (g *gcOrphanOps) KillSession(name string, opts tmux.Options) error {
 	return nil
 }
 
+func (g *gcOrphanOps) SetSessionTagValueForSessions(sessionNames []string, key, value string, _ tmux.Options) error {
+	g.heartbeatSessions = append(g.heartbeatSessions, sessionNames...)
+	g.heartbeatKey = key
+	g.heartbeatValue = value
+	return nil
+}
+
 func newGCTestApp(ops *gcOrphanOps) *App {
 	return &App{
 		tmuxAvailable:  true,
 		projectsLoaded: true,
+		instanceID:     "aaaaaaaaaaaaaaaa.1111111111111111",
 		tmuxService:    ops,
 	}
 }
@@ -158,6 +177,62 @@ func TestGcOrphanedTmuxSessions_KillsStaleDetachedOrphans(t *testing.T) {
 	}
 }
 
+func TestGcOrphanedTmuxSessions_SkipsDetachedOrphanWithLivePane(t *testing.T) {
+	now := time.Now()
+	ops := &gcOrphanOps{
+		sessionsWithTags: func(map[string]string, []string, tmux.Options) ([]tmux.SessionTagValues, error) {
+			return []tmux.SessionTagValues{{
+				Name: "running-orphan",
+				Tags: map[string]string{
+					"@amux_workspace":  "missing-workspace",
+					"@amux_created_at": strconv.FormatInt(now.Add(-2*time.Minute).Unix(), 10),
+				},
+			}}, nil
+		},
+		sessionHasClients: func(string, tmux.Options) (bool, error) { return false, nil },
+		sessionStateFor: func(string, tmux.Options) (tmux.SessionState, error) {
+			return tmux.SessionState{Exists: true, HasLivePane: true}, nil
+		},
+	}
+	app := newGCTestApp(ops)
+
+	result, ok := app.gcOrphanedTmuxSessions()().(orphanGCResult)
+	if !ok {
+		t.Fatal("GC did not return orphanGCResult")
+	}
+	if result.Killed != 0 || len(ops.killed) != 0 {
+		t.Fatalf("live orphan was killed: result=%+v killed=%v", result, ops.killed)
+	}
+}
+
+func TestGcOrphanedTmuxSessions_FailsClosedOnPaneLivenessError(t *testing.T) {
+	now := time.Now()
+	ops := &gcOrphanOps{
+		sessionsWithTags: func(map[string]string, []string, tmux.Options) ([]tmux.SessionTagValues, error) {
+			return []tmux.SessionTagValues{{
+				Name: "unverifiable-orphan",
+				Tags: map[string]string{
+					"@amux_workspace":  "missing-workspace",
+					"@amux_created_at": strconv.FormatInt(now.Add(-2*time.Minute).Unix(), 10),
+				},
+			}}, nil
+		},
+		sessionHasClients: func(string, tmux.Options) (bool, error) { return false, nil },
+		sessionStateFor: func(string, tmux.Options) (tmux.SessionState, error) {
+			return tmux.SessionState{}, errors.New("pane query failed")
+		},
+	}
+	app := newGCTestApp(ops)
+
+	result, ok := app.gcOrphanedTmuxSessions()().(orphanGCResult)
+	if !ok {
+		t.Fatal("GC did not return orphanGCResult")
+	}
+	if result.Killed != 0 || len(ops.killed) != 0 {
+		t.Fatalf("unverifiable orphan was killed: result=%+v killed=%v", result, ops.killed)
+	}
+}
+
 func TestGcOrphanedTmuxSessions_SkipsRecentOrphansUsingTmuxCreatedAtFallback(t *testing.T) {
 	now := time.Now()
 	recentTS := now.Add(-5 * time.Second).Unix()
@@ -191,7 +266,7 @@ func TestGcOrphanedTmuxSessions_SkipsRecentOrphansUsingTmuxCreatedAtFallback(t *
 	}
 }
 
-func TestGcOrphanedTmuxSessions_UsesInstanceScopedMatchWhenInstanceIDSet(t *testing.T) {
+func TestGcOrphanedTmuxSessions_EnumeratesInstancesForOwnershipReconciliation(t *testing.T) {
 	var capturedMatch map[string]string
 
 	ops := &gcOrphanOps{
@@ -201,7 +276,7 @@ func TestGcOrphanedTmuxSessions_UsesInstanceScopedMatchWhenInstanceIDSet(t *test
 		},
 	}
 	app := newGCTestApp(ops)
-	app.instanceID = "test-instance-123"
+	app.instanceID = "aaaaaaaaaaaaaaaa.1111111111111111"
 
 	cmd := app.gcOrphanedTmuxSessions()
 	_ = cmd()
@@ -212,8 +287,112 @@ func TestGcOrphanedTmuxSessions_UsesInstanceScopedMatchWhenInstanceIDSet(t *test
 	if capturedMatch["@amux"] != "1" {
 		t.Fatalf("expected @amux=1, got %v", capturedMatch["@amux"])
 	}
-	if capturedMatch["@amux_instance"] != "test-instance-123" {
-		t.Fatalf("expected @amux_instance=test-instance-123, got %v", capturedMatch["@amux_instance"])
+	if _, filtered := capturedMatch["@amux_instance"]; filtered {
+		t.Fatalf("expected no @amux_instance filter, got %v", capturedMatch)
+	}
+}
+
+func TestGcOrphanedTmuxSessions_ProtectsOnlyLiveForeignOwner(t *testing.T) {
+	now := time.Now()
+	for _, tt := range []struct {
+		name      string
+		heartbeat time.Time
+		wantKill  int
+	}{
+		{name: "fresh owner heartbeat", heartbeat: now, wantKill: 0},
+		{name: "stale owner heartbeat", heartbeat: now.Add(-sessionOwnerStaleAfter - time.Minute), wantKill: 1},
+		{name: "missing owner heartbeat", wantKill: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tags := map[string]string{
+				"@amux_workspace":  "foreign-workspace",
+				"@amux_instance":   "aaaaaaaaaaaaaaaa.2222222222222222",
+				"@amux_created_at": strconv.FormatInt(now.Add(-2*time.Minute).Unix(), 10),
+			}
+			if !tt.heartbeat.IsZero() {
+				tags[tmux.TagSessionOwnerHeartbeatAt] = strconv.FormatInt(tt.heartbeat.UnixMilli(), 10)
+			}
+			ops := &gcOrphanOps{
+				sessionsWithTags: func(map[string]string, []string, tmux.Options) ([]tmux.SessionTagValues, error) {
+					return []tmux.SessionTagValues{{Name: "foreign-session", Tags: tags}}, nil
+				},
+				sessionHasClients: func(string, tmux.Options) (bool, error) { return false, nil },
+			}
+			app := newGCTestApp(ops)
+			app.instanceID = "aaaaaaaaaaaaaaaa.1111111111111111"
+
+			msg := app.gcOrphanedTmuxSessions()()
+			result, ok := msg.(orphanGCResult)
+			if !ok {
+				t.Fatalf("GC returned %T, want orphanGCResult", msg)
+			}
+			if result.Killed != tt.wantKill {
+				t.Fatalf("killed = %d, want %d", result.Killed, tt.wantKill)
+			}
+		})
+	}
+}
+
+func TestGcOrphanedTmuxSessions_RefreshesCurrentOwnerHeartbeat(t *testing.T) {
+	now := time.Now()
+	ops := &gcOrphanOps{
+		sessionsWithTags: func(map[string]string, []string, tmux.Options) ([]tmux.SessionTagValues, error) {
+			return []tmux.SessionTagValues{{
+				Name: "owned-session",
+				Tags: map[string]string{
+					"@amux_workspace":  "new-workspace",
+					"@amux_instance":   "aaaaaaaaaaaaaaaa.1111111111111111",
+					"@amux_created_at": strconv.FormatInt(now.Unix(), 10),
+				},
+			}}, nil
+		},
+	}
+	app := newGCTestApp(ops)
+	app.instanceID = "aaaaaaaaaaaaaaaa.1111111111111111"
+
+	msg := app.gcOrphanedTmuxSessions()()
+	result, ok := msg.(orphanGCResult)
+	if !ok {
+		t.Fatalf("GC returned %T, want orphanGCResult", msg)
+	}
+	if result.Err != nil {
+		t.Fatalf("GC error: %v", result.Err)
+	}
+	if len(ops.heartbeatSessions) != 1 || ops.heartbeatSessions[0] != "owned-session" {
+		t.Fatalf("heartbeat sessions = %v", ops.heartbeatSessions)
+	}
+	if ops.heartbeatKey != tmux.TagSessionOwnerHeartbeatAt || ops.heartbeatValue == "" {
+		t.Fatalf("heartbeat write = key %q value %q", ops.heartbeatKey, ops.heartbeatValue)
+	}
+}
+
+func TestGcOrphanedTmuxSessions_IgnoresDifferentStateNamespace(t *testing.T) {
+	calledClients := false
+	ops := &gcOrphanOps{
+		sessionsWithTags: func(map[string]string, []string, tmux.Options) ([]tmux.SessionTagValues, error) {
+			return []tmux.SessionTagValues{{
+				Name: "other-profile-session",
+				Tags: map[string]string{
+					"@amux_workspace": "other-workspace",
+					"@amux_instance":  "bbbbbbbbbbbbbbbb.2222222222222222",
+				},
+			}}, nil
+		},
+		sessionHasClients: func(string, tmux.Options) (bool, error) {
+			calledClients = true
+			return false, nil
+		},
+	}
+	app := newGCTestApp(ops)
+	app.instanceID = "aaaaaaaaaaaaaaaa.1111111111111111"
+
+	msg := app.gcOrphanedTmuxSessions()()
+	result, ok := msg.(orphanGCResult)
+	if !ok {
+		t.Fatalf("GC returned %T, want orphanGCResult", msg)
+	}
+	if result.Killed != 0 || len(ops.killed) != 0 || calledClients {
+		t.Fatalf("different namespace was considered for cleanup: result=%+v killed=%v clients=%v", result, ops.killed, calledClients)
 	}
 }
 

--- a/internal/app/app_tmux_gc_test.go
+++ b/internal/app/app_tmux_gc_test.go
@@ -184,6 +184,19 @@ func gcSetTag(t *testing.T, opts tmux.Options, session, key, val string) {
 	}
 }
 
+func gcMarkSessionPaneDead(t *testing.T, opts tmux.Options, session string) {
+	t.Helper()
+	for _, args := range [][]string{
+		gcTmuxArgs(opts, "set-option", "-t", session, "remain-on-exit", "on"),
+		gcTmuxArgs(opts, "respawn-pane", "-k", "-t", session, "false"),
+	} {
+		cmd := exec.Command("tmux", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("mark session %q pane dead: %v\n%s", session, err, out)
+		}
+	}
+}
+
 func gcHasSession(t *testing.T, opts tmux.Options, name string) bool {
 	t.Helper()
 	args := gcTmuxArgs(opts, "has-session", "-t", name)
@@ -215,10 +228,14 @@ func TestGcOrphanedTmuxSessions_Integration(t *testing.T) {
 	knownWs := data.Workspace{Repo: "/test/repo", Root: "/test/repo/known"}
 	knownID := string(knownWs.ID())
 
-	// Create 3 sessions: 1 known, 2 orphans.
+	// Create 4 sessions: one known, two dead-pane orphans that are safe to
+	// collect, and one live-pane orphan whose process must survive.
 	gcCreateSession(t, opts, "known-sess", "sleep 300")
 	gcCreateSession(t, opts, "orphan1", "sleep 300")
 	gcCreateSession(t, opts, "orphan2", "sleep 300")
+	gcCreateSession(t, opts, "running-orphan", "sleep 300")
+	gcMarkSessionPaneDead(t, opts, "orphan1")
+	gcMarkSessionPaneDead(t, opts, "orphan2")
 	time.Sleep(50 * time.Millisecond)
 
 	// Tag all as @amux with different workspace IDs.
@@ -234,6 +251,10 @@ func TestGcOrphanedTmuxSessions_Integration(t *testing.T) {
 	gcSetTag(t, opts, "orphan2", "@amux", "1")
 	gcSetTag(t, opts, "orphan2", "@amux_workspace", "dead-ws-2")
 	gcSetTag(t, opts, "orphan2", "@amux_created_at", staleCreatedAt)
+
+	gcSetTag(t, opts, "running-orphan", "@amux", "1")
+	gcSetTag(t, opts, "running-orphan", "@amux_workspace", "dead-ws-3")
+	gcSetTag(t, opts, "running-orphan", "@amux_created_at", staleCreatedAt)
 
 	app := &App{
 		tmuxAvailable:  true,
@@ -276,6 +297,9 @@ func TestGcOrphanedTmuxSessions_Integration(t *testing.T) {
 	if gcHasSession(t, opts, "orphan2") {
 		t.Fatal("orphan2 should have been killed")
 	}
+	if !gcHasSession(t, opts, "running-orphan") {
+		t.Fatal("live-pane orphan was killed — its process should have survived GC")
+	}
 }
 
 func TestGcOrphanedTmuxSessions_DoesNotKillOrphansFromOtherInstances(t *testing.T) {
@@ -290,15 +314,16 @@ func TestGcOrphanedTmuxSessions_DoesNotKillOrphansFromOtherInstances(t *testing.
 
 	gcSetTag(t, opts, "other-orphan", "@amux", "1")
 	gcSetTag(t, opts, "other-orphan", "@amux_workspace", "dead-ws-other")
-	gcSetTag(t, opts, "other-orphan", "@amux_instance", "other-instance")
+	gcSetTag(t, opts, "other-orphan", "@amux_instance", "aaaaaaaaaaaaaaaa.2222222222222222")
 	gcSetTag(t, opts, "other-orphan", "@amux_created_at", staleCreatedAt)
+	gcSetTag(t, opts, "other-orphan", tmux.TagSessionOwnerHeartbeatAt, strconv.FormatInt(time.Now().UnixMilli(), 10))
 
 	app := &App{
 		tmuxAvailable:  true,
 		projectsLoaded: true,
 		tmuxOptions:    opts,
 		tmuxService:    tmuxOps{},
-		instanceID:     "my-instance",
+		instanceID:     "aaaaaaaaaaaaaaaa.1111111111111111",
 	}
 
 	cmd := app.gcOrphanedTmuxSessions()
@@ -315,7 +340,7 @@ func TestGcOrphanedTmuxSessions_DoesNotKillOrphansFromOtherInstances(t *testing.
 		t.Fatalf("GC error: %v", result.Err)
 	}
 	if result.Killed != 0 {
-		t.Fatalf("expected 0 killed (other instance), got %d", result.Killed)
+		t.Fatalf("expected 0 killed (live owner), got %d", result.Killed)
 	}
 
 	// Session from other instance must survive.

--- a/internal/app/defaults.go
+++ b/internal/app/defaults.go
@@ -70,6 +70,23 @@ const (
 	// orphanGCInterval controls how often the periodic tmux orphan GC runs.
 	orphanGCInterval = 60 * time.Second
 
+	// sessionOwnerHeartbeatInterval limits tmux writes while allowing peer amux
+	// processes to distinguish a live owner from a previous app launch.
+	sessionOwnerHeartbeatInterval = 30 * time.Second
+
+	// sessionOwnerStaleAfter allows two missed heartbeat intervals plus command
+	// scheduling jitter before a peer's detached sessions become collectible.
+	sessionOwnerStaleAfter = 2 * time.Minute
+
+	// metadataOrphanGracePeriod keeps a fresh record long enough for another
+	// amux process to finish registering its project/workspace before startup
+	// reconciliation considers the record unreachable.
+	metadataOrphanGracePeriod = time.Hour
+
+	// archivedMetadataRetention bounds how long metadata for a workspace that
+	// disappeared from git discovery is retained for possible rediscovery.
+	archivedMetadataRetention = 7 * 24 * time.Hour
+
 	// detachedAgentStaleAfter is the inactivity threshold for detached,
 	// clientless agent sessions before they are considered stale.
 	detachedAgentStaleAfter = 24 * time.Hour

--- a/internal/app/instance_id.go
+++ b/internal/app/instance_id.go
@@ -2,16 +2,78 @@ package app
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
 )
 
-func newInstanceID() string {
-	buf := make([]byte, 8)
+const instanceIDPartBytes = 8
+
+// newInstanceID combines a stable namespace for the amux state directory with
+// a random per-process suffix. Sessions can therefore be reconciled across app
+// restarts without crossing into a separate HOME/profile that happens to share
+// the same tmux server.
+func newInstanceID(stateRoot string) string {
+	namespaceHash := sha256.Sum256([]byte(data.NormalizePath(strings.TrimSpace(stateRoot))))
+	namespace := hex.EncodeToString(namespaceHash[:instanceIDPartBytes])
+
+	buf := make([]byte, instanceIDPartBytes)
 	if _, err := rand.Read(buf); err == nil {
-		return hex.EncodeToString(buf)
+		return namespace + "." + hex.EncodeToString(buf)
 	}
 	// Fallback to time-based value if crypto/rand fails.
-	return strconv.FormatInt(time.Now().UnixNano(), 10)
+	return namespace + "." + fmt.Sprintf("%016x", uint64(time.Now().UnixNano()))
+}
+
+func instanceStateNamespace(instanceID string) (string, bool) {
+	parts := strings.Split(strings.TrimSpace(instanceID), ".")
+	if len(parts) != 2 || len(parts[0]) != instanceIDPartBytes*2 || len(parts[1]) != instanceIDPartBytes*2 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(parts[0]); err != nil {
+		return "", false
+	}
+	if _, err := hex.DecodeString(parts[1]); err != nil {
+		return "", false
+	}
+	return parts[0], true
+}
+
+func instancesShareState(left, right string) bool {
+	leftNamespace, leftOK := instanceStateNamespace(left)
+	rightNamespace, rightOK := instanceStateNamespace(right)
+	if leftOK && rightOK {
+		return leftNamespace == rightNamespace
+	}
+	// Legacy process-only IDs had no state namespace. Only recognize the exact
+	// formats older amux releases emitted; an arbitrary malformed owner tag must
+	// fail closed instead of becoming eligible for cross-profile cleanup.
+	if leftOK {
+		return isLegacyInstanceID(right)
+	}
+	if rightOK {
+		return isLegacyInstanceID(left)
+	}
+	return isLegacyInstanceID(left) && isLegacyInstanceID(right)
+}
+
+func isLegacyInstanceID(instanceID string) bool {
+	id := strings.TrimSpace(instanceID)
+	if id == "" {
+		// Sessions created before instance tagging are also migration candidates.
+		return true
+	}
+	if len(id) == instanceIDPartBytes*2 {
+		if _, err := hex.DecodeString(id); err == nil {
+			return true
+		}
+	}
+	// crypto/rand failure used UnixNano formatted as a positive base-10 int64.
+	value, err := strconv.ParseInt(id, 10, 64)
+	return err == nil && value > 0
 }

--- a/internal/app/instance_id_test.go
+++ b/internal/app/instance_id_test.go
@@ -1,0 +1,67 @@
+package app
+
+import "testing"
+
+func TestNewInstanceIDCombinesStableStateAndUniqueProcessParts(t *testing.T) {
+	first := newInstanceID("/tmp/amux-home-a")
+	second := newInstanceID("/tmp/amux-home-a")
+	other := newInstanceID("/tmp/amux-home-b")
+
+	firstNamespace, firstOK := instanceStateNamespace(first)
+	secondNamespace, secondOK := instanceStateNamespace(second)
+	otherNamespace, otherOK := instanceStateNamespace(other)
+	if !firstOK || !secondOK || !otherOK {
+		t.Fatalf("generated IDs did not parse: %q %q %q", first, second, other)
+	}
+	if first == second {
+		t.Fatalf("per-process IDs should differ: %q", first)
+	}
+	if firstNamespace != secondNamespace {
+		t.Fatalf("same state root produced namespaces %q and %q", firstNamespace, secondNamespace)
+	}
+	if firstNamespace == otherNamespace {
+		t.Fatalf("different state roots produced the same namespace %q", firstNamespace)
+	}
+	if !instancesShareState(first, second) {
+		t.Fatal("instances from the same state root should share state")
+	}
+	if instancesShareState(first, other) {
+		t.Fatal("instances from different state roots must stay isolated")
+	}
+}
+
+func TestInstancesShareStateTreatsLegacyIDsAsMigratable(t *testing.T) {
+	modern := newInstanceID("/tmp/amux-home")
+	for _, legacy := range []string{
+		"0123456789abcdef",
+		"1700000000123456789",
+		"",
+	} {
+		if !instancesShareState(legacy, modern) {
+			t.Fatalf("legacy session ID %q should remain visible during migration", legacy)
+		}
+	}
+	for _, unknown := range []string{
+		"legacy-process-id",
+		"not-hex-not-hex!",
+		"-1700000000123456789",
+	} {
+		if instancesShareState(unknown, modern) {
+			t.Fatalf("unknown owner ID %q must fail closed", unknown)
+		}
+	}
+}
+
+func TestInstanceStateNamespaceRejectsMalformedIDs(t *testing.T) {
+	for _, id := range []string{
+		"",
+		"legacy-process-id",
+		"0000000000000000.111111111111111",
+		"0000000000000000.11111111111111111",
+		"not-hex-not-hex!.1111111111111111",
+	} {
+		if namespace, ok := instanceStateNamespace(id); ok {
+			t.Fatalf("instanceStateNamespace(%q) = %q, true; want malformed", id, namespace)
+		}
+	}
+}

--- a/internal/app/service_tmux.go
+++ b/internal/app/service_tmux.go
@@ -25,6 +25,10 @@ func (tmuxOps) SessionsWithTags(match map[string]string, keys []string, opts tmu
 	return tmux.SessionsWithTags(match, keys, opts)
 }
 
+func (tmuxOps) SetSessionTagValueForSessions(sessionNames []string, key, value string, opts tmux.Options) error {
+	return tmux.SetSessionTagValueForSessions(sessionNames, key, value, opts)
+}
+
 func (tmuxOps) AllSessionStates(opts tmux.Options) (map[string]tmux.SessionState, error) {
 	return tmux.AllSessionStates(opts)
 }

--- a/internal/app/workspace_lifecycle_fsm_test.go
+++ b/internal/app/workspace_lifecycle_fsm_test.go
@@ -122,6 +122,70 @@ func TestLifecycleCreateWhileProjectsLoading(t *testing.T) {
 	}
 }
 
+func TestCreatedWorkspaceSurvivesOlderProjectLoadUntilConfirmed(t *testing.T) {
+	repo := "/repo"
+	primary := data.NewWorkspace("repo", "main", "", repo, repo)
+	created := data.NewWorkspace("feature", "feature", "main", repo, "/workspaces/feature")
+	project := data.NewProject(repo)
+	project.Workspaces = []data.Workspace{*primary, *created}
+
+	app := &App{
+		lifecycle:        newWorkspaceLifecycleState(),
+		tmuxActivity:     newTmuxActivityState(),
+		dashboard:        dashboard.New(),
+		center:           center.New(nil),
+		workspaceService: newWorkspaceService(nil, nil, nil, t.TempDir()),
+		projects:         []data.Project{*project},
+		activeProject:    project,
+		activeWorkspace:  created,
+	}
+	app.center.SetWorkspace(created)
+	app.lifecycle.projectsLoadToken = 2
+	if !app.lifecycle.markCreating(string(created.ID())) {
+		t.Fatal("expected create phase to be accepted")
+	}
+
+	app.handleWorkspaceCreated(messages.WorkspaceCreated{Workspace: created})
+	if got := app.lifecycle.projectsLoadToken; got != 3 {
+		t.Fatalf("post-create load token = %d, want 3", got)
+	}
+
+	older := data.NewProject(repo)
+	older.Workspaces = []data.Workspace{*primary}
+	app.handleProjectsLoaded(messages.ProjectsLoaded{
+		Projects:  []data.Project{*older},
+		LoadToken: 2,
+	})
+	if app.activeWorkspace == nil || app.activeWorkspace.ID() != created.ID() {
+		t.Fatal("older project snapshot cleared the newly created active workspace")
+	}
+	if app.showWelcome {
+		t.Fatal("older project snapshot returned the UI home")
+	}
+
+	confirmed := data.NewProject(repo)
+	confirmed.Workspaces = []data.Workspace{*primary, *created}
+	app.handleProjectsLoaded(messages.ProjectsLoaded{
+		Projects:  []data.Project{*confirmed},
+		LoadToken: 3,
+	})
+	if app.activeWorkspace == nil || app.activeWorkspace.ID() != created.ID() {
+		t.Fatal("post-create project snapshot did not retain the active workspace")
+	}
+	if len(app.lifecycle.createdUntilProjectsLoadToken) != 0 {
+		t.Fatalf("post-create barriers were not released: %v", app.lifecycle.createdUntilProjectsLoadToken)
+	}
+
+	// Once the confirming load lands, a later real removal must still go home.
+	app.handleProjectsLoaded(messages.ProjectsLoaded{
+		Projects:  []data.Project{*older},
+		LoadToken: 4,
+	})
+	if app.activeWorkspace != nil || !app.showWelcome {
+		t.Fatal("later confirmed removal did not clear the active workspace")
+	}
+}
+
 func TestHandleCreateWorkspaceStopsWhenLifecycleRejectsCreate(t *testing.T) {
 	workspacesRoot := t.TempDir()
 	project := data.NewProject("/repo")

--- a/internal/app/workspace_lifecycle_state.go
+++ b/internal/app/workspace_lifecycle_state.go
@@ -73,6 +73,10 @@ type workspaceLifecycleState struct {
 	// Keys include both workspace IDs and root paths because ID normalization can
 	// change after the worktree path is removed.
 	deletedUntilProjectsLoadToken map[string]projectsLoadToken
+	// createdUntilProjectsLoadToken protects a newly created/activated workspace
+	// from older in-flight project snapshots that began before its metadata was
+	// visible. Keys include both workspace IDs and root paths.
+	createdUntilProjectsLoadToken map[string]projectsLoadToken
 	// localSaveMu guards localSavesAt (written from Cmd goroutines).
 	localSaveMu  sync.Mutex
 	localSavesAt map[string]localWorkspaceSaveMarker
@@ -84,6 +88,7 @@ func newWorkspaceLifecycleState() workspaceLifecycleState {
 		deletingRootID:                make(map[string]string),
 		dirty:                         make(map[string]bool),
 		deletedUntilProjectsLoadToken: make(map[string]projectsLoadToken),
+		createdUntilProjectsLoadToken: make(map[string]projectsLoadToken),
 		localSavesAt:                  make(map[string]localWorkspaceSaveMarker),
 	}
 }
@@ -267,6 +272,63 @@ func (w *workspaceLifecycleState) markDeletedUntilProjectsLoad(wsID, root string
 	if root != "" {
 		w.deletedUntilProjectsLoadToken[root] = token
 	}
+}
+
+func (w *workspaceLifecycleState) markCreatedUntilProjectsLoad(wsID, root string, token projectsLoadToken) {
+	if token == 0 || (wsID == "" && root == "") {
+		return
+	}
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	if w.createdUntilProjectsLoadToken == nil {
+		w.createdUntilProjectsLoadToken = make(map[string]projectsLoadToken)
+	}
+	if wsID != "" {
+		w.createdUntilProjectsLoadToken[wsID] = token
+	}
+	if root != "" {
+		w.createdUntilProjectsLoadToken[root] = token
+	}
+}
+
+func (w *workspaceLifecycleState) shouldRetainCreatedWorkspace(wsID, root string, loadToken projectsLoadToken) bool {
+	if loadToken == 0 || (wsID == "" && root == "") {
+		return false
+	}
+	w.phaseMu.RLock()
+	defer w.phaseMu.RUnlock()
+	for _, identity := range []string{wsID, root} {
+		if identity == "" {
+			continue
+		}
+		if until, ok := w.createdUntilProjectsLoadToken[identity]; ok && loadToken <= until {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *workspaceLifecycleState) clearCreatedProjectLoadBarriersThrough(loadToken projectsLoadToken, loadedIdentities map[string]bool) {
+	if loadToken == 0 {
+		return
+	}
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	for identity, until := range w.createdUntilProjectsLoadToken {
+		if loadToken < until {
+			continue
+		}
+		if loadedIdentities[identity] || loadToken > until {
+			delete(w.createdUntilProjectsLoadToken, identity)
+		}
+	}
+}
+
+func (w *workspaceLifecycleState) clearCreatedProjectLoadBarrier(wsID, root string) {
+	w.phaseMu.Lock()
+	defer w.phaseMu.Unlock()
+	delete(w.createdUntilProjectsLoadToken, wsID)
+	delete(w.createdUntilProjectsLoadToken, root)
 }
 
 func (w *workspaceLifecycleState) shouldFilterDeletedWorkspace(wsID, root string, loadToken projectsLoadToken) bool {

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -67,6 +67,9 @@ func (s *workspaceService) AddProject(path string) tea.Cmd {
 			logging.Error("Failed to add project to registry: %v", err)
 			return messages.Error{Err: err, Context: errorContext(errorServiceWorkspace, "adding project")}
 		}
+		// Restore managed worktrees automatically when a previously removed
+		// project is re-added; removing it left those files on disk.
+		s.importManagedWorkspaces(path)
 
 		logging.Info("Project added successfully: %s", path)
 		return messages.RefreshDashboard{}
@@ -448,25 +451,6 @@ func (s *workspaceService) handleStaleRemoveError(
 	}
 	logging.Warn("workspace delete stale cleanup workspace_id=%s workspace_root=%s remove_error=%v", wsID, ws.Root, err)
 	return nil
-}
-
-// RemoveProject removes a project from the registry (does not delete files).
-func (s *workspaceService) RemoveProject(project *data.Project) tea.Cmd {
-	if project == nil {
-		return func() tea.Msg {
-			return messages.Error{Err: errors.New("missing project"), Context: errorContext(errorServiceWorkspace, "removing project")}
-		}
-	}
-
-	return func() tea.Msg {
-		if s == nil || s.registry == nil {
-			return messages.Error{Err: errors.New("registry unavailable"), Context: errorContext(errorServiceWorkspace, "removing project")}
-		}
-		if err := s.registry.RemoveProject(project.Path); err != nil {
-			return messages.Error{Err: err, Context: errorContext(errorServiceWorkspace, "removing project")}
-		}
-		return messages.ProjectRemoved{Path: project.Path}
-	}
 }
 
 func (s *workspaceService) Save(workspace *data.Workspace) error {

--- a/internal/app/workspace_service_add_project_test.go
+++ b/internal/app/workspace_service_add_project_test.go
@@ -33,3 +33,81 @@ func TestAddProjectRejectsFakeGitDirectory(t *testing.T) {
 		t.Fatalf("expected no registered projects, got %d", len(paths))
 	}
 }
+
+func TestAddProjectRediscoversManagedWorktreesAfterRemoval(t *testing.T) {
+	skipIfNoGit(t)
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	workspacesRoot := filepath.Join(root, "workspaces")
+	managedRoot := filepath.Join(workspacesRoot, filepath.Base(repo), "feature")
+	if err := os.MkdirAll(filepath.Dir(managedRoot), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "worktree", "add", "-b", "feature", managedRoot, "main")
+
+	registry := data.NewRegistry(filepath.Join(root, "projects.json"))
+	store := data.NewWorkspaceStore(filepath.Join(root, "metadata"))
+	service := newWorkspaceService(registry, store, nil, workspacesRoot)
+	msg := service.AddProject(repo)()
+	if _, ok := msg.(messages.RefreshDashboard); !ok {
+		t.Fatalf("first AddProject returned %T, want RefreshDashboard", msg)
+	}
+	msg = service.RemoveProject(data.NewProject(repo))()
+	if _, ok := msg.(messages.ProjectRemoved); !ok {
+		t.Fatalf("RemoveProject returned %T, want ProjectRemoved", msg)
+	}
+	if workspaces, err := store.ListByRepo(repo); err != nil || len(workspaces) != 0 {
+		t.Fatalf("metadata after removal = %v, %v; want none", workspaces, err)
+	}
+	if _, err := os.Stat(managedRoot); err != nil {
+		t.Fatalf("managed worktree was removed from disk: %v", err)
+	}
+
+	msg = service.AddProject(repo)()
+	if _, ok := msg.(messages.RefreshDashboard); !ok {
+		t.Fatalf("second AddProject returned %T, want RefreshDashboard", msg)
+	}
+	workspaces, err := store.ListByRepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundManaged := false
+	for _, ws := range workspaces {
+		if normalizePath(ws.Root) == normalizePath(managedRoot) {
+			foundManaged = true
+			break
+		}
+	}
+	if !foundManaged {
+		t.Fatalf("re-added project did not rediscover managed worktree %s: %+v", managedRoot, workspaces)
+	}
+
+	// Simulate a delayed cleanup from another amux process that began before the
+	// re-add. Because the registry now contains the project, cleanup must restore
+	// the metadata it just removed instead of clobbering the later re-add.
+	service.removeProjectMetadata(repo)
+	workspaces, err = store.ListByRepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundManaged = false
+	for _, ws := range workspaces {
+		if normalizePath(ws.Root) == normalizePath(managedRoot) {
+			foundManaged = true
+			break
+		}
+	}
+	if !foundManaged {
+		t.Fatalf("late metadata cleanup clobbered re-added worktree %s: %+v", managedRoot, workspaces)
+	}
+}

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -23,6 +23,13 @@ func (s *workspaceService) LoadProjects(loadToken projectsLoadToken) tea.Cmd {
 		if err != nil {
 			return messages.Error{Err: err, Context: errorContext(errorServiceWorkspace, "loading projects")}
 		}
+		paths = s.pruneMissingTemporaryProjects(paths)
+		// Metadata reconciliation scans every persisted record. Run it for the
+		// initial dashboard load rather than on each UI refresh; explicit project
+		// and workspace removals clean their own state immediately.
+		if loadToken <= 1 {
+			s.reconcileWorkspaceMetadata(paths)
+		}
 
 		var projects []data.Project
 		for _, path := range paths {
@@ -102,6 +109,40 @@ func (s *workspaceService) LoadProjects(loadToken projectsLoadToken) tea.Cmd {
 		}
 
 		return messages.ProjectsLoaded{Projects: projects, LoadToken: int(loadToken)}
+	}
+}
+
+// importManagedWorkspaces discovers and persists amux-owned worktrees for one
+// project. It is best-effort because registration has already succeeded; a
+// transient git/store error should not roll back a valid project addition.
+func (s *workspaceService) importManagedWorkspaces(path string) {
+	if s == nil || s.store == nil || s.gitOps == nil || !git.IsGitRepository(path) {
+		return
+	}
+	project := data.NewProject(path)
+	discovered, err := s.gitOps.DiscoverWorkspaces(project)
+	if err != nil {
+		logging.Warn("Failed to discover workspaces while adding %s: %v", path, err)
+		return
+	}
+	for i := range discovered {
+		ws := &discovered[i]
+		if !s.shouldSurfaceWorkspace(path, ws) {
+			continue
+		}
+		wsID := string(ws.ID())
+		if strings.TrimSpace(ws.Assistant) == "" {
+			ws.Assistant = s.resolvedDefaultAssistant()
+		}
+		var upsertErr error
+		if !s.runUnlessDeleteInFlight(wsID, func() {
+			upsertErr = s.store.UpsertFromDiscovery(ws)
+		}) {
+			continue
+		}
+		if upsertErr != nil {
+			logging.Warn("Failed to import workspace %s while adding %s: %v", ws.Name, path, upsertErr)
+		}
 	}
 }
 

--- a/internal/app/workspace_service_prune.go
+++ b/internal/app/workspace_service_prune.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
+)
+
+type workspaceMetadataPruner interface {
+	PruneStale(data.WorkspacePruneOptions) (data.WorkspacePruneResult, error)
+}
+
+type workspaceRepoMetadataDeleter interface {
+	DeleteByRepo(repoPath string) ([]data.WorkspaceID, error)
+}
+
+func (s *workspaceService) reconcileWorkspaceMetadata(registeredRepos []string) {
+	if s == nil || s.store == nil {
+		return
+	}
+	pruner, ok := s.store.(workspaceMetadataPruner)
+	if !ok {
+		return
+	}
+	result, err := pruner.PruneStale(data.WorkspacePruneOptions{
+		RegisteredRepos:   registeredRepos,
+		ManagedRoot:       s.workspacesRoot,
+		Now:               time.Now(),
+		OrphanGracePeriod: metadataOrphanGracePeriod,
+		ArchivedRetention: archivedMetadataRetention,
+	})
+	if err != nil {
+		logging.Warn("workspace metadata reconciliation completed with errors: %v", err)
+	}
+	if result.MetadataRemoved() > 0 || result.OrphanLocksRemoved > 0 {
+		logging.Info(
+			"workspace metadata reconciliation: removed=%d unregistered=%d missing_root=%d archived=%d orphan_locks=%d",
+			result.MetadataRemoved(),
+			result.UnregisteredRemoved,
+			result.MissingRootRemoved,
+			result.ArchivedRemoved,
+			result.OrphanLocksRemoved,
+		)
+	}
+}
+
+// pruneMissingTemporaryProjects forgets vanished repositories rooted in the OS
+// temp directory. A missing arbitrary path may be an offline volume and is
+// retained; a vanished temp directory cannot come back with the same contents.
+func (s *workspaceService) pruneMissingTemporaryProjects(paths []string) []string {
+	if s == nil || s.registry == nil {
+		return paths
+	}
+	kept := make([]string, 0, len(paths))
+	for _, path := range paths {
+		_, statErr := os.Stat(path)
+		if !errors.Is(statErr, fs.ErrNotExist) || !isTemporaryProjectPath(path) {
+			kept = append(kept, path)
+			continue
+		}
+		if err := s.registry.RemoveProject(path); err != nil {
+			logging.Warn("Failed to remove vanished temporary project %s: %v", path, err)
+			kept = append(kept, path)
+			continue
+		}
+		s.removeProjectMetadata(path)
+		logging.Info("Removed vanished temporary project from registry: %s", path)
+	}
+	return kept
+}
+
+func isTemporaryProjectPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	tempRoots := []string{os.TempDir()}
+	if os.TempDir() != "/tmp" {
+		tempRoots = append(tempRoots, "/tmp")
+	}
+	for _, root := range tempRoots {
+		if pathWithinAliasesStrict(workspacePathAliases(root), workspacePathAliases(path)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *workspaceService) removeProjectMetadata(repoPath string, knownWorkspaces ...data.Workspace) {
+	if s == nil {
+		return
+	}
+	idsToKill := make(map[string]struct{}, len(knownWorkspaces))
+	for i := range knownWorkspaces {
+		if id := string(knownWorkspaces[i].ID()); id != "" {
+			idsToKill[id] = struct{}{}
+		}
+	}
+	killCollectedSessions := func() {
+		for id := range idsToKill {
+			s.killWorkspaceSessionsForDelete(id)
+		}
+	}
+	if s.store == nil {
+		killCollectedSessions()
+		return
+	}
+	workspaces, listErr := s.store.ListByRepoIncludingArchived(repoPath)
+	if listErr != nil {
+		logging.Warn("Project removed, but workloads could not be fully enumerated for %s: %v", repoPath, listErr)
+	}
+	for _, ws := range workspaces {
+		if ws == nil || s.scripts == nil {
+			continue
+		}
+		if err := s.scripts.Stop(ws); err != nil {
+			logging.Warn("Project removed, but scripts could not be stopped for workspace %s: %v", ws.Name, err)
+		}
+		s.scripts.ReleaseWorkspace(ws)
+	}
+	if deleter, ok := s.store.(workspaceRepoMetadataDeleter); ok {
+		ids, err := deleter.DeleteByRepo(repoPath)
+		if err != nil {
+			logging.Warn("Project removed, but some metadata could not be cleaned for %s: %v", repoPath, err)
+		}
+		for _, id := range ids {
+			idsToKill[string(id)] = struct{}{}
+		}
+		killCollectedSessions()
+		s.restoreMetadataIfProjectReadded(repoPath)
+		return
+	}
+
+	// Compatibility path for test/custom stores implementing only WorkspaceStore.
+	if listErr != nil {
+		logging.Warn("Project removed, but metadata could not be listed for %s: %v", repoPath, listErr)
+		killCollectedSessions()
+		return
+	}
+	for _, ws := range workspaces {
+		if ws == nil {
+			continue
+		}
+		id := ws.ID()
+		if err := s.store.Delete(id); err != nil {
+			logging.Warn("Project removed, but workspace metadata %s could not be cleaned: %v", id, err)
+			continue
+		}
+		idsToKill[string(id)] = struct{}{}
+	}
+	killCollectedSessions()
+	s.restoreMetadataIfProjectReadded(repoPath)
+}
+
+func (s *workspaceService) restoreMetadataIfProjectReadded(repoPath string) {
+	if s == nil || s.registry == nil {
+		return
+	}
+	paths, err := s.registry.Projects()
+	if err != nil {
+		logging.Warn("Could not verify whether project %s was re-added during metadata cleanup: %v", repoPath, err)
+		return
+	}
+	target := data.NormalizePath(repoPath)
+	for _, path := range paths {
+		if data.NormalizePath(path) != target {
+			continue
+		}
+		// Registry removal happened before metadata cleanup. If the project is
+		// present again now, another process re-added it later and therefore wins.
+		s.importManagedWorkspaces(path)
+		return
+	}
+}

--- a/internal/app/workspace_service_remove_project.go
+++ b/internal/app/workspace_service_remove_project.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+)
+
+// RemoveProject removes a project without deleting repository or worktree files.
+func (s *workspaceService) RemoveProject(project *data.Project) tea.Cmd {
+	if project == nil {
+		return func() tea.Msg {
+			return messages.Error{Err: errors.New("missing project"), Context: errorContext(errorServiceWorkspace, "removing project")}
+		}
+	}
+
+	return func() tea.Msg {
+		if s == nil || s.registry == nil {
+			return messages.Error{Err: errors.New("registry unavailable"), Context: errorContext(errorServiceWorkspace, "removing project")}
+		}
+		if err := s.stopProjectScripts(project.Workspaces); err != nil {
+			return messages.Error{Err: err, Context: errorContext(errorServiceWorkspace, "stopping project scripts")}
+		}
+		if err := s.registry.RemoveProject(project.Path); err != nil {
+			return messages.Error{Err: err, Context: errorContext(errorServiceWorkspace, "removing project")}
+		}
+		s.releaseProjectPorts(project.Workspaces)
+		// Discard amux's metadata and sessions while deliberately leaving the
+		// repository and worktrees untouched, as promised by the dialog.
+		s.removeProjectMetadata(project.Path, project.Workspaces...)
+		return messages.ProjectRemoved{Path: project.Path}
+	}
+}
+
+func (s *workspaceService) stopProjectScripts(workspaces []data.Workspace) error {
+	if s == nil || s.scripts == nil {
+		return nil
+	}
+	var errs []error
+	for i := range workspaces {
+		ws := &workspaces[i]
+		if !s.scripts.IsRunning(ws) {
+			continue
+		}
+		if err := s.scripts.Stop(ws); err != nil {
+			errs = append(errs, fmt.Errorf("stop scripts for workspace %s: %w", ws.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s *workspaceService) releaseProjectPorts(workspaces []data.Workspace) {
+	if s == nil || s.scripts == nil {
+		return
+	}
+	for i := range workspaces {
+		s.scripts.ReleaseWorkspace(&workspaces[i])
+	}
+}

--- a/internal/app/workspace_service_test.go
+++ b/internal/app/workspace_service_test.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/messages"
@@ -139,6 +141,41 @@ func TestRemoveProjectSuccess(t *testing.T) {
 	}
 }
 
+func TestRemoveProjectStopsProjectScriptsAndReleasesPorts(t *testing.T) {
+	repo := t.TempDir()
+	workspaceRoot := t.TempDir()
+	ws := data.NewWorkspace("feature", "feature", "main", repo, workspaceRoot)
+	ws.ScriptMode = "nonconcurrent"
+	ws.Scripts.Run = "sleep 30"
+
+	runner := process.NewScriptRunner(6300, 10)
+	t.Cleanup(func() { _ = runner.Stop(ws) })
+	if _, err := runner.RunScript(ws, process.ScriptRun); err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if !runner.IsRunning(ws) {
+		t.Fatal("expected project script to be running before removal")
+	}
+	if _, allocated := runner.PortAllocated(ws); !allocated {
+		t.Fatal("expected project port to be allocated before removal")
+	}
+
+	reg := &fakeProjectRegistry{}
+	svc := newWorkspaceService(reg, nil, runner, "")
+	project := data.NewProject(repo)
+	project.Workspaces = []data.Workspace{*ws}
+	msg := svc.RemoveProject(project)()
+	if _, ok := msg.(messages.ProjectRemoved); !ok {
+		t.Fatalf("expected ProjectRemoved, got %T", msg)
+	}
+	if runner.IsRunning(ws) {
+		t.Fatal("project script remained running after removal")
+	}
+	if _, allocated := runner.PortAllocated(ws); allocated {
+		t.Fatal("project port remained allocated after removal")
+	}
+}
+
 // TestRemoveProjectSuccessWithRealRegistry exercises the success path end-to-end
 // against a real on-disk registry: a registered project is unregistered and the
 // projects.json no longer lists it.
@@ -174,6 +211,140 @@ func TestRemoveProjectSuccessWithRealRegistry(t *testing.T) {
 	}
 	if data.NormalizePath(paths[0]) != data.NormalizePath("/path/to/keep") {
 		t.Fatalf("expected remaining project /path/to/keep, got %q", paths[0])
+	}
+}
+
+func TestRemoveProjectCleansMetadataAndSessionsButLeavesFiles(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	workspaceRoot := filepath.Join(dir, "workspaces", "repo", "feature")
+	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	registry := data.NewRegistry(filepath.Join(dir, "projects.json"))
+	if err := registry.AddProject(repo); err != nil {
+		t.Fatal(err)
+	}
+	store := data.NewWorkspaceStore(filepath.Join(dir, "metadata"))
+	ws := data.NewWorkspace("feature", "feature", "main", repo, workspaceRoot)
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(registry, store, nil, filepath.Join(dir, "workspaces"))
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	msg := svc.RemoveProject(data.NewProject(repo))()
+	if _, ok := msg.(messages.ProjectRemoved); !ok {
+		t.Fatalf("expected ProjectRemoved, got %T", msg)
+	}
+	if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workspace metadata still exists, err = %v", err)
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+	if _, err := os.Stat(workspaceRoot); err != nil {
+		t.Fatalf("RemoveProject deleted workspace files: %v", err)
+	}
+}
+
+func TestRemoveProjectCleansKnownSessionsWithoutMetadataStore(t *testing.T) {
+	repo := t.TempDir()
+	ws := data.NewWorkspace("feature", "feature", "main", repo, filepath.Join(repo, "feature"))
+	project := data.NewProject(repo)
+	project.Workspaces = []data.Workspace{*ws}
+
+	svc := newWorkspaceService(&fakeProjectRegistry{}, nil, nil, "")
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	msg := svc.RemoveProject(project)()
+	if _, ok := msg.(messages.ProjectRemoved); !ok {
+		t.Fatalf("expected ProjectRemoved, got %T", msg)
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+}
+
+func TestPruneMissingTemporaryProjectsKeepsNonTemporaryMissingPaths(t *testing.T) {
+	missingTemp := filepath.Join(t.TempDir(), "gone", "repo")
+	missingNonTemp := filepath.Join(string(filepath.Separator), "amux-missing-volume", "repo")
+	registry := &fakeProjectRegistry{}
+	svc := newWorkspaceService(registry, nil, nil, "")
+
+	kept := svc.pruneMissingTemporaryProjects([]string{missingTemp, missingNonTemp})
+	if len(registry.removedPaths) != 1 || registry.removedPaths[0] != missingTemp {
+		t.Fatalf("removed paths = %v, want only %s", registry.removedPaths, missingTemp)
+	}
+	if len(kept) != 1 || kept[0] != missingNonTemp {
+		t.Fatalf("kept paths = %v, want only %s", kept, missingNonTemp)
+	}
+}
+
+func TestLoadProjectsReconcilesMetadataOnlyOnInitialLoad(t *testing.T) {
+	root := t.TempDir()
+	metadataRoot := filepath.Join(root, "metadata")
+	store := data.NewWorkspaceStore(metadataRoot)
+	ws := data.NewWorkspace(
+		"stale",
+		"stale",
+		"main",
+		filepath.Join(root, "unregistered-repo"),
+		filepath.Join(root, "workspaces", "stale"),
+	)
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	metadataPath := filepath.Join(metadataRoot, string(ws.ID()), "workspace.json")
+	old := time.Now().Add(-metadataOrphanGracePeriod - time.Hour)
+	if err := os.Chtimes(metadataPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(&fakeProjectRegistry{}, store, nil, filepath.Join(root, "workspaces"))
+	_ = svc.LoadProjects(2)()
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("non-initial refresh pruned metadata: %v", err)
+	}
+
+	_ = svc.LoadProjects(1)()
+	if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("initial load did not reconcile stale metadata: %v", err)
+	}
+}
+
+func TestPruneMissingTemporaryProjectCleansOwnedStateButLeavesWorkspaceFiles(t *testing.T) {
+	root := t.TempDir()
+	missingRepo := filepath.Join(root, "gone", "repo")
+	workspaceRoot := filepath.Join(root, "workspaces", "repo", "feature")
+	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	registry := data.NewRegistry(filepath.Join(root, "projects.json"))
+	if err := registry.AddProject(missingRepo); err != nil {
+		t.Fatal(err)
+	}
+	store := data.NewWorkspaceStore(filepath.Join(root, "metadata"))
+	ws := data.NewWorkspace("feature", "feature", "main", missingRepo, workspaceRoot)
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(registry, store, nil, filepath.Join(root, "workspaces"))
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	if kept := svc.pruneMissingTemporaryProjects([]string{missingRepo}); len(kept) != 0 {
+		t.Fatalf("kept vanished temp project: %v", kept)
+	}
+	if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workspace metadata still exists, err = %v", err)
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+	if _, err := os.Stat(workspaceRoot); err != nil {
+		t.Fatalf("automatic registry cleanup deleted workspace files: %v", err)
 	}
 }
 

--- a/internal/data/workspace_store_prune.go
+++ b/internal/data/workspace_store_prune.go
@@ -1,0 +1,278 @@
+package data
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WorkspacePruneOptions describes state that is safe for the metadata store to
+// reconcile. Pruning only removes amux-owned metadata and lock files; it never
+// removes a workspace root or repository.
+type WorkspacePruneOptions struct {
+	RegisteredRepos   []string
+	ManagedRoot       string
+	Now               time.Time
+	OrphanGracePeriod time.Duration
+	ArchivedRetention time.Duration
+}
+
+// WorkspacePruneResult reports what a reconciliation pass removed.
+type WorkspacePruneResult struct {
+	UnregisteredRemoved int
+	MissingRootRemoved  int
+	ArchivedRemoved     int
+	OrphanLocksRemoved  int
+}
+
+// MetadataRemoved returns the total number of workspace metadata records
+// removed by a reconciliation pass.
+func (r WorkspacePruneResult) MetadataRemoved() int {
+	return r.UnregisteredRemoved + r.MissingRootRemoved + r.ArchivedRemoved
+}
+
+// DeleteByRepo removes every metadata record for repoPath and returns the
+// workspace IDs whose sessions should be cleaned. Workspace roots are
+// deliberately untouched.
+func (s *WorkspaceStore) DeleteByRepo(repoPath string) ([]WorkspaceID, error) {
+	if s == nil {
+		return nil, nil
+	}
+	targetRepo := canonicalLookupPath(repoPath)
+	if targetRepo == "" {
+		return nil, errors.New("repo path is required")
+	}
+	ids, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	removed := make([]WorkspaceID, 0)
+	var errs []error
+	for _, id := range ids {
+		ws, loadErr := s.Load(id)
+		if loadErr != nil {
+			errs = append(errs, fmt.Errorf("load workspace %s: %w", id, loadErr))
+			continue
+		}
+		if canonicalLookupPath(ws.Repo) != targetRepo {
+			continue
+		}
+		if deleteErr := s.Delete(id); deleteErr != nil {
+			errs = append(errs, fmt.Errorf("delete workspace metadata %s: %w", id, deleteErr))
+			continue
+		}
+		removed = append(removed, id)
+		// A loaded record can live under a legacy metadata directory while its
+		// canonical repo/root identity produces a newer ID. Sessions may carry
+		// either value during migration, so return both for best-effort cleanup.
+		if canonicalID := ws.ID(); canonicalID != id {
+			removed = append(removed, canonicalID)
+		}
+	}
+	return removed, errors.Join(errs...)
+}
+
+// PruneStale removes metadata that can no longer be reached from the project
+// registry, old archived records, metadata for missing amux-managed roots, and
+// lock files whose metadata no longer exists. The grace periods protect a
+// concurrent project add or workspace create from a stale registry snapshot.
+func (s *WorkspaceStore) PruneStale(options WorkspacePruneOptions) (WorkspacePruneResult, error) {
+	var result WorkspacePruneResult
+	if s == nil {
+		return result, nil
+	}
+	now := options.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	registered := make(map[string]struct{}, len(options.RegisteredRepos))
+	for _, repo := range options.RegisteredRepos {
+		if canonical := canonicalLookupPath(repo); canonical != "" {
+			registered[canonical] = struct{}{}
+		}
+	}
+
+	ids, err := s.List()
+	if err != nil {
+		return result, err
+	}
+	var errs []error
+	for _, id := range ids {
+		reason, pruneErr := s.pruneWorkspaceIfStale(id, options, registered, now)
+		if errors.Is(pruneErr, fs.ErrNotExist) {
+			// Another process already reconciled this snapshot entry.
+			continue
+		}
+		if pruneErr != nil {
+			// Unreadable metadata is retained: without a trustworthy repo/root we
+			// cannot prove it is stale.
+			errs = append(errs, fmt.Errorf("prune workspace %s: %w", id, pruneErr))
+			continue
+		}
+		if reason == "" {
+			continue
+		}
+		switch reason {
+		case "unregistered":
+			result.UnregisteredRemoved++
+		case "archived":
+			result.ArchivedRemoved++
+		case "missing_root":
+			result.MissingRootRemoved++
+		}
+	}
+
+	removedLocks, lockErr := s.pruneOrphanLocks()
+	result.OrphanLocksRemoved = removedLocks
+	if lockErr != nil {
+		errs = append(errs, lockErr)
+	}
+	return result, errors.Join(errs...)
+}
+
+// pruneWorkspaceIfStale evaluates and deletes one record while holding its
+// flock. A concurrent AddProject/rescan can therefore either refresh metadata
+// before this check (which makes it fresh) or recreate it after deletion; an
+// old pre-lock observation can never delete a newly refreshed record.
+func (s *WorkspaceStore) pruneWorkspaceIfStale(
+	id WorkspaceID,
+	options WorkspacePruneOptions,
+	registered map[string]struct{},
+	now time.Time,
+) (string, error) {
+	locks, err := s.lockWorkspaceIDs(id)
+	if err != nil {
+		return "", err
+	}
+	defer unlockRegistryFiles(locks)
+
+	ws, err := s.load(id, false)
+	if err != nil {
+		return "", err
+	}
+	modTime, err := s.metadataModTime(id)
+	if err != nil {
+		return "", err
+	}
+
+	reason := ""
+	repo := canonicalLookupPath(ws.Repo)
+	_, repoRegistered := registered[repo]
+	switch {
+	case repo != "" && !repoRegistered && oldEnough(modTime, now, options.OrphanGracePeriod):
+		reason = "unregistered"
+	case ws.Archived && oldEnough(archiveReferenceTime(ws, modTime), now, options.ArchivedRetention):
+		reason = "archived"
+	case repoRegistered && !ws.IsPrimaryCheckout() &&
+		withinManagedRoot(options.ManagedRoot, ws.Root) &&
+		pathMissing(ws.Root) && oldEnough(modTime, now, options.OrphanGracePeriod):
+		reason = "missing_root"
+	}
+	if reason == "" {
+		return "", nil
+	}
+	if err := s.deleteWorkspaceDir(id); err != nil {
+		return "", fmt.Errorf("delete %s metadata: %w", reason, err)
+	}
+	s.removeWorkspaceLockFile(id)
+	return reason, nil
+}
+
+func (s *WorkspaceStore) metadataModTime(id WorkspaceID) (time.Time, error) {
+	info, err := os.Stat(s.workspacePath(id))
+	if err == nil {
+		return info.ModTime(), nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return time.Time{}, err
+	}
+	backupInfo, backupErr := os.Stat(s.workspaceBackupPath(id))
+	if backupErr != nil {
+		return time.Time{}, backupErr
+	}
+	return backupInfo.ModTime(), nil
+}
+
+func (s *WorkspaceStore) pruneOrphanLocks() (int, error) {
+	entries, err := os.ReadDir(s.root)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".lock") {
+			continue
+		}
+		id := WorkspaceID(strings.TrimSuffix(entry.Name(), ".lock"))
+		if validateErr := validateWorkspaceID(id); validateErr != nil {
+			continue
+		}
+		locks, lockErr := s.lockWorkspaceIDs(id)
+		if lockErr != nil {
+			errs = append(errs, fmt.Errorf("lock orphan workspace %s: %w", id, lockErr))
+			continue
+		}
+		if s.workspaceMetadataExists(id) {
+			unlockRegistryFiles(locks)
+			continue
+		}
+		s.removeWorkspaceLockFile(id)
+		unlockRegistryFiles(locks)
+		removed++
+	}
+	return removed, errors.Join(errs...)
+}
+
+func oldEnough(reference, now time.Time, grace time.Duration) bool {
+	if reference.IsZero() || reference.After(now) {
+		return false
+	}
+	if grace <= 0 {
+		return true
+	}
+	return now.Sub(reference) >= grace
+}
+
+func archiveReferenceTime(ws *Workspace, fallback time.Time) time.Time {
+	if ws != nil && !ws.ArchivedAt.IsZero() {
+		return ws.ArchivedAt
+	}
+	return fallback
+}
+
+func withinManagedRoot(managedRoot, root string) bool {
+	// Check the lexical pair first. On macOS, a missing child under /var cannot
+	// be fully symlink-resolved to /private/var even though the existing managed
+	// root can, so comparing only NormalizePath results would miss it.
+	for _, pair := range [][2]string{
+		{filepath.Clean(strings.TrimSpace(managedRoot)), filepath.Clean(strings.TrimSpace(root))},
+		{canonicalLookupPath(managedRoot), canonicalLookupPath(root)},
+	} {
+		managed, target := pair[0], pair[1]
+		if managed == "" || managed == "." || target == "" || target == "." {
+			continue
+		}
+		rel, err := filepath.Rel(managed, target)
+		if err != nil || rel == "." || rel == ".." {
+			continue
+		}
+		if !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathMissing(path string) bool {
+	_, err := os.Stat(path)
+	return errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/data/workspace_store_prune_test.go
+++ b/internal/data/workspace_store_prune_test.go
@@ -1,0 +1,174 @@
+package data
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWorkspaceStorePruneStaleReconcilesOwnedState(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(filepath.Join(root, "metadata"))
+	managedRoot := filepath.Join(root, "workspaces")
+	registeredRepo := filepath.Join(root, "registered")
+	unregisteredRepo := filepath.Join(root, "removed")
+	for _, path := range []string{managedRoot, registeredRepo, unregisteredRepo} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	keepRoot := filepath.Join(managedRoot, "repo", "keep")
+	orphanRoot := filepath.Join(managedRoot, "repo", "orphan-files-stay")
+	archivedRoot := filepath.Join(managedRoot, "repo", "archived")
+	for _, path := range []string{keepRoot, orphanRoot, archivedRoot} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	keep := NewWorkspace("keep", "keep", "main", registeredRepo, keepRoot)
+	orphanOld := NewWorkspace("orphan-old", "old", "main", unregisteredRepo, orphanRoot)
+	orphanFresh := NewWorkspace("orphan-fresh", "fresh", "main", unregisteredRepo, filepath.Join(orphanRoot, "fresh"))
+	missing := NewWorkspace("missing", "missing", "main", registeredRepo, filepath.Join(managedRoot, "repo", "missing"))
+	archived := NewWorkspace("archived", "archived", "main", registeredRepo, archivedRoot)
+	archived.Archived = true
+	archived.ArchivedAt = now.Add(-8 * 24 * time.Hour)
+
+	for _, ws := range []*Workspace{keep, orphanOld, orphanFresh, missing, archived} {
+		if err := store.Save(ws); err != nil {
+			t.Fatalf("Save(%s): %v", ws.Name, err)
+		}
+		mtime := now.Add(-2 * time.Hour)
+		if ws == orphanFresh {
+			mtime = now.Add(-30 * time.Minute)
+		}
+		if err := os.Chtimes(store.workspacePath(ws.ID()), mtime, mtime); err != nil {
+			t.Fatalf("Chtimes(%s): %v", ws.Name, err)
+		}
+	}
+
+	orphanLockID := WorkspaceID("orphan-lock")
+	locks, err := store.lockWorkspaceIDs(orphanLockID)
+	if err != nil {
+		t.Fatalf("lockWorkspaceIDs: %v", err)
+	}
+	unlockRegistryFiles(locks)
+
+	result, err := store.PruneStale(WorkspacePruneOptions{
+		RegisteredRepos:   []string{registeredRepo},
+		ManagedRoot:       managedRoot,
+		Now:               now,
+		OrphanGracePeriod: time.Hour,
+		ArchivedRetention: 7 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("PruneStale: %v", err)
+	}
+	if result.UnregisteredRemoved != 1 || result.MissingRootRemoved != 1 || result.ArchivedRemoved != 1 {
+		t.Fatalf("unexpected prune result: %+v", result)
+	}
+	if result.OrphanLocksRemoved != 1 {
+		t.Fatalf("orphan locks removed = %d, want 1", result.OrphanLocksRemoved)
+	}
+
+	for _, ws := range []*Workspace{orphanOld, missing, archived} {
+		if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Load(%s) error = %v, want not exist", ws.Name, err)
+		}
+	}
+	for _, ws := range []*Workspace{keep, orphanFresh} {
+		if _, err := store.Load(ws.ID()); err != nil {
+			t.Fatalf("Load(%s): %v", ws.Name, err)
+		}
+	}
+	if _, err := os.Stat(orphanRoot); err != nil {
+		t.Fatalf("pruning metadata removed workspace files: %v", err)
+	}
+	if _, err := os.Stat(store.workspaceLockPath(orphanLockID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("orphan lock still exists, stat err = %v", err)
+	}
+}
+
+func TestWorkspaceStoreDeleteByRepoLeavesWorkspaceRoots(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(filepath.Join(root, "metadata"))
+	dropRepo := filepath.Join(root, "drop")
+	keepRepo := filepath.Join(root, "keep")
+	dropRootA := filepath.Join(root, "workspaces", "drop", "a")
+	dropRootB := filepath.Join(root, "workspaces", "drop", "b")
+	for _, path := range []string{dropRootA, dropRootB} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dropA := NewWorkspace("a", "a", "main", dropRepo, dropRootA)
+	dropB := NewWorkspace("b", "b", "main", dropRepo, dropRootB)
+	keep := NewWorkspace("keep", "keep", "main", keepRepo, keepRepo)
+	for _, ws := range []*Workspace{dropA, dropB, keep} {
+		if err := store.Save(ws); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removed, err := store.DeleteByRepo(dropRepo)
+	if err != nil {
+		t.Fatalf("DeleteByRepo: %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed IDs = %v, want 2", removed)
+	}
+	if _, err := store.Load(keep.ID()); err != nil {
+		t.Fatalf("unrelated metadata removed: %v", err)
+	}
+	for _, path := range []string{dropRootA, dropRootB} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("workspace root %s was removed: %v", path, err)
+		}
+	}
+}
+
+func TestWorkspaceStoreDeleteByRepoReturnsLegacyAndCanonicalSessionIDs(t *testing.T) {
+	root := t.TempDir()
+	store := NewWorkspaceStore(filepath.Join(root, "metadata"))
+	repo := filepath.Join(root, "repo")
+	workspaceRoot := filepath.Join(root, "workspaces", "repo", "feature")
+	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ws := NewWorkspace("feature", "feature", "main", repo, workspaceRoot)
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	canonicalID := ws.ID()
+	legacyID := WorkspaceID("legacy-record-id")
+	if err := os.Rename(
+		filepath.Join(store.root, string(canonicalID)),
+		filepath.Join(store.root, string(legacyID)),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(store.workspaceLockPath(canonicalID), store.workspaceLockPath(legacyID)); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := store.DeleteByRepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[WorkspaceID]bool{legacyID: true, canonicalID: true}
+	if len(removed) != len(want) {
+		t.Fatalf("removed IDs = %v, want legacy and canonical IDs", removed)
+	}
+	for _, id := range removed {
+		if !want[id] {
+			t.Fatalf("unexpected removed ID %s in %v", id, removed)
+		}
+	}
+	if _, err := os.Stat(workspaceRoot); err != nil {
+		t.Fatalf("DeleteByRepo removed workspace files: %v", err)
+	}
+}

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -1,8 +1,10 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/clipperhouse/displaywidth"
 )
@@ -11,5 +13,12 @@ func TestMain(m *testing.M) {
 	// Force deterministic glyph widths for snapshots across locales.
 	displaywidth.DefaultOptions.EastAsianWidth = false
 
-	os.Exit(m.Run())
+	if err := cleanupStaleBuiltAmuxBinaries(os.TempDir(), time.Now()); err != nil {
+		fmt.Fprintf(os.Stderr, "stale e2e binary cleanup: %v\n", err)
+	}
+	code := m.Run()
+	if err := cleanupBuiltAmuxBinary(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e binary cleanup: %v\n", err)
+	}
+	os.Exit(code)
 }

--- a/internal/e2e/pty.go
+++ b/internal/e2e/pty.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -19,6 +21,12 @@ import (
 
 // pollInterval is the fallback polling interval for WaitFor* methods.
 const pollInterval = 50 * time.Millisecond
+
+const (
+	e2eBuildDirPrefix     = "amux-e2e-bin-"
+	e2eBuildOwnerFilename = ".owner-pid"
+	legacyE2EBuildMaxAge  = 24 * time.Hour
+)
 
 type PTYSession struct {
 	cmd      *exec.Cmd
@@ -276,14 +284,21 @@ func buildAmuxBinary() (string, func(), error) {
 	}
 
 	buildOnce.Do(func() {
-		tmp, err := os.MkdirTemp("", "amux-e2e-bin-*")
+		tmp, err := os.MkdirTemp("", e2eBuildDirPrefix+"*")
 		if err != nil {
 			buildErr = err
+			return
+		}
+		ownerPath := filepath.Join(tmp, e2eBuildOwnerFilename)
+		if err := os.WriteFile(ownerPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+			_ = os.RemoveAll(tmp)
+			buildErr = fmt.Errorf("write e2e build owner: %w", err)
 			return
 		}
 		out := filepath.Join(tmp, "amux")
 		root, err := repoRoot()
 		if err != nil {
+			_ = os.RemoveAll(tmp)
 			buildErr = err
 			return
 		}
@@ -292,6 +307,7 @@ func buildAmuxBinary() (string, func(), error) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
+			_ = os.RemoveAll(tmp)
 			buildErr = err
 			return
 		}
@@ -302,14 +318,93 @@ func buildAmuxBinary() (string, func(), error) {
 		return "", func() {}, buildErr
 	}
 
-	cleanup := func() {
-		if buildPath == "" {
-			return
-		}
-		if os.Getenv("AMUX_E2E_CLEANUP_BIN") == "" {
-			return
-		}
-		_ = os.RemoveAll(filepath.Dir(buildPath))
+	// The binary is shared by every PTY session in this test process. Removing
+	// it from an individual session cleanup makes subsequent tests reuse a path
+	// that no longer exists, while never removing it leaks one directory per
+	// `go test` invocation. TestMain performs the process-scoped cleanup.
+	return buildPath, func() {}, nil
+}
+
+func cleanupBuiltAmuxBinary() error {
+	if buildPath == "" {
+		// An AMUX_E2E_BIN supplied by the caller is never owned by this test.
+		return nil
 	}
-	return buildPath, cleanup, nil
+	dir := filepath.Dir(buildPath)
+	if !strings.HasPrefix(filepath.Base(dir), e2eBuildDirPrefix) {
+		return fmt.Errorf("refusing to remove unexpected build directory %q", dir)
+	}
+	return os.RemoveAll(dir)
+}
+
+func cleanupStaleBuiltAmuxBinaries(tempRoot string, now time.Time) error {
+	return cleanupStaleBuiltAmuxBinariesWith(tempRoot, now, e2eBuildOwnerAlive)
+}
+
+func cleanupStaleBuiltAmuxBinariesWith(tempRoot string, now time.Time, ownerAlive func(int) bool) error {
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), e2eBuildDirPrefix) {
+			continue
+		}
+		dir := filepath.Join(tempRoot, entry.Name())
+		useAgeGuard, liveOwner, ownerErr := classifyE2EBuildOwner(
+			filepath.Join(dir, e2eBuildOwnerFilename),
+			ownerAlive,
+		)
+		if ownerErr != nil {
+			errs = append(errs, fmt.Errorf("read owner for %s: %w", entry.Name(), ownerErr))
+			continue
+		}
+		if liveOwner {
+			continue
+		}
+		if useAgeGuard {
+			// Directories made by older tests have no owner marker. Retain fresh
+			// ones so a concurrently starting legacy test cannot be disrupted.
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				errs = append(errs, fmt.Errorf("stat legacy build %s: %w", entry.Name(), infoErr))
+				continue
+			}
+			if info.ModTime().After(now) || now.Sub(info.ModTime()) < legacyE2EBuildMaxAge {
+				continue
+			}
+		}
+		if removeErr := os.RemoveAll(dir); removeErr != nil {
+			errs = append(errs, fmt.Errorf("remove stale build %s: %w", entry.Name(), removeErr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func classifyE2EBuildOwner(ownerPath string, ownerAlive func(int) bool) (useAgeGuard, liveOwner bool, err error) {
+	ownerData, err := os.ReadFile(ownerPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(ownerData)))
+	if parseErr != nil || pid <= 0 || ownerAlive == nil {
+		// A concurrent writer can expose a short-lived partial marker. Treat
+		// malformed markers like legacy directories and fail closed while they
+		// are fresh. A missing liveness probe follows the same safe path.
+		return true, false, nil
+	}
+	return false, ownerAlive(pid), nil
+}
+
+func e2eBuildOwnerAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/internal/e2e/pty_cleanup_test.go
+++ b/internal/e2e/pty_cleanup_test.go
@@ -1,0 +1,68 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanupStaleBuiltAmuxBinariesProtectsLiveAndFreshBuilds(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+
+	live := makeE2EBuildDir(t, root, "live", "101", now.Add(-25*time.Hour))
+	dead := makeE2EBuildDir(t, root, "dead", "202", now)
+	legacyOld := makeE2EBuildDir(t, root, "legacy-old", "", now.Add(-25*time.Hour))
+	legacyFresh := makeE2EBuildDir(t, root, "legacy-fresh", "", now)
+	invalidFresh := makeE2EBuildDir(t, root, "invalid-fresh", "invalid", now)
+	unrelated := filepath.Join(root, "unrelated")
+	if err := os.Mkdir(unrelated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cleanupStaleBuiltAmuxBinariesWith(root, now, func(pid int) bool {
+		return pid == 101
+	})
+	if err != nil {
+		t.Fatalf("cleanupStaleBuiltAmuxBinariesWith: %v", err)
+	}
+
+	assertPathExists(t, live)
+	assertPathMissing(t, dead)
+	assertPathMissing(t, legacyOld)
+	assertPathExists(t, legacyFresh)
+	assertPathExists(t, invalidFresh)
+	assertPathExists(t, unrelated)
+}
+
+func makeE2EBuildDir(t *testing.T, root, suffix, owner string, modTime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(root, e2eBuildDirPrefix+suffix)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if owner != "" {
+		if err := os.WriteFile(filepath.Join(dir, e2eBuildOwnerFilename), []byte(owner), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chtimes(dir, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func assertPathExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertPathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, stat error: %v", path, err)
+	}
+}

--- a/internal/tmux/command.go
+++ b/internal/tmux/command.go
@@ -90,6 +90,7 @@ func appendSessionTags(settings *strings.Builder, base, session string, tags Ses
 		{"@amux_instance", tags.InstanceID},
 		{TagSessionOwner, tags.SessionOwner},
 		{TagSessionLeaseAt, formatInt64Positive(tags.LeaseAtMS)},
+		{TagSessionOwnerHeartbeatAt, formatInt64Positive(tags.LeaseAtMS)},
 	}
 	for _, e := range entries {
 		if e.value != "" {

--- a/internal/tmux/tags.go
+++ b/internal/tmux/tags.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -23,6 +24,10 @@ const (
 	TagLastInputAt    = "@amux_last_input_at"
 	TagSessionOwner   = "@amux_session_owner"
 	TagSessionLeaseAt = "@amux_session_lease_ms"
+	// TagSessionOwnerHeartbeatAt is refreshed by the owning amux process. It is
+	// intentionally separate from TagSessionLeaseAt, which represents user/PTY
+	// activity and drives inactivity GC.
+	TagSessionOwnerHeartbeatAt = "@amux_owner_heartbeat_ms"
 	// TagAgentState publishes the semantic per-session agent state
 	// ("idle"/"working"/"done", see activity.AgentState.String()) computed by
 	// the activity scan's hysteresis. Written best-effort on state transitions
@@ -185,4 +190,105 @@ func SetSessionTagValues(sessionName string, tags []OptionValue, opts Options) e
 		return err
 	}
 	return nil
+}
+
+// SetSessionTagValueForSessions sets one option on a snapshot of sessions in
+// bounded batches. A single tmux client invocation handles each batch so owner
+// heartbeat refresh does not fork one process per persistent tab.
+func SetSessionTagValueForSessions(sessionNames []string, key, value string, opts Options) error {
+	key = strings.TrimSpace(key)
+	if len(sessionNames) == 0 || key == "" {
+		return nil
+	}
+	if err := EnsureAvailable(); err != nil {
+		return err
+	}
+	targets, err := sessionOptionTargets(sessionNames, opts)
+	if err != nil {
+		return err
+	}
+	const batchSize = 64
+	for start := 0; start < len(targets); start += batchSize {
+		end := min(start+batchSize, len(targets))
+		args, added := buildSessionTagBatchArgs(targets[start:end], key, value)
+		if added == 0 {
+			continue
+		}
+		cmd, cancel := tmuxCommand(opts, args...)
+		output, err := runTmuxCmdCombined(cmd)
+		cancel()
+		if err == nil {
+			continue
+		}
+		if isExitCode1(err) {
+			stderr := strings.TrimSpace(string(output))
+			if isSessionNotFoundStderr(stderr) {
+				continue
+			}
+			return fmt.Errorf("set-option on session batch: %s: %w", stderr, err)
+		}
+		return err
+	}
+	return nil
+}
+
+func sessionOptionTargets(sessionNames []string, opts Options) ([]string, error) {
+	requested := make(map[string]struct{}, len(sessionNames))
+	for _, rawName := range sessionNames {
+		if name := strings.TrimSpace(rawName); name != "" {
+			requested[name] = struct{}{}
+		}
+	}
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	lines, err := listTmux(opts, "list-sessions", "-F", "#{session_name}\t#{session_id}")
+	if err != nil {
+		return nil, err
+	}
+	return parseSessionOptionTargets(requested, lines), nil
+}
+
+func parseSessionOptionTargets(requested map[string]struct{}, lines []string) []string {
+	targets := make([]string, 0, len(requested))
+	for _, line := range lines {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		if _, ok := requested[name]; !ok {
+			continue
+		}
+		id := strings.TrimSpace(parts[1])
+		if len(id) < 2 || id[0] != '$' {
+			continue
+		}
+		if _, err := strconv.ParseUint(id[1:], 10, 64); err != nil {
+			continue
+		}
+		targets = append(targets, id)
+	}
+	return targets
+}
+
+func buildSessionTagBatchArgs(sessionTargets []string, key, value string) ([]string, int) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, 0
+	}
+	args := make([]string, 0, len(sessionTargets)*7)
+	added := 0
+	for _, rawTarget := range sessionTargets {
+		target := strings.TrimSpace(rawTarget)
+		if target == "" {
+			continue
+		}
+		if added > 0 {
+			args = append(args, ";")
+		}
+		args = append(args, "set-option", "-t", target, key, value)
+		added++
+	}
+	return args, added
 }

--- a/internal/tmux/tmux_option_values_integration_test.go
+++ b/internal/tmux/tmux_option_values_integration_test.go
@@ -37,6 +37,55 @@ func TestSetSessionTagValues_SetsSessionOptions(t *testing.T) {
 	}
 }
 
+func TestSetSessionTagValueForSessions_SetsEverySession(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	sessions := []string{"heartbeat-a", "heartbeat-b"}
+	for _, session := range sessions {
+		createSession(t, opts, session, "sleep 300")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	want := "1700000000456"
+	if err := SetSessionTagValueForSessions(sessions, TagSessionOwnerHeartbeatAt, want, opts); err != nil {
+		t.Fatalf("SetSessionTagValueForSessions: %v", err)
+	}
+	for _, session := range sessions {
+		got, err := SessionTagValue(session, TagSessionOwnerHeartbeatAt, opts)
+		if err != nil {
+			t.Fatalf("SessionTagValue(%s): %v", session, err)
+		}
+		if got != want {
+			t.Fatalf("%s heartbeat = %q, want %q", session, got, want)
+		}
+	}
+}
+
+func TestSetSessionTagValueForSessions_DoesNotPrefixMatchMissingSession(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+
+	createSession(t, opts, "heartbeat-target-10", "sleep 300")
+	time.Sleep(50 * time.Millisecond)
+
+	if err := SetSessionTagValueForSessions(
+		[]string{"heartbeat-target-1"},
+		TagSessionOwnerHeartbeatAt,
+		"1700000000456",
+		opts,
+	); err != nil {
+		t.Fatalf("SetSessionTagValueForSessions: %v", err)
+	}
+	got, err := SessionTagValue("heartbeat-target-10", TagSessionOwnerHeartbeatAt, opts)
+	if err != nil {
+		t.Fatalf("SessionTagValue: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("missing target prefix-matched heartbeat-target-10: heartbeat = %q", got)
+	}
+}
+
 func TestSetGlobalOptionValues_SetsGlobalOptions(t *testing.T) {
 	skipIfNoTmux(t)
 	opts := testServer(t)

--- a/internal/tmux/tmux_pure_test.go
+++ b/internal/tmux/tmux_pure_test.go
@@ -188,6 +188,44 @@ func TestBuildMultiSetOptionArgs_DoesNotAliasScope(t *testing.T) {
 	}
 }
 
+func TestBuildSessionTagBatchArgs(t *testing.T) {
+	args, added := buildSessionTagBatchArgs(
+		[]string{" $1 ", "", "$2"},
+		" @amux_owner_heartbeat_ms ",
+		"123",
+	)
+	want := []string{
+		"set-option", "-t", "$1", "@amux_owner_heartbeat_ms", "123",
+		";",
+		"set-option", "-t", "$2", "@amux_owner_heartbeat_ms", "123",
+	}
+	if added != 2 || !reflect.DeepEqual(args, want) {
+		t.Fatalf("buildSessionTagBatchArgs() = (%#v, %d), want (%#v, 2)", args, added, want)
+	}
+
+	args, added = buildSessionTagBatchArgs([]string{"$1"}, " ", "123")
+	if added != 0 || len(args) != 0 {
+		t.Fatalf("blank key should produce no args, got (%#v, %d)", args, added)
+	}
+}
+
+func TestParseSessionOptionTargetsMatchesExactNamesAndValidIDs(t *testing.T) {
+	requested := map[string]struct{}{
+		"session-1": {},
+		"session-2": {},
+	}
+	got := parseSessionOptionTargets(requested, []string{
+		"session-10\t$10",
+		"session-1\t$1",
+		"session-2\tnot-an-id",
+		"malformed",
+	})
+	want := []string{"$1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseSessionOptionTargets() = %#v, want %#v", got, want)
+	}
+}
+
 // TestSessionStateFor_EmptyName covers the guard that returns a zero-value
 // SessionState before any tmux command (EnsureAvailable) is reached.
 func TestSessionStateFor_EmptyName(t *testing.T) {

--- a/internal/ui/sidebar/terminal_pty_session_tags.go
+++ b/internal/ui/sidebar/terminal_pty_session_tags.go
@@ -123,6 +123,10 @@ func terminalTagChecks(tags tmux.SessionTags) []struct {
 			key  string
 			want string
 		}{key: tmux.TagSessionLeaseAt, want: strconv.FormatInt(tags.LeaseAtMS, 10)})
+		checks = append(checks, struct {
+			key  string
+			want string
+		}{key: tmux.TagSessionOwnerHeartbeatAt, want: strconv.FormatInt(tags.LeaseAtMS, 10)})
 	}
 	return checks
 }

--- a/internal/ui/sidebar/terminal_pty_session_tags_test.go
+++ b/internal/ui/sidebar/terminal_pty_session_tags_test.go
@@ -69,6 +69,7 @@ func TestTerminalTagChecks(t *testing.T) {
 				{key: "@amux", want: "1"},
 				{key: "@amux_created_at", want: "1"},
 				{key: tmux.TagSessionLeaseAt, want: "1"},
+				{key: tmux.TagSessionOwnerHeartbeatAt, want: "1"},
 			},
 		},
 		{
@@ -121,6 +122,7 @@ func TestTerminalTagChecks(t *testing.T) {
 				{key: "@amux_instance", want: "inst-9"},
 				{key: tmux.TagSessionOwner, want: "owner-x"},
 				{key: tmux.TagSessionLeaseAt, want: "1700000000123"},
+				{key: tmux.TagSessionOwnerHeartbeatAt, want: "1700000000123"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- reconcile stale workspace metadata, orphan locks, and vanished temporary projects automatically while preserving repositories and worktrees
- isolate tmux ownership by AMUX state root, refresh cross-instance heartbeats, and only collect orphan sessions after confirming their panes are dead
- make project removal clean scripts, ports, metadata, and owned sessions without deleting files, including metadata-store failure fallbacks
- prevent stale project-load snapshots from clearing a newly created workspace and clean generated E2E binaries without touching live test processes

## Validation

- `make devcheck`
- `make verify-loop`
- `make harness-presets`
- `make lint-strict-new`
- `go test ./internal/tmux ./internal/e2e -count=1`
- `go test -race ./internal/app ./internal/data -count=1`
- `GOOS=windows GOARCH=amd64 go build ./...`
- foreground pre-push CI-parity lint, harness, and E2E gate