### PR TITLE
fix: keep sync-frame flushes whole through the noise filter

### DIFF
--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -41,18 +41,26 @@ blank frame. Three mechanisms prevent that:
    with no body.
 
 (3) is what makes (2) work, and it is not optional. tmux writes the client
-socket in ≤1KB chunks, so a redraw larger than that spans several reads —
-measured on a streaming pane, 53% of reads end inside an open region, and
-without (3) 43% of flushes hand the vterm half a frame. The freeze in (2) then
-holds the *previous* frame, so the pane shows stale content and reports every
-line dirty (a full repaint) until the next flush closes the region. With (3)
-that drops to ~1% of flushes, at the same flush rate.
+socket in ≤1KB chunks, so a redraw larger than that spans several reads — on a
+captured streaming pane roughly half the reads (46% of 567) leave the terminal
+inside an open region. The freeze in (2) then holds the *previous* frame, so a
+flush that ends there shows stale content and reports every line dirty (a full
+repaint) until the next flush closes the region. Replaying that captured stream
+through the flush path: 84 of 456 flushes (18%) opened a mid-frame gap without
+(3), none with it, at an identical flush count.
+
+Measure this with the vterm parser, not by counting marker bytes: markers split
+across reads make a byte counter drift, and it drifts in the direction that
+overstates the problem.
 
 A writer that brackets its frames also makes the flush quiet period redundant
 for that frame — the debounce exists to guess where a frame ends — so a
 completed frame flushes immediately instead of waiting the quiet period out.
-The reader's frame-interval coalescing upstream still caps how often that can
-happen, so this lowers latency without raising the flush rate.
+That applies at the base cadence only: callers ask for a slower one by raising
+the quiet period (alt-screen timing, backpressure, the inactive-tab
+multipliers), and those still get the debounce. The reader's frame-interval
+coalescing upstream caps how often the early flush can fire, so it lowers
+latency without raising the flush rate.
 
 Sync-end deliberately does **not** invalidate the render cache: dirty marks
 accumulated during the window are preserved because frozen renders skip

--- a/internal/ui/center/model_input_lifecycle_flush_sync_test.go
+++ b/internal/ui/center/model_input_lifecycle_flush_sync_test.go
@@ -21,9 +21,15 @@ const (
 
 // syncFlushTab builds an active tab whose quiet period has elapsed (so the
 // flush gate is past its first branch) while both partial-frame ceilings are
-// still far off. The elapsed window clears every quiet value flushTiming can
-// pick — including the longer alt-screen one — so a deferral in these tests can
-// only come from the partial-frame hold, never from the quiet period.
+// still far off, so a deferral in these tests can only come from the
+// partial-frame hold, never from the quiet period.
+//
+// The elapsed window clears the base and alt-screen quiet periods. flushTiming
+// can also return the backpressure floor and the inactive-tab multiples, which
+// are larger — these tabs are active and buffer far less than the backpressure
+// threshold, so neither is reachable here. If that ever changes,
+// TestUpdatePTYFlush_HoldsLoneSyncBegin would quietly become a test of the
+// quiet branch instead (the other three would fail loudly).
 func syncFlushTab(t *testing.T, id, pending string) (*Model, *Tab, string) {
 	t.Helper()
 	if ptyFlushQuietElapsed <= ptyFlushQuiet || ptyFlushQuietElapsed <= ptyFlushQuietAlt {
@@ -61,10 +67,16 @@ func syncFlushTab(t *testing.T, id, pending string) (*Model, *Tab, string) {
 func TestUpdatePTYFlush_HoldsLoneSyncBegin(t *testing.T) {
 	m, tab, wsID := syncFlushTab(t, "tab-sync-begin", testSyncBegin)
 
-	_ = m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
+	cmd := m.updatePTYFlush(PTYFlush{WorkspaceID: wsID, TabID: tab.ID})
 
 	if got, want := string(tab.PendingOutput), testSyncBegin; got != want {
 		t.Fatalf("pending output = %q, want the sync-begin still buffered", got)
+	}
+	// The hold is only bounded because it re-arms: without a retry tick the
+	// frame sits until the next PTYOutput happens to arrive, which is the stall
+	// the ceilings exist to prevent.
+	if cmd == nil {
+		t.Fatal("hold scheduled no retry tick")
 	}
 	if tab.Terminal.SyncActive() {
 		t.Fatal("terminal is sync-frozen, want the partial frame withheld")

--- a/internal/ui/ptyio/flush.go
+++ b/internal/ui/ptyio/flush.go
@@ -55,8 +55,9 @@ func TrimOverflow(pending []byte, maxBuffered int, seed vterm.ParserCarryState) 
 // the terminal to hold the display steady, ESC[?2026l releases it. tmux wraps
 // every client redraw this way (amux advertises the sync terminal feature —
 // see internal/tmux/command.go), but it writes the client socket in ≤1KB
-// chunks, so any redraw bigger than that spans several reads: measured on a
-// streaming pane, 53% of reads end inside an open region.
+// chunks, so any redraw bigger than that spans several reads: on a captured
+// streaming pane roughly half the reads (46% of 567) leave the terminal inside
+// an open region.
 //
 // A flush that ends there hands the vterm half a frame. The vterm's freeze then
 // holds the *previous* frame, so the pane shows stale content and reports every
@@ -65,11 +66,12 @@ func TrimOverflow(pending []byte, maxBuffered int, seed vterm.ParserCarryState) 
 // So flushes end on frame boundaries: a flush stops at the last completed
 // region and leaves a partial frame buffered (TakeFlushChunkLocked), and when
 // nothing has completed there is nothing worth writing, so the flush waits
-// instead (FlushDelay). On the same streaming trace that takes flushes ending
-// mid-frame from 43% to ~1%, at an unchanged flush rate. Both waits are bounded
-// — the flush ceilings cap them, and a partial frame that reaches the terminal
-// anyway still has vterm.SyncStallTimeout behind it — so a writer that dies
-// mid-frame cannot stall the pane.
+// instead (FlushDelay). Replaying that captured stream through this path, 84 of
+// 456 flushes (18%) opened a mid-frame gap without the policy and none do with
+// it, at an identical flush count. Both waits are bounded — the flush ceilings
+// cap them, and a partial frame that reaches the terminal anyway still has
+// vterm.SyncStallTimeout behind it — so a writer that dies mid-frame cannot
+// stall the pane.
 
 // syncMarkerPrefix is the shared prefix of the DEC 2026 begin/end markers; the
 // byte after it selects which one — 'h' opens a region, 'l' closes it, and
@@ -85,17 +87,26 @@ var syncMarkerPrefix = []byte("\x1b[?2026")
 
 const (
 	// syncTailScanLimit bounds the marker scan so a large backlog does not pay
-	// for the whole buffer. It has to comfortably exceed one frame — a marker
-	// further back than this is invisible here, which for a sync-begin means the
-	// frame is flushed half-drawn after all — so it is sized for a full-screen
-	// truecolor repaint on a large pane rather than for the per-keystroke frames
-	// that motivated this. The scan stays cheap at that size: see
-	// BenchmarkScanSyncFrames, which is orders of magnitude under the cost of
-	// writing the same bytes to the vterm.
+	// for the whole buffer. It covers the redraws seen in practice with room to
+	// spare, but it is not a guarantee: a worst-case full-screen truecolor
+	// repaint (a 200x50 pane at ~20 bytes of SGR per cell) is several times this,
+	// and a marker further back than the window is invisible here. Both ways of
+	// being wrong about such a frame are bounded — a missed sync-begin flushes it
+	// half-drawn exactly as before this policy existed, and a missed sync-end
+	// holds it until a flush ceiling fires. Raising the limit costs scan time on
+	// every flush (see BenchmarkScanSyncFrames) to buy correctness for frames
+	// that large, which is why it is not simply set to the buffer cap.
 	syncTailScanLimit = 64 * 1024
 	// syncHoldRetry is how soon a flush held for a partial frame retries. The
 	// frame body that closes the region also restarts the quiet period, so this
 	// only needs to be short enough not to add visible latency itself.
+	//
+	// It is a rate/latency knob, and holds are common enough for it to matter:
+	// on a captured streaming pane a hold costs 2.7 retry ticks per flush (~61
+	// timer wakeups/sec for one busy tab) while the flush count itself is
+	// unchanged. Raising it trades those wakeups for up to that much extra delay
+	// in noticing a frame completed; the frame cannot be displayed until it does,
+	// so the cost is only in the noticing.
 	syncHoldRetry = 4 * time.Millisecond
 )
 
@@ -110,9 +121,9 @@ const (
 // goroutine twice per flush, and the backward form costs ~100x more per byte.
 //
 // It reads pending in isolation, which costs it two cases the vterm's parser
-// sees and it does not: a terminal already inside a region (only reachable once
-// a chunk cap has split a frame too large to fall back from), and a marker
-// split across the cut. Both report a buffer as ending outside a frame when it
+// sees and it does not: a terminal already inside a region — most often because
+// a flush ceiling fired on a partial frame, and also when a chunk cap split a
+// frame too large to fall back from — and a marker split across the cut. Both report a buffer as ending outside a frame when it
 // does not, and both cost at most the frozen frame that would have happened
 // anyway — never a dropped or reordered byte. Carrying that state would mean
 // threading the terminal through every flush call for cases that need a single
@@ -138,11 +149,17 @@ func scanSyncFrames(pending []byte) (safeLen int, hasCompleteFrame bool) {
 		switch window[i] {
 		case 'h':
 			open = true
+			i++
 		case 'l':
 			open = false
 			lastEnd = i + 1
+			i++
+		default:
+			// Not a terminator (a DECRQM '$' query, or an aborted prefix). Resume
+			// at this byte rather than past it: it may itself be the ESC opening
+			// the next marker, and skipping it would lose that marker. The next
+			// search still advances, so this cannot loop.
 		}
-		i++
 	}
 	hasCompleteFrame = lastEnd >= 0 && !open
 	switch {
@@ -155,11 +172,14 @@ func scanSyncFrames(pending []byte) (safeLen int, hasCompleteFrame bool) {
 	}
 }
 
-// FlushDelay implements the flush quiet-period policy: a flush is deferred
-// while output is still arriving (quietFor < quiet), or while the buffer holds
-// only the opening half of a synchronized-output frame, unless it has already
-// been pending longer than maxInterval. It returns the delay before the next
-// flush attempt and whether the flush should be deferred.
+// FlushDelay implements the flush quiet-period policy. A flush is deferred
+// while output is still arriving (quietFor < quiet), except that at the base
+// cadence a buffered complete synchronized-output frame goes out without
+// waiting. It is also deferred while the buffer holds only the opening half of
+// such a frame; that hold releases once either ceiling passes maxInterval —
+// pendingFor or quietFor, since pendingFor stays zero until a caller sets
+// FlushPendingSince. It returns the delay before the next flush attempt and
+// whether the flush should be deferred.
 func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (time.Duration, bool) {
 	quietFor := now.Sub(st.LastOutputAt)
 	pendingFor := time.Duration(0)
@@ -175,8 +195,9 @@ func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (ti
 	//
 	// Only at the base cadence, though. Every caller that wants a slower one —
 	// alt-screen timing, backpressure, the inactive-tab multipliers — asks by
-	// raising quiet above PtyFlushQuiet, and those exist to shed render work
-	// (an inactive tab flushes up to 12x less often). Skipping the wait for a
+	// raising quiet above PtyFlushQuiet, and those exist to shed render work (an
+	// inactive tab's quiet period is multiplied up to 12x; its ceiling grows less,
+	// being capped at ptyFlushInactiveMaxIntervalCap). Skipping the wait for a
 	// finished frame would undo precisely the throttling they asked for, and
 	// tmux brackets every redraw, so it would fire on nearly every flush.
 	earlyFrameFlush := hasCompleteFrame && quiet <= PtyFlushQuiet
@@ -202,10 +223,12 @@ func (st *State) FlushDelay(now time.Time, quiet, maxInterval time.Duration) (ti
 // non-positive maxChunk takes the whole buffer. The chunk also stops at the
 // last completed synchronized-output frame, so complete frames are displayed
 // now and a partial frame at the tail stays buffered instead of freezing the
-// terminal mid-redraw. A zero safe length is deliberately not clamped: that is
-// the case FlushDelay already held for as long as its ceilings allow, and
-// taking nothing would spin the flush tick forever. The caller must hold the
-// state lock.
+// terminal mid-redraw. A zero safe length is deliberately not clamped, and
+// taking nothing would spin the flush tick forever. That happens either because
+// FlushDelay already held this buffer for as long as its ceilings allow, or
+// because maxChunk cut inside the first frame while complete frames sit past
+// the cut — a buffer FlushDelay saw as safe. The caller must hold the state
+// lock.
 func (st *State) TakeFlushChunkLocked(maxChunk int) []byte {
 	chunkSize := len(st.PendingOutput)
 	if maxChunk > 0 && chunkSize > maxChunk {

--- a/internal/ui/ptyio/flush_sync_test.go
+++ b/internal/ui/ptyio/flush_sync_test.go
@@ -325,3 +325,50 @@ func flushPipelineRoundTrip(t *testing.T, chunkCap int, wantNoGaps bool) {
 		t.Fatalf("stream corrupted: wrote %d bytes, want %d", len(written), len(stream))
 	}
 }
+
+// The flush path deliberately ends a chunk right after ESC[?2026l, which puts
+// the closing marker in the trailing line the noise filter inspects. That test
+// runs on ANSI-stripped text, so a redraw whose visible tail happens to read
+// like a macOS malloc diagnostic used to take the marker into the carry with it
+// — leaving the terminal frozen on the previous frame despite the flush having
+// written what it believed was a whole frame.
+func TestWriteFilteredChunkKeepsSyncEnd(t *testing.T) {
+	frame := "\x1b[?2026h\x1b[2Kredraw\r\nsomefunc(42)\x1b[?2026l"
+	st := &State{PendingOutput: []byte(frame)}
+	term := vterm.New(80, 24)
+
+	chunk := st.TakeFlushChunkLocked(0)
+	if safe, complete := scanSyncFrames(chunk); !complete || safe != len(chunk) {
+		t.Fatalf("scan says safe=%d complete=%v, want the whole frame", safe, complete)
+	}
+
+	st.WriteFilteredChunkLocked(term.Write, chunk)
+
+	if term.SyncActive() {
+		t.Fatalf("terminal left sync-frozen; noise filter withheld %q", st.NoiseTrailing)
+	}
+	if bytes.Contains(st.NoiseTrailing, syncMarkerPrefix) {
+		t.Fatalf("NoiseTrailing carries a sync marker: %q", st.NoiseTrailing)
+	}
+}
+
+// The scan resumes at a non-terminator byte rather than past it, so a marker
+// starting immediately after an aborted prefix is still seen. Malformed output
+// only, but the vterm's parser cancels the aborted sequence and honors the
+// second marker, and the scan has to agree with it.
+func TestScanSyncFramesMarkerAfterAbortedPrefix(t *testing.T) {
+	pending := []byte("\x1b[?2026hbody\x1b[?2026l\x1b[?2026\x1b[?2026hpartial")
+	safe, complete := scanSyncFrames(pending)
+	if want := len("\x1b[?2026hbody\x1b[?2026l"); safe != want {
+		t.Fatalf("safeLen = %d, want %d (stop at the completed frame)", safe, want)
+	}
+	if !complete {
+		t.Fatal("hasCompleteFrame = false, want true")
+	}
+
+	term := vterm.New(80, 24)
+	term.Write(pending[:safe])
+	if term.SyncActive() {
+		t.Fatal("terminal left mid-frame after writing the reported safe prefix")
+	}
+}

--- a/internal/ui/ptyio/flush_test.go
+++ b/internal/ui/ptyio/flush_test.go
@@ -365,6 +365,22 @@ func TestFlushDelay(t *testing.T) {
 		}
 	})
 
+	// The counterpart to the defer case below: without this, extending the
+	// partial-frame hold to cover unbracketed output too would go unnoticed, and
+	// every plain streaming write would wait for the ceiling instead of the quiet
+	// period — the exact latency regression this whole path exists to avoid.
+	t.Run("unbracketed output flushes once the quiet period elapses", func(t *testing.T) {
+		st := &State{
+			LastOutputAt:      base,
+			FlushPendingSince: base,
+			PendingOutput:     []byte("plain streaming output"),
+		}
+		now := base.Add(quiet)
+		if delay, shouldDefer := st.FlushDelay(now, quiet, maxInterval); shouldDefer {
+			t.Fatalf("defer = true (delay %v), want false — unbracketed output must not be held", delay)
+		}
+	})
+
 	t.Run("output without frame markers still waits out the quiet period", func(t *testing.T) {
 		st := &State{
 			LastOutputAt:      base,

--- a/internal/ui/ptyio/pty_output_filter.go
+++ b/internal/ui/ptyio/pty_output_filter.go
@@ -229,6 +229,17 @@ func shouldBufferPotentialDiagnosticFragment(line []byte) bool {
 	if len(line) == 0 {
 		return false
 	}
+	// Never withhold a fragment carrying a synchronized-output marker. The test
+	// below runs on ANSI-stripped text, so a redraw whose visible tail happens to
+	// read like a malloc diagnostic ("somefunc(42)") would take its ESC[?2026l
+	// with it into the carry — and the flush path deliberately ends chunks right
+	// after that marker, which puts it in this trailing line every time. Holding
+	// it back leaves the terminal frozen on the previous frame until the next
+	// chunk or vterm.SyncStallTimeout releases it. A real malloc diagnostic never
+	// contains one.
+	if bytes.Contains(line, syncMarkerPrefix) {
+		return false
+	}
 	if bytes.IndexByte(line, 0x1b) >= 0 {
 		line = []byte(ansi.Strip(string(line)))
 	}

--- a/internal/ui/sidebar/terminal_flush_timing_test.go
+++ b/internal/ui/sidebar/terminal_flush_timing_test.go
@@ -1,0 +1,38 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// Background sidebar terminals keep streaming while another tab is selected, so
+// flush handlers must time the terminal they are flushing. Timing by the
+// selected tab hands an alt-screen terminal the faster non-alt cadence, and the
+// shared flush policy reads the quiet period to tell whether the caller asked
+// for a slower one (ptyio.FlushDelay gates its early frame flush on it).
+func TestFlushTimingForUsesTheGivenTerminal(t *testing.T) {
+	m := newTerminalModelWithWorkspace(t)
+	wsID := m.workspaceID()
+
+	altTerm := vterm.New(80, 24)
+	altTerm.Write([]byte("\x1b[?1049h")) // enter alt screen
+	if !altTerm.AltScreen {
+		t.Fatal("setup: terminal did not enter alt screen")
+	}
+	background := &TerminalTab{ID: "bg", Name: "bg", State: &TerminalState{VTerm: altTerm}}
+	selected := &TerminalTab{ID: "sel", Name: "sel", State: &TerminalState{VTerm: vterm.New(80, 24)}}
+
+	m.tabs.ByWorkspace[wsID] = []*TerminalTab{background, selected}
+	m.tabs.ActiveByWorkspace[wsID] = 1 // the non-alt tab is on screen
+
+	quiet, maxInterval := m.flushTimingFor(background.State)
+	if quiet != ptyFlushQuietAlt || maxInterval != ptyFlushMaxAlt {
+		t.Fatalf("background alt terminal timed as (%v, %v), want alt timing (%v, %v)",
+			quiet, maxInterval, ptyFlushQuietAlt, ptyFlushMaxAlt)
+	}
+
+	if quiet, _ := m.flushTimingFor(selected.State); quiet != ptyFlushQuiet {
+		t.Fatalf("selected non-alt terminal timed as %v, want %v", quiet, ptyFlushQuiet)
+	}
+}

--- a/internal/ui/sidebar/terminal_update.go
+++ b/internal/ui/sidebar/terminal_update.go
@@ -10,9 +10,13 @@ import (
 	"github.com/andyrewlee/amux/internal/ui/common"
 )
 
-// flushTiming returns the appropriate flush timing
-func (m *TerminalModel) flushTiming() (time.Duration, time.Duration) {
-	ts := m.getTerminal()
+// flushTimingFor returns the flush timing for a specific terminal. Callers must
+// pass the terminal they are flushing, not the selected one: background
+// terminals keep streaming, and timing them by whatever happens
+// to be on screen gives an alt-screen terminal the faster non-alt cadence — and
+// the flush policy reads the quiet period to decide whether a caller asked for
+// a slower cadence (see ptyio.FlushDelay).
+func (m *TerminalModel) flushTimingFor(ts *TerminalState) (time.Duration, time.Duration) {
 	if ts == nil {
 		return ptyFlushQuiet, ptyFlushMaxInterval
 	}

--- a/internal/ui/sidebar/terminal_update_pty.go
+++ b/internal/ui/sidebar/terminal_update_pty.go
@@ -54,7 +54,7 @@ func (m *TerminalModel) handlePTYOutput(msg messages.SidebarPTYOutput) tea.Cmd {
 	if !ts.FlushScheduled {
 		ts.FlushScheduled = true
 		ts.FlushPendingSince = now
-		quiet, _ := m.flushTiming()
+		quiet, _ := m.flushTimingFor(ts)
 		return common.SafeTick(quiet, func(t time.Time) tea.Msg {
 			return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
 		})
@@ -71,7 +71,7 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 		return nil
 	}
 	ts := tab.State
-	quiet, maxInterval := m.flushTiming()
+	quiet, maxInterval := m.flushTimingFor(ts)
 	if delay, deferred := ts.State.FlushGate(time.Now(), quiet, maxInterval); deferred {
 		return common.SafeTick(delay, func(t time.Time) tea.Msg {
 			return messages.SidebarPTYFlush{WorkspaceID: wsID, TabID: msg.TabID}
@@ -101,7 +101,7 @@ func (m *TerminalModel) handlePTYFlush(msg messages.SidebarPTYFlush) tea.Cmd {
 	if !ts.State.RearmFlush(time.Now(), nil) {
 		return nil
 	}
-	delay, _ := m.flushTiming()
+	delay, _ := m.flushTimingFor(ts)
 	if delay < time.Millisecond {
 		delay = time.Millisecond
 	}


### PR DESCRIPTION
Follow-ups from a review round on #621: three defects, two test gaps, and corrected numbers. Every fix is mutation-verified (reverting it fails a test).

## Defects

**The noise filter swallowed the closing sync marker.** `FilterKnownPTYNoiseStream` withholds a trailing line resembling a macOS malloc diagnostic, testing on ANSI-stripped text. #621 deliberately ends chunks right after `ESC[?2026l`, so that marker lands in the inspected line on *every* frame-boundary flush — a redraw whose visible tail reads like `somefunc(42)` left the terminal frozen on the previous frame until the next chunk or `SyncStallTimeout`. #621 made this systematic.

**`scanSyncFrames` could lose a marker** starting immediately after an aborted prefix, so the scan reported a buffer safe while the vterm parser opened the region.

**The sidebar timed the wrong terminal** — flush handlers used the *selected* tab, so a background alt-screen terminal got the faster non-alt cadence, which also wrongly enabled the early frame flush there. Pre-existing; #621 made it load-bearing.

## Test gaps (both let a mutation survive the whole suite)

- Nothing asserted plain **unbracketed** output flushes after the quiet period, so extending the hold to all output — a 12ms → 48ms regression on streaming — passed everything.
- The center tests discarded the returned `tea.Cmd`, hiding a hold that scheduled **no retry tick**; the ceilings' bound depends on it.

## Corrected claims

The `53% / 43% / ~1%` figures in #621 came from a simulation but read as measurements. Replaying the captured tmux stream through the real path: **46% of reads** land mid-region, **18% of flushes (84/456)** open a mid-frame gap without the policy, **none** with it, at an identical flush count. Measure with the vterm parser, not a byte counter — markers split across reads make it drift, overstating the problem (my first attempt said 84%).

Also: the early flush is gated on the base cadence (SCROLLING.md stated it unconditionally), the hold releases on *either* ceiling (the godoc named one), 64KB does not cover a worst-case full-screen truecolor repaint, and the inactive-tab `12x` applies to the quiet period not the capped ceiling. Documented the hold's measured cost (2.7 retry ticks per flush).

## Known gap

The sidebar's use of the flush policy still has no test coverage (no `2026` in any sidebar test). The timing bug above is fixed and tested; the policy path there is not.

## Test plan

`make devcheck`, `make lint`, `make lint-strict-new` clean. Local e2e failures are the documented flaky family that fails on unmodified `main` too.