### PR TITLE
fix: reliably clean deleted workspace sessions

### DIFF
--- a/internal/app/app_delete_no_kill_test.go
+++ b/internal/app/app_delete_no_kill_test.go
@@ -21,6 +21,7 @@ type killRecordingTmuxOps struct {
 	lastKillTags              map[string]string
 	lastMissingPrefix         string
 	lastMissingTag            string
+	killedSessionNames        []string
 }
 
 func (k *killRecordingTmuxOps) KillSessionsMatchingTags(tags map[string]string, _ tmux.Options) (bool, error) {
@@ -31,6 +32,11 @@ func (k *killRecordingTmuxOps) KillSessionsMatchingTags(tags map[string]string, 
 
 func (k *killRecordingTmuxOps) KillWorkspaceSessions(string, tmux.Options) error {
 	k.killWsCalls++
+	return nil
+}
+
+func (k *killRecordingTmuxOps) KillSession(name string, _ tmux.Options) error {
+	k.killedSessionNames = append(k.killedSessionNames, name)
 	return nil
 }
 
@@ -133,45 +139,46 @@ func TestHandleWorkspaceDeleted_NoTrailingSessionKill(t *testing.T) {
 	}
 }
 
-// TestKillWorkspaceSessionsSync_InstanceScoped proves the delete kill is scoped
-// to this instance and only uses a prefix fallback for legacy sessions that have
-// no @amux_instance tag, so a workspace shared with another amux process is not
-// torn down across instances.
-func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
-	t.Run("scopes tag match to instance and legacy prefix kill", func(t *testing.T) {
+// TestKillWorkspaceSessionsSync_AllInstances proves deletion tears down every
+// session for the workspace. A worktree is host-global, so retaining a session
+// merely because another amux instance created it leaves an agent running in a
+// deleted directory.
+func TestKillWorkspaceSessionsSync_AllInstances(t *testing.T) {
+	t.Run("uses a workspace-wide tag match and legacy prefix kill", func(t *testing.T) {
 		ops := &killRecordingTmuxOps{}
 		app := &App{tmuxService: ops, instanceID: "inst-A"}
 
-		app.killWorkspaceSessionsSync("ws-1")
+		if err := app.killWorkspaceSessionsSync("ws-1"); err != nil {
+			t.Fatal(err)
+		}
 
-		if ops.killWsCalls != 0 {
-			t.Fatalf("expected no prefix KillWorkspaceSessions (it ignores instance), got %d", ops.killWsCalls)
+		if ops.killWsCalls != 1 {
+			t.Fatalf("expected one workspace prefix cleanup, got %d", ops.killWsCalls)
 		}
-		if ops.killPrefixMissingTagCalls != 1 {
-			t.Fatalf("expected one legacy missing-tag prefix cleanup, got %d", ops.killPrefixMissingTagCalls)
+		if ops.killPrefixMissingTagCalls != 0 {
+			t.Fatalf("expected no instance-filtered legacy cleanup, got %d", ops.killPrefixMissingTagCalls)
 		}
-		if ops.lastMissingPrefix != tmux.SessionName("amux", "ws-1")+"-" || ops.lastMissingTag != "@amux_instance" {
-			t.Fatalf("unexpected legacy cleanup prefix/tag: %q %q", ops.lastMissingPrefix, ops.lastMissingTag)
-		}
-		if ops.lastKillTags["@amux_instance"] != "inst-A" {
-			t.Fatalf("expected @amux_instance scoping, got tags %v", ops.lastKillTags)
+		if _, ok := ops.lastKillTags["@amux_instance"]; ok {
+			t.Fatalf("delete cleanup must not be instance-scoped, got tags %v", ops.lastKillTags)
 		}
 		if ops.lastKillTags["@amux_workspace"] != "ws-1" {
 			t.Fatalf("expected @amux_workspace tag, got %v", ops.lastKillTags)
 		}
 	})
 
-	t.Run("empty instanceID keeps broad match", func(t *testing.T) {
+	t.Run("empty instance ID has the same workspace-wide behavior", func(t *testing.T) {
 		ops := &killRecordingTmuxOps{}
 		app := &App{tmuxService: ops, instanceID: ""}
 
-		app.killWorkspaceSessionsSync("ws-1")
+		if err := app.killWorkspaceSessionsSync("ws-1"); err != nil {
+			t.Fatal(err)
+		}
 
 		if _, ok := ops.lastKillTags["@amux_instance"]; ok {
 			t.Fatalf("empty instanceID must not add @amux_instance, got %v", ops.lastKillTags)
 		}
 		if ops.killWsCalls != 1 {
-			t.Fatalf("empty instanceID should keep broad workspace prefix cleanup, got %d", ops.killWsCalls)
+			t.Fatalf("expected broad workspace prefix cleanup, got %d", ops.killWsCalls)
 		}
 		if ops.killPrefixMissingTagCalls != 0 {
 			t.Fatalf("empty instanceID should not use missing-tag fallback, got %d", ops.killPrefixMissingTagCalls)
@@ -180,4 +187,16 @@ func TestKillWorkspaceSessionsSync_InstanceScoped(t *testing.T) {
 			t.Fatalf("expected @amux_workspace tag even when broad, got %v", ops.lastKillTags)
 		}
 	})
+}
+
+func TestKillWorkspaceSessionNamesSync_OnlyKillsAmuxNamespace(t *testing.T) {
+	ops := &killRecordingTmuxOps{}
+	app := &App{tmuxService: ops}
+
+	if err := app.killWorkspaceSessionNamesSync([]string{" amux-owned-agent ", "unrelated-session"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ops.killedSessionNames) != 1 || ops.killedSessionNames[0] != "amux-owned-agent" {
+		t.Fatalf("killed exact sessions = %v, want only amux-owned-agent", ops.killedSessionNames)
+	}
 }

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -207,6 +207,7 @@ func New(version, commit, date string) (*App, error) {
 	// Let the delete path tear down workspace tmux sessions after worktree
 	// removal succeeds, without killing live sessions for failed deletes.
 	workspaceService.killWorkspaceSessions = app.killWorkspaceSessionsSync
+	workspaceService.killWorkspaceSessionNames = app.killWorkspaceSessionNamesSync
 
 	return app, nil
 }

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -261,7 +261,7 @@ func (a *App) handleWorkspaceDeleteFailed(msg messages.WorkspaceDeleteFailed) te
 		// was deleted — leave the tombstone so startup recovery finishes the delete
 		// rather than resurfacing a dir-less ghost.
 		if a.workspaceService != nil && dirExists(msg.Workspace.Root) {
-			a.workspaceService.clearDeleteTombstone(msg.Workspace.ID())
+			a.workspaceService.clearWorkspaceDeleteTombstones(msg.Workspace)
 		}
 		if cmd := a.dashboard.SetWorkspaceDeleting(msg.Workspace.Root, false); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/app/app_tmux.go
+++ b/internal/app/app_tmux.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,40 +12,52 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-// killWorkspaceSessionsSync synchronously tears down a workspace's tmux sessions
-// by tag. The delete path calls this only after worktree removal succeeds, so a
-// failed delete does not destroy live agent sessions. No-op when tmux is
-// unavailable.
-func (a *App) killWorkspaceSessionsSync(wsID string) {
+// killWorkspaceSessionsSync synchronously tears down every tmux session for a
+// workspace, regardless of which amux instance created it. Worktree deletion is
+// host-global: once the directory is gone, a session owned by another instance
+// is just as invalid as one owned by this process. The delete path calls this
+// only after worktree removal succeeds, so a failed delete does not destroy live
+// agent sessions. No-op when tmux is unavailable.
+func (a *App) killWorkspaceSessionsSync(wsID string) error {
 	if a.tmuxService == nil || wsID == "" {
-		return
+		return nil
 	}
 	tags := map[string]string{
 		"@amux":           "1",
 		"@amux_workspace": wsID,
 	}
-	// Scope to this instance. Workspace IDs are sha1(repo+root), so the same
-	// workspace carries the same @amux_workspace tag across every amux process on
-	// the host (the user orchestrates many). Without an @amux_instance filter,
-	// deleting a workspace shared with another instance would kill that instance's
-	// live agent. An empty instanceID (legacy/untagged) keeps the broad behavior
-	// so single-instance cleanup of pre-existing untagged sessions still works.
-	if strings.TrimSpace(a.instanceID) != "" {
-		tags["@amux_instance"] = a.instanceID
+	_, taggedErr := a.tmuxService.KillSessionsMatchingTags(tags, a.tmuxOptions)
+	if taggedErr != nil {
+		logging.Warn("Failed to kill tagged tmux sessions for deleted workspace %s: %v", wsID, taggedErr)
 	}
-	if _, err := a.tmuxService.KillSessionsMatchingTags(tags, a.tmuxOptions); err != nil {
-		logging.Warn("Failed to kill tmux sessions for workspace %s before worktree removal: %v", wsID, err)
+	legacyErr := a.tmuxService.KillWorkspaceSessions(wsID, a.tmuxOptions)
+	if legacyErr != nil {
+		logging.Warn("Failed to kill legacy tmux sessions for deleted workspace %s: %v", wsID, legacyErr)
 	}
-	prefix := tmux.SessionName("amux", wsID) + "-"
-	if strings.TrimSpace(a.instanceID) == "" {
-		if err := a.tmuxService.KillWorkspaceSessions(wsID, a.tmuxOptions); err != nil {
-			logging.Warn("Failed to kill tmux legacy sessions for workspace %s before worktree removal: %v", wsID, err)
+	return errors.Join(taggedErr, legacyErr)
+}
+
+func (a *App) killWorkspaceSessionNamesSync(sessionNames []string) error {
+	if a.tmuxService == nil {
+		return nil
+	}
+	prefix := tmux.SessionName("amux") + "-"
+	var errs []error
+	for _, name := range sessionNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
 		}
-		return
+		if !strings.HasPrefix(name, prefix) {
+			logging.Warn("Skipping non-amux persisted tmux session during workspace delete: %s", name)
+			continue
+		}
+		if err := a.tmuxService.KillSession(name, a.tmuxOptions); err != nil {
+			logging.Warn("Failed to kill persisted tmux session %s for deleted workspace: %v", name, err)
+			errs = append(errs, err)
+		}
 	}
-	if err := a.tmuxService.KillSessionsWithPrefixMissingTag(prefix, "@amux_instance", a.tmuxOptions); err != nil {
-		logging.Warn("Failed to kill legacy tmux sessions for workspace %s before worktree removal: %v", wsID, err)
-	}
+	return errors.Join(errs...)
 }
 
 func (a *App) cleanupAllTmuxSessions() tea.Cmd {

--- a/internal/app/workspace_delete_isolation_test.go
+++ b/internal/app/workspace_delete_isolation_test.go
@@ -130,8 +130,12 @@ func TestKillWorkspaceSessionsSync_TagArgsAreWorkspaceScoped(t *testing.T) {
 	ops := &multiKillRecordingTmuxOps{}
 	app := &App{tmuxService: ops, instanceID: "inst-A"}
 
-	app.killWorkspaceSessionsSync("ws-A")
-	app.killWorkspaceSessionsSync("ws-B")
+	if err := app.killWorkspaceSessionsSync("ws-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.killWorkspaceSessionsSync("ws-B"); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(ops.allKillTags) != 2 {
 		t.Fatalf("expected exactly two kill calls, got %d", len(ops.allKillTags))
@@ -143,8 +147,8 @@ func TestKillWorkspaceSessionsSync_TagArgsAreWorkspaceScoped(t *testing.T) {
 		t.Fatalf("second cleanup must target ws-B, got @amux_workspace=%q", got)
 	}
 	for i, tags := range ops.allKillTags {
-		if tags["@amux_instance"] != "inst-A" {
-			t.Fatalf("call %d must stay instance-scoped, got %v", i, tags)
+		if _, ok := tags["@amux_instance"]; ok {
+			t.Fatalf("call %d must cover all instances, got %v", i, tags)
 		}
 	}
 }

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"os"
+	"strings"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
@@ -71,6 +72,29 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 		// A surviving worktree means an earlier delete failed before removing it;
 		// do not finish the delete — the workspace must stay usable.
 		return false
+	}
+	// The prior process may have exited after removing the worktree but before
+	// reaching the normal session cleanup. The missing root plus durable
+	// tombstone proves deletion passed validation, so no live agent for this
+	// workspace is safe to retain.
+	if err := s.killWorkspaceSessionsForDeletedWorkspace(ws); err != nil {
+		logging.Warn("startup recovery: failed to stop sessions for interrupted delete workspace_id=%s error=%v", ws.ID(), err)
+		if markErr := td.MarkDeleting(ws.ID()); markErr != nil {
+			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", ws.ID(), markErr)
+		}
+		return true
+	}
+	if s.gitOps != nil {
+		repoPath := data.NormalizePath(ws.Repo)
+		branch := strings.TrimSpace(ws.Branch)
+		if repoPath != "" && branch != "" {
+			unlock := s.lockRepoGit(repoPath)
+			err := s.gitOps.DeleteBranch(repoPath, branch)
+			unlock()
+			if err != nil {
+				logging.Warn("startup recovery: failed to remove branch for interrupted delete workspace_id=%s branch=%s error=%v", ws.ID(), branch, err)
+			}
+		}
 	}
 	if err := s.store.Delete(ws.ID()); err != nil {
 		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", ws.ID(), err)

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -1,8 +1,8 @@
 package app
 
 import (
+	"fmt"
 	"os"
-	"strings"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/logging"
@@ -28,17 +28,28 @@ func dirExists(path string) bool {
 }
 
 // markDeleteTombstone records a durable tombstone before a destructive delete.
-// Best-effort: a failure is logged but does not abort the delete (the tombstone
-// only aids crash recovery).
-func (s *workspaceService) markDeleteTombstone(id data.WorkspaceID) {
+// Once the store supports tombstones, failure must abort before the worktree is
+// removed; otherwise an interrupted session cleanup has no durable retry key.
+func (s *workspaceService) markDeleteTombstone(id data.WorkspaceID) error {
 	if s == nil || s.store == nil {
-		return
+		return nil
 	}
 	if td, ok := s.store.(workspaceTombstoneStore); ok {
 		if err := td.MarkDeleting(id); err != nil {
 			logging.Warn("workspace delete: failed to write tombstone workspace_id=%s error=%v", id, err)
+			return fmt.Errorf("write delete tombstone: %w", err)
 		}
 	}
+	return nil
+}
+
+func (s *workspaceService) markWorkspaceDeleteTombstones(ws *data.Workspace) error {
+	for _, id := range workspaceMetadataIDs(ws) {
+		if err := s.markDeleteTombstone(id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // clearDeleteTombstone removes a workspace's delete tombstone.
@@ -50,6 +61,12 @@ func (s *workspaceService) clearDeleteTombstone(id data.WorkspaceID) {
 		if err := td.ClearDeleting(id); err != nil {
 			logging.Warn("workspace delete: failed to clear tombstone workspace_id=%s error=%v", id, err)
 		}
+	}
+}
+
+func (s *workspaceService) clearWorkspaceDeleteTombstones(ws *data.Workspace) {
+	for _, id := range workspaceMetadataIDs(ws) {
+		s.clearDeleteTombstone(id)
 	}
 }
 
@@ -65,9 +82,20 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 		return false
 	}
 	td, ok := s.store.(workspaceTombstoneStore)
-	if !ok || !td.IsDeleting(ws.ID()) {
+	if !ok {
 		return false
 	}
+	deleting := false
+	for _, id := range workspaceMetadataIDs(ws) {
+		if td.IsDeleting(id) {
+			deleting = true
+			break
+		}
+	}
+	if !deleting {
+		return false
+	}
+	metadataID := ws.MetadataID()
 	if dirExists(ws.Root) {
 		// A surviving worktree means an earlier delete failed before removing it;
 		// do not finish the delete — the workspace must stay usable.
@@ -78,31 +106,19 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	// tombstone proves deletion passed validation, so no live agent for this
 	// workspace is safe to retain.
 	if err := s.killWorkspaceSessionsForDeletedWorkspace(ws); err != nil {
-		logging.Warn("startup recovery: failed to stop sessions for interrupted delete workspace_id=%s error=%v", ws.ID(), err)
-		if markErr := td.MarkDeleting(ws.ID()); markErr != nil {
-			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", ws.ID(), markErr)
+		logging.Warn("startup recovery: failed to stop sessions for interrupted delete workspace_id=%s error=%v", metadataID, err)
+		if markErr := s.markWorkspaceDeleteTombstones(ws); markErr != nil {
+			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", metadataID, markErr)
 		}
 		return true
 	}
-	if s.gitOps != nil {
-		repoPath := data.NormalizePath(ws.Repo)
-		branch := strings.TrimSpace(ws.Branch)
-		if repoPath != "" && branch != "" {
-			unlock := s.lockRepoGit(repoPath)
-			err := s.gitOps.DeleteBranch(repoPath, branch)
-			unlock()
-			if err != nil {
-				logging.Warn("startup recovery: failed to remove branch for interrupted delete workspace_id=%s branch=%s error=%v", ws.ID(), branch, err)
-			}
-		}
-	}
-	if err := s.store.Delete(ws.ID()); err != nil {
-		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", ws.ID(), err)
-		if markErr := td.MarkDeleting(ws.ID()); markErr != nil {
-			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", ws.ID(), markErr)
+	if err := s.deleteWorkspaceMetadata(ws); err != nil {
+		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", metadataID, err)
+		if markErr := s.markWorkspaceDeleteTombstones(ws); markErr != nil {
+			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", metadataID, markErr)
 		}
 		return true
 	}
-	logging.Info("startup recovery: finished interrupted delete workspace_id=%s", ws.ID())
+	logging.Info("startup recovery: finished interrupted delete workspace_id=%s", metadataID)
 	return true
 }

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -53,6 +53,11 @@ func (s *failingTombstoneWorkspaceStore) ClearDeleting(data.WorkspaceID) error {
 func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	store := data.NewWorkspaceStore(t.TempDir())
 	svc := newWorkspaceService(nil, store, nil, "")
+	branchDeleted := false
+	svc.gitOps = &mockGitOps{deleteBranch: func(repoPath, branch string) error {
+		branchDeleted = repoPath == "/repo" && branch == "feature"
+		return nil
+	}}
 
 	// Worktree root deliberately does not exist (simulating a crash after the
 	// worktree was removed but before the metadata was).
@@ -63,12 +68,23 @@ func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	if err := store.MarkDeleting(ws.ID()); err != nil {
 		t.Fatalf("MarkDeleting: %v", err)
 	}
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 
 	if !svc.finishInterruptedDelete(ws) {
 		t.Fatal("expected recovery to finish the interrupted delete")
 	}
 	if _, err := store.Load(ws.ID()); err == nil {
 		t.Fatal("expected metadata removed by recovery")
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+	if !branchDeleted {
+		t.Fatal("expected recovery to retry interrupted branch cleanup")
 	}
 }
 
@@ -83,12 +99,45 @@ func TestFinishInterruptedDelete_SkipsDirlessTombstonedWhenMetadataDeleteFails(t
 		deleteErr: errors.New("metadata busy"),
 	}
 	svc := newWorkspaceService(nil, store, nil, "")
+	svc.gitOps = &mockGitOps{}
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 
 	if !svc.finishInterruptedDelete(ws) {
 		t.Fatal("expected recovery to suppress a dir-less tombstoned workspace")
 	}
 	if store.markCount == 0 {
 		t.Fatal("expected failed cleanup to preserve the tombstone for a later retry")
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+}
+
+func TestFinishInterruptedDelete_RetainsMetadataWhenSessionCleanupFails(t *testing.T) {
+	store := data.NewWorkspaceStore(t.TempDir())
+	svc := newWorkspaceService(nil, store, nil, "")
+	svc.gitOps = &mockGitOps{}
+	ws := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone")
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkDeleting(ws.ID()); err != nil {
+		t.Fatal(err)
+	}
+	svc.killWorkspaceSessions = func(string) error { return errors.New("tmux busy") }
+
+	if !svc.finishInterruptedDelete(ws) {
+		t.Fatal("expected recovery to suppress the dir-less tombstoned workspace")
+	}
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("metadata must remain for a later cleanup retry: %v", err)
+	}
+	if !store.IsDeleting(ws.ID()) {
+		t.Fatal("delete tombstone must remain after session cleanup failure")
 	}
 }
 

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -2,15 +2,20 @@ package app
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/center"
 )
 
 type failingTombstoneWorkspaceStore struct {
 	workspace *data.Workspace
 	deleteErr error
+	markErr   error
 	markCount int
 }
 
@@ -39,7 +44,7 @@ func (s *failingTombstoneWorkspaceStore) ResolvedDefaultAssistant() string {
 
 func (s *failingTombstoneWorkspaceStore) MarkDeleting(data.WorkspaceID) error {
 	s.markCount++
-	return nil
+	return s.markErr
 }
 
 func (s *failingTombstoneWorkspaceStore) IsDeleting(id data.WorkspaceID) bool {
@@ -53,9 +58,8 @@ func (s *failingTombstoneWorkspaceStore) ClearDeleting(data.WorkspaceID) error {
 func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	store := data.NewWorkspaceStore(t.TempDir())
 	svc := newWorkspaceService(nil, store, nil, "")
-	branchDeleted := false
-	svc.gitOps = &mockGitOps{deleteBranch: func(repoPath, branch string) error {
-		branchDeleted = repoPath == "/repo" && branch == "feature"
+	svc.gitOps = &mockGitOps{deleteBranch: func(string, string) error {
+		t.Fatal("startup recovery must not delete a branch from a possibly replaced repository")
 		return nil
 	}}
 
@@ -82,9 +86,6 @@ func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	}
 	if len(killed) != 1 || killed[0] != string(ws.ID()) {
 		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
-	}
-	if !branchDeleted {
-		t.Fatal("expected recovery to retry interrupted branch cleanup")
 	}
 }
 
@@ -138,6 +139,91 @@ func TestFinishInterruptedDelete_RetainsMetadataWhenSessionCleanupFails(t *testi
 	}
 	if !store.IsDeleting(ws.ID()) {
 		t.Fatal("delete tombstone must remain after session cleanup failure")
+	}
+}
+
+func TestFinishInterruptedDelete_RemovesLegacyMetadataIDAndSessions(t *testing.T) {
+	root := t.TempDir()
+	store := data.NewWorkspaceStore(root)
+	ws := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone")
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	canonicalID := ws.ID()
+	legacyID := data.WorkspaceID("legacy-workspace-id")
+	if err := os.Rename(
+		filepath.Join(root, string(canonicalID)),
+		filepath.Join(root, string(legacyID)),
+	); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.Load(legacyID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.MetadataID() != legacyID {
+		t.Fatalf("metadata ID = %s, want %s", loaded.MetadataID(), legacyID)
+	}
+	// Simulate another amux instance migrating the record while this instance
+	// still holds a workspace value loaded from the legacy key.
+	canonicalCopy := data.NewWorkspace(loaded.Name, loaded.Branch, loaded.Base, loaded.Repo, loaded.Root)
+	canonicalCopy.OpenTabs = append([]data.TabInfo(nil), loaded.OpenTabs...)
+	if err := store.Save(canonicalCopy); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkDeleting(legacyID); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(nil, store, nil, "")
+	svc.gitOps = &mockGitOps{}
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
+	if !svc.finishInterruptedDelete(loaded) {
+		t.Fatal("expected recovery to finish legacy metadata delete")
+	}
+	if _, err := store.Load(legacyID); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy metadata still exists: %v", err)
+	}
+	if _, err := store.Load(canonicalID); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canonical metadata still exists: %v", err)
+	}
+	wantKilled := []string{string(legacyID), string(canonicalID)}
+	if !reflect.DeepEqual(killed, wantKilled) {
+		t.Fatalf("killed workspace IDs = %v, want %v", killed, wantKilled)
+	}
+}
+
+func TestDeleteWorkspace_AbortsWhenTombstoneWriteFails(t *testing.T) {
+	root := t.TempDir()
+	workspaceRoot := filepath.Join(root, "workspaces", "repo", "feature")
+	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ws := data.NewWorkspace("feature", "feature", "main", filepath.Join(root, "repo"), workspaceRoot)
+	store := &failingTombstoneWorkspaceStore{
+		workspace: ws,
+		markErr:   errors.New("metadata read-only"),
+	}
+	removeCalled := false
+	svc := newWorkspaceService(nil, store, nil, filepath.Join(root, "workspaces"))
+	svc.gitOps = &mockGitOps{removeWorkspace: func(string, string) error {
+		removeCalled = true
+		return nil
+	}}
+
+	msg := svc.DeleteWorkspace(data.NewProject(ws.Repo), ws)()
+	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+	if removeCalled {
+		t.Fatal("worktree removal must not begin without a durable tombstone")
+	}
+	if !dirExists(workspaceRoot) {
+		t.Fatal("workspace root must remain after tombstone failure")
 	}
 }
 

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -320,14 +320,16 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 		// removal, startup recovery can finish the delete rather than surfacing a
 		// dir-less ghost workspace. store.Delete removes the whole metadata dir,
 		// clearing the tombstone on success.
-		s.markDeleteTombstone(ws.ID())
+		if err := s.markWorkspaceDeleteTombstones(ws); err != nil {
+			return fail("mark_deleting", err)
+		}
 
 		warning, failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail)
 		if failMsg != nil {
 			return failMsg
 		}
 		if s.store != nil {
-			if err := s.store.Delete(ws.ID()); err != nil {
+			if err := s.deleteWorkspaceMetadata(ws); err != nil {
 				// Worktree and branch are already gone; because loading is store-
 				// first and shouldSurfaceWorkspace never stats the root, a surviving
 				// metadata dir resurfaces the just-deleted workspace on the next load,

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -369,10 +369,11 @@ func (s *workspaceService) stopWorkspaceScriptsForDelete(ws *data.Workspace) err
 	return s.scripts.Stop(ws)
 }
 
-func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) {
+func (s *workspaceService) killWorkspaceSessionsForDelete(wsID string) error {
 	if s != nil && s.killWorkspaceSessions != nil {
-		s.killWorkspaceSessions(wsID)
+		return s.killWorkspaceSessions(wsID)
 	}
+	return nil
 }
 
 func workspacePathGone(path string) bool {
@@ -396,8 +397,8 @@ func (s *workspaceService) archiveDeletedWorkspaceMetadata(ws *data.Workspace) e
 // removeWorktreeAndBranchLocked runs the git mutations (worktree remove + branch
 // delete) under the per-repo lock so concurrent same-repo deletes do not contend
 // on .git locks. It returns a non-fatal branch-delete warning and a failure
-// message that is non-nil only when the worktree removal hard-failed; the caller
-// then returns it and skips metadata removal.
+// message when worktree removal or required session cleanup fails; the caller
+// then returns it and preserves metadata for a later retry.
 func (s *workspaceService) removeWorktreeAndBranchLocked(
 	project *data.Project, ws *data.Workspace, projectPath, wsID string,
 	fail func(stage string, err error) tea.Msg,
@@ -414,7 +415,9 @@ func (s *workspaceService) removeWorktreeAndBranchLocked(
 	// The worktree removal has succeeded or an owned stale path was cleaned up.
 	// Tear down any remaining workspace tmux sessions before metadata deletion,
 	// but never kill sessions for a delete that failed and left the workspace.
-	s.killWorkspaceSessionsForDelete(wsID)
+	if err := s.killWorkspaceSessionsForDeletedWorkspace(ws); err != nil {
+		return "", fail("stop_sessions", err)
+	}
 
 	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
 		logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
@@ -432,14 +435,13 @@ func (s *workspaceService) handleStaleRemoveError(
 ) tea.Msg {
 	if !git.IsUnregisteredWorkspacePathError(err) {
 		if workspacePathGone(ws.Root) {
-			s.killWorkspaceSessionsForDelete(wsID)
+			return nil
 		}
 		return fail("remove_worktree", err)
 	}
 	if _, statErr := os.Stat(ws.Root); statErr != nil {
 		if os.IsNotExist(statErr) {
-			s.killWorkspaceSessionsForDelete(wsID)
-			return fail("remove_worktree", err)
+			return nil
 		}
 		return fail("remove_worktree", errors.Join(err, statErr))
 	}

--- a/internal/app/workspace_service_delete_kill_order_test.go
+++ b/internal/app/workspace_service_delete_kill_order_test.go
@@ -33,9 +33,10 @@ func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 
 	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
 	svc.gitOps = mock
-	svc.killWorkspaceSessions = func(wsID string) {
+	svc.killWorkspaceSessions = func(wsID string) error {
 		order++
 		killOrder = order
+		return nil
 	}
 
 	project := data.NewProject(projectPath)
@@ -53,6 +54,78 @@ func TestDeleteWorkspace_KillsSessionsAfterWorktreeRemoval(t *testing.T) {
 	}
 	if killOrder <= removeOrder {
 		t.Fatalf("expected kill (order %d) after worktree removal (order %d)", killOrder, removeOrder)
+	}
+}
+
+func TestDeleteWorkspace_KillsPersistedLegacySessionNames(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
+	svc.gitOps = &mockGitOps{}
+	var killed []string
+	svc.killWorkspaceSessionNames = func(names []string) error {
+		killed = append(killed, names...)
+		return nil
+	}
+
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+	ws.OpenTabs = []data.TabInfo{
+		{SessionName: "amux-legacy-workspace-tab-a"},
+		{SessionName: "amux-legacy-workspace-tab-a"},
+		{SessionName: "amux-legacy-workspace-tab-b"},
+	}
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleted); !ok {
+		t.Fatalf("expected WorkspaceDeleted, got %T", msg)
+	}
+	if len(killed) != 2 || killed[0] != "amux-legacy-workspace-tab-a" || killed[1] != "amux-legacy-workspace-tab-b" {
+		t.Fatalf("killed persisted sessions = %v", killed)
+	}
+}
+
+func TestDeleteWorkspace_RetainsMetadataWhenSessionCleanupFails(t *testing.T) {
+	tmp := t.TempDir()
+	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
+	projectPath := filepath.Join(tmp, "repo")
+	workspacePath := filepath.Join(workspacesRoot, "repo", "feature")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := data.NewWorkspaceStore(filepath.Join(tmp, "metadata"))
+	project := data.NewProject(projectPath)
+	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	branchDeleted := false
+	svc := newWorkspaceService(nil, store, nil, workspacesRoot)
+	svc.gitOps = &mockGitOps{deleteBranch: func(string, string) error {
+		branchDeleted = true
+		return nil
+	}}
+	svc.killWorkspaceSessions = func(string) error { return errors.New("tmux busy") }
+
+	msg := svc.DeleteWorkspace(project, ws)()
+	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
+		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	}
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("metadata must remain for cleanup retry: %v", err)
+	}
+	if !store.IsDeleting(ws.ID()) {
+		t.Fatal("delete tombstone must remain for startup recovery")
+	}
+	if branchDeleted {
+		t.Fatal("branch deletion must wait until required session cleanup succeeds")
 	}
 }
 
@@ -141,8 +214,9 @@ func TestDeleteWorkspace_DoesNotKillSessionsWhenWorktreeRemovalFails(t *testing.
 
 	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
 	svc.gitOps = mock
-	svc.killWorkspaceSessions = func(wsID string) {
+	svc.killWorkspaceSessions = func(wsID string) error {
 		t.Fatal("failed delete must not kill workspace tmux sessions")
+		return nil
 	}
 
 	project := data.NewProject(projectPath)
@@ -175,16 +249,17 @@ func TestDeleteWorkspace_KillsSessionsWhenRemovalFailsAfterPathGone(t *testing.T
 	svc := newWorkspaceService(nil, nil, nil, workspacesRoot)
 	svc.gitOps = mock
 	killed := false
-	svc.killWorkspaceSessions = func(wsID string) {
+	svc.killWorkspaceSessions = func(wsID string) error {
 		killed = true
+		return nil
 	}
 
 	project := data.NewProject(projectPath)
 	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
 
 	msg := svc.DeleteWorkspace(project, ws)()
-	if _, ok := msg.(messages.WorkspaceDeleteFailed); !ok {
-		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
+	if _, ok := msg.(messages.WorkspaceDeleted); !ok {
+		t.Fatalf("expected WorkspaceDeleted, got %T", msg)
 	}
 	if !killed {
 		t.Fatal("expected sessions killed when removal failed after deleting workspace path")

--- a/internal/app/workspace_service_delete_sessions.go
+++ b/internal/app/workspace_service_delete_sessions.go
@@ -2,10 +2,30 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/andyrewlee/amux/internal/data"
 )
+
+func workspaceMetadataIDs(ws *data.Workspace) []data.WorkspaceID {
+	if ws == nil {
+		return nil
+	}
+	ids := make([]data.WorkspaceID, 0, 2)
+	seen := make(map[data.WorkspaceID]struct{}, 2)
+	for _, id := range []data.WorkspaceID{ws.MetadataID(), ws.ID()} {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
 
 // killWorkspaceSessionsForDeletedWorkspace cleans both current-ID sessions and
 // exact persisted session names. The latter covers agents created before a
@@ -14,9 +34,12 @@ func (s *workspaceService) killWorkspaceSessionsForDeletedWorkspace(ws *data.Wor
 	if ws == nil {
 		return nil
 	}
-	idErr := s.killWorkspaceSessionsForDelete(string(ws.ID()))
+	var errs []error
+	for _, id := range workspaceMetadataIDs(ws) {
+		errs = append(errs, s.killWorkspaceSessionsForDelete(string(id)))
+	}
 	if s.killWorkspaceSessionNames == nil {
-		return idErr
+		return errors.Join(errs...)
 	}
 	sessionNames := make([]string, 0, len(ws.OpenTabs))
 	seen := make(map[string]struct{}, len(ws.OpenTabs))
@@ -32,7 +55,20 @@ func (s *workspaceService) killWorkspaceSessionsForDeletedWorkspace(ws *data.Wor
 		sessionNames = append(sessionNames, name)
 	}
 	if len(sessionNames) > 0 {
-		return errors.Join(idErr, s.killWorkspaceSessionNames(sessionNames))
+		errs = append(errs, s.killWorkspaceSessionNames(sessionNames))
 	}
-	return idErr
+	return errors.Join(errs...)
+}
+
+func (s *workspaceService) deleteWorkspaceMetadata(ws *data.Workspace) error {
+	if s == nil || s.store == nil || ws == nil {
+		return nil
+	}
+	var errs []error
+	for _, id := range workspaceMetadataIDs(ws) {
+		if err := s.store.Delete(id); err != nil {
+			errs = append(errs, fmt.Errorf("delete workspace metadata %s: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/app/workspace_service_delete_sessions.go
+++ b/internal/app/workspace_service_delete_sessions.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+// killWorkspaceSessionsForDeletedWorkspace cleans both current-ID sessions and
+// exact persisted session names. The latter covers agents created before a
+// workspace-ID normalization migration.
+func (s *workspaceService) killWorkspaceSessionsForDeletedWorkspace(ws *data.Workspace) error {
+	if ws == nil {
+		return nil
+	}
+	idErr := s.killWorkspaceSessionsForDelete(string(ws.ID()))
+	if s.killWorkspaceSessionNames == nil {
+		return idErr
+	}
+	sessionNames := make([]string, 0, len(ws.OpenTabs))
+	seen := make(map[string]struct{}, len(ws.OpenTabs))
+	for _, tab := range ws.OpenTabs {
+		name := strings.TrimSpace(tab.SessionName)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		sessionNames = append(sessionNames, name)
+	}
+	if len(sessionNames) > 0 {
+		return errors.Join(idErr, s.killWorkspaceSessionNames(sessionNames))
+	}
+	return idErr
+}

--- a/internal/app/workspace_service_delete_test.go
+++ b/internal/app/workspace_service_delete_test.go
@@ -349,7 +349,7 @@ func TestDeleteWorkspaceDoesNotDeleteMetadataOnSignalKilledRemoveFailure(t *test
 	}
 }
 
-func TestDeleteWorkspaceFailsWhenRemoveWorkspaceAlreadyMovedPathAside(t *testing.T) {
+func TestDeleteWorkspaceCompletesWhenRemoveWorkspaceAlreadyMovedPathAside(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -377,12 +377,8 @@ func TestDeleteWorkspaceFailsWhenRemoveWorkspaceAlreadyMovedPathAside(t *testing
 	svc.gitOps = mock
 	msg := svc.DeleteWorkspace(project, ws)()
 
-	failed, ok := msg.(messages.WorkspaceDeleteFailed)
-	if !ok {
-		t.Fatalf("expected WorkspaceDeleteFailed, got %T", msg)
-	}
-	if failed.Err == nil || !strings.Contains(failed.Err.Error(), "cleanup pending") {
-		t.Fatalf("expected staged-cleanup failure to be preserved, got %v", failed.Err)
+	if _, ok := msg.(messages.WorkspaceDeleted); !ok {
+		t.Fatalf("expected WorkspaceDeleted, got %T", msg)
 	}
 }
 

--- a/internal/app/workspace_service_init.go
+++ b/internal/app/workspace_service_init.go
@@ -53,7 +53,11 @@ type workspaceService struct {
 	// Wired in app_init; nil in directly-constructed services (a no-op). Called
 	// only after worktree removal succeeds, so failed deletes leave live sessions
 	// intact.
-	killWorkspaceSessions func(wsID string)
+	killWorkspaceSessions func(wsID string) error
+	// killWorkspaceSessionNames tears down exact persisted session names. This
+	// complements workspace-ID cleanup for sessions created before an ID
+	// normalization migration.
+	killWorkspaceSessionNames func(sessionNames []string) error
 	// repoGitLocks serializes git worktree/branch mutations per repository (keyed
 	// by normalized project path) so concurrent create/delete of workspaces in the
 	// same repo do not contend on .git locks (index.lock / packed-refs).

--- a/internal/app/workspace_service_prune.go
+++ b/internal/app/workspace_service_prune.go
@@ -33,6 +33,16 @@ func (s *workspaceService) reconcileWorkspaceMetadata(registeredRepos []string) 
 		Now:               time.Now(),
 		OrphanGracePeriod: metadataOrphanGracePeriod,
 		ArchivedRetention: archivedMetadataRetention,
+		BeforeMissingRootRemove: func(cleanup data.WorkspacePruneCleanup) error {
+			var errs []error
+			for _, id := range cleanup.WorkspaceIDs {
+				errs = append(errs, s.killWorkspaceSessionsForDelete(string(id)))
+			}
+			if s.killWorkspaceSessionNames != nil && len(cleanup.SessionNames) > 0 {
+				errs = append(errs, s.killWorkspaceSessionNames(cleanup.SessionNames))
+			}
+			return errors.Join(errs...)
+		},
 	})
 	if err != nil {
 		logging.Warn("workspace metadata reconciliation completed with errors: %v", err)
@@ -103,7 +113,9 @@ func (s *workspaceService) removeProjectMetadata(repoPath string, knownWorkspace
 	}
 	killCollectedSessions := func() {
 		for id := range idsToKill {
-			s.killWorkspaceSessionsForDelete(id)
+			if err := s.killWorkspaceSessionsForDelete(id); err != nil {
+				logging.Warn("Project removed, but workspace sessions could not be fully stopped for %s: %v", id, err)
+			}
 		}
 	}
 	if s.store == nil {

--- a/internal/app/workspace_service_test.go
+++ b/internal/app/workspace_service_test.go
@@ -233,7 +233,10 @@ func TestRemoveProjectCleansMetadataAndSessionsButLeavesFiles(t *testing.T) {
 
 	svc := newWorkspaceService(registry, store, nil, filepath.Join(dir, "workspaces"))
 	var killed []string
-	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 	msg := svc.RemoveProject(data.NewProject(repo))()
 	if _, ok := msg.(messages.ProjectRemoved); !ok {
 		t.Fatalf("expected ProjectRemoved, got %T", msg)
@@ -257,7 +260,10 @@ func TestRemoveProjectCleansKnownSessionsWithoutMetadataStore(t *testing.T) {
 
 	svc := newWorkspaceService(&fakeProjectRegistry{}, nil, nil, "")
 	var killed []string
-	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 	msg := svc.RemoveProject(project)()
 	if _, ok := msg.(messages.ProjectRemoved); !ok {
 		t.Fatalf("expected ProjectRemoved, got %T", msg)
@@ -303,6 +309,11 @@ func TestLoadProjectsReconcilesMetadataOnlyOnInitialLoad(t *testing.T) {
 	}
 
 	svc := newWorkspaceService(&fakeProjectRegistry{}, store, nil, filepath.Join(root, "workspaces"))
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 	_ = svc.LoadProjects(2)()
 	if _, err := store.Load(ws.ID()); err != nil {
 		t.Fatalf("non-initial refresh pruned metadata: %v", err)
@@ -311,6 +322,54 @@ func TestLoadProjectsReconcilesMetadataOnlyOnInitialLoad(t *testing.T) {
 	_ = svc.LoadProjects(1)()
 	if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("initial load did not reconcile stale metadata: %v", err)
+	}
+	if len(killed) != 0 {
+		t.Fatalf("unregistered metadata cleanup must not kill potentially foreign sessions, killed=%v", killed)
+	}
+}
+
+func TestLoadProjectsReconciliationKillsSessionsForMissingManagedRoot(t *testing.T) {
+	root := t.TempDir()
+	metadataRoot := filepath.Join(root, "metadata")
+	managedRoot := filepath.Join(root, "workspaces")
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	registry := &fakeProjectRegistry{projectsValue: []string{repo}}
+	store := data.NewWorkspaceStore(metadataRoot)
+	ws := data.NewWorkspace("gone", "gone", "main", repo, filepath.Join(managedRoot, "repo", "gone"))
+	ws.OpenTabs = []data.TabInfo{{SessionName: "legacy-gone-session"}}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	metadataPath := filepath.Join(metadataRoot, string(ws.ID()), "workspace.json")
+	old := time.Now().Add(-metadataOrphanGracePeriod - time.Hour)
+	if err := os.Chtimes(metadataPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := newWorkspaceService(registry, store, nil, managedRoot)
+	var killed []string
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
+	var killedSessionNames []string
+	svc.killWorkspaceSessionNames = func(names []string) error {
+		killedSessionNames = append(killedSessionNames, names...)
+		return nil
+	}
+	_ = svc.LoadProjects(1)()
+
+	if _, err := store.Load(ws.ID()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("initial load did not reconcile missing-root metadata: %v", err)
+	}
+	if len(killed) != 1 || killed[0] != string(ws.ID()) {
+		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+	if len(killedSessionNames) != 1 || killedSessionNames[0] != "legacy-gone-session" {
+		t.Fatalf("killed persisted sessions = %v, want [legacy-gone-session]", killedSessionNames)
 	}
 }
 
@@ -333,7 +392,10 @@ func TestPruneMissingTemporaryProjectCleansOwnedStateButLeavesWorkspaceFiles(t *
 
 	svc := newWorkspaceService(registry, store, nil, filepath.Join(root, "workspaces"))
 	var killed []string
-	svc.killWorkspaceSessions = func(id string) { killed = append(killed, id) }
+	svc.killWorkspaceSessions = func(id string) error {
+		killed = append(killed, id)
+		return nil
+	}
 	if kept := svc.pruneMissingTemporaryProjects([]string{missingRepo}); len(kept) != 0 {
 		t.Fatalf("kept vanished temp project: %v", kept)
 	}

--- a/internal/data/workspace.go
+++ b/internal/data/workspace.go
@@ -88,6 +88,16 @@ func (w Workspace) ID() WorkspaceID {
 	return workspaceIDFromIdentity(workspaceIdentity(w.Repo, w.Root))
 }
 
+// MetadataID returns the store key this workspace was loaded from. Legacy
+// records can live under an older key even though ID now computes a normalized
+// identity. New or unsaved workspaces fall back to their canonical ID.
+func (w Workspace) MetadataID() WorkspaceID {
+	if w.storeID != "" {
+		return w.storeID
+	}
+	return w.ID()
+}
+
 // IsPrimaryCheckout returns true if this is the primary checkout
 func (w Workspace) IsPrimaryCheckout() bool {
 	repo := NormalizePath(w.Repo)

--- a/internal/data/workspace_store_prune.go
+++ b/internal/data/workspace_store_prune.go
@@ -19,6 +19,17 @@ type WorkspacePruneOptions struct {
 	Now               time.Time
 	OrphanGracePeriod time.Duration
 	ArchivedRetention time.Duration
+	// BeforeMissingRootRemove runs while the workspace metadata is still
+	// present. Returning an error retains the record so cleanup can retry on a
+	// later reconciliation pass.
+	BeforeMissingRootRemove func(WorkspacePruneCleanup) error
+}
+
+// WorkspacePruneCleanup identifies sessions belonging to a missing-root
+// workspace. Both the stored and canonical IDs are included when they differ.
+type WorkspacePruneCleanup struct {
+	WorkspaceIDs []WorkspaceID
+	SessionNames []string
 }
 
 // WorkspacePruneResult reports what a reconciliation pass removed.
@@ -175,6 +186,20 @@ func (s *WorkspaceStore) pruneWorkspaceIfStale(
 	}
 	if reason == "" {
 		return "", nil
+	}
+	if reason == "missing_root" && options.BeforeMissingRootRemove != nil {
+		cleanup := WorkspacePruneCleanup{WorkspaceIDs: []WorkspaceID{id}}
+		if canonicalID := ws.ID(); canonicalID != "" && canonicalID != id {
+			cleanup.WorkspaceIDs = append(cleanup.WorkspaceIDs, canonicalID)
+		}
+		for _, tab := range ws.OpenTabs {
+			if name := strings.TrimSpace(tab.SessionName); name != "" {
+				cleanup.SessionNames = append(cleanup.SessionNames, name)
+			}
+		}
+		if err := options.BeforeMissingRootRemove(cleanup); err != nil {
+			return "", fmt.Errorf("clean up missing-root workspace: %w", err)
+		}
 	}
 	if err := s.deleteWorkspaceDir(id); err != nil {
 		return "", fmt.Errorf("delete %s metadata: %w", reason, err)

--- a/internal/data/workspace_store_prune_test.go
+++ b/internal/data/workspace_store_prune_test.go
@@ -34,6 +34,7 @@ func TestWorkspaceStorePruneStaleReconcilesOwnedState(t *testing.T) {
 	orphanOld := NewWorkspace("orphan-old", "old", "main", unregisteredRepo, orphanRoot)
 	orphanFresh := NewWorkspace("orphan-fresh", "fresh", "main", unregisteredRepo, filepath.Join(orphanRoot, "fresh"))
 	missing := NewWorkspace("missing", "missing", "main", registeredRepo, filepath.Join(managedRoot, "repo", "missing"))
+	missing.OpenTabs = []TabInfo{{SessionName: "legacy-missing-session"}}
 	archived := NewWorkspace("archived", "archived", "main", registeredRepo, archivedRoot)
 	archived.Archived = true
 	archived.ArchivedAt = now.Add(-8 * 24 * time.Hour)
@@ -58,12 +59,17 @@ func TestWorkspaceStorePruneStaleReconcilesOwnedState(t *testing.T) {
 	}
 	unlockRegistryFiles(locks)
 
+	var missingCleanup WorkspacePruneCleanup
 	result, err := store.PruneStale(WorkspacePruneOptions{
 		RegisteredRepos:   []string{registeredRepo},
 		ManagedRoot:       managedRoot,
 		Now:               now,
 		OrphanGracePeriod: time.Hour,
 		ArchivedRetention: 7 * 24 * time.Hour,
+		BeforeMissingRootRemove: func(cleanup WorkspacePruneCleanup) error {
+			missingCleanup = cleanup
+			return nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("PruneStale: %v", err)
@@ -73,6 +79,12 @@ func TestWorkspaceStorePruneStaleReconcilesOwnedState(t *testing.T) {
 	}
 	if result.OrphanLocksRemoved != 1 {
 		t.Fatalf("orphan locks removed = %d, want 1", result.OrphanLocksRemoved)
+	}
+	if len(missingCleanup.WorkspaceIDs) != 1 || missingCleanup.WorkspaceIDs[0] != missing.ID() {
+		t.Fatalf("missing-root workspace IDs = %v, want [%s]", missingCleanup.WorkspaceIDs, missing.ID())
+	}
+	if len(missingCleanup.SessionNames) != 1 || missingCleanup.SessionNames[0] != "legacy-missing-session" {
+		t.Fatalf("missing-root session names = %v, want [legacy-missing-session]", missingCleanup.SessionNames)
 	}
 
 	for _, ws := range []*Workspace{orphanOld, missing, archived} {
@@ -90,6 +102,43 @@ func TestWorkspaceStorePruneStaleReconcilesOwnedState(t *testing.T) {
 	}
 	if _, err := os.Stat(store.workspaceLockPath(orphanLockID)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("orphan lock still exists, stat err = %v", err)
+	}
+}
+
+func TestWorkspaceStorePruneStaleRetainsMissingRootWhenCleanupFails(t *testing.T) {
+	root := t.TempDir()
+	managedRoot := filepath.Join(root, "workspaces")
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := NewWorkspaceStore(filepath.Join(root, "metadata"))
+	ws := NewWorkspace("missing", "missing", "main", repo, filepath.Join(managedRoot, "repo", "missing"))
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(store.workspacePath(ws.ID()), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := store.PruneStale(WorkspacePruneOptions{
+		RegisteredRepos:   []string{repo},
+		ManagedRoot:       managedRoot,
+		Now:               time.Now(),
+		OrphanGracePeriod: time.Hour,
+		BeforeMissingRootRemove: func(WorkspacePruneCleanup) error {
+			return errors.New("tmux busy")
+		},
+	})
+	if err == nil {
+		t.Fatal("expected cleanup failure")
+	}
+	if result.MissingRootRemoved != 0 {
+		t.Fatalf("missing-root removed = %d, want 0", result.MissingRootRemoved)
+	}
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("metadata must remain for a later cleanup retry: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- clean deleted workspace sessions across amux instances, current IDs, legacy stored IDs, and persisted session names
- require durable delete tombstones before removing a worktree so failed cleanup always remains retryable
- remove both legacy and canonical metadata records during normal and interrupted deletion
- reconcile missing-root metadata only after session cleanup succeeds
- restrict persisted exact-name cleanup to the amux session namespace
- avoid delayed branch deletion during startup recovery because the repository path may have been replaced

## Validation

- make devcheck
- make lint-strict-new
- make verify-loop
- go test ./internal/app ./internal/data
- go test ./internal/tmux
- go test ./internal/e2e -run TestWorkspaceDeleteTearsDownAgent -count=1
- pre-commit formatting, golangci-lint, and file-length checks
- pre-push CI-parity strict lint, headless UI harness, and full E2E suite