### PR TITLE
fix: end PTY flushes on synchronized-output frame boundaries

### DIFF
--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -27,7 +27,7 @@ bytes (`tabEventWriteOutput` is never shed — see the invariants in
 
 A flush can land mid-repaint: the parser may have consumed a `2J` clear but
 not yet the repaint that follows, and rendering that state shows a torn or
-blank frame. Two mechanisms prevent that:
+blank frame. Three mechanisms prevent that:
 
 1. The session bootstrap (`internal/tmux/command.go`) advertises the `sync`
    terminal feature for amux's client TERM before attaching, so tmux wraps
@@ -35,6 +35,24 @@ blank frame. Two mechanisms prevent that:
 2. `internal/vterm` freezes `RenderBuffers()` at the sync-begin snapshot until
    sync-end. Bytes parsed inside the window mutate the live buffers (and mark
    lines dirty) but are never rendered mid-frame.
+3. `ptyio`'s flush policy ends flushes on region boundaries
+   (`scanSyncFrames`): a chunk stops at the last completed region, and when
+   nothing has completed the flush waits rather than writing an opening marker
+   with no body.
+
+(3) is what makes (2) work, and it is not optional. tmux writes the client
+socket in ≤1KB chunks, so a redraw larger than that spans several reads —
+measured on a streaming pane, 53% of reads end inside an open region, and
+without (3) 43% of flushes hand the vterm half a frame. The freeze in (2) then
+holds the *previous* frame, so the pane shows stale content and reports every
+line dirty (a full repaint) until the next flush closes the region. With (3)
+that drops to ~1% of flushes, at the same flush rate.
+
+A writer that brackets its frames also makes the flush quiet period redundant
+for that frame — the debounce exists to guess where a frame ends — so a
+completed frame flushes immediately instead of waiting the quiet period out.
+The reader's frame-interval coalescing upstream still caps how often that can
+happen, so this lowers latency without raising the flush rate.
 
 Sync-end deliberately does **not** invalidate the render cache: dirty marks
 accumulated during the window are preserved because frozen renders skip

--- a/internal/ui/center/model_input_lifecycle_flush_sync_test.go
+++ b/internal/ui/center/model_input_lifecycle_flush_sync_test.go
@@ -1,0 +1,123 @@
+package center
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+const (
+	testSyncBegin = "\x1b[?2026h"
+	testSyncEnd   = "\x1b[?2026l"
+	// ptyFlushQuietElapsed is how long output has been idle in these tests:
+	// past every quiet period, short of every flush ceiling. Asserted in
+	// syncFlushTab so a retuning of either constant fails loudly instead of
+	// quietly turning these into tests of the quiet branch.
+	ptyFlushQuietElapsed = 30 * time.Millisecond
+)
+
+// syncFlushTab builds an active tab whose quiet period has elapsed (so the
+// flush gate is past its first branch) while both partial-frame ceilings are
+// still far off. The elapsed window clears every quiet value flushTiming can
+// pick — including the longer alt-screen one — so a deferral in these tests can
+// only come from the partial-frame hold, never from the quiet period.
+func syncFlushTab(t *testing.T, id, pending string) (*Model, *Tab, string) {
+	t.Helper()
+	if ptyFlushQuietElapsed <= ptyFlushQuiet || ptyFlushQuietElapsed <= ptyFlushQuietAlt {
+		t.Fatalf("ptyFlushQuietElapsed %v must exceed both quiet periods (%v, %v)",
+			ptyFlushQuietElapsed, ptyFlushQuiet, ptyFlushQuietAlt)
+	}
+	if ptyFlushQuietElapsed >= ptyFlushMaxInterval {
+		t.Fatalf("ptyFlushQuietElapsed %v must stay under the flush ceiling %v",
+			ptyFlushQuietElapsed, ptyFlushMaxInterval)
+	}
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	quietElapsed := time.Now().Add(-ptyFlushQuietElapsed)
+	tab := &Tab{
+		ID:        TabID(id),
+		Workspace: ws,
+		Terminal:  vterm.New(80, 24),
+		Running:   true,
+		State: ptyio.State{
+			LastOutputAt:      quietElapsed,
+			FlushPendingSince: quietElapsed,
+			PendingOutput:     []byte(pending),
+		},
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+	return m, tab, wsID
+}
+
+// Some agents write the DEC 2026 sync-begin on its own, well ahead of the frame
+// body. Flushing it alone freezes the vterm on the previous frame and marks
+// every line dirty until the region closes, so the flush must wait instead.
+func TestUpdatePTYFlush_HoldsLoneSyncBegin(t *testing.T) {
+	m, tab, wsID := syncFlushTab(t, "tab-sync-begin", testSyncBegin)
+
+	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+
+	if got, want := string(tab.PendingOutput), testSyncBegin; got != want {
+		t.Fatalf("pending output = %q, want the sync-begin still buffered", got)
+	}
+	if tab.Terminal.SyncActive() {
+		t.Fatal("terminal is sync-frozen, want the partial frame withheld")
+	}
+}
+
+// Once the body closes the region the whole frame flushes in one write, leaving
+// the terminal unfrozen and the content visible.
+func TestUpdatePTYFlush_WritesCompletedSyncFrame(t *testing.T) {
+	m, tab, wsID := syncFlushTab(t, "tab-sync-frame", testSyncBegin+"hello"+testSyncEnd)
+
+	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+
+	if len(tab.PendingOutput) != 0 {
+		t.Fatalf("pending output = %q, want drained", tab.PendingOutput)
+	}
+	if tab.Terminal.SyncActive() {
+		t.Fatal("terminal is sync-frozen after a complete frame")
+	}
+	if !strings.Contains(tab.Terminal.Render(), "hello") {
+		t.Fatal("completed frame did not reach the terminal")
+	}
+}
+
+// A completed frame ahead of a freshly opened one must not wait for the second
+// frame: the flush splits at the boundary so the ready frame is displayed now.
+func TestUpdatePTYFlush_SplitsAtCompletedSyncFrameBoundary(t *testing.T) {
+	m, tab, wsID := syncFlushTab(t, "tab-sync-split", testSyncBegin+"hello"+testSyncEnd+testSyncBegin)
+
+	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+
+	if got, want := string(tab.PendingOutput), testSyncBegin; got != want {
+		t.Fatalf("pending output = %q, want only the next frame's sync-begin buffered", got)
+	}
+	if tab.Terminal.SyncActive() {
+		t.Fatal("terminal is sync-frozen, want the partial second frame withheld")
+	}
+	if !strings.Contains(tab.Terminal.Render(), "hello") {
+		t.Fatal("completed frame did not reach the terminal")
+	}
+}
+
+// The hold is bounded: a writer that opens a region and goes silent must not
+// stall the pane past the flush ceiling.
+func TestUpdatePTYFlush_FlushesLoneSyncBeginPastCeiling(t *testing.T) {
+	m, tab, wsID := syncFlushTab(t, "tab-sync-stall", testSyncBegin)
+	stale := time.Now().Add(-(ptyFlushMaxInterval + 10*time.Millisecond))
+	tab.State.LastOutputAt = stale
+	tab.State.FlushPendingSince = stale
+
+	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+
+	if len(tab.PendingOutput) != 0 {
+		t.Fatalf("pending output = %q, want flushed once the ceiling elapsed", tab.PendingOutput)
+	}
+}

--- a/internal/ui/center/model_pty_reader.go
+++ b/internal/ui/center/model_pty_reader.go
@@ -25,8 +25,12 @@ func (m *Model) flushTiming(tab *Tab, active bool) (time.Duration, time.Duration
 	tab.mu.Unlock()
 
 	// Only use slower Alt timing for true AltScreen mode (full-screen TUIs).
-	// SyncActive (DEC 2026) already handles partial updates via screen snapshots,
-	// so we don't need slower flush timing - it just makes streaming text feel laggy.
+	// A DEC 2026 writer does not need slower flush timing — that just makes
+	// streaming text feel laggy — because the flush policy keeps its frames
+	// whole by ending flushes on region boundaries (see scanSyncFrames in
+	// internal/ui/ptyio). Note the vterm's sync snapshot alone does not: it
+	// freezes on the *previous* frame, so a flush that opens a region without
+	// its body shows stale content until the next one.
 	if altScreen {
 		quiet = ptyFlushQuietAlt
 		maxInterval = ptyFlushMaxAlt

--- a/internal/ui/ptyio/flush.go
+++ b/internal/ui/ptyio/flush.go
@@ -1,6 +1,7 @@
 package ptyio
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/perf"
@@ -50,8 +51,113 @@ func TrimOverflow(pending []byte, maxBuffered int, seed vterm.ParserCarryState) 
 	return append([]byte(nil), retainedSlice...), carry, droppedFromFront
 }
 
+// DEC 2026 synchronized output brackets one complete frame: ESC[?2026h tells
+// the terminal to hold the display steady, ESC[?2026l releases it. tmux wraps
+// every client redraw this way (amux advertises the sync terminal feature —
+// see internal/tmux/command.go), but it writes the client socket in ≤1KB
+// chunks, so any redraw bigger than that spans several reads: measured on a
+// streaming pane, 53% of reads end inside an open region.
+//
+// A flush that ends there hands the vterm half a frame. The vterm's freeze then
+// holds the *previous* frame, so the pane shows stale content and reports every
+// line dirty — a full repaint — until the next flush closes the region.
+//
+// So flushes end on frame boundaries: a flush stops at the last completed
+// region and leaves a partial frame buffered (TakeFlushChunkLocked), and when
+// nothing has completed there is nothing worth writing, so the flush waits
+// instead (FlushDelay). On the same streaming trace that takes flushes ending
+// mid-frame from 43% to ~1%, at an unchanged flush rate. Both waits are bounded
+// — the flush ceilings cap them, and a partial frame that reaches the terminal
+// anyway still has vterm.SyncStallTimeout behind it — so a writer that dies
+// mid-frame cannot stall the pane.
+
+// syncMarkerPrefix is the shared prefix of the DEC 2026 begin/end markers; the
+// byte after it selects which one — 'h' opens a region, 'l' closes it, and
+// anything else (notably '$' for a DECRQM query) is neither.
+//
+// Only this standalone form is recognized. The vterm's mode dispatch walks
+// every parameter, so it would also honor 2026 bundled with other modes
+// (ESC[?25;2026h); parsing parameter lists here would cost more than it is
+// worth while no known agent emits that form. The consequence of missing one
+// is bounded: that frame flushes half-drawn, exactly as it did before any of
+// this existed.
+var syncMarkerPrefix = []byte("\x1b[?2026")
+
+const (
+	// syncTailScanLimit bounds the marker scan so a large backlog does not pay
+	// for the whole buffer. It has to comfortably exceed one frame — a marker
+	// further back than this is invisible here, which for a sync-begin means the
+	// frame is flushed half-drawn after all — so it is sized for a full-screen
+	// truecolor repaint on a large pane rather than for the per-keystroke frames
+	// that motivated this. The scan stays cheap at that size: see
+	// BenchmarkScanSyncFrames, which is orders of magnitude under the cost of
+	// writing the same bytes to the vterm.
+	syncTailScanLimit = 64 * 1024
+	// syncHoldRetry is how soon a flush held for a partial frame retries. The
+	// frame body that closes the region also restarts the quiet period, so this
+	// only needs to be short enough not to add visible latency itself.
+	syncHoldRetry = 4 * time.Millisecond
+)
+
+// scanSyncFrames walks pending's DEC 2026 markers and reports how much of it
+// may be written without leaving the terminal inside an unterminated region —
+// all of it when the buffer does not end mid-frame, otherwise the prefix
+// through the last completed region, and 0 when nothing has completed — plus
+// whether a complete frame is in there at all.
+//
+// The scan runs forward rather than backward from the tail because bytes.Index
+// is vectorized and bytes.LastIndex is not; on a busy tab this runs on the UI
+// goroutine twice per flush, and the backward form costs ~100x more per byte.
+//
+// It reads pending in isolation, which costs it two cases the vterm's parser
+// sees and it does not: a terminal already inside a region (only reachable once
+// a chunk cap has split a frame too large to fall back from), and a marker
+// split across the cut. Both report a buffer as ending outside a frame when it
+// does not, and both cost at most the frozen frame that would have happened
+// anyway — never a dropped or reordered byte. Carrying that state would mean
+// threading the terminal through every flush call for cases that need a single
+// frame to exceed the chunk cap.
+func scanSyncFrames(pending []byte) (safeLen int, hasCompleteFrame bool) {
+	window, offset := pending, 0
+	if len(window) > syncTailScanLimit {
+		offset = len(window) - syncTailScanLimit
+		window = window[offset:]
+	}
+	lastEnd, open := -1, false
+	for i := 0; i < len(window); {
+		j := bytes.Index(window[i:], syncMarkerPrefix)
+		if j < 0 {
+			break
+		}
+		i += j + len(syncMarkerPrefix)
+		if i >= len(window) {
+			// A marker split by the buffer tail: the vterm parser carries the
+			// fragment, so it decides nothing here.
+			break
+		}
+		switch window[i] {
+		case 'h':
+			open = true
+		case 'l':
+			open = false
+			lastEnd = i + 1
+		}
+		i++
+	}
+	hasCompleteFrame = lastEnd >= 0 && !open
+	switch {
+	case !open:
+		return len(pending), hasCompleteFrame // the buffer does not end mid-frame
+	case lastEnd < 0:
+		return 0, false // nothing but a partial frame
+	default:
+		return offset + lastEnd, true
+	}
+}
+
 // FlushDelay implements the flush quiet-period policy: a flush is deferred
-// while output is still arriving (quietFor < quiet) unless it has already
+// while output is still arriving (quietFor < quiet), or while the buffer holds
+// only the opening half of a synchronized-output frame, unless it has already
 // been pending longer than maxInterval. It returns the delay before the next
 // flush attempt and whether the flush should be deferred.
 func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (time.Duration, bool) {
@@ -60,24 +166,57 @@ func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (ti
 	if !st.FlushPendingSince.IsZero() {
 		pendingFor = now.Sub(st.FlushPendingSince)
 	}
-	if quietFor < quiet && pendingFor < maxInterval {
+	safeLen, hasCompleteFrame := scanSyncFrames(st.PendingOutput)
+	// The quiet period is a guess at where a frame ends, for writers that give
+	// no better signal. A writer that brackets its frames has already said, so
+	// a finished frame goes out now instead of waiting out the debounce. This
+	// cannot flush more often than output arrives: the reader's frame-interval
+	// coalescing upstream is what actually caps the rate.
+	//
+	// Only at the base cadence, though. Every caller that wants a slower one —
+	// alt-screen timing, backpressure, the inactive-tab multipliers — asks by
+	// raising quiet above PtyFlushQuiet, and those exist to shed render work
+	// (an inactive tab flushes up to 12x less often). Skipping the wait for a
+	// finished frame would undo precisely the throttling they asked for, and
+	// tmux brackets every redraw, so it would fire on nearly every flush.
+	earlyFrameFlush := hasCompleteFrame && quiet <= PtyFlushQuiet
+	if quietFor < quiet && pendingFor < maxInterval && !earlyFrameFlush {
 		delay := quiet - quietFor
 		if delay < time.Millisecond {
 			delay = time.Millisecond
 		}
 		return delay, true
 	}
+	// Both ceilings bound the partial-frame hold independently: pendingFor caps
+	// it while output keeps arriving, quietFor caps it when the writer stopped
+	// mid-frame. Either one alone can stall — pendingFor is zero until a caller
+	// sets FlushPendingSince, and quietFor stays small under continuous output.
+	if pendingFor < maxInterval && quietFor < maxInterval && len(st.PendingOutput) > 0 && safeLen == 0 {
+		return syncHoldRetry, true
+	}
 	return 0, false
 }
 
 // TakeFlushChunkLocked removes up to maxChunk bytes from the front of
 // PendingOutput and returns a copy (nil when nothing is buffered). A
-// non-positive maxChunk takes the whole buffer. The caller must hold the
+// non-positive maxChunk takes the whole buffer. The chunk also stops at the
+// last completed synchronized-output frame, so complete frames are displayed
+// now and a partial frame at the tail stays buffered instead of freezing the
+// terminal mid-redraw. A zero safe length is deliberately not clamped: that is
+// the case FlushDelay already held for as long as its ceilings allow, and
+// taking nothing would spin the flush tick forever. The caller must hold the
 // state lock.
 func (st *State) TakeFlushChunkLocked(maxChunk int) []byte {
 	chunkSize := len(st.PendingOutput)
 	if maxChunk > 0 && chunkSize > maxChunk {
 		chunkSize = maxChunk
+	}
+	// Scan the prefix actually being taken, not the whole buffer: what matters
+	// is where this chunk ends. When maxChunk cuts a large backlog the buffer's
+	// own tail is irrelevant, and looking at it would miss the frame boundary
+	// sitting just before the cut.
+	if safe, _ := scanSyncFrames(st.PendingOutput[:chunkSize]); safe > 0 && safe < chunkSize {
+		chunkSize = safe
 	}
 	if chunkSize == 0 {
 		return nil

--- a/internal/ui/ptyio/flush_sync_test.go
+++ b/internal/ui/ptyio/flush_sync_test.go
@@ -1,0 +1,327 @@
+package ptyio
+
+// Coverage for the DEC 2026 half of the flush policy: which prefix of the
+// buffer is safe to hand the terminal, and what the chunk take does with the
+// partial frame left at the tail. The flush-gate side lives with the rest of
+// the timing policy in TestFlushDelay.
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+func TestScanSyncFrames(t *testing.T) {
+	tests := []struct {
+		name         string
+		pending      []byte
+		want         int
+		wantComplete bool
+	}{
+		{"empty buffer", nil, 0, false},
+		{"no markers", []byte("plain output"), len("plain output"), false},
+		{"lone sync begin", []byte("\x1b[?2026h"), 0, false},
+		{"open region with partial frame", []byte("\x1b[?2026h\x1b[2Khalf"), 0, false},
+		{"complete region", []byte("\x1b[?2026hframe\x1b[?2026l"), len("\x1b[?2026hframe\x1b[?2026l"), true},
+		{"trailing text after close", []byte("\x1b[?2026hframe\x1b[?2026lmore"), len("\x1b[?2026hframe\x1b[?2026lmore"), true},
+		{"close without open", []byte("frame\x1b[?2026l"), len("frame\x1b[?2026l"), true},
+		// The vterm answers DECRQM for mode 2026 (see executeDECRQM), so this
+		// query really does appear on the wire. It is not a region boundary.
+		{"DECRQM mode query", []byte("\x1b[?2026$p"), len("\x1b[?2026$p"), false},
+		{
+			"DECRQM query inside an open region",
+			[]byte("\x1b[?2026h\x1b[?2026$p"),
+			0, false,
+		},
+		{"marker truncated at the buffer tail", []byte("frame\x1b[?2026"), len("frame\x1b[?2026"), false},
+		{
+			"open region then a truncated marker",
+			[]byte("\x1b[?2026hframe\x1b[?2026"),
+			0, false,
+		},
+		{
+			"complete then reopened stops at the boundary",
+			[]byte("\x1b[?2026hone\x1b[?2026l\x1b[?2026htwo"),
+			len("\x1b[?2026hone\x1b[?2026l"), true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, complete := scanSyncFrames(tt.pending)
+			if got != tt.want {
+				t.Fatalf("scanSyncFrames safeLen = %d, want %d", got, tt.want)
+			}
+			if complete != tt.wantComplete {
+				t.Fatalf("scanSyncFrames hasCompleteFrame = %v, want %v", complete, tt.wantComplete)
+			}
+		})
+	}
+
+	// Only the tail is scanned, so a region that opened further back than
+	// syncTailScanLimit reads as closed rather than holding the flush forever.
+	t.Run("region older than the tail scan limit reads as closed", func(t *testing.T) {
+		pending := append([]byte("\x1b[?2026h"), bytes.Repeat([]byte("x"), syncTailScanLimit+16)...)
+		if got, _ := scanSyncFrames(pending); got != len(pending) {
+			t.Fatalf("scanSyncFrames safeLen = %d, want %d (whole buffer) beyond the tail scan limit", got, len(pending))
+		}
+	})
+
+	// A boundary inside the scanned tail is still reported as an absolute
+	// offset into the full buffer, not an offset into the window.
+	t.Run("boundary offset is absolute when the buffer is truncated", func(t *testing.T) {
+		head := bytes.Repeat([]byte("x"), syncTailScanLimit)
+		pending := append(append(head, []byte("\x1b[?2026hframe\x1b[?2026l")...), []byte("\x1b[?2026h")...)
+		want := len(pending) - len("\x1b[?2026h")
+		if got, _ := scanSyncFrames(pending); got != want {
+			t.Fatalf("scanSyncFrames safeLen = %d, want %d", got, want)
+		}
+	})
+}
+
+func TestTakeFlushChunkLockedSyncBoundary(t *testing.T) {
+	t.Run("stops at the last completed frame", func(t *testing.T) {
+		complete := "\x1b[?2026hone\x1b[?2026l"
+		st := &State{PendingOutput: []byte(complete + "\x1b[?2026h")}
+		chunk := st.TakeFlushChunkLocked(0)
+		if string(chunk) != complete {
+			t.Fatalf("chunk = %q, want %q (complete frame only)", chunk, complete)
+		}
+		if string(st.PendingOutput) != "\x1b[?2026h" {
+			t.Fatalf("PendingOutput = %q, want the partial frame left buffered", st.PendingOutput)
+		}
+	})
+
+	t.Run("takes a buffer that is only a partial frame rather than stalling", func(t *testing.T) {
+		st := &State{PendingOutput: []byte("\x1b[?2026h\x1b[2Khalf")}
+		chunk := st.TakeFlushChunkLocked(0)
+		if string(chunk) != "\x1b[?2026h\x1b[2Khalf" {
+			t.Fatalf("chunk = %q, want the whole buffer (no safe boundary to clamp to)", chunk)
+		}
+		if len(st.PendingOutput) != 0 {
+			t.Fatalf("PendingOutput = %q, want drained", st.PendingOutput)
+		}
+	})
+
+	t.Run("maxChunk still wins when it is the tighter bound", func(t *testing.T) {
+		st := &State{PendingOutput: []byte("\x1b[?2026hone\x1b[?2026l\x1b[?2026h")}
+		chunk := st.TakeFlushChunkLocked(4)
+		if len(chunk) != 4 {
+			t.Fatalf("len(chunk) = %d, want 4 (maxChunk)", len(chunk))
+		}
+	})
+
+	// When maxChunk cuts a large backlog the cut, not the buffer tail, is what
+	// can land mid-frame — so the boundary just before the cut is the one to
+	// find. The property under test is the terminal's state after the write,
+	// which is what a mid-frame chunk actually damages.
+	t.Run("a maxChunk cut inside a frame body falls back to the previous boundary", func(t *testing.T) {
+		first := "\x1b[?2026hone\x1b[?2026l"
+		st := &State{PendingOutput: []byte(first + "\x1b[?2026htwo\x1b[?2026l\x1b[?2026hthree\x1b[?2026l")}
+		cut := len(first) + len("\x1b[?2026h") + 1 // inside the second frame's body
+		chunk := st.TakeFlushChunkLocked(cut)
+		if string(chunk) != first {
+			t.Fatalf("chunk = %q, want %q (boundary before the cut)", chunk, first)
+		}
+		term := vterm.New(80, 24)
+		term.Write(chunk)
+		if term.SyncActive() {
+			t.Fatal("chunk left the terminal mid-frame")
+		}
+	})
+
+	// A cut inside the marker itself is harmless: no region has opened yet and
+	// the vterm parser carries the fragment to the next chunk.
+	t.Run("a maxChunk cut inside a marker leaves the terminal outside a frame", func(t *testing.T) {
+		first := "\x1b[?2026hone\x1b[?2026l"
+		st := &State{PendingOutput: []byte(first + "\x1b[?2026htwo\x1b[?2026l")}
+		chunk := st.TakeFlushChunkLocked(len(first) + 5)
+		term := vterm.New(80, 24)
+		term.Write(chunk)
+		if term.SyncActive() {
+			t.Fatalf("chunk %q left the terminal mid-frame", chunk)
+		}
+	})
+
+	t.Run("a maxChunk cut with no boundary before it takes the full chunk", func(t *testing.T) {
+		st := &State{PendingOutput: []byte("\x1b[?2026h" + string(bytes.Repeat([]byte("x"), 200)) + "\x1b[?2026l")}
+		chunk := st.TakeFlushChunkLocked(64)
+		if len(chunk) != 64 {
+			t.Fatalf("len(chunk) = %d, want 64 — no boundary exists to clamp to", len(chunk))
+		}
+	})
+
+	t.Run("buffer without markers is unaffected", func(t *testing.T) {
+		st := &State{PendingOutput: []byte("plain output")}
+		chunk := st.TakeFlushChunkLocked(0)
+		if string(chunk) != "plain output" {
+			t.Fatalf("chunk = %q, want the whole buffer", chunk)
+		}
+	})
+}
+
+// BenchmarkScanSyncFrames guards the flush hot path: scanSyncFrames runs on
+// the UI goroutine twice per flush (the gate, then the chunk take), so it has to
+// stay negligible against a busy tab's buffer. The scan direction is the whole
+// game here — an equivalent bytes.LastIndex implementation measured ~100x worse
+// per byte, enough to cost more than the flush it guards.
+func BenchmarkScanSyncFrames(b *testing.B) {
+	frame := append(append([]byte("\x1b[?2026h"), bytes.Repeat([]byte("x"), 1400)...), []byte("\x1b[?2026l")...)
+	cases := []struct {
+		name    string
+		pending []byte
+	}{
+		{"one frame", frame},
+		{"no markers", bytes.Repeat([]byte("x"), 1400)},
+		{"backlog past the scan limit", bytes.Repeat([]byte("x"), 1024*1024)},
+		{"scan window packed with frames", bytes.Repeat(frame, syncTailScanLimit/len(frame)+1)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = scanSyncFrames(tc.pending)
+			}
+		})
+	}
+}
+
+// TestFlushPipelineKeepsFramesWholeAndLossless drives the three pieces together
+// — buffer, gate, chunk take, vterm write — over a stream shaped the way tmux
+// actually delivers one: frames bracketed in DEC 2026, chopped into ≤1KB socket
+// writes, so most reads land inside a region. It asserts the two properties the
+// policy exists for: no flush ever leaves the terminal mid-frame, and not one
+// byte is dropped or reordered on the way there.
+//
+// The ceilings are set out of reach and the quiet period to zero so the gate
+// exercises the frame-boundary logic alone; the ceiling escapes are covered in
+// TestFlushDelay.
+func TestFlushPipelineKeepsFramesWholeAndLossless(t *testing.T) {
+	// Two regimes. At a realistic cap no frame comes close to it, so the
+	// no-mid-frame property must hold outright. At a cap smaller than a single
+	// frame the split is forced, and the guarantee weakens to what is actually
+	// achievable: the gap closes promptly and no byte is lost.
+	t.Run("realistic chunk cap", func(t *testing.T) {
+		flushPipelineRoundTrip(t, PtyFlushChunkSize, true)
+	})
+	t.Run("cap smaller than one frame", func(t *testing.T) {
+		flushPipelineRoundTrip(t, 512, false)
+	})
+}
+
+func flushPipelineRoundTrip(t *testing.T, chunkCap int, wantNoGaps bool) {
+	t.Helper()
+	const (
+		tmuxWrite = 1024
+		frames    = 40
+		quiet     = time.Duration(0)
+		ceiling   = time.Hour
+	)
+
+	var stream []byte
+	maxFrame := 0
+	for i := 0; i < frames; i++ {
+		row := bytes.Repeat([]byte("x"), 700+37*i%900)
+		frame := append([]byte("\x1b[?2026h"), row...)
+		frame = append(frame, []byte("\x1b[?2026l")...)
+		if len(frame) > maxFrame {
+			maxFrame = len(frame)
+		}
+		stream = append(stream, frame...)
+	}
+
+	var reads [][]byte
+	for off := 0; off < len(stream); off += tmuxWrite {
+		end := off + tmuxWrite
+		if end > len(stream) {
+			end = len(stream)
+		}
+		reads = append(reads, stream[off:end])
+	}
+
+	// Sanity: the fixture has to reproduce the hazard, or the test proves nothing.
+	midRegion, depth := 0, 0
+	for _, r := range reads {
+		depth += bytes.Count(r, []byte("\x1b[?2026h")) - bytes.Count(r, []byte("\x1b[?2026l"))
+		if depth > 0 {
+			midRegion++
+		}
+	}
+	if midRegion == 0 {
+		t.Fatalf("fixture does not split any region across reads (%d reads)", len(reads))
+	}
+	t.Logf("fixture: %d reads, %d (%d%%) end inside an open region",
+		len(reads), midRegion, 100*midRegion/len(reads))
+
+	term := vterm.New(120, 40)
+	st := &State{}
+	var written []byte
+	now := time.Now()
+	flushes, forced := 0, 0
+	gapOpenedAt, maxGapFlushes := 0, 0
+
+	for _, r := range reads {
+		st.PendingOutput = append(st.PendingOutput, r...)
+		now = now.Add(time.Millisecond)
+		st.LastOutputAt = now
+		if st.FlushPendingSince.IsZero() {
+			st.FlushPendingSince = now
+		}
+		for {
+			if _, deferred := st.FlushGate(now, quiet, ceiling); deferred {
+				break
+			}
+			chunk := st.TakeFlushChunkLocked(chunkCap)
+			if len(chunk) == 0 {
+				t.Fatal("flush gate passed but the take returned nothing — the flush tick would spin")
+			}
+			flushes++
+			written = append(written, chunk...)
+			safe, _ := scanSyncFrames(chunk)
+			wasActive := term.SyncActive()
+			term.Write(chunk)
+			// Check the transition, not the state: once the cap has forced a
+			// split the terminal stays mid-frame until that frame's closing
+			// bytes are written, and the chunks in between cannot help that.
+			if !wasActive && term.SyncActive() {
+				if wantNoGaps {
+					t.Fatalf("flush %d opened a mid-frame gap (chunk %d bytes, cap %d, safe %d)",
+						flushes, len(chunk), chunkCap, safe)
+				}
+				forced++
+				gapOpenedAt = flushes
+			}
+			if wasActive && !term.SyncActive() && gapOpenedAt > 0 {
+				if span := flushes - gapOpenedAt; span > maxGapFlushes {
+					maxGapFlushes = span
+				}
+				gapOpenedAt = 0
+			}
+			if !st.RearmFlush(now, nil) {
+				break
+			}
+		}
+	}
+
+	if flushes == 0 {
+		t.Fatal("no flushes happened")
+	}
+	t.Logf("%d flushes, %d forced mid-frame gaps (widest %d flushes) at a %d-byte cap",
+		flushes, forced, maxGapFlushes, chunkCap)
+	if gapOpenedAt != 0 {
+		t.Fatal("a mid-frame gap was still open when the stream ended")
+	}
+	// A forced split resolves as fast as the cap allows: the rest of the frame is
+	// already buffered, so it takes the chunks that frame needs and no more.
+	if want := (maxFrame+chunkCap-1)/chunkCap - 1; maxGapFlushes > want {
+		t.Fatalf("a mid-frame gap stayed open for %d flushes, want at most %d "+
+			"(largest frame %d bytes at a %d-byte cap)", maxGapFlushes, want, maxFrame, chunkCap)
+	}
+	if len(st.PendingOutput) != 0 {
+		t.Fatalf("%d bytes still buffered after a stream ending on a frame boundary", len(st.PendingOutput))
+	}
+	if !bytes.Equal(written, stream) {
+		t.Fatalf("stream corrupted: wrote %d bytes, want %d", len(written), len(stream))
+	}
+}

--- a/internal/ui/ptyio/flush_test.go
+++ b/internal/ui/ptyio/flush_test.go
@@ -331,4 +331,140 @@ func TestFlushDelay(t *testing.T) {
 			t.Fatalf("delay = %v, want %v", delay, want)
 		}
 	})
+
+	// A quiet buffer holding only the opening half of a DEC 2026 frame must not
+	// be flushed: writing a lone sync-begin freezes the vterm on the stale frame
+	// and marks every line dirty until the region closes.
+	t.Run("holds a buffer that is only the opening half of a sync frame", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026h"),
+		}
+		now := base.Add(quiet) // quiet period fully elapsed
+		delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval)
+		if !shouldDefer {
+			t.Fatalf("defer = false, want true while the frame is still incomplete")
+		}
+		if delay != syncHoldRetry {
+			t.Fatalf("delay = %v, want %v (sync hold retry)", delay, syncHoldRetry)
+		}
+	})
+
+	// A bracketed frame states its own end, so it does not wait out the quiet
+	// period that exists to guess where unbracketed output stops.
+	t.Run("a completed frame flushes without waiting out the quiet period", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026hframe\x1b[?2026l"),
+		}
+		now := base.Add(time.Millisecond) // well inside the quiet period
+		if delay, shouldDefer := st.FlushDelay(now, PtyFlushQuiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false for a completed frame", delay)
+		}
+	})
+
+	t.Run("output without frame markers still waits out the quiet period", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("plain streaming output"),
+		}
+		now := base.Add(time.Millisecond)
+		if _, shouldDefer := st.FlushDelay(now, PtyFlushQuiet, maxInterval); !shouldDefer {
+			t.Fatal("defer = false, want true — unbracketed output still needs the debounce")
+		}
+	})
+
+	// A raised quiet period is how the panes throttle: alt-screen timing,
+	// backpressure, and the inactive-tab multipliers all slow the cadence that
+	// way. tmux brackets every redraw, so an early flush that ignored them would
+	// fire on nearly every flush and undo the throttle.
+	t.Run("a completed frame still waits when the caller slowed the cadence", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026hframe\x1b[?2026l"),
+		}
+		throttled := PtyFlushQuiet * 4 // e.g. an inactive tab
+		now := base.Add(time.Millisecond)
+		if _, shouldDefer := st.FlushDelay(now, throttled, maxInterval); !shouldDefer {
+			t.Fatal("defer = false, want true — a throttled cadence must still be honored")
+		}
+	})
+
+	// The early flush must not fire for a frame that has not finished, or it
+	// would defeat the partial-frame hold entirely.
+	t.Run("a partial frame does not trigger the early flush", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026h\x1b[2Khalf"),
+		}
+		now := base.Add(time.Millisecond)
+		if _, shouldDefer := st.FlushDelay(now, PtyFlushQuiet, maxInterval); !shouldDefer {
+			t.Fatal("defer = false, want true while the frame is incomplete")
+		}
+	})
+
+	t.Run("flushes once the sync region closes", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026hframe\x1b[?2026l"),
+		}
+		now := base.Add(quiet)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false for a complete sync frame", delay)
+		}
+	})
+
+	// A completed frame ahead of a freshly opened one must not wait: the take
+	// path splits at the boundary, so the gate has to let it through.
+	t.Run("does not hold when a completed frame is buffered ahead of a partial one", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026hone\x1b[?2026l\x1b[?2026h"),
+		}
+		now := base.Add(quiet)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false when a complete frame is ready", delay)
+		}
+	})
+
+	t.Run("flushes a partial frame once pendingFor exceeds maxInterval", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base.Add(maxInterval), // output still arriving
+			FlushPendingSince: base,
+			PendingOutput:     []byte("\x1b[?2026h"),
+		}
+		now := base.Add(maxInterval + time.Millisecond)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false once pendingFor bounds the hold", delay)
+		}
+	})
+
+	// The pendingFor ceiling alone cannot bound the hold: FlushPendingSince is
+	// zero until a caller sets it, which would otherwise hold forever.
+	t.Run("flushes a partial frame once quietFor exceeds maxInterval", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:  base,
+			PendingOutput: []byte("\x1b[?2026h"),
+			// FlushPendingSince left zero -> pendingFor stays 0
+		}
+		now := base.Add(maxInterval + time.Millisecond)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false once the writer went quiet mid-frame", delay)
+		}
+	})
+
+	t.Run("empty buffer never holds for a partial frame", func(t *testing.T) {
+		st := &State{LastOutputAt: base, FlushPendingSince: base}
+		now := base.Add(quiet)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false for an empty buffer", delay)
+		}
+	})
 }


### PR DESCRIPTION
## What

tmux wraps every client redraw in DEC 2026 (amux advertises the `sync` terminal feature) but writes the client socket in ≤1KB chunks, so any redraw larger than that spans several reads. Measured on a streaming pane, **53% of reads end inside an open region, and 43% of flushes handed the vterm half a frame**. The vterm's sync freeze then holds the *previous* frame, so the pane showed stale content and reported every line dirty — a full repaint — until the next flush closed the region.

Flushes now end on frame boundaries:

- A chunk stops at the last completed region and leaves a partial frame buffered.
- When nothing has completed, the flush waits rather than writing an opening marker with no body.

On the same streaming trace that takes mid-frame flushes from **43% to ~1% at an unchanged flush rate** (134 flushes either way — the reader's frame-interval coalescing is the binding constraint). Both waits are bounded by the existing flush ceilings, with `vterm.SyncStallTimeout` behind them.

A completed frame also no longer waits out the quiet period — that debounce exists to guess where a frame ends, and a bracketed frame has already said. Worth **~8–12ms** of per-keystroke latency for agents whose redraws tmux brackets. This applies **only at the base cadence**: alt-screen timing, backpressure, and the inactive-tab multipliers all throttle by *raising* the quiet period, and skipping it would undo exactly the render work they shed (an inactive tab flushes up to 12x less often).

## Why

Started from droid feeling laggy to type in. That turned out to be mostly its own byte volume — it repaints 7 full lines per keystroke, so tmux ships ~1500 bytes across ~8.6 reads, against Claude Code's ~1.4 bytes in one read — which amux can't fix. But the frame-boundary bug was real and hits **every agent during streaming**.

## Notes

- The marker scan runs forward, not backward from the tail: `bytes.Index` is vectorized and `bytes.LastIndex` is not. It runs on the UI goroutine twice per flush, where the backward form measured ~100x worse per byte (504µs vs 45ns on a 64KB buffer). `BenchmarkScanSyncFrames` guards this: 26–55ns typical, zero allocations.
- The scan is stateless, which costs it two cases the vterm parser sees: a terminal already inside a region (only reachable once a chunk cap splits a frame too large to fall back from), and a marker split across the cut. Both cost at most the frozen frame that would have happened anyway, never a dropped byte. Documented at `scanSyncFrames`.
- `SCROLLING.md`'s frame-atomicity section claimed two mechanisms prevent torn frames; the vterm freeze alone is not sufficient, since it holds the previous frame. Updated to three.

## Test plan

- `TestFlushPipelineKeepsFramesWholeAndLossless` drives buffer → gate → take → vterm over a tmux-shaped stream (frames bracketed in DEC 2026, chopped into ≤1KB writes, 97% of reads landing inside a region) and asserts no flush leaves the terminal mid-frame and the byte stream arrives intact and in order. Run at two chunk caps: at a realistic cap the property holds outright (0 gaps); at a cap smaller than one frame the split is forced, and the gap is bounded by the chunks that frame requires.
- Center-level integration tests for the hold, the completed frame, the boundary split, and the bounded ceiling escape.
- All four behaviors mutation-checked — removing the hold, the clamp, the prefix scan, or the early flush each fails tests.
- `make devcheck`, `make lint-strict-new`, `make verify-loop` pass.
- `make perf-check` does not reach this code: both harness modes call `WriteToTerminal` → `Terminal.Write` directly and never enter the flush path.