### PR TITLE
feat: land in a live agent when creating a workspace

### DIFF
--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -110,6 +110,11 @@ type App struct {
 	pendingWorkspaceProject *data.Project
 	pendingWorkspaceName    string
 	pendingWorkspaceBase    string
+	// Assistant chosen during workspace creation, launched once that workspace
+	// is activated so creating a workspace lands the user in a live agent tab
+	// instead of making them re-pick the same assistant.
+	pendingLaunchWorkspaceID string
+	pendingLaunchAssistant   string
 
 	// commitAllFn is the git commit-all seam. Nil in production (falls back to
 	// git.CommitAll); tests install a fake to assert the dialog→commit wiring

--- a/internal/app/app_core.go
+++ b/internal/app/app_core.go
@@ -110,11 +110,13 @@ type App struct {
 	pendingWorkspaceProject *data.Project
 	pendingWorkspaceName    string
 	pendingWorkspaceBase    string
-	// Assistant chosen during workspace creation, launched once that workspace
-	// is activated so creating a workspace lands the user in a live agent tab
-	// instead of making them re-pick the same assistant.
-	pendingLaunchWorkspaceID string
-	pendingLaunchAssistant   string
+	// Assistants chosen during workspace creation, keyed by workspace ID and
+	// launched once that workspace is activated, so creating a workspace lands
+	// the user in a live agent tab instead of making them re-pick the same
+	// assistant. Keyed rather than a single slot because creations are async and
+	// unordered: two started back to back are both in flight, and a single slot
+	// would let the second overwrite the first, leaving it with no agent.
+	pendingLaunchAssistants map[string]string
 
 	// commitAllFn is the git commit-all seam. Nil in production (falls back to
 	// git.CommitAll); tests install a fake to assert the dialog→commit wiring

--- a/internal/app/app_input_messages_center.go
+++ b/internal/app/app_input_messages_center.go
@@ -27,6 +27,13 @@ func (a *App) handleLaunchAgent(msg messages.LaunchAgent) tea.Cmd {
 func (a *App) handleTabCreated(msg messages.TabCreated) tea.Cmd {
 	logging.Info("Tab created: %s", msg.Name)
 	cmd := a.center.StartPTYReaders()
+	// A layout too narrow for the center pane does not render it, so moving
+	// keyboard focus there would type into a tab the user cannot see. The tab
+	// still runs; it takes focus once the center is visible again. This mirrors
+	// the visibility checks in workspace activation and pane navigation.
+	if a.layout != nil && !a.layout.ShowCenter() {
+		return cmd
+	}
 	if a.center != nil && a.center.HasDiffViewer() {
 		a.setFocusedPane(messages.PaneCenter)
 		return cmd

--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -315,8 +315,10 @@ func (a *App) handleWorkspaceActivated(msg messages.WorkspaceActivated) []tea.Cm
 	}
 	a.sidebarTerminal.SetWorkspacePreview(msg.Workspace)
 	// Discover shared tmux tabs first; restore/sync happens below.
-	if discoverCmd := a.discoverWorkspaceTabsFromTmux(msg.Workspace); discoverCmd != nil {
-		cmds = append(cmds, discoverCmd)
+	if !a.hasPendingAgentLaunch(msg.Workspace) {
+		if discoverCmd := a.discoverWorkspaceTabsFromTmux(msg.Workspace); discoverCmd != nil {
+			cmds = append(cmds, discoverCmd)
+		}
 	}
 	if discoverTermCmd := a.discoverSidebarTerminalsFromTmux(msg.Workspace); discoverTermCmd != nil {
 		cmds = append(cmds, discoverTermCmd)
@@ -404,6 +406,12 @@ func (a *App) handleWorkspaceActivated(msg messages.WorkspaceActivated) []tea.Cm
 	// terminals are exempt, so a workspace that grew over the limit while
 	// active becomes evictable only once the user switches away.
 	a.enforceAttachedTerminalTabLimit()
+	// Start the assistant picked during creation, now that this workspace owns
+	// the center pane. The tab this creates re-runs the limit checks above via
+	// TabCreated, so it is enforced against the new tab too.
+	if cmd := a.launchPendingAgent(msg.Workspace); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	return cmds
 }
 

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -103,9 +104,95 @@ func (a *App) handleWorkspaceCreated(msg messages.WorkspaceCreated) []tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 		cmds = append(cmds, a.runSetupAsync(msg.Workspace))
+		// Open the new workspace immediately and arm the assistant the user
+		// already picked in the create flow, so creation ends in a live agent
+		// tab instead of a dashboard row they must click into and re-pick.
+		if cmd := a.activateCreatedWorkspace(msg.Workspace); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 	cmds = append(cmds, a.loadProjectsAfterCreate(msg.Workspace))
 	return cmds
+}
+
+// activateCreatedWorkspace returns a command activating a freshly created
+// workspace. The assistant recorded on the workspace is armed for launch and
+// fires from handleWorkspaceActivated, after the activation has switched the
+// center pane over, so the agent tab is created against the right workspace.
+func (a *App) activateCreatedWorkspace(ws *data.Workspace) tea.Cmd {
+	if ws == nil {
+		return nil
+	}
+	// Activating with an unresolvable project would leave activeWorkspace set
+	// and activeProject nil, which disables the workspace-scoped commands. Stay
+	// put instead and let the projects reload settle selection.
+	project := a.findProjectByPath(ws.Repo)
+	if project == nil {
+		logging.Warn("created workspace %s has no loaded project for %s; skipping activation", ws.ID(), ws.Repo)
+		return nil
+	}
+	if assistant := strings.TrimSpace(ws.Assistant); a.canAutoLaunchAssistant(assistant) {
+		a.pendingLaunchWorkspaceID = string(ws.ID())
+		a.pendingLaunchAssistant = assistant
+	}
+	// The projects reload carrying this workspace is still in flight, so the
+	// dashboard holds the selection until its row appears.
+	if a.dashboard != nil {
+		a.dashboard.SelectWorkspace(string(ws.ID()))
+	}
+	return func() tea.Msg {
+		return messages.WorkspaceActivated{Project: project, Workspace: ws}
+	}
+}
+
+// canAutoLaunchAssistant reports whether the assistant recorded on a new
+// workspace can be started for the user. Agent tabs need tmux, so a host
+// without it is left alone: the explicit new-agent paths report that with an
+// install hint rather than failing silently from an auto-launch. An unfinished
+// tmux check is treated as available — it settles during startup, long before
+// a workspace can be created, and assuming otherwise would skip the launch.
+func (a *App) canAutoLaunchAssistant(assistant string) bool {
+	if assistant == "" || !a.isKnownAssistant(assistant) {
+		return false
+	}
+	return a.tmuxAvailable || !a.tmuxCheckDone
+}
+
+// hasPendingAgentLaunch reports whether ws is a workspace created moments ago
+// whose assistant is about to be launched, which activation uses to skip the
+// tmux agent discovery it would otherwise queue in the same batch as the
+// launch. Both run concurrently, so a delayed scan could list the session the
+// launch just created and, finding no tab registered for it yet, adopt it into
+// a second tab bound to the same session. A workspace created this instant owns
+// no sessions this process did not just start, so the scan has nothing to find.
+//
+// This covers only that same-batch scan. The periodic sync tick
+// (handleTmuxSyncTick) runs the same discovery against the active workspace and
+// can still land inside the window between session creation and tab
+// registration — a pre-existing race shared with the manual new-agent flow,
+// since the arming is already consumed by the time that window opens. Closing
+// it needs the center to dedupe against in-flight session names.
+func (a *App) hasPendingAgentLaunch(ws *data.Workspace) bool {
+	if ws == nil || a.pendingLaunchWorkspaceID == "" {
+		return false
+	}
+	return string(ws.ID()) == a.pendingLaunchWorkspaceID
+}
+
+// launchPendingAgent starts the assistant armed by activateCreatedWorkspace
+// when ws is the workspace it was armed for. The arming is single-shot: it is
+// cleared whether or not a launch command is produced.
+func (a *App) launchPendingAgent(ws *data.Workspace) tea.Cmd {
+	if !a.hasPendingAgentLaunch(ws) {
+		return nil
+	}
+	assistant := a.pendingLaunchAssistant
+	a.pendingLaunchWorkspaceID = ""
+	a.pendingLaunchAssistant = ""
+	if assistant == "" || a.center == nil {
+		return nil
+	}
+	return a.handleLaunchAgent(messages.LaunchAgent{Assistant: assistant, Workspace: ws})
 }
 
 // handleWorkspaceSetupComplete handles the WorkspaceSetupComplete message.

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -26,6 +26,11 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		return nil
 	}
 	a.lifecycle.clearCreatedProjectLoadBarrier(string(msg.Workspace.ID()), msg.Workspace.Root)
+	// Disarm any auto-launch still pending for this workspace. Workspace IDs are
+	// derived from project+name, so a delete-then-recreate at the same name
+	// reuses the ID (see the recreate note in handleWorkspaceDeleted below) and a
+	// stale arming would otherwise fire against the new workspace.
+	a.clearPendingAgentLaunchFor(msg.Workspace)
 	// Do NOT kill the workspace's tmux sessions here. All real delete validation
 	// (primary-checkout guard, repo/path checks, worktree removal) runs later in
 	// the async DeleteWorkspace cmd; killing up-front means a rejected or failed
@@ -132,8 +137,10 @@ func (a *App) activateCreatedWorkspace(ws *data.Workspace) tea.Cmd {
 		return nil
 	}
 	if assistant := strings.TrimSpace(ws.Assistant); a.canAutoLaunchAssistant(assistant) {
-		a.pendingLaunchWorkspaceID = string(ws.ID())
-		a.pendingLaunchAssistant = assistant
+		if a.pendingLaunchAssistants == nil {
+			a.pendingLaunchAssistants = make(map[string]string)
+		}
+		a.pendingLaunchAssistants[string(ws.ID())] = assistant
 	}
 	// The projects reload carrying this workspace is still in flight, so the
 	// dashboard holds the selection until its row appears.
@@ -173,10 +180,20 @@ func (a *App) canAutoLaunchAssistant(assistant string) bool {
 // since the arming is already consumed by the time that window opens. Closing
 // it needs the center to dedupe against in-flight session names.
 func (a *App) hasPendingAgentLaunch(ws *data.Workspace) bool {
-	if ws == nil || a.pendingLaunchWorkspaceID == "" {
+	if ws == nil || len(a.pendingLaunchAssistants) == 0 {
 		return false
 	}
-	return string(ws.ID()) == a.pendingLaunchWorkspaceID
+	_, ok := a.pendingLaunchAssistants[string(ws.ID())]
+	return ok
+}
+
+// clearPendingAgentLaunchFor disarms a pending auto-launch when it belongs to
+// ws. Armings for other workspaces are left alone.
+func (a *App) clearPendingAgentLaunchFor(ws *data.Workspace) {
+	if ws == nil {
+		return
+	}
+	delete(a.pendingLaunchAssistants, string(ws.ID()))
 }
 
 // launchPendingAgent starts the assistant armed by activateCreatedWorkspace
@@ -186,9 +203,8 @@ func (a *App) launchPendingAgent(ws *data.Workspace) tea.Cmd {
 	if !a.hasPendingAgentLaunch(ws) {
 		return nil
 	}
-	assistant := a.pendingLaunchAssistant
-	a.pendingLaunchWorkspaceID = ""
-	a.pendingLaunchAssistant = ""
+	assistant := a.pendingLaunchAssistants[string(ws.ID())]
+	delete(a.pendingLaunchAssistants, string(ws.ID()))
 	if assistant == "" || a.center == nil {
 		return nil
 	}

--- a/internal/app/app_workspace_created_autolaunch_test.go
+++ b/internal/app/app_workspace_created_autolaunch_test.go
@@ -46,39 +46,87 @@ func TestHandleWorkspaceCreatedActivatesAndArmsAssistant(t *testing.T) {
 	if activated.Project == nil || activated.Project.Path != "/repo" {
 		t.Fatalf("expected activation to carry the owning project, got %v", activated.Project)
 	}
-	if app.pendingLaunchWorkspaceID != string(ws.ID()) {
-		t.Fatalf("expected assistant armed for %s, got %q", ws.ID(), app.pendingLaunchWorkspaceID)
-	}
-	if app.pendingLaunchAssistant != "claude" {
-		t.Fatalf("expected armed assistant claude, got %q", app.pendingLaunchAssistant)
+	if got := app.pendingLaunchAssistants[string(ws.ID())]; got != "claude" {
+		t.Fatalf("expected claude armed for %s, got %q", ws.ID(), got)
 	}
 }
 
-// Activating the workspace the assistant was armed for consumes the arming so
-// the agent is launched exactly once.
+// activationApp builds an App wired enough to run handleWorkspaceActivated,
+// with the center pane visible.
+func activationApp(t *testing.T) *App {
+	t.Helper()
+	layoutManager := layout.NewManager()
+	layoutManager.Resize(140, 40)
+	return &App{
+		layout:          layoutManager,
+		dashboard:       dashboard.New(),
+		center:          center.New(nil),
+		sidebar:         sidebar.NewTabbedSidebar(),
+		sidebarTerminal: sidebar.NewTerminalModel(),
+	}
+}
+
+// Activating the workspace the assistant was armed for consumes the arming and
+// contributes a launch command. The command count is compared against an
+// identical unarmed activation because the launch is a queued tea.Cmd with no
+// synchronous side effect to observe — dropping it (rather than appending it to
+// cmds) would leave the arming cleared but start no agent, which a
+// fields-only assertion cannot catch.
 func TestHandleWorkspaceActivatedConsumesArmedAssistant(t *testing.T) {
 	project := data.NewProject("/repo")
 	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
 	project.Workspaces = append(project.Workspaces, *ws)
+	activation := messages.WorkspaceActivated{Project: project, Workspace: ws}
 
-	layoutManager := layout.NewManager()
-	layoutManager.Resize(140, 40)
+	unarmed := activationApp(t)
+	baseline := len(unarmed.handleWorkspaceActivated(activation))
 
-	app := &App{
-		layout:                   layoutManager,
-		dashboard:                dashboard.New(),
-		center:                   center.New(nil),
-		sidebar:                  sidebar.NewTabbedSidebar(),
-		sidebarTerminal:          sidebar.NewTerminalModel(),
-		pendingLaunchWorkspaceID: string(ws.ID()),
-		pendingLaunchAssistant:   "claude",
+	armed := activationApp(t)
+	armed.pendingLaunchAssistants = map[string]string{string(ws.ID()): "claude"}
+	got := len(armed.handleWorkspaceActivated(activation))
+
+	if len(armed.pendingLaunchAssistants) != 0 {
+		t.Fatalf("expected armed assistant to be consumed, got %v", armed.pendingLaunchAssistants)
 	}
+	if got != baseline+1 {
+		t.Fatalf("expected the armed activation to queue one extra (launch) command: got %d, unarmed %d", got, baseline)
+	}
+}
 
-	app.handleWorkspaceActivated(messages.WorkspaceActivated{Project: project, Workspace: ws})
+// The armed activation must skip the tmux agent discovery it would otherwise
+// queue alongside the launch, so a scan cannot adopt the session being created
+// into a duplicate tab. Removing that guard is invisible to a test that only
+// exercises hasPendingAgentLaunch directly, so this asserts the command count
+// actually drops.
+func TestHandleWorkspaceActivatedSkipsDiscoveryWhileArmed(t *testing.T) {
+	project := data.NewProject("/repo")
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	ws.OpenTabs = []data.TabInfo{{Assistant: "claude", Name: "claude", SessionName: "amux-existing", Status: "running"}}
+	project.Workspaces = append(project.Workspaces, *ws)
+	activation := messages.WorkspaceActivated{Project: project, Workspace: ws}
 
-	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
-		t.Fatalf("expected armed assistant to be consumed, got %q/%q",
-			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	// tmuxService must be present for discoverWorkspaceTabsFromTmux to produce a
+	// command at all; tmuxAvailable gates it.
+	unarmed := activationApp(t)
+	unarmed.tmuxAvailable = true
+	unarmed.tmuxService = stubTmuxOps{}
+	withDiscovery := len(unarmed.handleWorkspaceActivated(activation))
+
+	armed := activationApp(t)
+	armed.tmuxAvailable = true
+	armed.tmuxService = stubTmuxOps{}
+	armed.pendingLaunchAssistants = map[string]string{string(ws.ID()): "claude"}
+	withLaunch := len(armed.handleWorkspaceActivated(activation))
+
+	// Armed: one discovery command dropped, one launch command added.
+	if withLaunch != withDiscovery {
+		t.Fatalf("expected the armed activation to trade discovery for the launch: got %d, unarmed %d", withLaunch, withDiscovery)
+	}
+	// Guard the guard: prove discovery really was queued in the unarmed case, so
+	// the equality above cannot be satisfied by discovery never running at all.
+	noTmux := activationApp(t)
+	if base := len(noTmux.handleWorkspaceActivated(activation)); base >= withDiscovery {
+		t.Fatalf("expected tmux-enabled activation to queue a discovery command: %d vs %d without tmux", withDiscovery, base)
 	}
 }
 
@@ -89,15 +137,14 @@ func TestLaunchPendingAgentIgnoresOtherWorkspaces(t *testing.T) {
 	other := data.NewWorkspace("other", "other", "main", "/repo", "/repo/other")
 
 	app := &App{
-		pendingLaunchWorkspaceID: string(created.ID()),
-		pendingLaunchAssistant:   "claude",
+		pendingLaunchAssistants: map[string]string{string(created.ID()): "claude"},
 	}
 
 	if cmd := app.launchPendingAgent(other); cmd != nil {
 		t.Fatal("expected no launch for an unrelated workspace")
 	}
-	if app.pendingLaunchWorkspaceID != string(created.ID()) {
-		t.Fatalf("expected arming to survive, got %q", app.pendingLaunchWorkspaceID)
+	if app.pendingLaunchAssistants[string(created.ID())] != "claude" {
+		t.Fatalf("expected arming to survive, got %v", app.pendingLaunchAssistants)
 	}
 }
 
@@ -109,8 +156,7 @@ func TestHasPendingAgentLaunchMatchesOnlyTheArmedWorkspace(t *testing.T) {
 	other := data.NewWorkspace("other", "other", "main", "/repo", "/repo/other")
 
 	app := &App{
-		pendingLaunchWorkspaceID: string(created.ID()),
-		pendingLaunchAssistant:   "claude",
+		pendingLaunchAssistants: map[string]string{string(created.ID()): "claude"},
 	}
 
 	if !app.hasPendingAgentLaunch(created) {
@@ -123,7 +169,7 @@ func TestHasPendingAgentLaunchMatchesOnlyTheArmedWorkspace(t *testing.T) {
 		t.Fatal("expected no match for a nil workspace")
 	}
 
-	app.pendingLaunchWorkspaceID = ""
+	delete(app.pendingLaunchAssistants, string(created.ID()))
 	if app.hasPendingAgentLaunch(created) {
 		t.Fatal("expected discovery to resume once the launch is consumed")
 	}
@@ -146,9 +192,8 @@ func TestActivateCreatedWorkspaceSkipsUnknownAssistant(t *testing.T) {
 	if cmd := app.activateCreatedWorkspace(ws); cmd == nil {
 		t.Fatal("expected the workspace to be activated anyway")
 	}
-	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
-		t.Fatalf("expected no arming for an unknown assistant, got %q/%q",
-			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	if len(app.pendingLaunchAssistants) != 0 {
+		t.Fatalf("expected no arming for an unknown assistant, got %v", app.pendingLaunchAssistants)
 	}
 }
 
@@ -164,9 +209,8 @@ func TestActivateCreatedWorkspaceSkipsLaunchWithoutTmux(t *testing.T) {
 	if cmd := app.activateCreatedWorkspace(ws); cmd == nil {
 		t.Fatal("expected the workspace to be activated even without tmux")
 	}
-	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
-		t.Fatalf("expected no arming without tmux, got %q/%q",
-			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	if len(app.pendingLaunchAssistants) != 0 {
+		t.Fatalf("expected no arming without tmux, got %v", app.pendingLaunchAssistants)
 	}
 }
 
@@ -182,9 +226,8 @@ func TestActivateCreatedWorkspaceSkipsUnknownProject(t *testing.T) {
 	if cmd := app.activateCreatedWorkspace(ws); cmd != nil {
 		t.Fatal("expected no activation for a workspace with no loaded project")
 	}
-	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
-		t.Fatalf("expected no arming without an activation, got %q/%q",
-			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	if len(app.pendingLaunchAssistants) != 0 {
+		t.Fatalf("expected no arming without an activation, got %v", app.pendingLaunchAssistants)
 	}
 }
 
@@ -225,5 +268,91 @@ func TestHandleTabCreatedFocusesVisibleCenter(t *testing.T) {
 
 	if app.focusedPane != messages.PaneCenter {
 		t.Fatalf("expected focus to move to the center pane, got %v", app.focusedPane)
+	}
+}
+
+// Two creations can be in flight at once — the create dialog closes immediately
+// and the dashboard stays usable — and their completion order is not
+// guaranteed. Each workspace must keep its own armed assistant: a single shared
+// slot let the second creation overwrite the first, so the first workspace was
+// activated with nothing armed and silently got no agent.
+func TestConcurrentCreationsEachKeepTheirArmedAssistant(t *testing.T) {
+	project := data.NewProject("/repo")
+	first := data.NewWorkspace("first", "first", "main", "/repo", "/repo/first")
+	first.Assistant = "claude"
+	second := data.NewWorkspace("second", "second", "main", "/repo", "/repo/second")
+	second.Assistant = "codex"
+
+	app := &App{
+		lifecycle: newWorkspaceLifecycleState(),
+		dashboard: dashboard.New(),
+		center:    center.New(nil),
+	}
+	app.projects = []data.Project{*project}
+
+	// Both creations complete before either activation is processed.
+	app.handleWorkspaceCreated(messages.WorkspaceCreated{Workspace: first})
+	app.handleWorkspaceCreated(messages.WorkspaceCreated{Workspace: second})
+
+	if got := app.pendingLaunchAssistants[string(first.ID())]; got != "claude" {
+		t.Fatalf("expected the first workspace to keep claude armed, got %q", got)
+	}
+	if got := app.pendingLaunchAssistants[string(second.ID())]; got != "codex" {
+		t.Fatalf("expected the second workspace to keep codex armed, got %q", got)
+	}
+
+	// Each activation consumes only its own arming.
+	if cmd := app.launchPendingAgent(first); cmd == nil {
+		t.Fatal("expected the first workspace to still launch its agent")
+	}
+	if app.hasPendingAgentLaunch(first) {
+		t.Fatal("expected the first arming to be consumed")
+	}
+	if got := app.pendingLaunchAssistants[string(second.ID())]; got != "codex" {
+		t.Fatalf("expected the second arming to survive, got %q", got)
+	}
+}
+
+// Deleting a workspace disarms its pending launch. Workspace IDs are a hash of
+// project+name, so a delete-then-recreate at the same name reuses the ID and a
+// stale arming would fire against the new workspace.
+func TestDeleteWorkspaceDisarmsPendingLaunch(t *testing.T) {
+	doomed := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	other := data.NewWorkspace("other", "other", "main", "/repo", "/repo/other")
+	project := data.NewProject("/repo")
+
+	app := &App{
+		lifecycle: newWorkspaceLifecycleState(),
+		dashboard: dashboard.New(),
+		pendingLaunchAssistants: map[string]string{
+			string(doomed.ID()): "claude",
+			string(other.ID()):  "codex",
+		},
+	}
+
+	app.handleDeleteWorkspace(messages.DeleteWorkspace{Project: project, Workspace: doomed})
+
+	if app.hasPendingAgentLaunch(doomed) {
+		t.Fatal("expected the deleted workspace's launch to be disarmed")
+	}
+	if got := app.pendingLaunchAssistants[string(other.ID())]; got != "codex" {
+		t.Fatalf("expected an unrelated arming to survive the delete, got %q", got)
+	}
+}
+
+// The tmux check resolves during startup, long before a workspace can be
+// created. Treating "not yet checked" as unavailable would skip the launch on a
+// perfectly good host, so the unresolved case must arm.
+func TestCanAutoLaunchAssistantArmsBeforeTmuxCheckResolves(t *testing.T) {
+	unresolved := &App{tmuxCheckDone: false, tmuxAvailable: false}
+	if !unresolved.canAutoLaunchAssistant("claude") {
+		t.Fatal("expected an unresolved tmux check to arm the launch")
+	}
+	resolvedMissing := &App{tmuxCheckDone: true, tmuxAvailable: false}
+	if resolvedMissing.canAutoLaunchAssistant("claude") {
+		t.Fatal("expected a resolved-missing tmux check to skip the launch")
+	}
+	if (&App{tmuxAvailable: true}).canAutoLaunchAssistant("") {
+		t.Fatal("expected an empty assistant to never arm")
 	}
 }

--- a/internal/app/app_workspace_created_autolaunch_test.go
+++ b/internal/app/app_workspace_created_autolaunch_test.go
@@ -1,0 +1,229 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/config"
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+	"github.com/andyrewlee/amux/internal/ui/layout"
+	"github.com/andyrewlee/amux/internal/ui/sidebar"
+)
+
+// A workspace created from the dialog already carries the assistant the user
+// picked, so creation must activate that workspace and arm its assistant rather
+// than dropping the user back on the dashboard to pick the same agent again.
+func TestHandleWorkspaceCreatedActivatesAndArmsAssistant(t *testing.T) {
+	project := data.NewProject("/repo")
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	ws.Assistant = "claude"
+
+	app := &App{
+		lifecycle: newWorkspaceLifecycleState(),
+		dashboard: dashboard.New(),
+	}
+	app.projects = []data.Project{*project}
+
+	cmds := app.handleWorkspaceCreated(messages.WorkspaceCreated{Workspace: ws})
+
+	var activated *messages.WorkspaceActivated
+	for _, cmd := range cmds {
+		if cmd == nil {
+			continue
+		}
+		if msg, ok := cmd().(messages.WorkspaceActivated); ok {
+			activated = &msg
+		}
+	}
+	if activated == nil {
+		t.Fatal("expected the created workspace to be activated")
+	}
+	if activated.Workspace != ws {
+		t.Fatalf("expected activation of the created workspace, got %v", activated.Workspace)
+	}
+	if activated.Project == nil || activated.Project.Path != "/repo" {
+		t.Fatalf("expected activation to carry the owning project, got %v", activated.Project)
+	}
+	if app.pendingLaunchWorkspaceID != string(ws.ID()) {
+		t.Fatalf("expected assistant armed for %s, got %q", ws.ID(), app.pendingLaunchWorkspaceID)
+	}
+	if app.pendingLaunchAssistant != "claude" {
+		t.Fatalf("expected armed assistant claude, got %q", app.pendingLaunchAssistant)
+	}
+}
+
+// Activating the workspace the assistant was armed for consumes the arming so
+// the agent is launched exactly once.
+func TestHandleWorkspaceActivatedConsumesArmedAssistant(t *testing.T) {
+	project := data.NewProject("/repo")
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	project.Workspaces = append(project.Workspaces, *ws)
+
+	layoutManager := layout.NewManager()
+	layoutManager.Resize(140, 40)
+
+	app := &App{
+		layout:                   layoutManager,
+		dashboard:                dashboard.New(),
+		center:                   center.New(nil),
+		sidebar:                  sidebar.NewTabbedSidebar(),
+		sidebarTerminal:          sidebar.NewTerminalModel(),
+		pendingLaunchWorkspaceID: string(ws.ID()),
+		pendingLaunchAssistant:   "claude",
+	}
+
+	app.handleWorkspaceActivated(messages.WorkspaceActivated{Project: project, Workspace: ws})
+
+	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
+		t.Fatalf("expected armed assistant to be consumed, got %q/%q",
+			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	}
+}
+
+// Activating some other workspace while a creation is in flight must leave the
+// arming alone: the agent belongs to the workspace that was created.
+func TestLaunchPendingAgentIgnoresOtherWorkspaces(t *testing.T) {
+	created := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	other := data.NewWorkspace("other", "other", "main", "/repo", "/repo/other")
+
+	app := &App{
+		pendingLaunchWorkspaceID: string(created.ID()),
+		pendingLaunchAssistant:   "claude",
+	}
+
+	if cmd := app.launchPendingAgent(other); cmd != nil {
+		t.Fatal("expected no launch for an unrelated workspace")
+	}
+	if app.pendingLaunchWorkspaceID != string(created.ID()) {
+		t.Fatalf("expected arming to survive, got %q", app.pendingLaunchWorkspaceID)
+	}
+}
+
+// hasPendingAgentLaunch gates the activation-time tmux agent discovery, which
+// would otherwise race the launch and adopt its session into a second tab. It
+// must be true only for the workspace whose launch is still armed.
+func TestHasPendingAgentLaunchMatchesOnlyTheArmedWorkspace(t *testing.T) {
+	created := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	other := data.NewWorkspace("other", "other", "main", "/repo", "/repo/other")
+
+	app := &App{
+		pendingLaunchWorkspaceID: string(created.ID()),
+		pendingLaunchAssistant:   "claude",
+	}
+
+	if !app.hasPendingAgentLaunch(created) {
+		t.Fatal("expected the armed workspace to skip agent discovery")
+	}
+	if app.hasPendingAgentLaunch(other) {
+		t.Fatal("expected an unrelated workspace to still discover agent tabs")
+	}
+	if app.hasPendingAgentLaunch(nil) {
+		t.Fatal("expected no match for a nil workspace")
+	}
+
+	app.pendingLaunchWorkspaceID = ""
+	if app.hasPendingAgentLaunch(created) {
+		t.Fatal("expected discovery to resume once the launch is consumed")
+	}
+}
+
+// An unknown assistant (a stale value on the workspace record) must not arm a
+// launch; creation still activates the workspace.
+func TestActivateCreatedWorkspaceSkipsUnknownAssistant(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	ws.Assistant = "not-an-agent"
+
+	app := &App{
+		dashboard: dashboard.New(),
+		config: &config.Config{
+			Assistants: map[string]config.AssistantConfig{"claude": {Command: "claude"}},
+		},
+	}
+	app.projects = []data.Project{*data.NewProject("/repo")}
+
+	if cmd := app.activateCreatedWorkspace(ws); cmd == nil {
+		t.Fatal("expected the workspace to be activated anyway")
+	}
+	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
+		t.Fatalf("expected no arming for an unknown assistant, got %q/%q",
+			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	}
+}
+
+// Agent tabs need tmux. Without it the explicit new-agent paths report an
+// install hint, so an auto-launch must not fire and fail on its own.
+func TestActivateCreatedWorkspaceSkipsLaunchWithoutTmux(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/repo", "/repo/feature")
+	ws.Assistant = "claude"
+
+	app := &App{dashboard: dashboard.New(), tmuxCheckDone: true, tmuxAvailable: false}
+	app.projects = []data.Project{*data.NewProject("/repo")}
+
+	if cmd := app.activateCreatedWorkspace(ws); cmd == nil {
+		t.Fatal("expected the workspace to be activated even without tmux")
+	}
+	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
+		t.Fatalf("expected no arming without tmux, got %q/%q",
+			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	}
+}
+
+// A workspace whose project is not loaded must not be activated: that would
+// leave activeWorkspace set with a nil activeProject, disabling the
+// workspace-scoped commands.
+func TestActivateCreatedWorkspaceSkipsUnknownProject(t *testing.T) {
+	ws := data.NewWorkspace("feature", "feature", "main", "/gone", "/gone/feature")
+	ws.Assistant = "claude"
+
+	app := &App{dashboard: dashboard.New()}
+
+	if cmd := app.activateCreatedWorkspace(ws); cmd != nil {
+		t.Fatal("expected no activation for a workspace with no loaded project")
+	}
+	if app.pendingLaunchWorkspaceID != "" || app.pendingLaunchAssistant != "" {
+		t.Fatalf("expected no arming without an activation, got %q/%q",
+			app.pendingLaunchWorkspaceID, app.pendingLaunchAssistant)
+	}
+}
+
+// A layout too narrow to render the center pane must not take keyboard focus
+// when a tab is created: the auto-launch now creates a tab on every workspace
+// creation, and focusing a hidden pane would send keystrokes to an agent the
+// user cannot see.
+func TestHandleTabCreatedKeepsFocusWhenCenterHidden(t *testing.T) {
+	narrow := layout.NewManager()
+	narrow.Resize(60, 30)
+	if narrow.ShowCenter() {
+		t.Fatal("expected a 60-column layout to hide the center pane")
+	}
+
+	app := &App{layout: narrow, center: center.New(nil), dashboard: dashboard.New()}
+	app.setFocusedPane(messages.PaneDashboard)
+
+	app.handleTabCreated(messages.TabCreated{Name: "claude"})
+
+	if app.focusedPane != messages.PaneDashboard {
+		t.Fatalf("expected focus to stay on the dashboard, got %v", app.focusedPane)
+	}
+}
+
+// The same tab creation in a layout that does render the center pane still
+// focuses it, so the user lands in the agent they just started.
+func TestHandleTabCreatedFocusesVisibleCenter(t *testing.T) {
+	wide := layout.NewManager()
+	wide.Resize(140, 40)
+	if !wide.ShowCenter() {
+		t.Fatal("expected a 140-column layout to show the center pane")
+	}
+
+	app := &App{layout: wide, center: center.New(nil), dashboard: dashboard.New()}
+	app.setFocusedPane(messages.PaneDashboard)
+
+	app.handleTabCreated(messages.TabCreated{Name: "claude"})
+
+	if app.focusedPane != messages.PaneCenter {
+		t.Fatalf("expected focus to move to the center pane, got %v", app.focusedPane)
+	}
+}

--- a/internal/e2e/agent_dupe_test.go
+++ b/internal/e2e/agent_dupe_test.go
@@ -35,14 +35,10 @@ func TestWorkspaceCreateAgentsHaveDistinctSessions(t *testing.T) {
 
 	waitForUIContains(t, session, filepath.Base(repo), workspaceAgentTimeout)
 
-	createWorkspaceAndOpenAgentPicker(t, session, "feature", workspaceAgentTimeout)
-	selectAgentFromPicker(t, session, 0) // claude
-	if err := session.WaitForAbsent("New Agent", 3*time.Second); err != nil {
-		t.Fatalf("wait for picker close: %v", err)
-	}
-	createAgentTabWithSelection(t, session, 1, workspaceAgentTimeout) // codex
-
 	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
+	createWorkspaceWithAgent(t, session, "feature", opts, workspaceAgentTimeout) // claude
+	createAgentTabWithSelection(t, session, 1, workspaceAgentTimeout)            // codex
+
 	byAssistant := waitForAssistantSessions(t, opts, map[string]bool{"claude": true, "codex": true}, workspaceAgentTimeout)
 
 	uniqueSessions := make(map[string]struct{})

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/tmux"
 )
 
 func createWorkspaceFromDashboard(t *testing.T, session *PTYSession, name string) {
@@ -25,16 +26,27 @@ func createWorkspaceFromDashboard(t *testing.T, session *PTYSession, name string
 	}
 }
 
-func createWorkspaceAndOpenAgentPicker(t *testing.T, session *PTYSession, name string, timeout time.Duration) {
+// createWorkspaceWithAgent drives the dashboard create flow and picks the first
+// assistant. Creation activates the new workspace and launches that assistant,
+// so this returns with the agent tab already live — the caller does not have to
+// click into the workspace and pick the same agent a second time.
+//
+// It returns only once that agent's tmux session exists. The screen shows the
+// workspace name while creation is still running (the dashboard renders a
+// creating placeholder row), so waiting on text alone would hand back control
+// before the workspace is active — and a leader sequence sent then lands with
+// no active workspace and is answered with "select a workspace" instead of the
+// agent picker.
+func createWorkspaceWithAgent(t *testing.T, session *PTYSession, name string, opts tmux.Options, timeout time.Duration) {
 	t.Helper()
 	createWorkspaceFromDashboard(t, session, name)
 	waitForUIContains(t, session, "New Agent", timeout)
 	selectAgentFromPicker(t, session, 0)
+	if err := session.WaitForAbsent("New Agent", timeout); err != nil {
+		t.Fatalf("wait for agent picker to close: %v", err)
+	}
 	waitForUIContains(t, session, name, timeout)
-	selectWorkspaceRow(t, session, name, timeout)
-	waitForUIContains(t, session, "[New agent]", timeout)
-	clickVisibleLabel(t, session, "[New agent]", "New Agent", timeout)
-	waitForUIContains(t, session, "New Agent", timeout)
+	waitForAgentSessions(t, opts, timeout)
 }
 
 func createSidebarTerminalTab(t *testing.T, session *PTYSession) {
@@ -111,31 +123,4 @@ func workspaceRowY(t *testing.T, session *PTYSession, workspaceName string, time
 	}
 	t.Fatalf("timeout waiting for workspace row %q\n\nScreen:\n%s", workspaceName, lastScreen)
 	return 0
-}
-
-func clickVisibleLabel(t *testing.T, session *PTYSession, label, opened string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var lastScreen string
-	for time.Now().Before(deadline) {
-		lastScreen = session.ScreenASCII()
-		for y, line := range strings.Split(lastScreen, "\n") {
-			if x := strings.Index(line, label); x >= 0 {
-				candidates := []int{y}
-				if y > 0 {
-					candidates = append(candidates, y-1)
-				}
-				for _, candidateY := range candidates {
-					if err := session.SendString(leftClickInput(x+1, candidateY)); err != nil {
-						t.Fatalf("click label %q: %v", label, err)
-					}
-					if session.WaitForContains(opened, 2*time.Second) == nil {
-						return
-					}
-				}
-			}
-		}
-		time.Sleep(screenPollInterval)
-	}
-	t.Fatalf("timeout clicking label %q to open %q\n\nScreen:\n%s", label, opened, lastScreen)
 }

--- a/internal/e2e/multi_instance_gc_test.go
+++ b/internal/e2e/multi_instance_gc_test.go
@@ -52,11 +52,8 @@ func TestMultiInstanceOrphanGCDoesNotKillNewWorkspace(t *testing.T) {
 
 	waitForUIContains(t, sessionA, filepath.Base(repo), 10*time.Second)
 
-	createWorkspaceAndOpenAgentPicker(t, sessionA, "feature-gc", 15*time.Second)
-	selectAgentFromPicker(t, sessionA, 0)
-	waitForUIContains(t, sessionA, "claude", 15*time.Second)
-
 	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
-	waitForAgentSessions(t, opts, 15*time.Second)
+	createWorkspaceWithAgent(t, sessionA, "feature-gc", opts, 15*time.Second)
+	waitForUIContains(t, sessionA, "claude", 15*time.Second)
 	assertAgentSessionsStayLive(t, opts, 8*time.Second)
 }

--- a/internal/e2e/workspace_agent_test.go
+++ b/internal/e2e/workspace_agent_test.go
@@ -35,12 +35,10 @@ func TestWorkspaceCreateAgentTabStaysRunning(t *testing.T) {
 
 	waitForUIContains(t, session, filepath.Base(repo), workspaceAgentTimeout)
 
-	createWorkspaceAndOpenAgentPicker(t, session, "feature", workspaceAgentTimeout)
-	selectAgentFromPicker(t, session, 0)
+	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
+	createWorkspaceWithAgent(t, session, "feature", opts, workspaceAgentTimeout)
 	waitForUIContains(t, session, "claude", workspaceAgentTimeout)
 
-	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
-	waitForAgentSessions(t, opts, workspaceAgentTimeout)
 	assertAgentSessionsStayLive(t, opts, 8*time.Second)
 	assertScreenNeverContains(t, session, []string{"STOPPED", "DETACHED"}, 5*time.Second)
 }
@@ -76,12 +74,9 @@ func TestWorkspaceDeleteTearsDownAgent(t *testing.T) {
 
 	waitForUIContains(t, session, filepath.Base(repo), workspaceAgentTimeout)
 
-	createWorkspaceAndOpenAgentPicker(t, session, "feature", workspaceAgentTimeout)
-	selectAgentFromPicker(t, session, 0)
-	waitForUIContains(t, session, "claude", workspaceAgentTimeout)
-
 	opts := tmux.Options{ServerName: server, ConfigPath: "/dev/null"}
-	waitForAgentSessions(t, opts, workspaceAgentTimeout)
+	createWorkspaceWithAgent(t, session, "feature", opts, workspaceAgentTimeout)
+	waitForUIContains(t, session, "claude", workspaceAgentTimeout)
 
 	// Delete the workspace through the real UI while the agent is live.
 	deleteSelectedWorkspace(t, session, "feature", workspaceAgentTimeout)

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -51,6 +51,11 @@ func (m *Model) workspaceRowIndex(wsID string) int {
 	return -1
 }
 
+// pendingSelectMaxLoads bounds how many project rebuilds a pending selection
+// may wait for. Two covers the reload the creation itself queued plus one
+// concurrent reload landing first.
+const pendingSelectMaxLoads = 2
+
 // SelectWorkspace moves the cursor onto the workspace row with the given ID. A
 // workspace that has no row yet (its projects reload is still in flight, as is
 // the case right after creation) is remembered and selected by the next
@@ -60,21 +65,42 @@ func (m *Model) SelectWorkspace(wsID string) {
 		return
 	}
 	m.pendingSelectID = wsID
+	m.pendingSelectLoads = pendingSelectMaxLoads
 	m.applyPendingSelection()
 }
 
-// applyPendingSelection lands the cursor on the pending workspace once its row
-// exists. It is a no-op while that row is still missing.
-func (m *Model) applyPendingSelection() {
+// clearPendingSelection drops a selection that is still waiting on a row.
+func (m *Model) clearPendingSelection() {
+	m.pendingSelectID = ""
+	m.pendingSelectLoads = 0
+}
+
+// applyPendingSelection lands the cursor on the pending workspace if its row
+// already exists. It reports whether the selection was consumed.
+func (m *Model) applyPendingSelection() bool {
 	if m.pendingSelectID == "" {
-		return
+		return false
 	}
 	idx := m.workspaceRowIndex(m.pendingSelectID)
 	if idx == -1 {
-		return
+		return false
 	}
 	m.cursor = idx
-	m.pendingSelectID = ""
+	m.clearPendingSelection()
+	return true
+}
+
+// applyPendingSelectionForLoad applies the pending selection against a freshly
+// rebuilt row set, and spends one of its bounded waits when the row still is
+// not there — so a row that never arrives cannot strand the ID (see the
+// pendingSelectLoads field comment).
+func (m *Model) applyPendingSelectionForLoad() {
+	if m.pendingSelectID == "" || m.applyPendingSelection() {
+		return
+	}
+	if m.pendingSelectLoads--; m.pendingSelectLoads <= 0 {
+		m.clearPendingSelection()
+	}
 }
 
 // resolveCursorAfterRebuild re-anchors the cursor to the workspace selected

--- a/internal/ui/dashboard/dashboard_navigation.go
+++ b/internal/ui/dashboard/dashboard_navigation.go
@@ -51,6 +51,32 @@ func (m *Model) workspaceRowIndex(wsID string) int {
 	return -1
 }
 
+// SelectWorkspace moves the cursor onto the workspace row with the given ID. A
+// workspace that has no row yet (its projects reload is still in flight, as is
+// the case right after creation) is remembered and selected by the next
+// rebuild instead of being dropped.
+func (m *Model) SelectWorkspace(wsID string) {
+	if wsID == "" {
+		return
+	}
+	m.pendingSelectID = wsID
+	m.applyPendingSelection()
+}
+
+// applyPendingSelection lands the cursor on the pending workspace once its row
+// exists. It is a no-op while that row is still missing.
+func (m *Model) applyPendingSelection() {
+	if m.pendingSelectID == "" {
+		return
+	}
+	idx := m.workspaceRowIndex(m.pendingSelectID)
+	if idx == -1 {
+		return
+	}
+	m.cursor = idx
+	m.pendingSelectID = ""
+}
+
 // resolveCursorAfterRebuild re-anchors the cursor to the workspace selected
 // before the rebuild. If that workspace is gone (deleted), it falls back to the
 // nearest selectable row at or ABOVE the previous index — the predecessor — so

--- a/internal/ui/dashboard/dashboard_select_workspace_test.go
+++ b/internal/ui/dashboard/dashboard_select_workspace_test.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/data"
+)
+
+// A workspace that already has a row is selected immediately.
+func TestSelectWorkspace_MovesCursorToExistingRow(t *testing.T) {
+	wsList := []data.Workspace{
+		*data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1"),
+		*data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2"),
+	}
+
+	m := New()
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: wsList}})
+
+	target := string(wsList[1].ID())
+	m.SelectWorkspace(target)
+
+	if got := m.selectedWorkspaceIDAt(m.cursor); got != target {
+		t.Fatalf("expected cursor on %s, got %q", target, got)
+	}
+}
+
+// A just-created workspace is activated before the projects reload that carries
+// it lands, so the selection has to survive until its row exists.
+func TestSelectWorkspace_AppliesOnceRowAppears(t *testing.T) {
+	existing := *data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1")
+	created := *data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2")
+
+	m := New()
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing}}})
+
+	createdID := string(created.ID())
+	m.SelectWorkspace(createdID)
+	if got := m.selectedWorkspaceIDAt(m.cursor); got == createdID {
+		t.Fatal("expected no selection before the workspace has a row")
+	}
+
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing, created}}})
+
+	if got := m.selectedWorkspaceIDAt(m.cursor); got != createdID {
+		t.Fatalf("expected cursor on the created workspace, got %q", got)
+	}
+	if m.pendingSelectID != "" {
+		t.Fatalf("expected pending selection cleared, got %q", m.pendingSelectID)
+	}
+}
+
+// Navigating by hand while a selection is still pending drops it, so a later
+// reload cannot yank the cursor off the row the user chose.
+func TestSelectWorkspace_UserNavigationCancelsPendingSelection(t *testing.T) {
+	existing := *data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1")
+	created := *data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2")
+
+	m := New()
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing}}})
+	m.Focus()
+	m.SelectWorkspace(string(created.ID()))
+
+	m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if m.pendingSelectID != "" {
+		t.Fatalf("expected user navigation to drop the pending selection, got %q", m.pendingSelectID)
+	}
+
+	before := m.cursor
+	m.SetProjects([]data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing, created}}})
+	if m.cursor != before {
+		t.Fatalf("expected cursor to stay at %d after reload, got %d", before, m.cursor)
+	}
+}
+
+// The pending selection must not override a later reload once it has been
+// applied: normal cursor anchoring takes over again.
+func TestSelectWorkspace_DoesNotReapplyAfterConsumption(t *testing.T) {
+	first := *data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1")
+	second := *data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2")
+	all := []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{first, second}}}
+
+	m := New()
+	m.SetProjects(all)
+	m.SelectWorkspace(string(second.ID()))
+
+	m.moveCursor(-1)
+	movedTo := m.selectedWorkspaceIDAt(m.cursor)
+
+	m.SetProjects(all)
+
+	if got := m.selectedWorkspaceIDAt(m.cursor); got != movedTo {
+		t.Fatalf("expected cursor to stay on %q after reload, got %q", movedTo, got)
+	}
+}

--- a/internal/ui/dashboard/dashboard_select_workspace_test.go
+++ b/internal/ui/dashboard/dashboard_select_workspace_test.go
@@ -62,7 +62,14 @@ func TestSelectWorkspace_UserNavigationCancelsPendingSelection(t *testing.T) {
 	m.Focus()
 	m.SelectWorkspace(string(created.ID()))
 
+	// Start below the first selectable row so 'k' demonstrably moves the cursor:
+	// pressing it on the top row would prove only "some key was handled".
+	m.moveCursor(1)
+	moved := m.cursor
 	m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if m.cursor == moved {
+		t.Fatal("expected 'k' to move the cursor; test would not prove navigation clears the selection")
+	}
 	if m.pendingSelectID != "" {
 		t.Fatalf("expected user navigation to drop the pending selection, got %q", m.pendingSelectID)
 	}
@@ -92,5 +99,72 @@ func TestSelectWorkspace_DoesNotReapplyAfterConsumption(t *testing.T) {
 
 	if got := m.selectedWorkspaceIDAt(m.cursor); got != movedTo {
 		t.Fatalf("expected cursor to stay on %q after reload, got %q", movedTo, got)
+	}
+}
+
+// Mouse input clears a pending selection too. Only the keyboard path was
+// covered, so dropping either mouse clear was silent.
+func TestSelectWorkspace_MouseInputCancelsPendingSelection(t *testing.T) {
+	existing := *data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1")
+	created := *data.NewWorkspace("ws2", "feature2", "main", "/repo", "/repo/ws2")
+	projects := []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing}}}
+
+	for _, tc := range []struct {
+		name string
+		msg  tea.Msg
+	}{
+		{"wheel", tea.MouseWheelMsg{Button: tea.MouseWheelDown}},
+		{"click", tea.MouseClickMsg{Button: tea.MouseLeft, X: 2, Y: 2}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New()
+			m.SetSize(80, 24)
+			m.SetProjects(projects)
+			m.Focus()
+			m.SelectWorkspace(string(created.ID()))
+
+			m.Update(tc.msg)
+
+			if m.pendingSelectID != "" {
+				t.Fatalf("expected %s input to drop the pending selection, got %q", tc.name, m.pendingSelectID)
+			}
+		})
+	}
+}
+
+// A pending selection whose row never appears (created-with-warning, or deleted
+// before its reload landed) must not linger. Workspace IDs are a hash of
+// project+name, so a later delete-then-recreate at the same name reproduces the
+// ID and a stranded selection would yank the cursor away long afterwards. The
+// dashboard cannot rely on input to clear it: this flow parks focus on the
+// center pane, and every input-side clear is gated on being focused.
+func TestSelectWorkspace_ExpiresWhenRowNeverArrives(t *testing.T) {
+	existing := *data.NewWorkspace("ws1", "feature1", "main", "/repo", "/repo/ws1")
+	ghost := *data.NewWorkspace("ghost", "ghost", "main", "/repo", "/repo/ghost")
+	projects := []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing}}}
+
+	m := New()
+	m.SetProjects(projects)
+	m.Blur() // this flow leaves the dashboard unfocused
+	m.SelectWorkspace(string(ghost.ID()))
+
+	for i := 0; i < pendingSelectMaxLoads; i++ {
+		if m.pendingSelectID == "" {
+			t.Fatalf("selection expired after %d reloads, before its row could arrive", i)
+		}
+		m.SetProjects(projects)
+	}
+
+	if m.pendingSelectID != "" {
+		t.Fatalf("expected the pending selection to expire after %d reloads, got %q",
+			pendingSelectMaxLoads, m.pendingSelectID)
+	}
+
+	// The recreated workspace must not inherit the abandoned selection.
+	withGhost := []data.Project{{Name: "repo", Path: "/repo", Workspaces: []data.Workspace{existing, ghost}}}
+	m.cursor = 0
+	m.SetProjects(withGhost)
+	if got := m.selectedWorkspaceIDAt(m.cursor); got == string(ghost.ID()) {
+		t.Fatal("expected an expired selection not to grab the cursor when the row later appears")
 	}
 }

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -91,6 +91,15 @@ type Model struct {
 	// projects reload carrying it arrives, so the selection has to wait for the
 	// rebuild rather than being dropped.
 	pendingSelectID string
+	// pendingSelectLoads bounds how many rebuilds that wait may span. A creation
+	// that never yields a row (created-with-warning, deleted before its reload
+	// landed) would otherwise strand the ID for the session — and since a
+	// workspace ID is a hash of project+name, a later delete-then-recreate at the
+	// same name reproduces it and would yank the cursor off the user's row long
+	// afterwards. The dashboard cannot rely on input to clear it, because this
+	// flow deliberately parks focus on the center pane and every input-side
+	// clear is gated on being focused.
+	pendingSelectLoads int
 
 	// Loading state
 	creatingWorkspaces map[string]*data.Workspace // Workspaces currently being created
@@ -228,7 +237,7 @@ func (m *Model) SetProjects(projects []data.Project) {
 	m.projects = projects
 	m.rebuildRows()
 	m.resolveCursorAfterRebuild(prevCursor, selectedID)
-	m.applyPendingSelection()
+	m.applyPendingSelectionForLoad()
 	if m.cursor == prevCursor {
 		m.scrollOffset = prevOffset
 		m.clampScrollOffset()

--- a/internal/ui/dashboard/model.go
+++ b/internal/ui/dashboard/model.go
@@ -86,6 +86,11 @@ type Model struct {
 	toolbarFocused  bool            // Whether toolbar actions are focused
 	toolbarIndex    int             // Focused toolbar action index
 	deleteIconX     int             // X position of delete "x" icon for currently selected row
+	// pendingSelectID holds a workspace ID the cursor should land on as soon as
+	// that workspace has a row. A just-created workspace is activated before the
+	// projects reload carrying it arrives, so the selection has to wait for the
+	// rebuild rather than being dropped.
+	pendingSelectID string
 
 	// Loading state
 	creatingWorkspaces map[string]*data.Workspace // Workspaces currently being created
@@ -223,6 +228,7 @@ func (m *Model) SetProjects(projects []data.Project) {
 	m.projects = projects
 	m.rebuildRows()
 	m.resolveCursorAfterRebuild(prevCursor, selectedID)
+	m.applyPendingSelection()
 	if m.cursor == prevCursor {
 		m.scrollOffset = prevOffset
 		m.clampScrollOffset()

--- a/internal/ui/dashboard/model_update.go
+++ b/internal/ui/dashboard/model_update.go
@@ -19,6 +19,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if !m.focused {
 			return m, nil
 		}
+		// Moving the cursor by hand outranks a selection still waiting on a
+		// workspace row, so a late reload cannot yank the user off their row.
+		m.pendingSelectID = ""
 		delta := common.ScrollDeltaForHeight(m.visibleHeight(), 10) // ~10% of visible
 		if msg.Button == tea.MouseWheelUp {
 			m.moveCursor(-delta)
@@ -33,6 +36,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if !m.focused {
 			return m, nil
 		}
+		m.pendingSelectID = ""
 		if msg.Button == tea.MouseLeft {
 			// Check toolbar clicks first
 			if cmd := m.handleToolbarClick(msg.X, msg.Y); cmd != nil {
@@ -76,6 +80,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if !m.focused {
 			return m, nil
 		}
+		m.pendingSelectID = ""
 		toolbarItems := m.toolbarItems()
 		if m.toolbarFocused {
 			return m.handleToolbarKey(msg, toolbarItems)

--- a/internal/ui/dashboard/model_update.go
+++ b/internal/ui/dashboard/model_update.go
@@ -21,7 +21,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		}
 		// Moving the cursor by hand outranks a selection still waiting on a
 		// workspace row, so a late reload cannot yank the user off their row.
-		m.pendingSelectID = ""
+		m.clearPendingSelection()
 		delta := common.ScrollDeltaForHeight(m.visibleHeight(), 10) // ~10% of visible
 		if msg.Button == tea.MouseWheelUp {
 			m.moveCursor(-delta)
@@ -36,7 +36,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if !m.focused {
 			return m, nil
 		}
-		m.pendingSelectID = ""
+		m.clearPendingSelection()
 		if msg.Button == tea.MouseLeft {
 			// Check toolbar clicks first
 			if cmd := m.handleToolbarClick(msg.X, msg.Y); cmd != nil {
@@ -80,7 +80,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if !m.focused {
 			return m, nil
 		}
-		m.pendingSelectID = ""
+		m.clearPendingSelection()
 		toolbarItems := m.toolbarItems()
 		if m.toolbarFocused {
 			return m.handleToolbarKey(msg, toolbarItems)


### PR DESCRIPTION
## Problem

Creating a workspace from the dashboard already asks which assistant to use — but that choice was only recorded on the workspace record. Creation dropped you back on the dashboard, where you had to click into the new workspace, hit **New agent**, and pick the same assistant a second time.

## What changed

`WorkspaceCreated` now activates the new workspace and launches the assistant you already chose. The launch is armed at creation and fires from `handleWorkspaceActivated`, after activation has switched the center pane over, so the tab is created against the right workspace. Focus lands on the agent through the existing `TabCreated` → `focusPane(PaneCenter)` path.

The dashboard holds the new workspace's selection until its row exists, since the projects reload carrying it is still in flight.

## Guards

- **No tmux, no auto-launch.** The explicit new-agent paths refuse with an install hint; an auto-launch would instead fail from under the user.
- **No activation without a loaded project** — that would leave `activeWorkspace` set with `activeProject` nil, disabling every workspace-scoped command.
- **Activation skips the tmux agent discovery it batches alongside the launch.** Both run concurrently, so a delayed scan could list the session the launch just created and, finding no tab registered yet, adopt it into a duplicate tab.
- **Tab creation no longer steals focus when the layout is too narrow to render the center pane** (`LayoutOnePane`, below ~92 columns). Previously this only triggered on a deliberate `⎵ t a`; auto-launch made it fire on every creation, which would have typed into an invisible tab.
- **Deliberate dashboard navigation** (key, click, wheel) drops a pending selection.

## Defects found in review and fixed here

Both were caught reviewing the first commit, and each is pinned by a test verified to fail against a mutation of the code it covers.

1. **Concurrent creations clobbered each other.** The armed assistant lived in a single pair of fields, but the create dialog closes immediately, so a second workspace can be started while the first is still building. The second creation overwrote the first's arming; the first workspace was then activated with nothing armed and **silently got no agent**. The arming is now keyed by workspace ID. Deleting a workspace disarms only its own entry — IDs are a hash of project+name, so a delete-then-recreate at the same name reuses the ID and would otherwise inherit a stale arming.

2. **The dashboard's pending selection had no reachable cancel path.** All three input-side clears sit behind `if !m.focused`, and this flow deliberately parks focus on the center pane. A creation that never yielded a row left the ID set for the rest of the session, so a later recreate at the same name would yank the cursor off whatever row the user was on. The wait is now bounded to two rebuilds.

## Tests

Four behaviors were previously untested and silently mutable — the launch command being appended, the discovery-skip guard, and both mouse-side selection clears. Each now has a test confirmed to fail when the corresponding line is mutated.

The e2e helper `createWorkspaceAndOpenAgentPicker` encoded the old two-step dance and is replaced by `createWorkspaceWithAgent`, which returns only once the auto-launched agent's tmux session exists. Waiting on screen text alone was not enough: the dashboard renders a creating-placeholder row bearing the workspace name, so the helper handed back control before the workspace was active, and a leader sequence sent then was answered with "select a workspace" instead of the agent picker. That produced a real ~1-in-3 flake, diagnosed by tracing keypresses against the app's own logs.

## Verification

- `make devcheck`, `make verify-loop`, `make lint-strict-new` — green
- `go test -race ./internal/app ./internal/ui/dashboard` — green
- `internal/e2e` — 3 consecutive clean full-package runs (plus 6 more while fixing the flake)
- `make perf-check` — **not a usable signal on this host right now.** It fails on unmodified `main` too, and worse (baseline CENTER p95 3.57ms vs 2.27ms on this branch; MONITOR 9.87ms vs 2.47ms) — another workspace is running `tsc`/qemu at >100% CPU. This change does not touch the render path, and the failing presets (sidebar, monitor) exercise none of it. Worth a re-run on a quiet box.

## Known, unchanged

- The agent starts while `setup-workspace` scripts may still be running. Waiting for `WorkspaceSetupComplete` could stall the user for minutes on an `npm install`, and the same overlap already existed for anyone clicking into a workspace quickly.
- The periodic tmux sync tick (every 7s) runs the same discovery against the active workspace and can still land in the window between session creation and tab registration. That is a pre-existing race shared with the manual new-agent flow; closing it needs the center to dedupe against in-flight session names, which is surgery on the tab-creation path and belongs in its own change. Documented in `hasPendingAgentLaunch`.
