### PR TITLE
fix: keep wide glyphs from shifting terminal lines sideways

### DIFF
--- a/internal/app/harness_wide_glyph_test.go
+++ b/internal/app/harness_wide_glyph_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestCenterPaneKeepsWideGlyphColumns renders a real composed frame containing a
+// wide glyph and asserts the glyph survives and the text after it keeps its
+// column. The compositor used to write an explicit zero-width continuation cell,
+// which made ultraviolet blank the wide base and drop the placeholder from the
+// output — every cell after a wide glyph then drew one column to the left.
+func TestCenterPaneKeepsWideGlyphColumns(t *testing.T) {
+	h, err := NewHarness(HarnessOptions{
+		Mode:    HarnessCenter,
+		Tabs:    1,
+		Width:   120,
+		Height:  36,
+		HotTabs: 0,
+	})
+	if err != nil {
+		t.Fatalf("harness init: %v", err)
+	}
+	if len(h.tabs) == 0 || h.tabs[0] == nil {
+		t.Fatalf("harness produced no center tabs")
+	}
+
+	const marker = "AB✅CD"
+	h.tabs[0].WriteToTerminal([]byte("\x1b[2J\x1b[H" + marker))
+
+	content := h.Render().Content
+	if content == "" {
+		t.Fatalf("rendered frame is empty")
+	}
+
+	lines := strings.Split(content, "\n")
+	var found string
+	for _, line := range lines {
+		// Match on the marker's narrow halves so the row is still found when
+		// the wide glyph between them is dropped (the bug being guarded).
+		if plain := ansi.Strip(line); strings.Contains(plain, "AB") && strings.Contains(plain, "CD") {
+			found = plain
+			break
+		}
+	}
+	if found == "" {
+		t.Fatalf("rendered frame has no line containing the marker")
+	}
+	if !strings.Contains(found, marker) {
+		t.Fatalf("wide glyph lost or line collapsed: got %q, want a line containing %q", found, marker)
+	}
+
+	// Every row of the frame is the same display width; a dropped zero-width
+	// cell shortens the glyph's row by exactly one column, which is what pulls
+	// the rest of the line left on screen.
+	want := ansi.StringWidth(ansi.Strip(lines[0]))
+	if got := ansi.StringWidth(found); got != want {
+		t.Fatalf("glyph row width = %d, want %d (other rows) — line: %q", got, want, found)
+	}
+}

--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -23,6 +23,44 @@ Every hop coalesces or throttles; none of them may reorder or drop output
 bytes (`tabEventWriteOutput` is never shed — see the invariants in
 `tab_actor.go`).
 
+### Wide glyphs (why lines don't drift left)
+
+`VTermLayer.DrawAt` writes only the *base* cell of a wide glyph. Ultraviolet's
+`Line.Set` stamps the zero-width placeholder for the second column itself, and
+it reads a write *to* a placeholder as "something is overwriting half of a wide
+glyph" — so writing the continuation cell explicitly blanks the base we just
+drew and leaves an orphan placeholder. The renderer emits nothing for a
+zero-width cell, so every cell after it lands one column to the left.
+
+A wide glyph is two cells — a base (`Width == 2`) and a continuation
+(`Width == 0`) — and a renderer must draw exactly one column per cell. Both
+halves can be orphaned, and each drifts the line a different way:
+
+- **Orphan continuation** (zero-width cell with no wide base at `x-1`, e.g. a
+  half-erased glyph): renderers emit nothing for it, so the line drifts
+  **left**. Ask `vterm.IsWideContinuation(row, x)`; draw a blank when false.
+- **Widowed base** (`Width == 2` whose continuation was overwritten, or pushed
+  out of the viewport by a resize — `resizeRows` keeps rows wider than the
+  viewport): it draws two columns where the buffer owns one, so the line drifts
+  **right**. Ask `vterm.HasWideContinuation(row, x, visibleWidth)`; substitute a
+  blank when false.
+
+Both guards are required at all four renderers: `VTermLayer.DrawAt`,
+`compositor.Canvas.DrawScreen`, and `vterm`'s `renderRow` /
+`renderWithScrollbackFrom`. `normalizeLine` enforces the same pair of rules on
+the write side (against `len(line)`), and the erase ops plus `putChar`'s
+wide-glyph wrap call it — or clear the stale half directly — so neither shape
+normally reaches a snapshot at all. The renderer guards are defense in depth,
+and they are load-bearing for rows that are legitimately wider than the
+viewport, where the write side cannot know the render width.
+
+Regression tests: `internal/ui/compositor/vtermlayer_widecell_test.go`,
+`internal/vterm/render_wide_orphan_test.go`,
+`internal/vterm/render_wide_widow_test.go`,
+`internal/vterm/erase_wide_normalize_test.go`,
+`internal/ui/center/model_scrolled_history_wide_test.go` (the scrolled chat
+path), and the composed-frame test `internal/app/harness_wide_glyph_test.go`.
+
 ### Frame atomicity (why agents don't flicker)
 
 A flush can land mid-repaint: the parser may have consumed a `2J` clear but

--- a/internal/ui/center/model_scrolled_history_wide_test.go
+++ b/internal/ui/center/model_scrolled_history_wide_test.go
@@ -1,0 +1,108 @@
+package center
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/ui/compositor"
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// wideHistoryLine builds a scrollback line holding a wide glyph followed by
+// narrow text, as a streaming agent that prints emoji would produce.
+func wideHistoryLine(width int) []vterm.Cell {
+	line := vterm.MakeBlankLine(width)
+	line[0] = vterm.Cell{Rune: '✅', Width: 2}
+	line[1] = vterm.Cell{Width: 0}
+	line[2] = vterm.Cell{Rune: 'o', Width: 1}
+	line[3] = vterm.Cell{Rune: 'k', Width: 1}
+	return line
+}
+
+// A chat tab scrolled into history renders a scrollback-only window
+// (applyScrolledChatHistoryViewLocked). This is the exact path a user is on
+// while scrolling up through agent output, so pin that a wide glyph in that
+// window keeps both its glyph and its column alignment through the real
+// snapshot -> layer -> canvas pipeline.
+func TestScrolledChatHistoryPreservesWideGlyphColumns(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+	term.Scrollback[0] = wideHistoryLine(term.Width)
+
+	term.ScrollView(1)
+	layer := m.TerminalLayer()
+	if layer == nil || layer.Snap == nil {
+		t.Fatal("expected terminal layer snapshot")
+	}
+
+	row := layer.Snap.Screen[0]
+	if row[0].Rune != '✅' || row[0].Width != 2 {
+		t.Fatalf("wide glyph lost in scrolled history snapshot: %+v", row[0])
+	}
+	if row[1].Width != 0 {
+		t.Fatalf("continuation cell lost in scrolled history snapshot: %+v", row[1])
+	}
+
+	// Through the canvas renderer the row must still occupy exactly Width
+	// columns, with the glyph intact and the narrow text after it in place.
+	out := compositor.RenderSnapshotWithCanvas(
+		nil, layer.Snap, layer.Snap.Width, layer.Snap.Height,
+		vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault},
+	)
+	first := ansi.Strip(out)
+	if idx := indexByte(first, '\n'); idx >= 0 {
+		first = first[:idx]
+	}
+	if got, want := ansi.StringWidth(first), term.Width; got != want {
+		t.Fatalf("scrolled history row width = %d, want %d (%q)", got, want, first)
+	}
+	if want := "✅ok"; !hasPrefix(first, want) {
+		t.Fatalf("scrolled history row = %q, want it to start with %q", first, want)
+	}
+}
+
+// The same scrolled-history window, but the history line holds a wide base
+// whose continuation was overwritten (a half-erased glyph). It must render as a
+// blank occupying one column, not as two columns that push the rest right.
+func TestScrolledChatHistoryBlanksWidowedWideBase(t *testing.T) {
+	m, tab := setupScrolledChatHistoryModel()
+	term := tab.Terminal
+
+	line := vterm.MakeBlankLine(term.Width)
+	line[0] = vterm.Cell{Rune: '✅', Width: 2}
+	line[1] = vterm.Cell{Rune: 'o', Width: 1} // continuation overwritten
+	line[2] = vterm.Cell{Rune: 'k', Width: 1}
+	term.Scrollback[0] = line
+
+	term.ScrollView(1)
+	layer := m.TerminalLayer()
+	if layer == nil || layer.Snap == nil {
+		t.Fatal("expected terminal layer snapshot")
+	}
+
+	out := compositor.RenderSnapshotWithCanvas(
+		nil, layer.Snap, layer.Snap.Width, layer.Snap.Height,
+		vterm.Color{Type: vterm.ColorDefault}, vterm.Color{Type: vterm.ColorDefault},
+	)
+	first := ansi.Strip(out)
+	if idx := indexByte(first, '\n'); idx >= 0 {
+		first = first[:idx]
+	}
+	if got, want := ansi.StringWidth(first), term.Width; got != want {
+		t.Fatalf("row width = %d, want %d — widowed base drew two columns (%q)", got, want, first)
+	}
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/internal/ui/compositor/canvas.go
+++ b/internal/ui/compositor/canvas.go
@@ -116,7 +116,17 @@ func (c *Canvas) DrawScreen(x, y, w, h int, screen [][]vterm.Cell, cursor Cursor
 		maxX := min(w, len(line))
 		for col := 0; col < maxX; col++ {
 			cell := line[col]
-			if cell.Width == 2 && col+1 >= w {
+			// A wide base that lost its second column — to a narrow overwrite
+			// or to a viewport edge — would draw two columns where the buffer
+			// now owns one, shifting the rest of the line right.
+			if cell.Width == 2 && !vterm.HasWideContinuation(line, col, w) {
+				cell = vterm.DefaultCell()
+			}
+			// Render skips zero-width cells, so a continuation column whose wide
+			// base is gone would silently pull the rest of the line one column
+			// left. Substitute a blank for orphans (VTermLayer.DrawAt does the
+			// same for the layer-based path).
+			if cell.Width == 0 && !vterm.IsWideContinuation(line, col) {
 				cell = vterm.DefaultCell()
 			}
 			if selActive && vterm.SelectionContains(selStartX, selStartY, selEndX, selEndY, col, row) {

--- a/internal/ui/compositor/vtermlayer.go
+++ b/internal/ui/compositor/vtermlayer.go
@@ -108,19 +108,31 @@ func (l *VTermLayer) DrawAt(s uv.Screen, posX, posY, maxWidth, maxHeight int) {
 		for x := 0; x < width && x < len(row); x++ {
 			cell := row[x]
 
-			// A wide glyph landing on the last visible column can't render its
-			// second half; substitute a blank there instead of emitting a
-			// truncated wide cell. Mirrors canvas.go's DrawScreen guard.
-			if cell.Width == 2 && x+1 >= width {
+			// A wide glyph that can't render its second half — it landed on the
+			// last visible column, or a narrow write took the continuation away
+			// — draws two columns where the buffer owns one, shifting the rest
+			// of the line right. Substitute a blank. Mirrors canvas.go.
+			if cell.Width == 2 && !vterm.HasWideContinuation(row, x, width) {
 				cell = vterm.DefaultCell()
 			}
 
-			// For continuation cells (part of wide character), write an empty cell
-			// to clear any stale content at that position from previous renders.
+			// Continuation column of a wide glyph. Do NOT write a zero-width cell
+			// here: ultraviolet's Line.Set already stamped a placeholder when the
+			// base cell was set, and it treats a *write* to a placeholder as
+			// "something is overwriting half of a wide glyph", which blanks the
+			// base cell we just drew. The result is a space plus an orphan
+			// placeholder, and since the renderer emits nothing for a zero-width
+			// cell, the rest of the line lands one column to the left. Skipping
+			// the write still clears stale content at this position, because
+			// setting the base cell rewrites the placeholder.
 			if cell.Width == 0 {
-				uvCell = uv.Cell{Content: "", Width: 0}
-				s.SetCell(posX+x, posY+y, &uvCell)
-				continue
+				if vterm.IsWideContinuation(row, x) {
+					continue
+				}
+				// Orphan placeholder with no wide base (e.g. a line edit erased
+				// the base). Draw a blank so the column still occupies a cell
+				// instead of collapsing the line leftward.
+				cell = vterm.DefaultCell()
 			}
 
 			// Build the ultraviolet cell into the reused local.

--- a/internal/ui/compositor/vtermlayer_widecell_test.go
+++ b/internal/ui/compositor/vtermlayer_widecell_test.go
@@ -1,0 +1,142 @@
+package compositor
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// wideGlyphRow builds a single-row snapshot of the form "<wide>ab" padded to
+// width, i.e. a wide glyph followed by narrow cells.
+func wideGlyphRow(width int) *VTermSnapshot {
+	row := vterm.MakeBlankLine(width)
+	row[0] = vterm.Cell{Rune: '中', Width: 2}
+	row[1] = vterm.Cell{Width: 0}
+	row[2] = vterm.Cell{Rune: 'a', Width: 1}
+	row[3] = vterm.Cell{Rune: 'b', Width: 1}
+	return &VTermSnapshot{Screen: [][]vterm.Cell{row}, Width: width, Height: 1}
+}
+
+// TestVTermLayerKeepsWideGlyphAndColumnAlignment is the regression test for the
+// "text drifts one column left" rendering bug: writing an explicit zero-width
+// continuation cell made ultraviolet's Line.Set blank the wide base cell it
+// belonged to, leaving an orphan placeholder that emits nothing, so every cell
+// after a wide glyph rendered one column too far left.
+func TestVTermLayerKeepsWideGlyphAndColumnAlignment(t *testing.T) {
+	layer := NewVTermLayer(wideGlyphRow(4))
+
+	canvas := lipgloss.NewCanvas(4, 1)
+	canvas.Compose(&PositionedVTermLayer{VTermLayer: layer, PosX: 0, PosY: 0, Width: 4, Height: 1})
+
+	if got, want := canvas.Render(), "中ab"; got != want {
+		t.Fatalf("rendered %q, want %q (line shifted left / wide glyph lost)", got, want)
+	}
+
+	base := canvas.CellAt(0, 0)
+	if base == nil || base.Content != "中" || base.Width != 2 {
+		t.Fatalf("expected wide glyph at column 0, got %+v", base)
+	}
+	for x, want := range map[int]string{2: "a", 3: "b"} {
+		if cell := canvas.CellAt(x, 0); cell == nil || cell.Content != want {
+			t.Fatalf("expected %q at column %d, got %+v", want, x, cell)
+		}
+	}
+}
+
+// TestVTermLayerBlanksOrphanContinuationCell covers a zero-width cell whose
+// wide base is missing (a half-erased glyph): it must occupy its column as a
+// blank rather than collapse the rest of the line leftward.
+func TestVTermLayerBlanksOrphanContinuationCell(t *testing.T) {
+	row := vterm.MakeBlankLine(3)
+	row[0] = vterm.Cell{Width: 0} // orphan at the start of the line
+	row[1] = vterm.Cell{Rune: 'a', Width: 1}
+	row[2] = vterm.Cell{Rune: 'b', Width: 1}
+	snap := &VTermSnapshot{Screen: [][]vterm.Cell{row}, Width: 3, Height: 1}
+
+	canvas := lipgloss.NewCanvas(3, 1)
+	canvas.Compose(&PositionedVTermLayer{VTermLayer: NewVTermLayer(snap), PosX: 0, PosY: 0, Width: 3, Height: 1})
+
+	if got, want := canvas.Render(), " ab"; got != want {
+		t.Fatalf("rendered %q, want %q", got, want)
+	}
+}
+
+// TestCanvasDrawScreenBlanksOrphanContinuationCell is the string-render
+// counterpart: Canvas.Render skips zero-width cells, so an orphan there would
+// shorten the line by a column.
+func TestCanvasDrawScreenBlanksOrphanContinuationCell(t *testing.T) {
+	row := vterm.MakeBlankLine(3)
+	row[0] = vterm.Cell{Width: 0}
+	row[1] = vterm.Cell{Rune: 'a', Width: 1}
+	row[2] = vterm.Cell{Rune: 'b', Width: 1}
+
+	canvas := NewCanvas(3, 1)
+	canvas.DrawScreen(0, 0, 3, 1, [][]vterm.Cell{row}, CursorState{}, 0, SelectionRegion{})
+
+	if got, want := canvas.Cells[0][0].Width, 1; got != want {
+		t.Fatalf("orphan continuation width = %d, want %d", got, want)
+	}
+	if got := canvas.Cells[0][1]; got.Rune != 'a' || got.Width != 1 {
+		t.Fatalf("cell after the orphan was disturbed: %+v", got)
+	}
+}
+
+// TestCanvasBlanksWidowedWideBase covers the mirror defect: a wide base whose
+// continuation was overwritten still draws two columns, so the rendered line
+// comes out one column too wide and everything after it shifts right.
+func TestCanvasBlanksWidowedWideBase(t *testing.T) {
+	row := vterm.MakeBlankLine(4)
+	row[0] = vterm.Cell{Rune: '中', Width: 2}
+	row[1] = vterm.Cell{Rune: 'a', Width: 1} // continuation overwritten
+	row[2] = vterm.Cell{Rune: 'b', Width: 1}
+
+	canvas := NewCanvas(4, 1)
+	canvas.DrawScreen(0, 0, 4, 1, [][]vterm.Cell{row}, CursorState{}, 0, SelectionRegion{})
+
+	if got, want := ansi.StringWidth(ansi.Strip(canvas.Render())), 4; got != want {
+		t.Fatalf("rendered width = %d, want %d (%q)", got, want, ansi.Strip(canvas.Render()))
+	}
+}
+
+// TestCanvasRenderKeepsColumnCount asserts on the rendered string rather than
+// on individual cells, so the orphan guard is pinned end-to-end through
+// Canvas.Render (the center pane's string fallback) and not just in the buffer.
+func TestCanvasRenderKeepsColumnCount(t *testing.T) {
+	row := vterm.MakeBlankLine(3)
+	row[0] = vterm.Cell{Width: 0} // orphan
+	row[1] = vterm.Cell{Rune: 'a', Width: 1}
+	row[2] = vterm.Cell{Rune: 'b', Width: 1}
+
+	canvas := NewCanvas(3, 1)
+	canvas.DrawScreen(0, 0, 3, 1, [][]vterm.Cell{row}, CursorState{}, 0, SelectionRegion{})
+
+	out := ansi.Strip(canvas.Render())
+	if got, want := ansi.StringWidth(out), 3; got != want {
+		t.Fatalf("rendered width = %d, want %d (%q)", got, want, out)
+	}
+	if want := " ab"; out != want {
+		t.Fatalf("rendered %q, want %q", out, want)
+	}
+}
+
+// TestCanvasDrawScreenKeepsWideGlyph pins that the orphan guard does not touch
+// a legitimate wide/continuation pair.
+func TestCanvasDrawScreenKeepsWideGlyph(t *testing.T) {
+	row := vterm.MakeBlankLine(4)
+	row[0] = vterm.Cell{Rune: '中', Width: 2}
+	row[1] = vterm.Cell{Width: 0}
+	row[2] = vterm.Cell{Rune: 'a', Width: 1}
+
+	canvas := NewCanvas(4, 1)
+	canvas.DrawScreen(0, 0, 4, 1, [][]vterm.Cell{row}, CursorState{}, 0, SelectionRegion{})
+
+	if canvas.Cells[0][0].Rune != '中' || canvas.Cells[0][0].Width != 2 {
+		t.Fatalf("wide base was altered: %+v", canvas.Cells[0][0])
+	}
+	if canvas.Cells[0][1].Width != 0 {
+		t.Fatalf("continuation cell was altered: %+v", canvas.Cells[0][1])
+	}
+}

--- a/internal/vterm/cell.go
+++ b/internal/vterm/cell.go
@@ -44,6 +44,33 @@ func DefaultCell() Cell {
 	return Cell{Rune: ' ', Width: 1}
 }
 
+// IsWideContinuation reports whether row[x] is the second column of a wide
+// glyph whose base sits at x-1.
+//
+// Every renderer emits nothing for a zero-width cell, on the assumption that
+// the wide glyph before it already covered both columns. A zero-width cell that
+// fails this test is an orphan (a half-erased glyph), and skipping it pulls the
+// rest of the line one column to the left — so renderers must draw a blank
+// there instead. normalizeLine uses the same rule to keep orphans out of the
+// buffer in the first place.
+func IsWideContinuation(row []Cell, x int) bool {
+	return x > 0 && x < len(row) && row[x].Width == 0 && row[x-1].Width == 2
+}
+
+// HasWideContinuation reports whether the wide glyph based at row[x] still owns
+// its second column within visibleWidth.
+//
+// This is the mirror of IsWideContinuation, and renderers need both. A wide
+// base draws two columns but is followed by a cell that draws one, so a base
+// that has lost its continuation — to a narrow overwrite, or to a resize that
+// pushed the second column out of view — makes the line render one column too
+// WIDE, drifting the rest of it right. Renderers must substitute a blank for
+// such a base. normalizeLine enforces the same rule on the write side, against
+// len(line) rather than a viewport width.
+func HasWideContinuation(row []Cell, x, visibleWidth int) bool {
+	return x >= 0 && x+1 < visibleWidth && x+1 < len(row) && row[x+1].Width == 0
+}
+
 // MakeBlankLine creates a blank line
 func MakeBlankLine(width int) []Cell {
 	line := make([]Cell, width)

--- a/internal/vterm/erase_wide_normalize_test.go
+++ b/internal/vterm/erase_wide_normalize_test.go
@@ -1,0 +1,56 @@
+package vterm
+
+import "testing"
+
+// Erasing part of a line can cut a wide glyph in half. Whichever half survives
+// is invalid: a lone continuation cell (Width 0) renders as nothing and pulls
+// the rest of the line one column left, and a lone wide cell (Width 2) claims a
+// column it no longer owns. eraseLine/eraseDisplay must normalize the line.
+func TestEraseSplitsWideGlyphIntoBlanks(t *testing.T) {
+	tests := []struct {
+		name string
+		seq  string
+	}{
+		// Cursor on the wide base; erase start-to-cursor leaves an orphan
+		// continuation at column 1.
+		{name: "EL1 leaves orphan continuation", seq: "\x1b[1;1H\x1b[1K"},
+		{name: "ED1 leaves orphan continuation", seq: "\x1b[1;1H\x1b[1J"},
+		// Cursor on the continuation column; erase cursor-to-end leaves a wide
+		// base at column 0 with no continuation.
+		{name: "EL0 leaves half a wide base", seq: "\x1b[1;2H\x1b[0K"},
+		{name: "ED0 leaves half a wide base", seq: "\x1b[1;2H\x1b[0J"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			term := New(4, 1)
+			term.Write([]byte("中ab"))
+			if term.Screen[0][0].Width != 2 || term.Screen[0][1].Width != 0 {
+				t.Fatalf("setup: expected wide pair, got %+v %+v", term.Screen[0][0], term.Screen[0][1])
+			}
+
+			term.Write([]byte(tc.seq))
+
+			for x := 0; x < 2; x++ {
+				if got := term.Screen[0][x].Width; got != 1 {
+					t.Fatalf("column %d width = %d, want 1 (line: %+v)", x, got, term.Screen[0])
+				}
+			}
+		})
+	}
+}
+
+// The normalization must not disturb an intact wide glyph elsewhere on the line.
+func TestEraseKeepsUntouchedWideGlyph(t *testing.T) {
+	term := New(6, 1)
+	term.Write([]byte("ab中cd"))
+	// Erase the two leading narrow cells only.
+	term.Write([]byte("\x1b[1;2H\x1b[1K"))
+
+	if term.Screen[0][2].Rune != '中' || term.Screen[0][2].Width != 2 {
+		t.Fatalf("wide glyph was dropped: %+v", term.Screen[0][2])
+	}
+	if term.Screen[0][3].Width != 0 {
+		t.Fatalf("continuation cell was dropped: %+v", term.Screen[0][3])
+	}
+}

--- a/internal/vterm/lineedit.go
+++ b/internal/vterm/lineedit.go
@@ -137,12 +137,12 @@ func normalizeLine(line []Cell) {
 		switch line[i].Width {
 		case 0:
 			// Continuation without a leading wide cell is invalid.
-			if i == 0 || line[i-1].Width != 2 {
+			if !IsWideContinuation(line, i) {
 				line[i] = DefaultCell()
 			}
 		case 2:
 			// If the continuation cell is missing, drop the wide glyph.
-			if i+1 >= len(line) || line[i+1].Width != 0 {
+			if !HasWideContinuation(line, i, len(line)) {
 				line[i] = DefaultCell()
 			}
 		}

--- a/internal/vterm/ops.go
+++ b/internal/vterm/ops.go
@@ -68,6 +68,12 @@ func (v *VTerm) putChar(r rune) {
 	if width == 2 && v.CursorX == v.Width-1 {
 		// Put a space in the last column and wrap
 		if v.CursorY >= 0 && v.CursorY < len(v.Screen) {
+			// The space may land on the continuation of a wide glyph based one
+			// column left; clear that base too, or it is left claiming a column
+			// it no longer owns and the line renders one column too wide.
+			if IsWideContinuation(v.Screen[v.CursorY], v.CursorX) {
+				v.Screen[v.CursorY][v.CursorX-1] = DefaultCell()
+			}
 			v.Screen[v.CursorY][v.CursorX] = Cell{
 				Rune:  ' ',
 				Style: v.CurrentStyle,
@@ -196,6 +202,7 @@ func (v *VTerm) eraseDisplay(mode int) {
 					v.Screen[v.CursorY][x] = DefaultCell()
 				}
 			}
+			normalizeLine(v.Screen[v.CursorY])
 		}
 		// Clear all lines below
 		for y := v.CursorY + 1; y < v.Height; y++ {
@@ -218,6 +225,7 @@ func (v *VTerm) eraseDisplay(mode int) {
 					v.Screen[v.CursorY][x] = DefaultCell()
 				}
 			}
+			normalizeLine(v.Screen[v.CursorY])
 		}
 		v.markDirtyRange(0, v.CursorY)
 	case 2, 3: // Entire display (3 normally also clears scrollback)
@@ -259,6 +267,9 @@ func (v *VTerm) eraseLine(mode int) {
 		return
 	}
 
+	// A partial erase can cut a wide glyph in half; normalizeLine drops the
+	// leftover half so the line keeps exactly one cell per column. Mode 2
+	// replaces the whole line with blanks, so it needs no normalization.
 	switch mode {
 	case 0: // Cursor to end
 		for x := v.CursorX; x < v.Width; x++ {
@@ -266,12 +277,14 @@ func (v *VTerm) eraseLine(mode int) {
 				v.Screen[v.CursorY][x] = DefaultCell()
 			}
 		}
+		normalizeLine(v.Screen[v.CursorY])
 	case 1: // Start to cursor
 		for x := 0; x <= v.CursorX && x < v.Width; x++ {
 			if x < len(v.Screen[v.CursorY]) {
 				v.Screen[v.CursorY][x] = DefaultCell()
 			}
 		}
+		normalizeLine(v.Screen[v.CursorY])
 	case 2: // Entire line
 		v.Screen[v.CursorY] = MakeBlankLine(v.Width)
 	}

--- a/internal/vterm/render.go
+++ b/internal/vterm/render.go
@@ -271,8 +271,20 @@ func (v *VTerm) renderRow(row []Cell, y int) string {
 			lastReverse = inSel
 		}
 
-		// Skip continuation cells (part of wide character)
+		// Skip continuation cells (part of wide character). An orphan gets a
+		// blank instead: emitting nothing for it would shift the rest of the
+		// line one column left (see IsWideContinuation).
 		if cell.Width == 0 {
+			if IsWideContinuation(row, x) {
+				continue
+			}
+			buf.WriteByte(' ')
+			continue
+		}
+		// A wide base that lost its second column would render one column too
+		// wide, shifting the rest of the line right (see HasWideContinuation).
+		if cell.Width == 2 && !HasWideContinuation(row, x, v.Width) {
+			buf.WriteByte(' ')
 			continue
 		}
 
@@ -342,8 +354,18 @@ func (v *VTerm) renderWithScrollbackFrom(screen [][]Cell, scrollbackLen int) str
 				firstCell = false
 			}
 
-			// Skip continuation cells (part of wide character)
+			// Skip continuation cells (part of wide character). An orphan gets
+			// a blank instead; see IsWideContinuation.
 			if cell.Width == 0 {
+				if IsWideContinuation(row, x) {
+					continue
+				}
+				buf.WriteByte(' ')
+				continue
+			}
+			// A wide base that lost its second column; see HasWideContinuation.
+			if cell.Width == 2 && !HasWideContinuation(row, x, v.Width) {
+				buf.WriteByte(' ')
 				continue
 			}
 

--- a/internal/vterm/render_wide_orphan_test.go
+++ b/internal/vterm/render_wide_orphan_test.go
@@ -1,0 +1,114 @@
+package vterm
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func orphanLine() []Cell {
+	return []Cell{
+		{Rune: 'a', Width: 1},
+		{Width: 0}, // zero-width cell with no wide glyph before it
+		{Rune: 'b', Width: 1},
+		{Rune: 'c', Width: 1},
+	}
+}
+
+func widePairLine() []Cell {
+	return []Cell{
+		{Rune: '中', Width: 2},
+		{Width: 0},
+		{Rune: 'b', Width: 1},
+		{Rune: 'c', Width: 1},
+	}
+}
+
+// Renderers emit nothing for a zero-width cell. That is correct for the second
+// column of a wide glyph and wrong for an orphan, which must occupy its column
+// or the rest of the line renders one column too far left.
+func TestRenderBlanksOrphanContinuation(t *testing.T) {
+	t.Run("live screen", func(t *testing.T) {
+		term := New(4, 1)
+		term.Screen[0] = orphanLine()
+		term.invalidateRenderCache()
+
+		out := ansi.Strip(term.Render())
+		if got, want := ansi.StringWidth(out), 4; got != want {
+			t.Fatalf("rendered width = %d, want %d (%q)", got, want, out)
+		}
+		if want := "a bc"; out != want {
+			t.Fatalf("rendered %q, want %q", out, want)
+		}
+	})
+
+	t.Run("scrollback view", func(t *testing.T) {
+		term := New(4, 1)
+		term.Scrollback = [][]Cell{orphanLine()}
+		term.ScrollView(1)
+		if term.ViewOffset == 0 {
+			t.Fatalf("setup: expected a scrolled view")
+		}
+
+		out := ansi.Strip(term.Render())
+		if got, want := ansi.StringWidth(out), 4; got != want {
+			t.Fatalf("rendered width = %d, want %d (%q)", got, want, out)
+		}
+		if want := "a bc"; out != want {
+			t.Fatalf("rendered %q, want %q", out, want)
+		}
+	})
+}
+
+// The blank substitution must not touch a legitimate wide pair, which really
+// does occupy two columns with one emitted glyph.
+func TestRenderKeepsWidePair(t *testing.T) {
+	t.Run("live screen", func(t *testing.T) {
+		term := New(4, 1)
+		term.Screen[0] = widePairLine()
+		term.invalidateRenderCache()
+
+		if got, want := ansi.Strip(term.Render()), "中bc"; got != want {
+			t.Fatalf("rendered %q, want %q", got, want)
+		}
+	})
+
+	t.Run("scrollback view", func(t *testing.T) {
+		term := New(4, 1)
+		term.Scrollback = [][]Cell{widePairLine()}
+		term.ScrollView(1)
+
+		if got, want := ansi.Strip(term.Render()), "中bc"; got != want {
+			t.Fatalf("rendered %q, want %q", got, want)
+		}
+	})
+}
+
+func TestIsWideContinuation(t *testing.T) {
+	pair := widePairLine()
+	orphan := orphanLine()
+
+	tests := []struct {
+		name string
+		row  []Cell
+		x    int
+		want bool
+	}{
+		{name: "continuation of a wide glyph", row: pair, x: 1, want: true},
+		{name: "the wide base itself", row: pair, x: 0, want: false},
+		{name: "narrow cell", row: pair, x: 2, want: false},
+		{name: "orphan after a narrow cell", row: orphan, x: 1, want: false},
+		{name: "zero-width cell at column 0", row: []Cell{{Width: 0}}, x: 0, want: false},
+		{name: "index past the row", row: pair, x: len(pair), want: false},
+		{name: "negative index", row: pair, x: -1, want: false},
+		{name: "empty row", row: nil, x: 1, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsWideContinuation(tc.row, tc.x); got != tc.want {
+				t.Fatalf("IsWideContinuation(%v) = %v, want %v", tc.x, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vterm/render_wide_widow_test.go
+++ b/internal/vterm/render_wide_widow_test.go
@@ -1,0 +1,102 @@
+package vterm
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A wide glyph draws two columns. If it loses its continuation cell it still
+// draws two while the buffer owns one, so the line renders one column too wide
+// and everything after it shifts right — the mirror of the orphan bug.
+func TestRenderBlanksWidowedWideBase(t *testing.T) {
+	t.Run("continuation pushed out of view by resize", func(t *testing.T) {
+		// resizeRows keeps rows wider than the viewport, so after shrinking the
+		// wide base sits in the last visible column with its continuation just
+		// outside it.
+		v := New(8, 1)
+		v.Write([]byte("abc中de"))
+		v.Resize(4, 1)
+
+		out := ansi.Strip(v.Render())
+		if got, want := ansi.StringWidth(out), v.Width; got != want {
+			t.Fatalf("rendered width = %d, want %d (%q)", got, want, out)
+		}
+	})
+
+	t.Run("scrollback line wider than the viewport", func(t *testing.T) {
+		v := New(4, 2)
+		v.PrependScrollbackWithSize([]byte("abc中de\nqqqq"), 8, 2)
+		v.ScrollViewTo(2)
+		if v.ViewOffset == 0 {
+			t.Fatalf("setup: expected a scrolled view")
+		}
+
+		out := ansi.Strip(v.Render())
+		for i, line := range splitLines(out) {
+			if got, want := ansi.StringWidth(line), v.Width; got != want {
+				t.Fatalf("scrolled line %d width = %d, want %d (%q)", i, got, want, line)
+			}
+		}
+	})
+
+	t.Run("continuation overwritten mid-line", func(t *testing.T) {
+		// A wide glyph at the last two columns, then another wide glyph starting
+		// in the final column: the second one wraps, and the space it leaves
+		// behind lands on the first one's continuation cell.
+		v := New(12, 2)
+		v.Write([]byte("\x1b[1;11H中"))
+		v.Write([]byte("\x1b[1;12H中"))
+
+		if v.Screen[0][10].Width == 2 && v.Screen[0][11].Width != 0 {
+			t.Fatalf("putChar left a widowed wide base at column 10: %+v", v.Screen[0][10])
+		}
+		for i, line := range splitLines(ansi.Strip(v.Render())) {
+			if got, want := ansi.StringWidth(line), v.Width; got != want {
+				t.Fatalf("line %d width = %d, want %d (%q)", i, got, want, line)
+			}
+		}
+	})
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, s[start:])
+}
+
+func TestHasWideContinuation(t *testing.T) {
+	pair := []Cell{{Rune: '中', Width: 2}, {Width: 0}, {Rune: 'a', Width: 1}}
+	widowed := []Cell{{Rune: '中', Width: 2}, {Rune: 'a', Width: 1}, {Rune: 'b', Width: 1}}
+
+	tests := []struct {
+		name         string
+		row          []Cell
+		x            int
+		visibleWidth int
+		want         bool
+	}{
+		{name: "intact pair", row: pair, x: 0, visibleWidth: 3, want: true},
+		{name: "continuation overwritten", row: widowed, x: 0, visibleWidth: 3, want: false},
+		{name: "continuation outside the viewport", row: pair, x: 0, visibleWidth: 1, want: false},
+		{name: "base in the last visible column", row: pair, x: 2, visibleWidth: 3, want: false},
+		{name: "index past the row", row: pair, x: len(pair), visibleWidth: 9, want: false},
+		{name: "negative index", row: pair, x: -1, visibleWidth: 3, want: false},
+		{name: "empty row", row: nil, x: 0, visibleWidth: 3, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasWideContinuation(tc.row, tc.x, tc.visibleWidth); got != tc.want {
+				t.Fatalf("HasWideContinuation(x=%d, w=%d) = %v, want %v",
+					tc.x, tc.visibleWidth, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

Terminal text jumped one column to the **left** while scrolling and while output streamed in, snapping back when scrolling stopped.

A wide glyph (CJK/emoji) occupies two cells — a base (`Width 2`) and a continuation (`Width 0`) — and a renderer must draw exactly one column per cell. Both halves could be orphaned, and each drifted the line a different way.

### Drift left (the reported symptom)

`VTermLayer.DrawAt` explicitly wrote the zero-width continuation cell. But ultraviolet's `Line.Set` *already* stamps that placeholder when the base cell is set, and it reads a write **to** a placeholder as "something is overwriting half of a wide glyph" — so our explicit write blanked the base we had just drawn, leaving a space plus an orphan placeholder. Renderers emit nothing for a zero-width cell, so every cell after it landed one column to the left.

Measured on a real composed frame:

```
before:  | AB CD    ...  |     row width 117   <- glyph gone, line short
after:   | AB✅CD   ...  |     row width 118   <- matches every other row
```

### Drift right (found while reviewing the fix)

The mirror case: a base whose continuation was overwritten, or pushed out of the viewport by a resize (`resizeRows` deliberately keeps rows wider than the viewport), still drew two columns where the buffer owned one. The pre-existing guard only covered a base in the *last visible column*, so a mid-line widowed base slipped through:

```
New(8,1); Write("abc中de"); Resize(4,1)  ->  renders 5 columns in a 4-wide terminal
```

`putChar`'s wide-glyph wrap was one producer of that shape: the space it writes into the last column could land on another glyph's continuation cell.

## The fix

Both rules now live in one place — `vterm.IsWideContinuation` and `vterm.HasWideContinuation` — and are applied at **all four** renderers: `VTermLayer.DrawAt`, `Canvas.DrawScreen`, and vterm's `renderRow` / `renderWithScrollbackFrom`. Previously only the compositor had (half of) the logic, hand-rolled.

`normalizeLine` enforces the same pair on the write side. The erase ops now call it, and `putChar`'s wrap clears the stale half it used to leave behind, so neither shape normally reaches a snapshot at all. The renderer guards remain as defense in depth, and are load-bearing for rows legitimately wider than the viewport — where the write side cannot know the render width.

## Verification

Every hunk is covered by a test that fails when that hunk alone is reverted:

| Reverted | Caught by |
|---|---|
| `vtermlayer.go` | `TestVTermLayerKeepsWideGlyphAndColumnAlignment`, `TestCenterPaneKeepsWideGlyphColumns` (real composed frame) |
| `canvas.go` | `TestCanvasDrawScreenBlanksOrphanContinuationCell`, `TestScrolledChatHistoryBlanksWidowedWideBase` |
| `render.go` | `TestRenderBlanksOrphanContinuation`, `TestRenderBlanksWidowedWideBase` (all subtests) |
| `ops.go` | `TestEraseSplitsWideGlyphIntoBlanks` (all 4 subtests) |

Coverage includes the **scrolled chat-history view** (`model_scrolled_history_wide_test.go`) — the exact path the user was on when they hit this.

- `make devcheck` — exit 0
- `make lint-strict-new` — 0 issues
- Rebased onto `fe460339` and re-verified.
- `make perf-check` fails on this host **both with and without these changes** (unmodified control measured *worse*: 39.9ms CENTER vs 19.1ms with the fix, against a 1.04ms baseline) — it is measuring host load, not this change. The new guard short-circuits on `cell.Width == 2` exactly like the code it replaces, so narrow cells cost the same.

## Review notes

Two independent adversarial reviews ran against this. One tried to refute correctness with a differential test driving randomized vterm traffic through the incremental snapshot/dirty-line/row-reuse path against a fresh full snapshot — zero divergence, and confirmed stale-column scrubbing still happens via `Line.Set`. The other swept every `Width == 0` consumer in the repo; the six text-extraction sites (clipboard copy, activity hashing, cursor glyph, scrollback delta, `CellsToASCII`) correctly need no guard. Both independently surfaced the drift-right mirror defect, which is fixed here.