### PR TITLE
perf: collapse the reattach bootstrap from ~60 tmux round-trips to ~6

### DIFF
--- a/internal/tmux/activity.go
+++ b/internal/tmux/activity.go
@@ -73,6 +73,9 @@ func SessionActiveWithin(sessionName string, window time.Duration, opts Options)
 
 // SessionLatestActivity reports the most recent tmux window_activity timestamp
 // for a session without applying any second-resolution slack.
+//
+// The reattach bootstrap reads this from a SessionProbe instead; this remains as
+// the independent reference the probe is cross-checked against.
 func SessionLatestActivity(sessionName string, opts Options) (time.Time, bool, error) {
 	latest, err := sessionLatestActivitySeconds(sessionName, opts)
 	if err != nil {

--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -39,7 +39,11 @@ var (
 	errPaneSnapshotMetadataDrift  = errors.New("tmux pane snapshot metadata changed during capture")
 )
 
-type paneSnapshotMetadata struct {
+// PaneSnapshotMeta is the pane metadata a full-pane snapshot is validated
+// against: the geometry it was taken at, the cursor position to restore, and the
+// VT mode state. Comparing it before and after a capture is how a snapshot taken
+// across a change is detected and discarded.
+type PaneSnapshotMeta struct {
 	Cols      int
 	Rows      int
 	HasSize   bool
@@ -49,27 +53,29 @@ type paneSnapshotMetadata struct {
 	ModeState PaneModeState
 }
 
+// Eligible reports whether the metadata is complete enough to anchor a
+// full-pane snapshot: real dimensions plus the VT mode state needed to replay
+// alt-screen and scroll-region state into the local terminal.
+func (m PaneSnapshotMeta) Eligible() bool {
+	return m.HasSize && m.Cols > 0 && m.Rows > 0 && m.ModeState.HasState
+}
+
 // sessionPaneID resolves the active pane ID for a session using exact name matching.
 // Returns empty string if the session does not exist.
 func sessionPaneID(sessionName string, opts Options) (string, error) {
-	exists, err := hasSession(sessionName, opts)
-	if err != nil {
-		return "", err
-	}
-	if !exists {
-		return "", nil
-	}
 	// Use list-panes instead of display-message. display-message may return an
 	// empty pane_id for detached sessions on some tmux versions.
-	cmd, cancel := tmuxCommand(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_id}\t#{pane_active}\t#{pane_dead}")
-	defer cancel()
-	output, err := runTmuxCmd(cmd)
+	//
+	// No has-session pre-check: list-panes exits 1 for a missing session, which
+	// listTmux maps to "no lines", yielding the same empty pane ID for half the
+	// tmux round-trips.
+	lines, err := listTmux(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_id}\t#{pane_active}\t#{pane_dead}")
 	if err != nil {
 		return "", err
 	}
 
 	var firstAlive string
-	for _, line := range parseOutputLines(output) {
+	for _, line := range lines {
 		parts := strings.Split(line, "\t")
 		if len(parts) < 3 {
 			continue
@@ -152,6 +158,9 @@ func parsePaneSize(lines []string, paneID string) (int, int, bool, error) {
 // SessionPaneSnapshotInfo reports whether a session's active pane is eligible
 // for an authoritative full-pane snapshot, along with its current size. This
 // uses only pane metadata and does not capture pane history.
+//
+// The reattach bootstrap reads this from a SessionProbe instead; this remains as
+// the independent reference the probe is cross-checked against.
 func SessionPaneSnapshotInfo(sessionName string, opts Options) (int, int, bool, error) {
 	if sessionName == "" {
 		return 0, 0, false, nil
@@ -165,6 +174,9 @@ func SessionPaneSnapshotInfo(sessionName string, opts Options) (int, int, bool, 
 
 // SessionPaneID reports the active pane ID for a session using only tmux
 // metadata. Returns an empty string if the session does not exist.
+//
+// The reattach bootstrap reads this from a SessionProbe instead; this remains as
+// the independent reference the probe is cross-checked against.
 func SessionPaneID(sessionName string, opts Options) (string, error) {
 	if sessionName == "" {
 		return "", nil
@@ -175,6 +187,9 @@ func SessionPaneID(sessionName string, opts Options) (string, error) {
 // SessionPaneSize reports the current size of a session's active pane using
 // only tmux metadata. The returned size is independent of whether the pane is
 // eligible for authoritative full-pane snapshots.
+//
+// The reattach bootstrap reads this from a SessionProbe instead; this remains as
+// the independent reference the probe is cross-checked against.
 func SessionPaneSize(sessionName string, opts Options) (int, int, bool, error) {
 	if sessionName == "" {
 		return 0, 0, false, nil
@@ -280,15 +295,10 @@ func paneCoversVisibleWindow(paneID string, opts Options) (bool, error) {
 // ResizePaneToSize updates a managed session's window size to the given cell
 // dimensions before any new client attaches. This is used to capture an
 // authoritative snapshot at the size a reattached client will render.
+// A missing session needs no has-session pre-check: runTmux already treats
+// tmux's exit code 1 for a missing target as success.
 func ResizePaneToSize(sessionName string, cols, rows int, opts Options) error {
 	if sessionName == "" || cols <= 0 || rows <= 0 {
-		return nil
-	}
-	exists, err := hasSession(sessionName, opts)
-	if err != nil {
-		return err
-	}
-	if !exists {
 		return nil
 	}
 	return runTmux(
@@ -314,26 +324,12 @@ func CapturePane(sessionName string, opts Options) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if paneID == "" {
-		return nil, nil
-	}
-	// -p: output to stdout
-	// -e: include escape sequences (ANSI styling)
-	// -S -: start from beginning of history
-	// -N: preserve trailing spaces in each captured row. History-only callers
-	// also rely on this so post-attach deltas keep padded/status-bar rows intact.
-	// -E -1: end at last scrollback line (excludes visible screen)
-	// -t: target pane by globally unique pane ID
-	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-e", "-N", "-S", "-", "-E", "-1", "-t", paneID)
-	defer cancel()
-	output, err := runTmuxCmd(cmd)
-	if err != nil {
-		return nil, err
-	}
-	if len(output) == 0 {
-		return nil, nil
-	}
-	return output, nil
+	// CapturePaneHistoryData does the capture itself. Both functions feed the
+	// same restore path — this one pre-attach by session name, that one
+	// post-attach from an already-probed pane ID — so they must capture with
+	// identical flags or the two halves of a restore would disagree. Sharing the
+	// one implementation is what guarantees that.
+	return CapturePaneHistoryData(paneID, opts)
 }
 
 // CapturePaneSnapshot captures the full tmux pane state (scrollback plus the

--- a/internal/tmux/capture_snapshot.go
+++ b/internal/tmux/capture_snapshot.go
@@ -19,7 +19,7 @@ func paneSnapshotInfoForPane(
 	paneID string,
 	opts Options,
 	coversVisibleWindow func(string, Options) (bool, error),
-	metadata func(string, Options) (paneSnapshotMetadata, error),
+	metadata func(string, Options) (PaneSnapshotMeta, error),
 ) (int, int, bool, error) {
 	if paneID == "" {
 		return 0, 0, false, nil
@@ -48,7 +48,7 @@ func capturePaneSnapshotForPane(
 	paneID string,
 	opts Options,
 	captureData func(string, Options) ([]byte, error),
-	metadata func(string, Options) (paneSnapshotMetadata, error),
+	metadata func(string, Options) (PaneSnapshotMeta, error),
 ) (PaneSnapshot, error) {
 	before, err := metadata(paneID, opts)
 	if err != nil {
@@ -89,9 +89,9 @@ func capturePaneSnapshotForPane(
 	return snapshot, nil
 }
 
-func paneSnapshotMetadataForPane(paneID string, opts Options) (paneSnapshotMetadata, error) {
+func paneSnapshotMetadataForPane(paneID string, opts Options) (PaneSnapshotMeta, error) {
 	if paneID == "" {
-		return paneSnapshotMetadata{}, nil
+		return PaneSnapshotMeta{}, nil
 	}
 	cmd, cancel := tmuxCommand(
 		opts,
@@ -104,14 +104,14 @@ func paneSnapshotMetadataForPane(paneID string, opts Options) (paneSnapshotMetad
 	defer cancel()
 	output, err := runTmuxCmd(cmd)
 	if err != nil {
-		return paneSnapshotMetadata{}, err
+		return PaneSnapshotMeta{}, err
 	}
 	for _, line := range parseOutputLines(output) {
 		parts, err := parseTabFields(line, 12)
 		if err != nil || parts[0] != paneID {
 			continue
 		}
-		meta := paneSnapshotMetadata{}
+		meta := PaneSnapshotMeta{}
 		cols, errCols := strconv.Atoi(parts[1])
 		rows, errRows := strconv.Atoi(parts[2])
 		if errCols == nil && errRows == nil && cols > 0 && rows > 0 {
@@ -139,5 +139,5 @@ func paneSnapshotMetadataForPane(paneID string, opts Options) (paneSnapshotMetad
 		meta.ModeState = modeState
 		return meta, nil
 	}
-	return paneSnapshotMetadata{}, nil
+	return PaneSnapshotMeta{}, nil
 }

--- a/internal/tmux/capture_snapshot_test.go
+++ b/internal/tmux/capture_snapshot_test.go
@@ -16,8 +16,8 @@ func TestCapturePaneSnapshotForPane_RejectsModeMetadataErrors(t *testing.T) {
 			}
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{}, modeErr
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{}, modeErr
 		},
 	)
 	if !errors.Is(err, modeErr) {
@@ -30,8 +30,8 @@ func TestCapturePaneSnapshotForPane_RejectsModeMetadataErrors(t *testing.T) {
 		func(paneID string, opts Options) ([]byte, error) {
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{Cols: 80, Rows: 24, HasSize: true}, nil
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{Cols: 80, Rows: 24, HasSize: true}, nil
 		},
 	)
 	if !errors.Is(err, errPaneSnapshotModeState) {
@@ -46,8 +46,8 @@ func TestCapturePaneSnapshotForPane_PreservesPaneSizeMetadata(t *testing.T) {
 		func(paneID string, opts Options) ([]byte, error) {
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{
 				Cols:      91,
 				Rows:      27,
 				HasSize:   true,
@@ -76,8 +76,8 @@ func TestCapturePaneSnapshotForPane_RejectsMissingPaneSizeMetadata(t *testing.T)
 		func(paneID string, opts Options) ([]byte, error) {
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{ModeState: PaneModeState{HasState: true}}, nil
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{ModeState: PaneModeState{HasState: true}}, nil
 		},
 	)
 	if !errors.Is(err, errPaneSnapshotSizeMetadata) {
@@ -93,8 +93,8 @@ func TestCapturePaneSnapshotForPane_PropagatesPaneSizeLookupErrors(t *testing.T)
 		func(paneID string, opts Options) ([]byte, error) {
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{}, sizeErr
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{}, sizeErr
 		},
 	)
 	if !errors.Is(err, sizeErr) {
@@ -110,9 +110,9 @@ func TestCapturePaneSnapshotForPane_RejectsMetadataDriftDuringCapture(t *testing
 		func(paneID string, opts Options) ([]byte, error) {
 			return []byte("snapshot frame"), nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
 			metadataCalls++
-			meta := paneSnapshotMetadata{
+			meta := PaneSnapshotMeta{
 				Cols:      91,
 				Rows:      27,
 				HasSize:   true,
@@ -139,8 +139,8 @@ func TestPaneSnapshotInfoForPane_RequiresModeMetadata(t *testing.T) {
 		func(paneID string, opts Options) (bool, error) {
 			return true, nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{Cols: 91, Rows: 27, HasSize: true}, nil
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{Cols: 91, Rows: 27, HasSize: true}, nil
 		},
 	)
 	if err != nil {
@@ -158,8 +158,8 @@ func TestPaneSnapshotInfoForPane_PreservesAuthoritativeSize(t *testing.T) {
 		func(paneID string, opts Options) (bool, error) {
 			return true, nil
 		},
-		func(paneID string, opts Options) (paneSnapshotMetadata, error) {
-			return paneSnapshotMetadata{
+		func(paneID string, opts Options) (PaneSnapshotMeta, error) {
+			return PaneSnapshotMeta{
 				Cols:      91,
 				Rows:      27,
 				HasSize:   true,

--- a/internal/tmux/clients.go
+++ b/internal/tmux/clients.go
@@ -42,15 +42,13 @@ func SessionHasClients(sessionName string, opts Options) (bool, error) {
 
 // SessionClientCount reports how many tmux clients are currently attached to a
 // session.
+//
+// A missing session needs no has-session pre-check: list-clients exits 1 for it,
+// which listTmux already maps to "no lines", and a session that does not exist
+// has no clients either way. Skipping the pre-check halves the tmux round-trips,
+// which matters because the reattach guards call this repeatedly.
 func SessionClientCount(sessionName string, opts Options) (int, error) {
 	if sessionName == "" {
-		return 0, nil
-	}
-	exists, err := hasSession(sessionName, opts)
-	if err != nil {
-		return 0, err
-	}
-	if !exists {
 		return 0, nil
 	}
 	lines, err := listTmux(opts, "list-clients", "-t", sessionTarget(sessionName), "-F", "#{client_name}")
@@ -61,24 +59,17 @@ func SessionClientCount(sessionName string, opts Options) (int, error) {
 }
 
 // SessionCreatedAt returns the tmux session creation timestamp (unix seconds).
+// A session that does not exist yields 0 with no error: the name simply does not
+// appear in the listing, so no has-session pre-check is needed.
 func SessionCreatedAt(sessionName string, opts Options) (int64, error) {
 	if sessionName == "" {
 		return 0, nil
 	}
-	exists, err := hasSession(sessionName, opts)
+	lines, err := listTmux(opts, "list-sessions", "-F", "#{session_name}\t#{session_created}")
 	if err != nil {
 		return 0, err
 	}
-	if !exists {
-		return 0, nil
-	}
-	cmd, cancel := tmuxCommand(opts, "list-sessions", "-F", "#{session_name}\t#{session_created}")
-	defer cancel()
-	output, err := runTmuxCmd(cmd)
-	if err != nil {
-		return 0, err
-	}
-	for _, line := range parseOutputLines(output) {
+	for _, line := range lines {
 		name, raw, ok := strings.Cut(line, "\t")
 		if !ok || name != sessionName {
 			continue

--- a/internal/tmux/command.go
+++ b/internal/tmux/command.go
@@ -49,22 +49,7 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 	// Swallowed on tmux < 3.2 (no terminal-features).
 	syncFeatureSet := "(" + base + " set-option -s 'terminal-features[16]' 'xterm*:sync' 2>/dev/null || true)"
 
-	var settings strings.Builder
-	// Disable tmux prefix for this session only (not global) to make it transparent
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix None 2>/dev/null; ", base, optionTgt))
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s prefix2 None 2>/dev/null; ", base, optionTgt))
-	if opts.HideStatus {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s status off 2>/dev/null; ", base, optionTgt))
-	}
-	if opts.DisableMouse {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s mouse off 2>/dev/null; ", base, optionTgt))
-	}
-	if opts.DefaultTerminal != "" {
-		settings.WriteString(fmt.Sprintf("%s set-option -t %s default-terminal %s 2>/dev/null; ", base, optionTgt, shellutil.ShellQuote(opts.DefaultTerminal)))
-	}
-	// Ensure activity timestamps update for window_activity-based tracking.
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s -w monitor-activity on 2>/dev/null; ", base, optionTgt))
-	appendSessionTags(&settings, base, optionTgt, tags)
+	settings := sessionSettingArgs(optionTgt, opts, tags)
 
 	// Attach to the session, optionally detaching other clients.
 	attachFlag := "-t"
@@ -73,14 +58,81 @@ func clientCommand(sessionName, workDir, command string, opts Options, tags Sess
 	}
 	attach := fmt.Sprintf("%s attach %s %s", base, attachFlag, sessionTgt)
 
-	return fmt.Sprintf("%s && %s && %s%s", ensureSession, syncFeatureSet, settings.String(), attach)
+	// The settings are braced so their internal `||` fallback cannot bind to the
+	// preceding `&&`. Without the braces, sh's equal-precedence left-associative
+	// parsing makes a failed ensureSession fall through into the per-option
+	// fallback, spending a tmux round-trip per option against a session that does
+	// not exist.
+	return fmt.Sprintf("%s && %s && { %s}; %s", ensureSession, syncFeatureSet, settingsScript(base, settings), attach)
 }
 
-func appendSessionTags(settings *strings.Builder, base, session string, tags SessionTags) {
-	if tags.WorkspaceID == "" && tags.TabID == "" && tags.Type == "" && tags.Assistant == "" && tags.CreatedAt == 0 && tags.InstanceID == "" && tags.SessionOwner == "" && tags.LeaseAtMS == 0 {
-		return
+// sessionSettingArgs returns the argument list of every `set-option` amux applies
+// to a managed session, in apply order. Each entry is the argv that follows
+// `set-option`, so the same list can be rendered either chained into one tmux
+// invocation or as separate ones.
+func sessionSettingArgs(optionTgt string, opts Options, tags SessionTags) [][]string {
+	// Disable tmux prefix for this session only (not global) to make it transparent
+	settings := [][]string{
+		{"-t", optionTgt, "prefix", "None"},
+		{"-t", optionTgt, "prefix2", "None"},
 	}
-	settings.WriteString(fmt.Sprintf("%s set-option -t %s @amux 1 2>/dev/null; ", base, session))
+	if opts.HideStatus {
+		settings = append(settings, []string{"-t", optionTgt, "status", "off"})
+	}
+	if opts.DisableMouse {
+		settings = append(settings, []string{"-t", optionTgt, "mouse", "off"})
+	}
+	if opts.DefaultTerminal != "" {
+		settings = append(settings, []string{"-t", optionTgt, "default-terminal", shellutil.ShellQuote(opts.DefaultTerminal)})
+	}
+	// Ensure activity timestamps update for window_activity-based tracking.
+	settings = append(settings, []string{"-t", optionTgt, "-w", "monitor-activity", "on"})
+	return append(settings, sessionTagArgs(optionTgt, tags)...)
+}
+
+// settingsScript renders the session settings as shell text, always terminated
+// with "; " so the attach that follows runs regardless of the outcome.
+//
+// The happy path chains every set-option into a single tmux invocation using
+// tmux's own `;` command separator. That matters because amux runs one shared,
+// single-threaded tmux server: on a busy server each exec is a round-trip
+// costing tens to hundreds of milliseconds, and a reattach used to pay for ~20
+// of them here alone.
+//
+// tmux aborts a chained sequence at the first command that fails, so a single
+// option that a given tmux version rejects would skip every option after it. The
+// `||` fallback re-runs the same options one invocation at a time, each with its
+// own stderr suppressed, which is exactly the per-option best-effort behavior
+// this used to have. set-option is idempotent, so re-applying the ones that
+// already succeeded is harmless.
+func settingsScript(base string, settings [][]string) string {
+	if len(settings) == 0 {
+		return ""
+	}
+
+	var chained strings.Builder
+	chained.WriteString(base)
+	for i, args := range settings {
+		if i > 0 {
+			chained.WriteString(" ';'")
+		}
+		chained.WriteString(" set-option ")
+		chained.WriteString(strings.Join(args, " "))
+	}
+
+	var sequential strings.Builder
+	for _, args := range settings {
+		sequential.WriteString(fmt.Sprintf("%s set-option %s 2>/dev/null; ", base, strings.Join(args, " ")))
+	}
+
+	return fmt.Sprintf("{ %s; } 2>/dev/null || { %strue; }; ", chained.String(), sequential.String())
+}
+
+func sessionTagArgs(session string, tags SessionTags) [][]string {
+	if tags.WorkspaceID == "" && tags.TabID == "" && tags.Type == "" && tags.Assistant == "" && tags.CreatedAt == 0 && tags.InstanceID == "" && tags.SessionOwner == "" && tags.LeaseAtMS == 0 {
+		return nil
+	}
+	args := [][]string{{"-t", session, "@amux", "1"}}
 	entries := []struct{ key, value string }{
 		{"@amux_workspace", tags.WorkspaceID},
 		{"@amux_tab", tags.TabID},
@@ -94,9 +146,10 @@ func appendSessionTags(settings *strings.Builder, base, session string, tags Ses
 	}
 	for _, e := range entries {
 		if e.value != "" {
-			settings.WriteString(fmt.Sprintf("%s set-option -t %s %s %s 2>/dev/null; ", base, session, e.key, shellutil.ShellQuote(e.value)))
+			args = append(args, []string{"-t", session, e.key, shellutil.ShellQuote(e.value)})
 		}
 	}
+	return args
 }
 
 func formatInt64NonZero(v int64) string {

--- a/internal/tmux/command_batching_test.go
+++ b/internal/tmux/command_batching_test.go
@@ -1,0 +1,173 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The session settings are chained into a single tmux invocation because amux
+// talks to one shared, single-threaded tmux server: on a busy server each exec
+// costs tens to hundreds of milliseconds, and a reattach used to pay for one per
+// option. tmux aborts a chained sequence at the first failure, so the script
+// falls back to running them one at a time. These tests pin both branches with a
+// fake tmux, since a silently-skipped option is exactly the failure mode the
+// `2>/dev/null` suppression would otherwise hide.
+
+// fakeTmux puts a recording `tmux` on PATH. It appends one line per invocation
+// to a log file and exits 1 for any invocation mentioning failOn (empty means
+// never fail), mimicking tmux's "invalid option" rejection.
+func fakeTmux(t *testing.T, failOn string) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.log")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *%s*) echo "invalid option" >&2; exit 1 ;;
+esac
+exit 0
+`, logPath, failOn)
+	if failOn == "" {
+		// An unmatchable pattern keeps the case arm valid while never failing.
+		script = strings.Replace(script, "**)", "*__never_matches__*)", 1)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func runSettingsScript(t *testing.T, logPath, script string) []string {
+	t.Helper()
+	// The script's own exit status is not meaningful: it ends with "; " so the
+	// attach that normally follows runs regardless.
+	_ = exec.Command("sh", "-c", script).Run()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return nil
+	}
+	var calls []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			calls = append(calls, line)
+		}
+	}
+	return calls
+}
+
+func testSettings() [][]string {
+	return sessionSettingArgs("'sess'", Options{
+		HideStatus:      true,
+		DisableMouse:    true,
+		DefaultTerminal: "xterm-256color",
+	}, SessionTags{WorkspaceID: "w", TabID: "t", Type: "agent"})
+}
+
+// wantAppliedOptions is every option name testSettings produces, so a test can
+// assert none of them was skipped.
+func wantAppliedOptions() []string {
+	return []string{
+		"prefix", "prefix2", "status", "mouse", "default-terminal",
+		"monitor-activity", "@amux", "@amux_workspace", "@amux_tab", "@amux_type",
+	}
+}
+
+func assertAllOptionsApplied(t *testing.T, calls []string) {
+	t.Helper()
+	joined := strings.Join(calls, "\n")
+	for _, opt := range wantAppliedOptions() {
+		if !strings.Contains(joined, opt) {
+			t.Errorf("option %q was never applied; calls:\n%s", opt, joined)
+		}
+	}
+}
+
+func TestSettingsScript_ChainsIntoOneInvocationOnSuccess(t *testing.T) {
+	logPath := fakeTmux(t, "")
+	calls := runSettingsScript(t, logPath, settingsScript("tmux", testSettings()))
+
+	if len(calls) != 1 {
+		t.Fatalf("expected every set-option chained into one tmux invocation, got %d:\n%s",
+			len(calls), strings.Join(calls, "\n"))
+	}
+	assertAllOptionsApplied(t, calls)
+}
+
+func TestSettingsScript_FallsBackToOneInvocationPerOption(t *testing.T) {
+	// tmux stops a chained sequence at the first rejected command, so a single
+	// unsupported option would otherwise skip every option after it.
+	logPath := fakeTmux(t, "default-terminal")
+	calls := runSettingsScript(t, logPath, settingsScript("tmux", testSettings()))
+
+	if len(calls) < 2 {
+		t.Fatalf("expected a per-option fallback after the chain failed, got %d invocation(s):\n%s",
+			len(calls), strings.Join(calls, "\n"))
+	}
+	// Everything except the genuinely unsupported option must still be applied,
+	// including the ones that would have followed it in the chain.
+	for _, opt := range wantAppliedOptions() {
+		if opt == "default-terminal" {
+			continue
+		}
+		var applied bool
+		for _, call := range calls[1:] {
+			if strings.Contains(call, opt) {
+				applied = true
+				break
+			}
+		}
+		if !applied {
+			t.Errorf("option %q was skipped by the fallback; calls:\n%s", opt, strings.Join(calls, "\n"))
+		}
+	}
+}
+
+func TestSettingsScript_EmptySettingsProducesNoScript(t *testing.T) {
+	if got := settingsScript("tmux", nil); got != "" {
+		t.Fatalf("no settings must produce no script, got %q", got)
+	}
+}
+
+func TestSettingsScript_AlwaysEndsSoAttachStillRuns(t *testing.T) {
+	// The attach is appended directly after this script, so it must terminate
+	// with an unconditional separator rather than && — a failed set-option must
+	// never prevent the user's session from being attached.
+	script := settingsScript("tmux", testSettings())
+	if !strings.HasSuffix(script, "; ") {
+		t.Fatalf("settings script must end with an unconditional separator, got %q", script)
+	}
+
+	logPath := fakeTmux(t, "set-option")
+	// Every set-option fails, chained and sequential alike; the marker still runs.
+	marker := filepath.Join(t.TempDir(), "attached")
+	_ = exec.Command("sh", "-c", script+"touch "+marker).Run()
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected the attach to run even when every set-option failed: %v", err)
+	}
+	if calls := runSettingsScript(t, logPath, script); len(calls) == 0 {
+		t.Fatal("expected the fake tmux to have been invoked")
+	}
+}
+
+func TestSessionSettingArgs_OmitsDisabledOptions(t *testing.T) {
+	args := sessionSettingArgs("'sess'", Options{}, SessionTags{})
+	joined := fmt.Sprint(args)
+	for _, unwanted := range []string{"status", "mouse", "default-terminal", "@amux"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("expected %q to be omitted when unconfigured, got %v", unwanted, args)
+		}
+	}
+	// The prefix disabling and activity monitoring are unconditional: they are
+	// what make a managed session transparent and trackable.
+	for _, required := range []string{"prefix", "prefix2", "monitor-activity"} {
+		if !strings.Contains(joined, required) {
+			t.Errorf("expected %q to always be applied, got %v", required, args)
+		}
+	}
+}

--- a/internal/tmux/create_pipeline_test.go
+++ b/internal/tmux/create_pipeline_test.go
@@ -45,12 +45,22 @@ func TestClientCommandAppliesOptionsAndTagsOnRealTmux(t *testing.T) {
 		WorkDir: t.TempDir(),
 		Command: "sleep 300",
 		Options: Options{
-			ServerName:   opts.ServerName,
-			ConfigPath:   opts.ConfigPath,
-			HideStatus:   true,
-			DisableMouse: true,
+			ServerName:      opts.ServerName,
+			ConfigPath:      opts.ConfigPath,
+			HideStatus:      true,
+			DisableMouse:    true,
+			DefaultTerminal: "xterm-256color",
 		},
-		Tags:           SessionTags{WorkspaceID: "ws-create", Type: "agent", Assistant: "claude"},
+		Tags: SessionTags{
+			WorkspaceID:  "ws-create",
+			TabID:        "tab-create",
+			Type:         "agent",
+			Assistant:    "claude",
+			CreatedAt:    1700000000,
+			InstanceID:   "inst-create",
+			SessionOwner: "inst-create",
+			LeaseAtMS:    1700000000000,
+		},
 		DetachExisting: true,
 	})
 
@@ -61,20 +71,48 @@ func TestClientCommandAppliesOptionsAndTagsOnRealTmux(t *testing.T) {
 
 	waitForSessionExists(t, opts, session)
 
+	// Every option the pipeline sets, not a sample: these are now applied as one
+	// chained tmux invocation, so a single rejected command would silently skip
+	// every option after it. Checking only a few would leave that gap open.
 	checks := []struct{ key, want string }{
 		{"prefix", "None"},
+		{"prefix2", "None"},
 		{"status", "off"},
 		{"mouse", "off"},
+		{"default-terminal", "xterm-256color"},
 		{"@amux", "1"},
 		{"@amux_workspace", "ws-create"},
+		{"@amux_tab", "tab-create"},
 		{"@amux_type", "agent"},
 		{"@amux_assistant", "claude"},
+		{"@amux_created_at", "1700000000"},
+		{"@amux_instance", "inst-create"},
+		{TagSessionOwner, "inst-create"},
+		{TagSessionLeaseAt, "1700000000000"},
+		{TagSessionOwnerHeartbeatAt, "1700000000000"},
 	}
 	for _, c := range checks {
 		if got := showSessionOption(t, opts, session, c.key); got != c.want {
 			t.Errorf("session option %s = %q, want %q (a rejected set-option would no-op here)", c.key, got, c.want)
 		}
 	}
+
+	// monitor-activity is the only chained entry carrying a scope flag (-w), and
+	// the pre-attach quiet check depends on it. A mid-chain -w must scope to its
+	// own command and not leak into the entries that follow, which the tag checks
+	// above would catch.
+	if got := showWindowOption(t, opts, session, "monitor-activity"); got != "on" {
+		t.Errorf("window option monitor-activity = %q, want \"on\" — the activity-based quiet check depends on it", got)
+	}
+}
+
+func showWindowOption(t *testing.T, opts Options, session, key string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", tmuxArgs(opts, "show-options", "-w", "-t", session, "-v", key)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("show-options -w %s on %s: %v\n%s", key, session, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func waitForSessionExists(t *testing.T, opts Options, session string) {

--- a/internal/tmux/liveness_seam_test.go
+++ b/internal/tmux/liveness_seam_test.go
@@ -24,11 +24,13 @@ type seamResult struct {
 }
 
 // livenessSeam installs a runTmuxCmd fake that dispatches on the tmux
-// subcommand (has-session / list-panes / list-clients) and records each call,
-// so multi-step reads — a has-session pre-check followed by the list — can be
-// driven per step without a server. It also pins the command shape: the
-// list-panes and list-clients invocations must carry the exact -F format the
-// production code relies on.
+// subcommand (has-session / list-panes / list-clients) and records each call, so
+// multi-step reads — SessionStateFor's has-session followed by list-panes — can
+// be driven per step without a server. Recording the calls also lets a test
+// assert which subcommands did *not* run, which is how the single-round-trip
+// reads below pin that no has-session pre-check crept back in. It pins the
+// command shape too: the list-panes and list-clients invocations must carry the
+// exact -F format the production code relies on.
 func livenessSeam(t *testing.T, responses map[string]seamResult) *[]string {
 	t.Helper()
 	var calls []string
@@ -86,14 +88,15 @@ func failOnAnyTmuxCall(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // hasLivePane: any pane_dead=="0" -> live; all "1" -> dead; exit 1 (session or
-// server gone) -> not live, no error; other error -> propagated.
-// hasLivePane never calls EnsureAvailable, so these run without tmux on PATH.
+// server gone) -> not live, no error; other error -> propagated. It reaches tmux
+// exactly once — list-panes' exit 1 already means "session gone", so there is no
+// has-session pre-check to drive. hasLivePane never calls EnsureAvailable, so
+// these run without tmux on PATH.
 // ---------------------------------------------------------------------------
 
 func TestHasLivePane_AllPanesLive(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {},
-		"list-panes":  {out: []byte("0\n0\n")},
+		"list-panes": {out: []byte("0\n0\n")},
 	})
 	live, err := hasLivePane("amux-live", testOpts())
 	if err != nil {
@@ -106,8 +109,7 @@ func TestHasLivePane_AllPanesLive(t *testing.T) {
 
 func TestHasLivePane_OneLivePaneAmongDeadIsLive(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {},
-		"list-panes":  {out: []byte("1\n0\n1\n")},
+		"list-panes": {out: []byte("1\n0\n1\n")},
 	})
 	live, err := hasLivePane("amux-mixed", testOpts())
 	if err != nil {
@@ -120,8 +122,7 @@ func TestHasLivePane_OneLivePaneAmongDeadIsLive(t *testing.T) {
 
 func TestHasLivePane_AllPanesDeadIsNotLive(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {},
-		"list-panes":  {out: []byte("1\n1\n")},
+		"list-panes": {out: []byte("1\n1\n")},
 	})
 	live, err := hasLivePane("amux-dead", testOpts())
 	if err != nil {
@@ -134,26 +135,27 @@ func TestHasLivePane_AllPanesDeadIsNotLive(t *testing.T) {
 
 func TestHasLivePane_SessionGoneExitCode1IsNotLiveNotError(t *testing.T) {
 	calls := livenessSeam(t, map[string]seamResult{
-		"has-session": {err: exitCode1Err(t)},
+		"list-panes": {err: exitCode1Err(t)},
 	})
 	live, err := hasLivePane("amux-gone", testOpts())
 	if err != nil {
-		t.Fatalf("exit 1 on has-session means session gone, not an error; got %v", err)
+		t.Fatalf("exit 1 on list-panes means session gone, not an error; got %v", err)
 	}
 	if live {
 		t.Fatalf("a missing session must not classify as live")
 	}
+	// list-panes' own exit 1 already answers "session gone", so the extra
+	// has-session round-trip this used to pay for must not come back.
 	for _, call := range *calls {
-		if call == "list-panes" {
-			t.Fatalf("list-panes must not run once has-session reports the session gone; calls %v", *calls)
+		if call == "has-session" {
+			t.Fatalf("has-session pre-check must not run; calls %v", *calls)
 		}
 	}
 }
 
 func TestHasLivePane_ListPanesExitCode1IsNotLiveNotError(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {},
-		"list-panes":  {err: exitCode1Err(t)},
+		"list-panes": {err: exitCode1Err(t)},
 	})
 	live, err := hasLivePane("amux-racy", testOpts())
 	if err != nil {
@@ -164,12 +166,13 @@ func TestHasLivePane_ListPanesExitCode1IsNotLiveNotError(t *testing.T) {
 	}
 }
 
-func TestHasLivePane_HasSessionOtherErrorPropagates(t *testing.T) {
+func TestSessionStateFor_HasSessionOtherErrorPropagates(t *testing.T) {
+	skipIfNoTmux(t)
 	want := errors.New("lost server")
 	livenessSeam(t, map[string]seamResult{
 		"has-session": {err: want},
 	})
-	if _, err := hasLivePane("amux-x", testOpts()); !errors.Is(err, want) {
+	if _, err := SessionStateFor("amux-x", testOpts()); !errors.Is(err, want) {
 		t.Fatalf("non-exit-1 has-session error must propagate, got %v", err)
 	}
 }
@@ -177,8 +180,7 @@ func TestHasLivePane_HasSessionOtherErrorPropagates(t *testing.T) {
 func TestHasLivePane_ListPanesOtherErrorPropagates(t *testing.T) {
 	want := errors.New("connection refused")
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {},
-		"list-panes":  {err: want},
+		"list-panes": {err: want},
 	})
 	if _, err := hasLivePane("amux-x", testOpts()); !errors.Is(err, want) {
 		t.Fatalf("non-exit-1 list-panes error must propagate, got %v", err)
@@ -259,9 +261,9 @@ func TestSessionStateFor_OtherErrorPropagates(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// SessionClientCount / SessionHasClients: attached-client guard. Neither calls
-// EnsureAvailable (the has-session pre-check and list-clients both go through
-// the runTmuxCmd seam), so these run without tmux on PATH.
+// SessionClientCount / SessionHasClients: attached-client guard. Both answer in
+// a single list-clients call — its exit 1 covers the missing-session case — and
+// neither calls EnsureAvailable, so these run without tmux on PATH.
 // ---------------------------------------------------------------------------
 
 func TestSessionClientCount_EmptyNameIsZeroWithoutExec(t *testing.T) {
@@ -274,25 +276,26 @@ func TestSessionClientCount_EmptyNameIsZeroWithoutExec(t *testing.T) {
 
 func TestSessionClientCount_SessionGoneIsZeroNotError(t *testing.T) {
 	calls := livenessSeam(t, map[string]seamResult{
-		"has-session": {err: exitCode1Err(t)},
+		"list-clients": {err: exitCode1Err(t)},
 	})
 	count, err := SessionClientCount("amux-gone", testOpts())
 	if err != nil {
-		t.Fatalf("exit 1 on has-session means session gone, not an error; got %v", err)
+		t.Fatalf("exit 1 on list-clients means session gone, not an error; got %v", err)
 	}
 	if count != 0 {
 		t.Fatalf("missing session must count 0 clients, got %d", count)
 	}
+	// The missing-session answer comes straight from list-clients' exit 1, so the
+	// extra has-session round-trip this used to pay for must not come back.
 	for _, call := range *calls {
-		if call == "list-clients" {
-			t.Fatalf("list-clients must not run for a missing session; calls %v", *calls)
+		if call == "has-session" {
+			t.Fatalf("has-session pre-check must not run; calls %v", *calls)
 		}
 	}
 }
 
 func TestSessionClientCount_CountsClientLines(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session":  {},
 		"list-clients": {out: []byte("client-0\nclient-1\nclient-2\n")},
 	})
 	count, err := SessionClientCount("amux-attached", testOpts())
@@ -306,7 +309,6 @@ func TestSessionClientCount_CountsClientLines(t *testing.T) {
 
 func TestSessionClientCount_ListClientsExitCode1IsZeroNotError(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session":  {},
 		"list-clients": {err: exitCode1Err(t)},
 	})
 	count, err := SessionClientCount("amux-racy", testOpts())
@@ -321,7 +323,6 @@ func TestSessionClientCount_ListClientsExitCode1IsZeroNotError(t *testing.T) {
 func TestSessionClientCount_OtherErrorPropagates(t *testing.T) {
 	want := errors.New("no server running on /tmp/x")
 	livenessSeam(t, map[string]seamResult{
-		"has-session":  {},
 		"list-clients": {err: want},
 	})
 	if _, err := SessionClientCount("amux-x", testOpts()); !errors.Is(err, want) {
@@ -331,7 +332,6 @@ func TestSessionClientCount_OtherErrorPropagates(t *testing.T) {
 
 func TestSessionHasClients_TrueWhenAttached(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session":  {},
 		"list-clients": {out: []byte("client-0\n")},
 	})
 	has, err := SessionHasClients("amux-attached", testOpts())
@@ -345,7 +345,6 @@ func TestSessionHasClients_TrueWhenAttached(t *testing.T) {
 
 func TestSessionHasClients_FalseWhenNoClients(t *testing.T) {
 	livenessSeam(t, map[string]seamResult{
-		"has-session":  {},
 		"list-clients": {out: []byte("")},
 	})
 	has, err := SessionHasClients("amux-detached", testOpts())
@@ -360,7 +359,7 @@ func TestSessionHasClients_FalseWhenNoClients(t *testing.T) {
 func TestSessionHasClients_ErrorPropagates(t *testing.T) {
 	want := errors.New("lost server")
 	livenessSeam(t, map[string]seamResult{
-		"has-session": {err: want},
+		"list-clients": {err: want},
 	})
 	has, err := SessionHasClients("amux-x", testOpts())
 	if !errors.Is(err, want) {

--- a/internal/tmux/probe.go
+++ b/internal/tmux/probe.go
@@ -1,0 +1,282 @@
+package tmux
+
+import (
+	"strconv"
+	"time"
+)
+
+// SessionProbe is a one-round-trip snapshot of the session and active-pane facts
+// the reattach bootstrap needs.
+//
+// Every field here is individually available from a dedicated helper
+// (SessionCreatedAt, SessionHasClients, SessionPaneID, ...), but the bootstrap
+// guards re-read the same handful of facts several times per reattach, and each
+// helper is a separate tmux exec. amux runs one shared, single-threaded tmux
+// server that is also pumping pane output for every attached agent, so a command
+// round-trip costs anywhere from ~15ms idle to ~200ms under load. Collapsing a
+// guard's worth of reads into a single exec is the difference between a reattach
+// that feels instant and one the user watches happen.
+//
+// Reading the facts together is also strictly more consistent than reading them
+// one at a time: a probe is a single point-in-time view, so the generation
+// checks below cannot straddle a session change the way sequential reads can.
+//
+// The per-fact helpers remain as the independent reference this is checked
+// against: TestProbeSession_MatchesDedicatedHelpers runs both against a live
+// tmux server and asserts they agree, so a format-string or field-order mistake
+// here cannot quietly change what the bootstrap sees.
+type SessionProbe struct {
+	// Exists reports whether the session was found at all.
+	Exists bool
+	// CreatedAt is #{session_created} in unix seconds; part of the session
+	// generation identity used to detect a session being recreated underneath us.
+	CreatedAt int64
+	// ClientCount is the number of tmux clients currently attached.
+	ClientCount int
+	// PaneID identifies the pane a reattaching client will render, chosen with
+	// the same precedence and the same active-window scope sessionPaneID uses:
+	// the active pane of the active window, else any live pane in that window.
+	// Empty when the active window has no live pane.
+	PaneID string
+	// PaneCols/PaneRows are that pane's current cell dimensions.
+	PaneCols int
+	PaneRows int
+	// HasPaneSize reports whether tmux returned usable dimensions.
+	HasPaneSize bool
+	// HasLivePane reports whether the active window has a pane that is not dead,
+	// the same scope hasLivePane (and so SessionStateFor) uses.
+	HasLivePane bool
+	// SinglePaneWindow reports whether the chosen pane is the only pane in its
+	// window. Split (or zoomed-split) windows are ineligible for the pre-attach
+	// resize because the resize would also SIGWINCH the hidden siblings.
+	SinglePaneWindow bool
+	// LatestActivity is the maximum #{window_activity} across the session's
+	// windows, in unix seconds. Zero when tmux reported none.
+	LatestActivity int64
+	// PaneMeta is the chosen pane's snapshot metadata (geometry, cursor, VT mode
+	// state). Carrying it here is what lets a single probe serve both as a guard
+	// checkpoint and as the before/after anchor for a full-pane capture.
+	PaneMeta PaneSnapshotMeta
+}
+
+// sessionProbeFormat lists the fields parseSessionProbe expects, in order. The
+// trailing pane fields mirror the format paneSnapshotMetadataForPane requests,
+// so a probe doubles as that call.
+const sessionProbeFormat = "#{session_created}\t#{session_attached}\t#{window_activity}\t" +
+	"#{window_active}\t#{window_id}\t#{pane_id}\t#{pane_active}\t#{pane_dead}\t" +
+	"#{pane_width}\t#{pane_height}\t#{cursor_x}\t#{cursor_y}\t#{alternate_on}\t" +
+	"#{alternate_saved_x}\t#{alternate_saved_y}\t#{cursor_flag}\t#{origin_flag}\t" +
+	"#{scroll_region_upper}\t#{scroll_region_lower}"
+
+// sessionProbeFieldCount is the number of fields sessionProbeFormat requests.
+const sessionProbeFieldCount = 19
+
+// ProbeSession collects the session/pane facts above in a single tmux exec.
+// A session that does not exist yields a zero SessionProbe and no error, matching
+// the exit-1-means-empty convention the other read paths use.
+func ProbeSession(sessionName string, opts Options) (SessionProbe, error) {
+	if sessionName == "" {
+		return SessionProbe{}, nil
+	}
+	if err := EnsureAvailable(); err != nil {
+		return SessionProbe{}, err
+	}
+	// -s: every pane in every window of the session, so window_activity can be
+	// maximized across windows without a second list-windows call.
+	lines, err := listTmux(opts, "list-panes", "-s", "-t", sessionTarget(sessionName), "-F", sessionProbeFormat)
+	if err != nil {
+		return SessionProbe{}, err
+	}
+	return parseSessionProbe(lines), nil
+}
+
+type probePaneRow struct {
+	windowActive bool
+	windowID     string
+	paneID       string
+	paneActive   bool
+	paneDead     bool
+	meta         PaneSnapshotMeta
+}
+
+// parseSessionProbe is the pure half of ProbeSession. Choosing the pane and
+// maximizing activity across windows is the genuinely bug-prone part, so it is
+// unit-testable without a live tmux server.
+func parseSessionProbe(lines []string) SessionProbe {
+	probe := SessionProbe{}
+	rows := make([]probePaneRow, 0, len(lines))
+	panesPerWindow := make(map[string]int)
+
+	for _, line := range lines {
+		parts, err := parseTabFields(line, sessionProbeFieldCount)
+		if err != nil {
+			continue
+		}
+		if !probe.Exists {
+			probe.Exists = true
+			if createdAt, err := strconv.ParseInt(parts[0], 10, 64); err == nil && createdAt > 0 {
+				probe.CreatedAt = createdAt
+			}
+			if clients, err := strconv.Atoi(parts[1]); err == nil && clients > 0 {
+				probe.ClientCount = clients
+			}
+		}
+		if activity, err := strconv.ParseInt(parts[2], 10, 64); err == nil && activity > probe.LatestActivity {
+			probe.LatestActivity = activity
+		}
+
+		row := probePaneRow{
+			windowActive: parts[3] == "1",
+			windowID:     parts[4],
+			paneID:       parts[5],
+			paneActive:   parts[6] == "1",
+			paneDead:     parts[7] == "1",
+		}
+		if row.paneID == "" || row.paneID[0] != '%' {
+			continue
+		}
+		row.meta = parseProbePaneMeta(parts, row.paneID)
+		// Liveness is scoped to the active window, matching hasLivePane (and so
+		// SessionStateFor). A live pane in some other window does not make the
+		// window a reattaching client would actually render live.
+		if row.windowActive && !row.paneDead {
+			probe.HasLivePane = true
+		}
+		panesPerWindow[row.windowID]++
+		rows = append(rows, row)
+	}
+
+	chosen, ok := chooseProbePane(rows)
+	if !ok {
+		return probe
+	}
+	probe.PaneID = chosen.paneID
+	probe.PaneMeta = chosen.meta
+	probe.PaneCols, probe.PaneRows = chosen.meta.Cols, chosen.meta.Rows
+	probe.HasPaneSize = chosen.meta.HasSize
+	probe.SinglePaneWindow = panesPerWindow[chosen.windowID] == 1
+	return probe
+}
+
+// parseProbePaneMeta reads the pane-metadata tail of a probe row. It reuses
+// parsePaneModeState so the mode-state parsing stays in one place: the probe
+// requests those fields in the same order paneSnapshotMetadataForPane does.
+func parseProbePaneMeta(parts []string, paneID string) PaneSnapshotMeta {
+	meta := PaneSnapshotMeta{}
+	cols, errCols := strconv.Atoi(parts[8])
+	rows, errRows := strconv.Atoi(parts[9])
+	if errCols == nil && errRows == nil && cols > 0 && rows > 0 {
+		meta.Cols, meta.Rows, meta.HasSize = cols, rows, true
+	}
+	cursorX, errCursorX := strconv.Atoi(parts[10])
+	cursorY, errCursorY := strconv.Atoi(parts[11])
+	if errCursorX == nil && errCursorY == nil {
+		meta.CursorX, meta.CursorY, meta.HasCursor = cursorX, cursorY, true
+	}
+	meta.ModeState, _ = parsePaneModeState([]string{
+		paneID,
+		parts[12], // alternate_on
+		parts[13], // alternate_saved_x
+		parts[14], // alternate_saved_y
+		parts[15], // cursor_flag
+		parts[16], // origin_flag
+		parts[17], // scroll_region_upper
+		parts[18], // scroll_region_lower
+	}, paneID)
+	return meta
+}
+
+// chooseProbePane picks the pane a reattaching client renders, mirroring
+// sessionPaneID: the active pane of the active window wins, else any live pane
+// in the active window. Dead panes are never chosen.
+//
+// Panes outside the active window are deliberately never chosen, even when the
+// active window has nothing live. sessionPaneID cannot reach them — it reads
+// `list-panes -t <session>`, which tmux scopes to the active window — whereas
+// the probe reads `list-panes -s`, which spans every window. Picking a pane the
+// client will not display would be actively harmful: the pre-attach
+// ResizePaneToSize targets the session, which tmux also resolves to the active
+// window, so the resize would land on one window while the snapshot described
+// another. The guards could not catch that, because the pane being described
+// never changes. Returning no pane instead falls back to history replay.
+func chooseProbePane(rows []probePaneRow) (probePaneRow, bool) {
+	var fallback probePaneRow
+	var haveFallback bool
+	for _, row := range rows {
+		if row.paneDead || !row.windowActive {
+			continue
+		}
+		if row.paneActive {
+			return row, true
+		}
+		if !haveFallback {
+			fallback, haveFallback = row, true
+		}
+	}
+	return fallback, haveFallback
+}
+
+// ActiveWithin reports whether the probed session saw window activity inside the
+// given window, applying the same whole-second slack SessionActiveWithin uses.
+func (p SessionProbe) ActiveWithin(window time.Duration, now time.Time) bool {
+	return activityWithinWindow(p.LatestActivity, window, now)
+}
+
+// HasClients reports whether any tmux client is attached to the probed session.
+func (p SessionProbe) HasClients() bool { return p.ClientCount > 0 }
+
+// SnapshotEligible reports whether the probed pane can anchor an authoritative
+// full-pane snapshot: it must be the sole pane in its window (otherwise the
+// pre-attach resize would also SIGWINCH hidden siblings) and report complete
+// geometry and mode metadata.
+func (p SessionProbe) SnapshotEligible() bool {
+	return p.PaneID != "" && p.SinglePaneWindow && p.PaneMeta.Eligible()
+}
+
+// SameGeneration reports whether two probes describe the same incarnation of a
+// session. A session killed and recreated under the same name gets a new
+// creation timestamp and a new pane ID, so any capture taken across that gap
+// must be discarded.
+func (p SessionProbe) SameGeneration(other SessionProbe) bool {
+	if p.CreatedAt <= 0 || p.PaneID == "" {
+		return false
+	}
+	return p.CreatedAt == other.CreatedAt && p.PaneID == other.PaneID
+}
+
+// CapturePaneFullData captures a resolved pane's scrollback plus its visible
+// screen. Unlike CapturePaneSnapshot it takes an already-resolved pane ID and
+// performs no validation, so a caller holding probes on both sides of the
+// capture pays one tmux round-trip instead of four.
+func CapturePaneFullData(paneID string, opts Options) ([]byte, error) {
+	if paneID == "" {
+		return nil, errPaneSnapshotUnavailable
+	}
+	return capturePaneSnapshotData(paneID, opts)
+}
+
+// CapturePaneHistoryData captures a resolved pane's scrollback, excluding the
+// visible screen. It is the shared implementation behind CapturePane, which
+// differs only in resolving the pane from a session name first.
+func CapturePaneHistoryData(paneID string, opts Options) ([]byte, error) {
+	if paneID == "" {
+		return nil, nil
+	}
+	// -p: output to stdout
+	// -e: include escape sequences (ANSI styling)
+	// -S -: start from beginning of history
+	// -N: preserve trailing spaces in each captured row. History-only callers
+	// also rely on this so post-attach deltas keep padded/status-bar rows intact.
+	// -E -1: end at last scrollback line (excludes visible screen)
+	// -t: target pane by globally unique pane ID
+	cmd, cancel := tmuxCommand(opts, "capture-pane", "-p", "-e", "-N", "-S", "-", "-E", "-1", "-t", paneID)
+	defer cancel()
+	output, err := runTmuxCmd(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if len(output) == 0 {
+		return nil, nil
+	}
+	return output, nil
+}

--- a/internal/tmux/probe_live_test.go
+++ b/internal/tmux/probe_live_test.go
@@ -1,0 +1,306 @@
+package tmux
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// These exercise ProbeSession and the pane-targeted capture helpers against a
+// real tmux server. They are the counterweight to the pure parser tests in
+// probe_test.go: those feed parseSessionProbe hand-written rows in
+// sessionProbeFormat's order and so can never notice if that format string is
+// reordered, while these compare the probe's output against the dedicated
+// single-purpose helpers that request the same fields through their own format
+// strings. Shared fixtures (probeLine, livePane) live in probe_test.go.
+
+// TestCapturePaneData_AgainstLiveTmux exercises the real bodies of the two
+// pane-targeted capture helpers. Every other test injects fakes for them, so
+// without this their tmux invocations never actually run.
+func TestCapturePaneData_AgainstLiveTmux(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+	// Emit more lines than the pane is tall so some are pushed into scrollback,
+	// which is the only part a history capture is allowed to return.
+	createSession(t, opts, "cap", `for i in $(seq 1 200); do echo "line-$i"; done; sleep 60`)
+
+	probe := waitForScrollback(t, opts, "cap")
+
+	history, err := CapturePaneHistoryData(probe.PaneID, opts)
+	if err != nil {
+		t.Fatalf("CapturePaneHistoryData: %v", err)
+	}
+	full, err := CapturePaneFullData(probe.PaneID, opts)
+	if err != nil {
+		t.Fatalf("CapturePaneFullData: %v", err)
+	}
+
+	// The full capture is scrollback plus the visible screen, so it must be the
+	// strictly larger of the two. This is what makes them different calls.
+	if len(full) <= len(history) {
+		t.Fatalf("full capture (%d bytes) must exceed history-only (%d bytes)", len(full), len(history))
+	}
+	if !bytes.Contains(full, []byte("line-200")) {
+		t.Error("expected the full capture to include the visible screen's last line")
+	}
+	if bytes.Contains(history, []byte("line-200")) {
+		t.Error("expected the history capture to exclude the visible screen (-E -1)")
+	}
+	// -N pads each row with trailing spaces, so the first line reads "line-1 ".
+	// The trailing space also disambiguates it from line-10 and line-100.
+	if !bytes.Contains(history, []byte("line-1 ")) {
+		t.Error("expected the history capture to reach the start of scrollback (-S -)")
+	}
+
+	// CapturePane is the same capture reached by session name instead of pane
+	// ID; identical bytes is what lets the pre- and post-attach halves of a
+	// restore be compared against each other.
+	viaSession, err := CapturePane("cap", opts)
+	if err != nil {
+		t.Fatalf("CapturePane: %v", err)
+	}
+	if !bytes.Equal(viaSession, history) {
+		t.Errorf("CapturePane and CapturePaneHistoryData disagree: %d vs %d bytes",
+			len(viaSession), len(history))
+	}
+}
+
+func TestCapturePaneData_EmptyPaneID(t *testing.T) {
+	// The two helpers deliberately differ here: a history capture with nothing to
+	// target is an ordinary empty result, but a full-pane capture is only ever
+	// requested for a pane a probe already resolved, so an empty ID means the
+	// caller's own bookkeeping is wrong.
+	if data, err := CapturePaneHistoryData("", testOpts()); data != nil || err != nil {
+		t.Errorf("CapturePaneHistoryData(\"\") = (%q, %v), want (nil, nil)", data, err)
+	}
+	if _, err := CapturePaneFullData("", testOpts()); err == nil {
+		t.Error("CapturePaneFullData(\"\") must report an error rather than an empty capture")
+	}
+}
+
+// waitForScrollback waits until the session's pane has pushed lines into
+// scrollback, so the capture tests read a settled pane rather than racing the
+// shell's output.
+func waitForScrollback(t *testing.T, opts Options, session string) SessionProbe {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		probe, err := ProbeSession(session, opts)
+		if err == nil && probe.PaneID != "" {
+			if data, err := CapturePaneHistoryData(probe.PaneID, opts); err == nil &&
+				bytes.Contains(data, []byte("line-1 ")) {
+				return probe
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("session %q never produced scrollback", session)
+	return SessionProbe{}
+}
+
+// TestProbeSession_MultiWindowMatchesSessionPaneID is the live-tmux half of
+// TestParseSessionProbe_NeverChoosesPaneOutsideActiveWindow. The probe reads
+// `list-panes -s` (every window) while sessionPaneID reads
+// `list-panes -t <session>` (active window only), so only a real server with a
+// second window proves the two scopes still agree.
+func TestProbeSession_MultiWindowMatchesSessionPaneID(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+	createSession(t, opts, "multi", "sleep 60")
+	addWindow(t, opts, "multi", "sleep 60")
+
+	probe, err := ProbeSession("multi", opts)
+	if err != nil {
+		t.Fatalf("ProbeSession: %v", err)
+	}
+	paneID, err := SessionPaneID("multi", opts)
+	if err != nil {
+		t.Fatalf("SessionPaneID: %v", err)
+	}
+	if probe.PaneID != paneID {
+		t.Fatalf("PaneID: probe=%q helper=%q — the probe must not reach past the active window",
+			probe.PaneID, paneID)
+	}
+	// A second window must not make the chosen pane's own window look shared.
+	cols, rows, hasSize, err := SessionPaneSize("multi", opts)
+	if err != nil || cols != probe.PaneCols || rows != probe.PaneRows || hasSize != probe.HasPaneSize {
+		t.Fatalf("PaneSize: probe=(%d,%d,%v) helper=(%d,%d,%v) (err %v)",
+			probe.PaneCols, probe.PaneRows, probe.HasPaneSize, cols, rows, hasSize, err)
+	}
+	_, _, supported, err := SessionPaneSnapshotInfo("multi", opts)
+	if err != nil || supported != probe.SnapshotEligible() {
+		t.Fatalf("SnapshotEligible: probe=%v helper=%v (err %v)", probe.SnapshotEligible(), supported, err)
+	}
+	state, err := SessionStateFor("multi", opts)
+	if err != nil || state.HasLivePane != probe.HasLivePane {
+		t.Fatalf("HasLivePane: probe=%v helper=%v (err %v)", probe.HasLivePane, state.HasLivePane, err)
+	}
+}
+
+// TestProbeSession_MatchesDedicatedHelpers pins the probe against a real tmux
+// server. The probe replaced a ladder of single-purpose reads in the reattach
+// bootstrap; this asserts it reports exactly what those reads still report, so
+// the round-trip savings never come at the cost of a different answer.
+func TestProbeSession_MatchesDedicatedHelpers(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+	// Emit output a second after the session is created. tmux reports both
+	// session_created and window_activity as whole-second unix stamps, and in a
+	// freshly made session they are the same second — which would make a
+	// transposition between those two format fields invisible. Waiting for them
+	// to diverge is what gives the CreatedAt/LatestActivity comparisons teeth.
+	createSession(t, opts, "probe", "sleep 1.2; echo settled; sleep 60")
+	probe := waitForActivityAfterCreation(t, opts, "probe")
+
+	createdAt, err := SessionCreatedAt("probe", opts)
+	if err != nil || createdAt != probe.CreatedAt {
+		t.Errorf("CreatedAt: probe=%d helper=%d (err %v)", probe.CreatedAt, createdAt, err)
+	}
+	// Pin that the two stamps really did diverge, so this test cannot quietly
+	// degrade into comparing one value against itself.
+	if probe.LatestActivity <= probe.CreatedAt {
+		t.Errorf("expected window_activity (%d) to be later than session_created (%d) so a transposition is visible",
+			probe.LatestActivity, probe.CreatedAt)
+	}
+	clientCount, err := SessionClientCount("probe", opts)
+	if err != nil || clientCount != probe.ClientCount {
+		t.Errorf("ClientCount: probe=%d helper=%d (err %v)", probe.ClientCount, clientCount, err)
+	}
+	paneID, err := SessionPaneID("probe", opts)
+	if err != nil || paneID != probe.PaneID {
+		t.Errorf("PaneID: probe=%q helper=%q (err %v)", probe.PaneID, paneID, err)
+	}
+	cols, rows, hasSize, err := SessionPaneSize("probe", opts)
+	if err != nil || cols != probe.PaneCols || rows != probe.PaneRows || hasSize != probe.HasPaneSize {
+		t.Errorf("PaneSize: probe=(%d,%d,%v) helper=(%d,%d,%v) (err %v)",
+			probe.PaneCols, probe.PaneRows, probe.HasPaneSize, cols, rows, hasSize, err)
+	}
+	infoCols, infoRows, supported, err := SessionPaneSnapshotInfo("probe", opts)
+	if err != nil || supported != probe.SnapshotEligible() {
+		t.Errorf("SnapshotEligible: probe=%v helper=%v (err %v)", probe.SnapshotEligible(), supported, err)
+	}
+	if supported && (infoCols != probe.PaneMeta.Cols || infoRows != probe.PaneMeta.Rows) {
+		t.Errorf("snapshot dims: probe=(%d,%d) helper=(%d,%d)",
+			probe.PaneMeta.Cols, probe.PaneMeta.Rows, infoCols, infoRows)
+	}
+	state, err := SessionStateFor("probe", opts)
+	if err != nil || state.Exists != probe.Exists || state.HasLivePane != probe.HasLivePane {
+		t.Errorf("state: probe=(%v,%v) helper=(%v,%v) (err %v)",
+			probe.Exists, probe.HasLivePane, state.Exists, state.HasLivePane, err)
+	}
+	if latest, has, err := SessionLatestActivity("probe", opts); err == nil && has && latest.Unix() != probe.LatestActivity {
+		t.Errorf("LatestActivity: probe=%d helper=%d", probe.LatestActivity, latest.Unix())
+	}
+
+	// Without real mode metadata the bootstrap could never take a full-pane
+	// snapshot, so this pins that tmux actually reports it here.
+	if !probe.PaneMeta.ModeState.HasState {
+		t.Error("expected tmux to report pane mode state")
+	}
+	if !probe.SnapshotEligible() {
+		t.Errorf("a detached single-pane session must be snapshot-eligible, got %+v", probe)
+	}
+
+	// Compare the whole metadata struct, not just the fields the guards read.
+	// The cursor position and mode state flow into the restored snapshot and
+	// drive cursor placement and alt-screen/scroll-region replay, but nothing
+	// else here would notice if two same-typed fields were transposed between
+	// sessionProbeFormat and parseProbePaneMeta's indices — swapping cursor_x
+	// with cursor_y, or alternate_on with cursor_flag, would silently replay the
+	// wrong screen. paneSnapshotMetadataForPane requests the same tmux fields
+	// through its own format string, so it catches exactly that class of error.
+	wantMeta, err := paneSnapshotMetadataForPane(probe.PaneID, opts)
+	if err != nil {
+		t.Fatalf("paneSnapshotMetadataForPane: %v", err)
+	}
+	if probe.PaneMeta != wantMeta {
+		t.Errorf("PaneMeta mismatch — probe and paneSnapshotMetadataForPane disagree on a field:\n probe=%+v\nhelper=%+v",
+			probe.PaneMeta, wantMeta)
+	}
+}
+
+// TestProbeSession_PaneMetaSurvivesAltScreen re-runs the metadata cross-check
+// against a pane in alt-screen mode with a moved cursor and a narrowed scroll
+// region. The default pane state leaves most mode fields at their zero value,
+// which makes a transposition between two zero fields invisible; driving them to
+// distinct non-zero values is what gives the comparison teeth.
+func TestProbeSession_PaneMetaSurvivesAltScreen(t *testing.T) {
+	skipIfNoTmux(t)
+	opts := testServer(t)
+	// Park the cursor somewhere distinctive, then enter the alt screen (which
+	// saves that position into alternate_saved_x/y), narrow the scroll region
+	// (DECSTBM), hide the cursor, and move again. tmux then reports
+	// cursor=(3,7), altsaved=(10,5), scroll=(2,19) — every coordinate distinct
+	// from every other, so any transposition among them changes a value.
+	createSession(t, opts, "alt",
+		`printf '\033[6;11H\033[?1049h\033[3;20r\033[?25l\033[8;4H'; sleep 60`)
+	waitForPaneMeta(t, opts, "alt")
+
+	probe, err := ProbeSession("alt", opts)
+	if err != nil {
+		t.Fatalf("ProbeSession: %v", err)
+	}
+	wantMeta, err := paneSnapshotMetadataForPane(probe.PaneID, opts)
+	if err != nil {
+		t.Fatalf("paneSnapshotMetadataForPane: %v", err)
+	}
+	if probe.PaneMeta != wantMeta {
+		t.Fatalf("PaneMeta mismatch under alt screen:\n probe=%+v\nhelper=%+v", probe.PaneMeta, wantMeta)
+	}
+	// Pin that the state really is distinctive, so this test cannot quietly
+	// degrade into comparing two sets of zero values.
+	if !probe.PaneMeta.ModeState.AltScreen {
+		t.Errorf("expected the pane to be in alt screen, got %+v", probe.PaneMeta.ModeState)
+	}
+	if probe.PaneMeta.CursorX == probe.PaneMeta.CursorY {
+		t.Errorf("expected distinct cursor coordinates so a transposition is visible, got %+v", probe.PaneMeta)
+	}
+	if probe.PaneMeta.ModeState.ScrollTop == 0 && probe.PaneMeta.ModeState.ScrollBottom == probe.PaneMeta.Rows {
+		t.Errorf("expected a narrowed scroll region so a transposition is visible, got %+v", probe.PaneMeta.ModeState)
+	}
+	mode := probe.PaneMeta.ModeState
+	if !mode.HasAltSavedCursor {
+		t.Fatalf("expected entering the alt screen to save a cursor position, got %+v", mode)
+	}
+	if mode.AltSavedCursorX == mode.AltSavedCursorY {
+		t.Errorf("expected distinct alt-saved coordinates so a transposition is visible, got %+v", mode)
+	}
+	// The saved pair must also differ from the live pair, so swapping a saved
+	// field with a live one cannot go unnoticed either.
+	if mode.AltSavedCursorX == probe.PaneMeta.CursorX || mode.AltSavedCursorY == probe.PaneMeta.CursorY {
+		t.Errorf("expected the alt-saved cursor to differ from the live cursor, got saved=(%d,%d) live=(%d,%d)",
+			mode.AltSavedCursorX, mode.AltSavedCursorY, probe.PaneMeta.CursorX, probe.PaneMeta.CursorY)
+	}
+}
+
+// waitForPaneMeta waits for a session's pane to report alt-screen mode, so the
+// tests above observe the shell's escape sequences after they land rather than
+// racing them.
+func waitForPaneMeta(t *testing.T, opts Options, session string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if probe, err := ProbeSession(session, opts); err == nil && probe.PaneMeta.ModeState.AltScreen {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pane for session %q never entered alt screen", session)
+}
+
+// waitForActivityAfterCreation waits until the session reports window activity
+// strictly later than its creation stamp, so a probe taken afterwards
+// distinguishes the two fields.
+func waitForActivityAfterCreation(t *testing.T, opts Options, session string) SessionProbe {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		probe, err := ProbeSession(session, opts)
+		if err == nil && probe.CreatedAt > 0 && probe.LatestActivity > probe.CreatedAt {
+			return probe
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("session %q never reported activity later than its creation stamp", session)
+	return SessionProbe{}
+}

--- a/internal/tmux/probe_test.go
+++ b/internal/tmux/probe_test.go
@@ -1,0 +1,340 @@
+package tmux
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// probeLine renders one list-panes row in sessionProbeFormat's field order, so
+// the parser tests read as data rather than as tab-counting.
+type probeLine struct {
+	sessionCreated  string
+	sessionAttached string
+	windowActivity  string
+	windowActive    string
+	windowID        string
+	paneID          string
+	paneActive      string
+	paneDead        string
+	paneWidth       string
+	paneHeight      string
+	cursorX         string
+	cursorY         string
+	alternateOn     string
+	altSavedX       string
+	altSavedY       string
+	cursorFlag      string
+	originFlag      string
+	scrollUpper     string
+	scrollLower     string
+}
+
+// livePane is a plausible single-pane row; tests override the fields they care
+// about.
+func livePane() probeLine {
+	return probeLine{
+		sessionCreated: "1700000000", sessionAttached: "0",
+		windowActivity: "1700000500", windowActive: "1", windowID: "@0",
+		paneID: "%1", paneActive: "1", paneDead: "0",
+		paneWidth: "80", paneHeight: "24",
+		cursorX: "3", cursorY: "7",
+		alternateOn: "0", altSavedX: "4294967295", altSavedY: "4294967295",
+		cursorFlag: "1", originFlag: "0",
+		scrollUpper: "0", scrollLower: "23",
+	}
+}
+
+func (p probeLine) String() string {
+	return strings.Join([]string{
+		p.sessionCreated, p.sessionAttached, p.windowActivity, p.windowActive,
+		p.windowID, p.paneID, p.paneActive, p.paneDead, p.paneWidth, p.paneHeight,
+		p.cursorX, p.cursorY, p.alternateOn, p.altSavedX, p.altSavedY,
+		p.cursorFlag, p.originFlag, p.scrollUpper, p.scrollLower,
+	}, "\t")
+}
+
+func probeLines(rows ...probeLine) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.String())
+	}
+	return out
+}
+
+func TestParseSessionProbe_SinglePane(t *testing.T) {
+	probe := parseSessionProbe(probeLines(livePane()))
+
+	if !probe.Exists || !probe.HasLivePane {
+		t.Fatalf("a live pane must report Exists and HasLivePane, got %+v", probe)
+	}
+	if probe.CreatedAt != 1700000000 {
+		t.Fatalf("CreatedAt = %d, want 1700000000", probe.CreatedAt)
+	}
+	if probe.ClientCount != 0 || probe.HasClients() {
+		t.Fatalf("session_attached=0 must mean no clients, got %d", probe.ClientCount)
+	}
+	if probe.PaneID != "%1" {
+		t.Fatalf("PaneID = %q, want %q", probe.PaneID, "%1")
+	}
+	if probe.PaneCols != 80 || probe.PaneRows != 24 || !probe.HasPaneSize {
+		t.Fatalf("pane size = (%d, %d, %v), want (80, 24, true)", probe.PaneCols, probe.PaneRows, probe.HasPaneSize)
+	}
+	if !probe.SinglePaneWindow {
+		t.Fatal("a window with one pane must report SinglePaneWindow")
+	}
+	if probe.LatestActivity != 1700000500 {
+		t.Fatalf("LatestActivity = %d, want 1700000500", probe.LatestActivity)
+	}
+	if probe.PaneMeta.CursorX != 3 || probe.PaneMeta.CursorY != 7 || !probe.PaneMeta.HasCursor {
+		t.Fatalf("cursor = (%d, %d, %v), want (3, 7, true)", probe.PaneMeta.CursorX, probe.PaneMeta.CursorY, probe.PaneMeta.HasCursor)
+	}
+	if !probe.PaneMeta.ModeState.HasState {
+		t.Fatal("expected mode state to be parsed from the probe row")
+	}
+	if !probe.SnapshotEligible() {
+		t.Fatalf("a quiet single live pane with full metadata must be snapshot-eligible, got %+v", probe)
+	}
+}
+
+func TestParseSessionProbe_PrefersActivePaneOfActiveWindow(t *testing.T) {
+	// The pane a reattaching client renders is the active pane of the active
+	// window, no matter what order tmux lists them in.
+	inactiveWindow := livePane()
+	inactiveWindow.windowActive = "0"
+	inactiveWindow.windowID = "@1"
+	inactiveWindow.paneID = "%9"
+
+	activeButNotFirst := livePane()
+	activeButNotFirst.paneID = "%2"
+
+	notActivePane := livePane()
+	notActivePane.paneID = "%3"
+	notActivePane.paneActive = "0"
+
+	probe := parseSessionProbe(probeLines(inactiveWindow, notActivePane, activeButNotFirst))
+	if probe.PaneID != "%2" {
+		t.Fatalf("PaneID = %q, want the active pane of the active window (%%2)", probe.PaneID)
+	}
+	// Two panes share window @0, so the pre-attach resize would disturb a sibling.
+	if probe.SinglePaneWindow {
+		t.Fatal("a window with two panes must not report SinglePaneWindow")
+	}
+	if probe.SnapshotEligible() {
+		t.Fatal("a split window must not be snapshot-eligible")
+	}
+}
+
+// TestParseSessionProbe_NeverChoosesPaneOutsideActiveWindow pins the scope
+// difference between the probe's `list-panes -s` (every window) and
+// sessionPaneID's `list-panes -t <session>` (active window only).
+//
+// Choosing a pane from an inactive window would be worse than choosing none:
+// ResizePaneToSize targets the session, which tmux resolves to the active
+// window, so the pre-attach resize would land on one window while the snapshot
+// described another — at the other window's dimensions. The bootstrap's guards
+// cannot catch that, because the pane being described never changes across
+// them.
+func TestParseSessionProbe_NeverChoosesPaneOutsideActiveWindow(t *testing.T) {
+	// The active window's only pane is dead; another window has a live one.
+	deadActiveWindow := livePane()
+	deadActiveWindow.windowID = "@1"
+	deadActiveWindow.paneID = "%1"
+	deadActiveWindow.paneDead = "1"
+
+	liveOtherWindow := livePane()
+	liveOtherWindow.windowActive = "0"
+	liveOtherWindow.windowID = "@0"
+	liveOtherWindow.paneID = "%0"
+
+	probe := parseSessionProbe(probeLines(liveOtherWindow, deadActiveWindow))
+	if probe.PaneID != "" {
+		t.Fatalf("PaneID = %q, want empty: a pane outside the active window must never be chosen", probe.PaneID)
+	}
+	if probe.SnapshotEligible() {
+		t.Fatal("expected no snapshot when the active window has no live pane")
+	}
+	// Liveness is scoped the same way, so it agrees with SessionStateFor.
+	if probe.HasLivePane {
+		t.Fatal("a live pane in a non-active window must not report HasLivePane")
+	}
+	// The session itself is still reported as existing.
+	if !probe.Exists {
+		t.Fatal("expected the session to still be reported as existing")
+	}
+}
+
+func TestParseSessionProbe_SkipsDeadPanes(t *testing.T) {
+	dead := livePane()
+	dead.paneID = "%1"
+	dead.paneDead = "1"
+
+	alive := livePane()
+	alive.paneID = "%2"
+	alive.paneActive = "0"
+
+	probe := parseSessionProbe(probeLines(dead, alive))
+	if probe.PaneID != "%2" {
+		t.Fatalf("PaneID = %q, want the live pane (%%2) rather than the dead active one", probe.PaneID)
+	}
+	if !probe.HasLivePane {
+		t.Fatal("one live pane among dead ones must report HasLivePane")
+	}
+}
+
+func TestParseSessionProbe_AllPanesDead(t *testing.T) {
+	dead := livePane()
+	dead.paneDead = "1"
+
+	probe := parseSessionProbe(probeLines(dead))
+	if !probe.Exists {
+		t.Fatal("a session with only dead panes still exists")
+	}
+	if probe.HasLivePane {
+		t.Fatal("all panes dead must report HasLivePane=false")
+	}
+	if probe.PaneID != "" {
+		t.Fatalf("PaneID = %q, want empty when every pane is dead", probe.PaneID)
+	}
+	if probe.SnapshotEligible() {
+		t.Fatal("a session with no live pane must not be snapshot-eligible")
+	}
+}
+
+func TestParseSessionProbe_MaximisesActivityAcrossWindows(t *testing.T) {
+	// Activity is per-window; the session is only quiet if every window is.
+	quiet := livePane()
+	quiet.windowActivity = "1700000100"
+
+	noisy := livePane()
+	noisy.windowActive = "0"
+	noisy.windowID = "@1"
+	noisy.paneID = "%9"
+	noisy.windowActivity = "1700009999"
+
+	probe := parseSessionProbe(probeLines(quiet, noisy))
+	if probe.LatestActivity != 1700009999 {
+		t.Fatalf("LatestActivity = %d, want the max across windows (1700009999)", probe.LatestActivity)
+	}
+}
+
+func TestParseSessionProbe_CountsAttachedClients(t *testing.T) {
+	attached := livePane()
+	attached.sessionAttached = "2"
+
+	probe := parseSessionProbe(probeLines(attached))
+	if probe.ClientCount != 2 || !probe.HasClients() {
+		t.Fatalf("ClientCount = %d, want 2", probe.ClientCount)
+	}
+}
+
+func TestParseSessionProbe_EmptyOutputIsZeroProbe(t *testing.T) {
+	probe := parseSessionProbe(nil)
+	if probe.Exists || probe.HasLivePane || probe.PaneID != "" {
+		t.Fatalf("no output must yield the zero probe, got %+v", probe)
+	}
+	if probe.SnapshotEligible() {
+		t.Fatal("the zero probe must not be snapshot-eligible")
+	}
+}
+
+func TestParseSessionProbe_SkipsMalformedLines(t *testing.T) {
+	// A short line is dropped rather than indexed into.
+	probe := parseSessionProbe([]string{"nonsense", livePane().String()})
+	if probe.PaneID != "%1" {
+		t.Fatalf("PaneID = %q, want the well-formed row to still be used", probe.PaneID)
+	}
+}
+
+func TestParseSessionProbe_MissingSizeIsNotEligible(t *testing.T) {
+	noSize := livePane()
+	noSize.paneWidth = "0"
+
+	probe := parseSessionProbe(probeLines(noSize))
+	if probe.HasPaneSize {
+		t.Fatal("a zero pane width must not report HasPaneSize")
+	}
+	if probe.SnapshotEligible() {
+		t.Fatal("a pane with no usable size must not be snapshot-eligible")
+	}
+}
+
+func TestSessionProbe_SameGeneration(t *testing.T) {
+	base := SessionProbe{CreatedAt: 100, PaneID: "%1"}
+
+	if !base.SameGeneration(SessionProbe{CreatedAt: 100, PaneID: "%1"}) {
+		t.Fatal("identical creation stamp and pane ID must be the same generation")
+	}
+	// A session killed and recreated under the same name gets both a new
+	// creation stamp and a new pane ID; either alone is enough to detect it.
+	if base.SameGeneration(SessionProbe{CreatedAt: 200, PaneID: "%1"}) {
+		t.Fatal("a new creation stamp must be a different generation")
+	}
+	if base.SameGeneration(SessionProbe{CreatedAt: 100, PaneID: "%2"}) {
+		t.Fatal("a new pane ID must be a different generation")
+	}
+	// An unusable baseline can never match, so a capture is never trusted after
+	// a probe that failed to identify the session.
+	if (SessionProbe{}).SameGeneration(SessionProbe{}) {
+		t.Fatal("the zero probe must not match any generation, including itself")
+	}
+}
+
+func TestSessionProbe_ActiveWithin(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	quiet := SessionProbe{LatestActivity: now.Add(-30 * time.Second).Unix()}
+	recent := SessionProbe{LatestActivity: now.Add(-1 * time.Second).Unix()}
+
+	if quiet.ActiveWithin(2*time.Second, now) {
+		t.Fatal("activity 30s ago must be outside a 2s quiet window")
+	}
+	if !recent.ActiveWithin(2*time.Second, now) {
+		t.Fatal("activity 1s ago must be inside a 2s quiet window")
+	}
+	if (SessionProbe{}).ActiveWithin(2*time.Second, now) {
+		t.Fatal("no reported activity must never count as active")
+	}
+}
+
+func TestProbeSession_EmptyNameSkipsExec(t *testing.T) {
+	orig := runTmuxCmd
+	runTmuxCmd = func(cmd *exec.Cmd) ([]byte, error) {
+		t.Errorf("expected no tmux invocation for an empty session name, got %v", cmd.Args)
+		return nil, errors.New("unexpected invocation")
+	}
+	t.Cleanup(func() { runTmuxCmd = orig })
+
+	probe, err := ProbeSession("", testOpts())
+	if err != nil || probe.Exists {
+		t.Fatalf("empty session name must yield the zero probe, got %+v err=%v", probe, err)
+	}
+}
+
+func TestProbeSession_MissingSessionIsZeroProbeNotError(t *testing.T) {
+	skipIfNoTmux(t)
+	orig := runTmuxCmd
+	runTmuxCmd = func(*exec.Cmd) ([]byte, error) { return nil, exitCode1Err(t) }
+	t.Cleanup(func() { runTmuxCmd = orig })
+
+	probe, err := ProbeSession("amux-gone", testOpts())
+	if err != nil {
+		t.Fatalf("exit 1 means the session is gone, not an error; got %v", err)
+	}
+	if probe.Exists {
+		t.Fatalf("a missing session must yield the zero probe, got %+v", probe)
+	}
+}
+
+func TestProbeSession_ErrorPropagates(t *testing.T) {
+	skipIfNoTmux(t)
+	want := errors.New("no server running on /tmp/x")
+	orig := runTmuxCmd
+	runTmuxCmd = func(*exec.Cmd) ([]byte, error) { return nil, want }
+	t.Cleanup(func() { runTmuxCmd = orig })
+
+	if _, err := ProbeSession("amux-x", testOpts()); !errors.Is(err, want) {
+		t.Fatalf("a non-exit-1 error must propagate, got %v", err)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -240,14 +240,11 @@ func hasSession(sessionName string, opts Options) (bool, error) {
 	return true, nil
 }
 
+// hasLivePane reports whether any pane in the session is not dead. Its only
+// caller (SessionStateFor) has already established that the session exists, and
+// list-panes exits 1 for a missing session anyway, so it does no has-session
+// pre-check of its own.
 func hasLivePane(sessionName string, opts Options) (bool, error) {
-	exists, err := hasSession(sessionName, opts)
-	if err != nil {
-		return false, err
-	}
-	if !exists {
-		return false, nil
-	}
 	lines, err := listTmux(opts, "list-panes", "-t", sessionTarget(sessionName), "-F", "#{pane_dead}")
 	if err != nil {
 		return false, err

--- a/internal/ui/center/model_render.go
+++ b/internal/ui/center/model_render.go
@@ -306,19 +306,23 @@ func (m *Model) terminalStatusLineLocked(tab *Tab) string {
 	if tab.Running && !tab.Detached {
 		return ""
 	}
-	status := ""
-	if tab.Detached {
-		status = " DETACHED "
-	} else if !tab.Running {
-		status = " STOPPED "
-	}
 	statusStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(common.ColorBackground()).
 		Background(common.ColorInfo())
+	// A reattach is several tmux round-trips against a server that is also
+	// pumping output for every other attached agent, so it can visibly take a
+	// moment. Saying so beats leaving DETACHED up, which reads as "nothing is
+	// happening" exactly when something is.
+	if tab.reattachInFlight {
+		return statusStyle.Render(" REATTACHING ")
+	}
+	status := ""
 	if tab.Detached {
+		status = " DETACHED "
 		statusStyle = statusStyle.Background(common.ColorWarning())
 	} else if !tab.Running {
+		status = " STOPPED "
 		statusStyle = statusStyle.Background(common.ColorError())
 	}
 	return statusStyle.Render(status)

--- a/internal/ui/center/model_render_status_test.go
+++ b/internal/ui/center/model_render_status_test.go
@@ -1,0 +1,101 @@
+package center
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// statusTab builds a tab with a terminal attached, since the status line is only
+// rendered for a tab that has one.
+func statusTab(m *Model) *Tab {
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+	tab := &Tab{
+		ID:        TabID("tab-status"),
+		Assistant: "codex",
+		Workspace: ws,
+		Terminal:  vterm.New(20, 4),
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.SetWorkspace(ws)
+	return tab
+}
+
+func TestTerminalStatusLine(t *testing.T) {
+	tests := []struct {
+		name             string
+		running          bool
+		detached         bool
+		reattachInFlight bool
+		want             string
+	}{
+		{
+			name:    "attached and running shows nothing",
+			running: true,
+			want:    "",
+		},
+		{
+			name:     "detached",
+			detached: true,
+			want:     "DETACHED",
+		},
+		{
+			name: "stopped",
+			want: "STOPPED",
+		},
+		{
+			// A reattach is several tmux round-trips against a server that is also
+			// pumping output for every other attached agent, so it can visibly take
+			// a moment. Leaving DETACHED up reads as "nothing is happening" exactly
+			// when something is.
+			name:             "reattach in flight reports progress instead of DETACHED",
+			detached:         true,
+			reattachInFlight: true,
+			want:             "REATTACHING",
+		},
+		{
+			name:             "reattach from a stopped tab also reports progress",
+			reattachInFlight: true,
+			want:             "REATTACHING",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModel()
+			tab := statusTab(m)
+			tab.Running = tt.running
+			tab.Detached = tt.detached
+			tab.reattachInFlight = tt.reattachInFlight
+
+			got := strings.TrimSpace(ansi.Strip(m.ActiveTerminalStatusLine()))
+			if got != tt.want {
+				t.Fatalf("status line = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTerminalStatusLine_ScrollPositionWinsOverReattach(t *testing.T) {
+	// While scrolled back the user is reading history, and the scroll position is
+	// the more useful thing to show; the reattach still finishes underneath.
+	m := newTestModel()
+	tab := statusTab(m)
+	tab.Detached = true
+	tab.reattachInFlight = true
+	tab.Terminal.Scrollback = [][]vterm.Cell{vterm.MakeBlankLine(20), vterm.MakeBlankLine(20)}
+
+	tab.mu.Lock()
+	m.scrollTerminalViewLocked(tab, 1)
+	tab.mu.Unlock()
+
+	got := ansi.Strip(m.ActiveTerminalStatusLine())
+	if !strings.Contains(got, "SCROLL") {
+		t.Fatalf("expected the scroll position to take precedence, got %q", got)
+	}
+}

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -15,20 +15,14 @@ import (
 // These package-level indirections are test seams for reattach/bootstrap
 // paths. Tests that override them must not use t.Parallel within this package.
 var (
-	sessionStateForFn         = tmux.SessionStateFor
-	sessionHasClientsFn       = tmux.SessionHasClients
-	sessionClientCountFn      = tmux.SessionClientCount
-	sessionActiveWithinFn     = tmux.SessionActiveWithin
-	sessionLatestActivityFn   = tmux.SessionLatestActivity
-	sessionCreatedAtFn        = tmux.SessionCreatedAt
-	sessionPaneIDFn           = tmux.SessionPaneID
-	sessionPaneSnapshotInfoFn = tmux.SessionPaneSnapshotInfo
-	sessionPaneSizeFn         = tmux.SessionPaneSize
-	killSessionFn             = tmux.KillSession
-	resizePaneToSizeFn        = tmux.ResizePaneToSize
-	capturePaneSnapshotFn     = tmux.CapturePaneSnapshot
-	capturePaneFn             = tmux.CapturePane
-	createAgentWithTagsFn     = func(
+	sessionStateForFn        = tmux.SessionStateFor
+	probeSessionFn           = tmux.ProbeSession
+	killSessionFn            = tmux.KillSession
+	resizePaneToSizeFn       = tmux.ResizePaneToSize
+	capturePaneFullDataFn    = tmux.CapturePaneFullData
+	capturePaneHistoryDataFn = tmux.CapturePaneHistoryData
+	capturePaneFn            = tmux.CapturePane
+	createAgentWithTagsFn    = func(
 		manager *appPty.AgentManager,
 		ws *data.Workspace,
 		agentType appPty.AgentType,
@@ -48,18 +42,11 @@ type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 func sessionBootstrap() ptyio.SessionBootstrap {
 	return ptyio.SessionBootstrap{
 		Fns: ptyio.SessionBootstrapFns{
-			SessionHasClients:       sessionHasClientsFn,
-			SessionClientCount:      sessionClientCountFn,
-			SessionActiveWithin:     sessionActiveWithinFn,
-			SessionLatestActivity:   sessionLatestActivityFn,
-			SessionCreatedAt:        sessionCreatedAtFn,
-			SessionPaneID:           sessionPaneIDFn,
-			SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
-			SessionPaneSize:         sessionPaneSizeFn,
-			ResizePaneToSize:        resizePaneToSizeFn,
-			CapturePaneSnapshot:     capturePaneSnapshotFn,
+			ProbeSession:           probeSessionFn,
+			ResizePaneToSize:       resizePaneToSizeFn,
+			CapturePaneFullData:    capturePaneFullDataFn,
+			CapturePaneHistoryData: capturePaneHistoryDataFn,
 		},
-		CapturePane: capturePaneFn,
 	}
 }
 

--- a/internal/ui/center/model_tabs_session_reattach_history_size_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_history_size_test.go
@@ -9,53 +9,33 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestReattachActiveTab_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
+// installHistoryFallbackSeams wires the seams shared by the history-fallback
+// tests below: the session exists and is live, the probe reports whatever
+// ineligibility the caller set up, and any resize or full-pane capture is a test
+// failure because the fallback path must reach neither.
+func installHistoryFallbackSeams(t *testing.T, calls *[]string, probe tmux.SessionProbe) {
+	t.Helper()
+	restoreReattachSeams(t)
 
-	calls := make([]string, 0, 4)
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	probeSeq(calls, probe)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("should not use"), nil
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("history"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("history"), nil
 	}
 	createAgentWithTagsFn = func(
@@ -66,9 +46,37 @@ func TestReattachActiveTab_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
 		rows, cols uint16,
 		tags tmux.SessionTags,
 	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
+		*calls = append(*calls, "attach")
 		return &appPty.Agent{Session: sessionName}, nil
 	}
+}
+
+// assertHistoryFallback asserts the reattach fell back to replaying history at
+// the live pane size, without ever resizing or snapshotting the pane.
+func assertHistoryFallback(t *testing.T, result ptyTabReattachResult, calls []string) {
+	t.Helper()
+	if result.CaptureFullPane {
+		t.Fatal("expected an ineligible session to skip the pre-attach full-pane snapshot")
+	}
+	if got := string(result.ScrollbackCapture); got != "history" {
+		t.Fatalf("expected history-only fallback, got %q", got)
+	}
+	if result.Cols != 123 || result.Rows != 45 {
+		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
+	}
+	assertCallOrder(t, calls, "state", "probe", "attach", "scrollback")
+	for _, call := range calls {
+		if call == "snapshot" || call == "resize" {
+			t.Fatalf("expected an ineligible session to avoid pre-attach resize/snapshot, got %v", calls)
+		}
+	}
+}
+
+func TestReattachActiveTab_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
+	var calls []string
+	busy := eligibleReattachProbe()
+	busy.LatestActivity = time.Now().Unix()
+	installHistoryFallbackSeams(t, &calls, busy)
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -90,86 +98,14 @@ func TestReattachActiveTab_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected busy session to skip pre-attach full-pane snapshot")
-	}
-	if got := string(result.ScrollbackCapture); got != "history" {
-		t.Fatalf("expected history-only fallback, got %q", got)
-	}
-	if result.Cols != 123 || result.Rows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "attach", "size", "scrollback")
-	for _, call := range calls {
-		if call == "snapshot" {
-			t.Fatalf("expected busy session to avoid full snapshot capture, got %v", calls)
-		}
-		if call == "resize" {
-			t.Fatalf("expected busy session to avoid pre-attach resize, got %v", calls)
-		}
-	}
+	assertHistoryFallback(t, result, calls)
 }
 
 func TestReattachActiveTab_SharedClientCapturesHistoryAfterAttach(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 4)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return true, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	shared := eligibleReattachProbe()
+	shared.ClientCount = 1
+	installHistoryFallbackSeams(t, &calls, shared)
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -191,83 +127,14 @@ func TestReattachActiveTab_SharedClientCapturesHistoryAfterAttach(t *testing.T) 
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected shared-client session to skip pre-attach full-pane snapshot")
-	}
-	if got := string(result.ScrollbackCapture); got != "history" {
-		t.Fatalf("expected history-only fallback, got %q", got)
-	}
-	if result.Cols != 123 || result.Rows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "attach", "size", "scrollback")
-	for _, call := range calls {
-		if call == "snapshot" || call == "resize" {
-			t.Fatalf("expected shared-client session to avoid pre-attach resize/snapshot, got %v", calls)
-		}
-	}
+	assertHistoryFallback(t, result, calls)
 }
 
 func TestReattachToSession_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 4)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	busy := eligibleReattachProbe()
+	busy.LatestActivity = time.Now().Unix()
+	installHistoryFallbackSeams(t, &calls, busy)
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -278,19 +145,5 @@ func TestReattachToSession_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected busy restore reattach to skip authoritative pane snapshot")
-	}
-	if got := string(result.ScrollbackCapture); got != "history" {
-		t.Fatalf("expected history-only fallback, got %q", got)
-	}
-	if result.Cols != 123 || result.Rows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "attach", "size", "scrollback")
-	for _, call := range calls {
-		if call == "snapshot" || call == "resize" {
-			t.Fatalf("expected busy restore reattach to avoid pre-attach resize/snapshot, got %v", calls)
-		}
-	}
+	assertHistoryFallback(t, result, calls)
 }

--- a/internal/ui/center/model_tabs_session_reattach_order_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_order_test.go
@@ -2,86 +2,43 @@ package center
 
 import (
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestReattachActiveTab_CapturesSnapshotBeforeAttach(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionLatestActivityFn := sessionLatestActivityFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionLatestActivityFn = oldSessionLatestActivityFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
+// installSnapshotSeams wires an eligible session: the pre-attach resize and
+// full-pane capture both succeed, and the post-attach probe reports the single
+// attaching client so the snapshot survives validation.
+func installSnapshotSeams(t *testing.T, calls *[]string) {
+	t.Helper()
+	restoreReattachSeams(t)
 
-	calls := make([]string, 0, 4)
+	attached := eligibleReattachProbe()
+	attached.ClientCount = 1
+
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionLatestActivityFn = func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-		return time.Time{}, false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 77, 19, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	// Quiet and unattached through the capture; the attaching client shows up in
+	// the post-attach validation probe.
+	probeSeq(calls, eligibleReattachProbe(), eligibleReattachProbe(), eligibleReattachProbe(), attached)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("frame"), Cols: 77, Rows: 19}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("frame"), nil
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("fallback"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("fallback"), nil
 	}
 	createAgentWithTagsFn = func(
@@ -92,9 +49,59 @@ func TestReattachActiveTab_CapturesSnapshotBeforeAttach(t *testing.T) {
 		rows, cols uint16,
 		tags tmux.SessionTags,
 	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
+		*calls = append(*calls, "attach")
 		return &appPty.Agent{Session: sessionName}, nil
 	}
+}
+
+// assertSnapshotBeforeAttach asserts the authoritative snapshot was taken before
+// the attach, at the probed pane size, with exactly one post-attach delta
+// capture to reconcile anything that landed in between.
+func assertSnapshotBeforeAttach(t *testing.T, result ptyTabReattachResult, calls []string) {
+	t.Helper()
+	if !result.CaptureFullPane {
+		t.Fatal("expected authoritative pane capture on live reattach")
+	}
+	if got := string(result.ScrollbackCapture); got != "frame" {
+		t.Fatalf("expected captured pane snapshot, got %q", got)
+	}
+	if got := string(result.PostAttachScrollbackCapture); got != "fallback" {
+		t.Fatalf("expected post-attach history reconciliation capture, got %q", got)
+	}
+	if result.SnapshotCols != 123 || result.SnapshotRows != 45 {
+		t.Fatalf("expected probed snapshot size 123x45, got %dx%d", result.SnapshotCols, result.SnapshotRows)
+	}
+	assertCallOrder(t, calls, "state", "probe", "resize", "snapshot", "attach", "scrollback")
+
+	snapshotCount, scrollbackCount := 0, 0
+	scrollbackIdx, attachIdx := -1, -1
+	for i, call := range calls {
+		switch call {
+		case "snapshot":
+			snapshotCount++
+		case "scrollback":
+			scrollbackCount++
+			if scrollbackIdx == -1 {
+				scrollbackIdx = i
+			}
+		case "attach":
+			attachIdx = i
+		}
+	}
+	if snapshotCount != 1 {
+		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
+	}
+	if scrollbackCount != 1 {
+		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
+	}
+	if scrollbackIdx < attachIdx {
+		t.Fatalf("expected reconciliation capture after attach, got %v", calls)
+	}
+}
+
+func TestReattachActiveTab_CapturesSnapshotBeforeAttach(t *testing.T) {
+	var calls []string
+	installSnapshotSeams(t, &calls)
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -115,193 +122,26 @@ func TestReattachActiveTab_CapturesSnapshotBeforeAttach(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected reattach command")
 	}
-	msg := cmd()
-	result, ok := msg.(ptyTabReattachResult)
+	result, ok := cmd().(ptyTabReattachResult)
 	if !ok {
-		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
+		t.Fatal("expected ptyTabReattachResult")
 	}
-	if !result.CaptureFullPane {
-		t.Fatal("expected authoritative pane capture on live reattach")
-	}
-	if got := string(result.ScrollbackCapture); got != "frame" {
-		t.Fatalf("expected captured pane snapshot, got %q", got)
-	}
-	if got := string(result.PostAttachScrollbackCapture); got != "fallback" {
-		t.Fatalf("expected post-attach history reconciliation capture, got %q", got)
-	}
-	if result.SnapshotCols != 77 || result.SnapshotRows != 19 {
-		t.Fatalf("expected actual snapshot size 77x19, got %dx%d", result.SnapshotCols, result.SnapshotRows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
-	snapshotCount := 0
-	scrollbackIdx := -1
-	scrollbackCount := 0
-	attachIdx := -1
-	for _, call := range calls {
-		if call == "snapshot" {
-			snapshotCount++
-		}
-	}
-	for i, call := range calls {
-		if call == "scrollback" {
-			scrollbackCount++
-			if scrollbackIdx == -1 {
-				scrollbackIdx = i
-			}
-		}
-		if call == "attach" {
-			attachIdx = i
-		}
-	}
-	if snapshotCount != 1 {
-		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
-	}
-	if scrollbackCount != 1 {
-		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected reconciliation capture after attach, got %v", calls)
-	}
+	assertSnapshotBeforeAttach(t, result, calls)
 }
 
 func TestReattachToSession_CapturesSnapshotBeforeAttach(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionLatestActivityFn := sessionLatestActivityFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionLatestActivityFn = oldSessionLatestActivityFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 4)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionLatestActivityFn = func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-		return time.Time{}, false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 77, 19, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("frame"), Cols: 77, Rows: 19}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("fallback"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	installSnapshotSeams(t, &calls)
 
 	m := newTestModel()
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
 
-	msg := m.reattachToSession(ws, TabID("tab-restore"), "codex", "session-restore")()
-	result, ok := msg.(ptyTabReattachResult)
+	result, ok := m.reattachToSession(ws, TabID("tab-restore"), "codex", "session-restore")().(ptyTabReattachResult)
 	if !ok {
-		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
+		t.Fatal("expected ptyTabReattachResult")
 	}
-	if !result.CaptureFullPane {
-		t.Fatal("expected authoritative pane capture during restore reattach")
-	}
-	if got := string(result.ScrollbackCapture); got != "frame" {
-		t.Fatalf("expected captured pane snapshot, got %q", got)
-	}
-	if got := string(result.PostAttachScrollbackCapture); got != "fallback" {
-		t.Fatalf("expected post-attach history reconciliation capture, got %q", got)
-	}
-	if result.SnapshotCols != 77 || result.SnapshotRows != 19 {
-		t.Fatalf("expected actual snapshot size 77x19, got %dx%d", result.SnapshotCols, result.SnapshotRows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
-	snapshotCount := 0
-	scrollbackIdx := -1
-	scrollbackCount := 0
-	attachIdx := -1
-	for _, call := range calls {
-		if call == "snapshot" {
-			snapshotCount++
-		}
-	}
-	for i, call := range calls {
-		if call == "scrollback" {
-			scrollbackCount++
-			if scrollbackIdx == -1 {
-				scrollbackIdx = i
-			}
-		}
-		if call == "attach" {
-			attachIdx = i
-		}
-	}
-	if snapshotCount != 1 {
-		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
-	}
-	if scrollbackCount != 1 {
-		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected reconciliation capture after attach, got %v", calls)
-	}
+	assertSnapshotBeforeAttach(t, result, calls)
 }
 
 func assertCallOrder(t *testing.T, calls []string, expected ...string) {

--- a/internal/ui/center/model_tabs_session_reattach_safety_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_safety_test.go
@@ -3,7 +3,6 @@ package center
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
@@ -11,81 +10,12 @@ import (
 )
 
 func TestReattachActiveTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 6)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 0, 0, false, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{}, errors.New("not whole window")
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	// A pane with no VT mode metadata cannot anchor an authoritative snapshot,
+	// so the bootstrap must fall back to history without touching the pane.
+	ineligible := eligibleReattachProbe()
+	ineligible.PaneMeta.ModeState = tmux.PaneModeState{}
+	installHistoryFallbackSeams(t, &calls, ineligible)
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -107,75 +37,27 @@ func TestReattachActiveTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected ineligible snapshot to disable authoritative full-pane restore")
-	}
-	if got := string(result.ScrollbackCapture); got != "history" {
-		t.Fatalf("expected history-only fallback, got %q", got)
-	}
-	if result.Cols != 123 || result.Rows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "attach", "size", "scrollback")
-	for _, call := range calls {
-		if call == "resize" || call == "snapshot" {
-			t.Fatalf("expected ineligible snapshot to skip pre-attach resize, got %v", calls)
-		}
-	}
+	assertHistoryFallback(t, result, calls)
 }
 
 func TestReattachActiveTab_AttachFailureRollsBackBootstrapResize(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
+	var calls []string
+	restoreReattachSeams(t)
 
-	calls := make([]string, 0, 8)
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
 		calls = append(calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
+	// Still unattached and unchanged at the rollback probe, so the rollback is
+	// safe to perform.
+	probeSeq(&calls, eligibleReattachProbe())
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
 		calls = append(calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
 		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("resized"), Cols: 77, Rows: 19}, nil
+		return []byte("resized"), nil
 	}
 	createAgentWithTagsFn = func(
 		manager *appPty.AgentManager,
@@ -212,5 +94,7 @@ func TestReattachActiveTab_AttachFailureRollsBackBootstrapResize(t *testing.T) {
 	if failed.Err == nil || failed.Err.Error() != "attach failed" {
 		t.Fatalf("expected attach failure, got %+v", failed)
 	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "resize")
+	// The trailing resize is the rollback: a failed attach must not leave the
+	// pane at the size the aborted bootstrap set.
+	assertCallOrder(t, calls, "state", "probe", "resize", "snapshot", "attach", "resize")
 }

--- a/internal/ui/center/model_tabs_session_reattach_snapshot_error_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_snapshot_error_test.go
@@ -3,7 +3,6 @@ package center
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	appPty "github.com/andyrewlee/amux/internal/pty"
@@ -11,67 +10,27 @@ import (
 )
 
 func TestReattachActiveTab_SnapshotCommandErrorFallsBackToHistoryOnly(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
+	var calls []string
+	restoreReattachSeams(t)
 
-	calls := make([]string, 0, 6)
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
 		calls = append(calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
+	probeSeq(&calls, eligibleReattachProbe())
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
 		calls = append(calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
 		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{}, errors.New("snapshot command failed")
+		return nil, errors.New("snapshot command failed")
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		calls = append(calls, "scrollback")
+		return []byte("history"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
 		calls = append(calls, "scrollback")
 		return []byte("history"), nil
 	}
@@ -116,5 +75,7 @@ func TestReattachActiveTab_SnapshotCommandErrorFallsBackToHistoryOnly(t *testing
 	if result.Cols != 123 || result.Rows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
 	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "resize", "attach", "size", "scrollback")
+	// The second resize is the rollback: a failed capture must not leave the pane
+	// at the size the aborted bootstrap set.
+	assertCallOrder(t, calls, "state", "probe", "resize", "snapshot", "resize", "attach", "scrollback")
 }

--- a/internal/ui/center/model_tabs_session_snapshot_race_test.go
+++ b/internal/ui/center/model_tabs_session_snapshot_race_test.go
@@ -9,82 +9,37 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
+// installPostAttachDemotionSeams wires a session that looks eligible right up to
+// the moment the client attaches, then reports postAttach on every later probe.
+// That is the shape of every race the pre-attach snapshot has to survive: the
+// snapshot is taken in good faith and only the post-attach validation can tell
+// it went stale.
+func installPostAttachDemotionSeams(t *testing.T, calls *[]string, postAttach tmux.SessionProbe) {
+	t.Helper()
+	restoreReattachSeams(t)
 
-	calls := make([]string, 0, 8)
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	createdAtCalls := 0
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		createdAtCalls++
-		return 111, nil
-	}
-	paneIDCalls := 0
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		paneIDCalls++
-		if paneIDCalls <= 4 {
-			return "%old", nil
-		}
-		return "%new", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	// Three probes bracket the capture (eligibility, post-resize, post-capture);
+	// everything after them is the post-attach world.
+	probeSeq(calls, eligibleReattachProbe(), eligibleReattachProbe(), eligibleReattachProbe(), postAttach)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("stale frame"), nil
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("fresh history"), nil
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("post history"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("post history"), nil
 	}
 	createAgentWithTagsFn = func(
 		manager *appPty.AgentManager,
@@ -94,38 +49,24 @@ func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 		rows, cols uint16,
 		tags tmux.SessionTags,
 	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
+		*calls = append(*calls, "attach")
 		return &appPty.Agent{Session: sessionName}, nil
 	}
+}
 
-	m := newTestModel()
-	setKnownViewport(m)
-	ws := newTestWorkspace("ws", "/repo/ws")
-	wsID := string(ws.ID())
-	tab := &Tab{
-		ID:          TabID("tab-reattach-race"),
-		Assistant:   "codex",
-		Workspace:   ws,
-		SessionName: "session-race",
-		Detached:    true,
-	}
-	m.workspace = ws
-	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
-	m.tabs.ActiveByWorkspace[wsID] = 0
-
-	msg := m.ReattachActiveTab()()
-	result, ok := msg.(ptyTabReattachResult)
-	if !ok {
-		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
-	}
+// assertSnapshotDemoted asserts the stale snapshot was thrown away in favor of
+// a fresh history capture, with no leftover snapshot metadata and no
+// reconciliation delta (there is nothing to reconcile against).
+func assertSnapshotDemoted(t *testing.T, result ptyTabReattachResult, calls []string) {
+	t.Helper()
 	if result.CaptureFullPane {
-		t.Fatal("expected recreated session to discard the pre-attach snapshot")
+		t.Fatal("expected a stale pre-attach snapshot to be discarded")
 	}
-	if got := string(result.ScrollbackCapture); got != "fresh history" {
-		t.Fatalf("expected post-attach history capture, got %q", got)
+	if got := string(result.ScrollbackCapture); got != "post history" {
+		t.Fatalf("expected post-attach history recapture, got %q", got)
 	}
 	if len(result.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(result.PostAttachScrollbackCapture))
+		t.Fatalf("expected no reconciliation delta after demotion, got %q", string(result.PostAttachScrollbackCapture))
 	}
 	if result.Cols != 123 || result.Rows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
@@ -133,97 +74,53 @@ func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 	if result.SnapshotCols != 0 || result.SnapshotRows != 0 {
 		t.Fatalf("expected stale snapshot metadata to be cleared, got %dx%d", result.SnapshotCols, result.SnapshotRows)
 	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertCallOrder(t, calls, "state", "probe", "resize", "snapshot", "attach", "probe", "scrollback")
+}
+
+// reattachRaceTab builds a detached tab pointing at the race session.
+func reattachRaceTab(m *Model, ws *data.Workspace, tabID TabID) {
+	wsID := string(ws.ID())
+	m.workspace = ws
+	m.tabs.ByWorkspace[wsID] = []*Tab{{
+		ID:          tabID,
+		Assistant:   "codex",
+		Workspace:   ws,
+		SessionName: "session-race",
+		Detached:    true,
+	}}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+}
+
+// recreatedProbe is the same session name running a different incarnation: new
+// creation stamp and new pane ID.
+func recreatedProbe() tmux.SessionProbe {
+	p := eligibleReattachProbe()
+	p.ClientCount = 1
+	p.CreatedAt = 999
+	p.PaneID = "%new"
+	return p
+}
+
+func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
+	var calls []string
+	installPostAttachDemotionSeams(t, &calls, recreatedProbe())
+
+	m := newTestModel()
+	setKnownViewport(m)
+	ws := newTestWorkspace("ws", "/repo/ws")
+	reattachRaceTab(m, ws, TabID("tab-reattach-race"))
+
+	msg := m.ReattachActiveTab()()
+	result, ok := msg.(ptyTabReattachResult)
+	if !ok {
+		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
+	}
+	assertSnapshotDemoted(t, result, calls)
 }
 
 func TestReattachToSession_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 8)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	createdAtCalls := 0
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		createdAtCalls++
-		return 111, nil
-	}
-	paneIDCalls := 0
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		paneIDCalls++
-		if paneIDCalls <= 4 {
-			return "%old", nil
-		}
-		return "%new", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("fresh history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	installPostAttachDemotionSeams(t, &calls, recreatedProbe())
 
 	m := newTestModel()
 	setKnownViewport(m)
@@ -234,250 +131,48 @@ func TestReattachToSession_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected recreated session to discard the pre-attach snapshot")
-	}
-	if got := string(result.ScrollbackCapture); got != "fresh history" {
-		t.Fatalf("expected post-attach history capture, got %q", got)
-	}
-	if len(result.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(result.PostAttachScrollbackCapture))
-	}
-	if result.Cols != 123 || result.Rows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", result.Cols, result.Rows)
-	}
-	if result.SnapshotCols != 0 || result.SnapshotRows != 0 {
-		t.Fatalf("expected stale snapshot metadata to be cleared, got %dx%d", result.SnapshotCols, result.SnapshotRows)
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSnapshotDemoted(t, result, calls)
 }
 
 func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionBecomesActive(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 12)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	activityCalls := 0
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		activityCalls++
-		return activityCalls >= 5, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 111, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%same", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("post history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	// The pane produced output after the snapshot was taken, so the snapshot no
+	// longer describes the current screen.
+	active := eligibleReattachProbe()
+	active.ClientCount = 1
+	active.LatestActivity = time.Now().Add(time.Hour).Unix()
+	installPostAttachDemotionSeams(t, &calls, active)
 
 	m := newTestModel()
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
-	wsID := string(ws.ID())
-	tab := &Tab{
-		ID:          TabID("tab-reattach-active-race"),
-		Assistant:   "codex",
-		Workspace:   ws,
-		SessionName: "session-race",
-		Detached:    true,
-	}
-	m.workspace = ws
-	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
-	m.tabs.ActiveByWorkspace[wsID] = 0
+	reattachRaceTab(m, ws, TabID("tab-reattach-active-race"))
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected activity after snapshot capture to demote back to history-only restore")
-	}
-	if got := string(result.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
-	}
-	if len(result.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation delta after stale snapshot demotion, got %q", string(result.PostAttachScrollbackCapture))
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSnapshotDemoted(t, result, calls)
 }
 
 func TestReattachActiveTab_DiscardsPreAttachSnapshotWhenSessionBecomesShared(t *testing.T) {
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldCreateAgentWithTagsFn := createAgentWithTagsFn
-	defer func() {
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		createAgentWithTagsFn = oldCreateAgentWithTagsFn
-	}()
-
-	calls := make([]string, 0, 12)
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 2, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 111, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%same", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("post history"), nil
-	}
-	createAgentWithTagsFn = func(
-		manager *appPty.AgentManager,
-		ws *data.Workspace,
-		agentType appPty.AgentType,
-		sessionName string,
-		rows, cols uint16,
-		tags tmux.SessionTags,
-	) (*appPty.Agent, error) {
-		calls = append(calls, "attach")
-		return &appPty.Agent{Session: sessionName}, nil
-	}
+	var calls []string
+	// Two clients: one is the client amux just attached, the other is something
+	// else driving the session, so the snapshot cannot be trusted.
+	shared := eligibleReattachProbe()
+	shared.ClientCount = 2
+	installPostAttachDemotionSeams(t, &calls, shared)
 
 	m := newTestModel()
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
-	wsID := string(ws.ID())
-	tab := &Tab{
-		ID:          TabID("tab-reattach-shared-race"),
-		Assistant:   "codex",
-		Workspace:   ws,
-		SessionName: "session-race",
-		Detached:    true,
-	}
-	m.workspace = ws
-	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
-	m.tabs.ActiveByWorkspace[wsID] = 0
+	reattachRaceTab(m, ws, TabID("tab-reattach-shared-race"))
 
 	msg := m.ReattachActiveTab()()
 	result, ok := msg.(ptyTabReattachResult)
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)
 	}
-	if result.CaptureFullPane {
-		t.Fatal("expected shared session after snapshot capture to demote back to history-only restore")
-	}
-	if got := string(result.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after shared-session demotion, got %q", got)
-	}
-	if len(result.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation delta after shared-session demotion, got %q", string(result.PostAttachScrollbackCapture))
-	}
-	assertCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSnapshotDemoted(t, result, calls)
 }

--- a/internal/ui/ptyio/session_bootstrap.go
+++ b/internal/ui/ptyio/session_bootstrap.go
@@ -21,28 +21,36 @@ type SessionBootstrapCapture struct {
 	NeedsRollback    bool
 }
 
+// SessionBootstrapFns are the tmux operations the bootstrap performs, injected
+// so the whole flow can be driven without a tmux server.
+//
+// Every read goes through ProbeSession, a single tmux round-trip returning all
+// the session and pane facts the guards below test. That is deliberate: amux
+// talks to one shared, single-threaded tmux server that is also pumping output
+// for every attached agent, so round-trips are the dominant cost of a reattach
+// and a busy server can make each one take hundreds of milliseconds. It also
+// makes each guard a genuine point-in-time check — reading the facts separately
+// let a guard straddle a change and reach a conclusion true of no single moment.
 type SessionBootstrapFns struct {
-	SessionHasClients       func(string, tmux.Options) (bool, error)
-	SessionClientCount      func(string, tmux.Options) (int, error)
-	SessionActiveWithin     func(string, time.Duration, tmux.Options) (bool, error)
-	SessionLatestActivity   func(string, tmux.Options) (time.Time, bool, error)
-	SessionCreatedAt        func(string, tmux.Options) (int64, error)
-	SessionPaneID           func(string, tmux.Options) (string, error)
-	SessionPaneSnapshotInfo func(string, tmux.Options) (int, int, bool, error)
-	SessionPaneSize         func(string, tmux.Options) (int, int, bool, error)
-	ResizePaneToSize        func(string, int, int, tmux.Options) error
-	CapturePaneSnapshot     func(string, tmux.Options) (tmux.PaneSnapshot, error)
+	// ProbeSession reads the session and active-pane state in one round-trip.
+	ProbeSession func(string, tmux.Options) (tmux.SessionProbe, error)
+	// ResizePaneToSize sets the session's window size before any client attaches.
+	ResizePaneToSize func(string, int, int, tmux.Options) error
+	// CapturePaneFullData captures a resolved pane's scrollback and visible
+	// screen. Validation is the caller's job, via the probes taken around it.
+	CapturePaneFullData func(paneID string, opts tmux.Options) ([]byte, error)
+	// CapturePaneHistoryData captures a resolved pane's scrollback only.
+	CapturePaneHistoryData func(paneID string, opts tmux.Options) ([]byte, error)
 }
 
-// SessionBootstrap bundles a SessionBootstrapFns (and the pane-capture fn) with
-// the bootstrap operations that consume them, so each caller constructs a single
-// instance from its own test-seam vars and invokes the operations as methods
-// instead of re-declaring a parallel set of package-level wrappers. The instance
-// is value-typed and cheap: callers rebuild it per call from their seam vars so a
-// test override of a seam var flows through the next operation.
+// SessionBootstrap bundles a SessionBootstrapFns with the bootstrap operations
+// that consume them, so each caller constructs a single instance from its own
+// test-seam vars and invokes the operations as methods instead of re-declaring a
+// parallel set of package-level wrappers. The instance is value-typed and cheap:
+// callers rebuild it per call from their seam vars so a test override of a seam
+// var flows through the next operation.
 type SessionBootstrap struct {
-	Fns         SessionBootstrapFns
-	CapturePane func(string, tmux.Options) ([]byte, error)
+	Fns SessionBootstrapFns
 }
 
 // CaptureExisting captures a pre-attach full-pane bootstrap snapshot of an
@@ -69,32 +77,39 @@ func (s SessionBootstrap) HistoryCaptureSize(sessionName string, fallbackCols, f
 
 // CaptureHistory captures the session scrollback plus its capture dimensions.
 func (s SessionBootstrap) CaptureHistory(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options) ([]byte, int, int) {
-	return CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, s.Fns, s.CapturePane)
+	return CaptureSessionHistory(sessionName, fallbackCols, fallbackRows, opts, s.Fns)
 }
 
-func SessionBootstrapExclusive(sessionName string, quietWindow time.Duration, opts tmux.Options, fns SessionBootstrapFns) bool {
-	hasClients, clientsErr := fns.SessionHasClients(sessionName, opts)
-	recentActivity, activityErr := fns.SessionActiveWithin(sessionName, quietWindow, opts)
-	return clientsErr == nil && activityErr == nil && !hasClients && !recentActivity
-}
-
-func sessionBootstrapHasNoClients(sessionName string, opts tmux.Options, fns SessionBootstrapFns) bool {
-	hasClients, err := fns.SessionHasClients(sessionName, opts)
-	return err == nil && !hasClients
-}
-
-func SessionBootstrapGeneration(sessionName string, opts tmux.Options, fns SessionBootstrapFns) (int64, string, bool) {
-	sessionCreatedAt, err := fns.SessionCreatedAt(sessionName, opts)
-	if err != nil || sessionCreatedAt <= 0 {
-		return 0, "", false
+// probe reads the session state, mapping any error to a zero probe. Callers
+// treat "could not read" and "not eligible" identically: both mean fall back to
+// the history-only bootstrap, which is always safe.
+func probe(sessionName string, opts tmux.Options, fns SessionBootstrapFns) tmux.SessionProbe {
+	if fns.ProbeSession == nil {
+		return tmux.SessionProbe{}
 	}
-	paneID, err := fns.SessionPaneID(sessionName, opts)
-	if err != nil || paneID == "" {
-		return 0, "", false
+	result, err := fns.ProbeSession(sessionName, opts)
+	if err != nil {
+		return tmux.SessionProbe{}
 	}
-	return sessionCreatedAt, paneID, true
+	return result
 }
 
+// bootstrapExclusive reports whether the session is quiet enough to mutate: no
+// client attached, and no window activity inside the quiet window. Both must
+// hold, because the pre-attach resize is visible to anything already watching.
+func bootstrapExclusive(p tmux.SessionProbe, quietWindow time.Duration) bool {
+	return p.Exists && !p.HasClients() && !p.ActiveWithin(quietWindow, time.Now())
+}
+
+// CaptureExistingSessionBootstrap takes an authoritative full-pane snapshot of a
+// detached session at the size the reattaching client will render, so the local
+// terminal can be seeded with the true screen instead of replayed history.
+//
+// The snapshot is only trustworthy if the session stayed unobserved and
+// unchanged throughout, so the flow is bracketed by probes: one to establish
+// eligibility and the session generation, one after the resize, and one after
+// the capture. Any drift between them abandons the snapshot (rolling the resize
+// back when it is safe to do so) and the caller falls back to history replay.
 func CaptureExistingSessionBootstrap(
 	sessionName string,
 	cols, rows int,
@@ -105,157 +120,172 @@ func CaptureExistingSessionBootstrap(
 	if cols <= 0 || rows <= 0 {
 		return SessionBootstrapCapture{}
 	}
-	if !SessionBootstrapExclusive(sessionName, quietWindow, opts, fns) {
+
+	before := probe(sessionName, opts, fns)
+	if !bootstrapExclusive(before, quietWindow) || !before.SnapshotEligible() {
 		return SessionBootstrapCapture{}
 	}
-	sessionCreatedAt, paneID, ok := SessionBootstrapGeneration(sessionName, opts, fns)
-	if !ok {
-		return SessionBootstrapCapture{}
-	}
-	rollbackCols, rollbackRows, supported, err := fns.SessionPaneSnapshotInfo(sessionName, opts)
-	if err != nil || !supported {
-		return SessionBootstrapCapture{}
-	}
+
 	bootstrap := SessionBootstrapCapture{
-		SessionCreatedAt: sessionCreatedAt,
-		PaneID:           paneID,
-		RollbackCols:     rollbackCols,
-		RollbackRows:     rollbackRows,
-		NeedsRollback:    rollbackCols > 0 && rollbackRows > 0,
+		SessionCreatedAt: before.CreatedAt,
+		PaneID:           before.PaneID,
+		RollbackCols:     before.PaneMeta.Cols,
+		RollbackRows:     before.PaneMeta.Rows,
+		NeedsRollback:    before.PaneMeta.Cols > 0 && before.PaneMeta.Rows > 0,
 	}
-	if !SessionBootstrapExclusive(sessionName, quietWindow, opts, fns) {
-		return SessionBootstrapCapture{}
-	}
-	recheckCreatedAt, recheckPaneID, ok := SessionBootstrapGeneration(sessionName, opts, fns)
-	if !ok || recheckCreatedAt != sessionCreatedAt || recheckPaneID != paneID {
-		return SessionBootstrapCapture{}
-	}
+
+	// `before` is the only activity sample taken before this mutation, so a
+	// session that starts producing output between that probe and here is still
+	// resized. That is an accepted tradeoff, not an oversight: activity cannot be
+	// rechecked after the resize because the resize itself bumps
+	// window_activity, and it cannot be resampled just before the resize without
+	// spending the round-trip this design exists to avoid. The exposure is
+	// smaller than it was when each guard read its facts separately — the gap is
+	// now one probe wide rather than three tmux calls wide — and the consequence
+	// is bounded: the post-attach validation discards the resulting snapshot, so
+	// the user sees a correctly replayed screen either way. What survives is a
+	// brief resize of a pane that just woke up, which tmux re-lays-out on attach
+	// regardless.
 	if err := fns.ResizePaneToSize(sessionName, cols, rows, opts); err != nil {
 		return SessionBootstrapCapture{}
 	}
-	if !sessionBootstrapHasNoClients(sessionName, opts, fns) {
-		return SessionBootstrapCapture{}
-	}
-	recheckCreatedAt, recheckPaneID, ok = SessionBootstrapGeneration(sessionName, opts, fns)
-	if !ok || recheckCreatedAt != sessionCreatedAt || recheckPaneID != paneID {
-		return SessionBootstrapCapture{}
-	}
+
+	// This checkpoint (and the one after the capture) deliberately tests only
+	// clients and generation, for the reason above: post-resize activity is
+	// self-inflicted and says nothing about the session.
 	snapshotCapturedAt := time.Now()
-	snapshot, err := fns.CapturePaneSnapshot(sessionName, opts)
+	atCapture := probe(sessionName, opts, fns)
+	if !before.SameGeneration(atCapture) || atCapture.HasClients() || !atCapture.SnapshotEligible() {
+		rollbackSessionBootstrap(sessionName, bootstrap, opts, fns)
+		return SessionBootstrapCapture{}
+	}
+
+	data, err := fns.CapturePaneFullData(before.PaneID, opts)
 	if err != nil {
 		rollbackSessionBootstrap(sessionName, bootstrap, opts, fns)
 		return SessionBootstrapCapture{}
 	}
-	if !sessionBootstrapHasNoClients(sessionName, opts, fns) {
+
+	after := probe(sessionName, opts, fns)
+	if !before.SameGeneration(after) || after.HasClients() {
 		rollbackSessionBootstrap(sessionName, bootstrap, opts, fns)
 		return SessionBootstrapCapture{}
 	}
-	recheckCreatedAt, recheckPaneID, ok = SessionBootstrapGeneration(sessionName, opts, fns)
-	if !ok || recheckCreatedAt != sessionCreatedAt || recheckPaneID != paneID {
+	// Identical metadata on both sides of the capture is what proves the bytes
+	// describe one coherent screen rather than a pane that moved mid-read.
+	if after.PaneMeta != atCapture.PaneMeta {
 		rollbackSessionBootstrap(sessionName, bootstrap, opts, fns)
 		return SessionBootstrapCapture{}
 	}
-	bootstrap.Snapshot = snapshot
+
+	bootstrap.Snapshot = tmux.PaneSnapshot{
+		Data:      data,
+		Cols:      atCapture.PaneMeta.Cols,
+		Rows:      atCapture.PaneMeta.Rows,
+		CursorX:   atCapture.PaneMeta.CursorX,
+		CursorY:   atCapture.PaneMeta.CursorY,
+		HasCursor: atCapture.PaneMeta.HasCursor,
+		ModeState: atCapture.PaneMeta.ModeState,
+	}
 	bootstrap.CaptureFullPane = true
 	bootstrap.SnapshotCaptured = snapshotCapturedAt
 	return bootstrap
 }
 
+// BootstrapSnapshotStillMatchesSession reports whether a snapshot taken before
+// the attach is still an accurate picture of the session now that a client is
+// attached. The attaching client is expected, so up to one client is tolerated;
+// a second means something else is driving the session.
 func BootstrapSnapshotStillMatchesSession(
 	sessionName string,
 	bootstrap SessionBootstrapCapture,
 	opts tmux.Options,
 	fns SessionBootstrapFns,
 ) bool {
-	if !bootstrap.CaptureFullPane || !bootstrapGenerationMatchesSession(sessionName, bootstrap, opts, fns) {
+	if !bootstrap.CaptureFullPane {
 		return false
 	}
 	if bootstrap.Snapshot.Cols <= 0 || bootstrap.Snapshot.Rows <= 0 {
 		return false
 	}
-	if fns.SessionPaneSize != nil {
-		cols, rows, hasSize, err := fns.SessionPaneSize(sessionName, opts)
-		if err != nil || !hasSize || cols != bootstrap.Snapshot.Cols || rows != bootstrap.Snapshot.Rows {
-			return false
-		}
+
+	current := probe(sessionName, opts, fns)
+	if !bootstrapGenerationMatches(bootstrap, current) {
+		return false
 	}
-	if fns.SessionClientCount != nil {
-		clientCount, err := fns.SessionClientCount(sessionName, opts)
-		if err != nil || clientCount > 1 {
-			return false
-		}
+	if !current.HasPaneSize ||
+		current.PaneMeta.Cols != bootstrap.Snapshot.Cols ||
+		current.PaneMeta.Rows != bootstrap.Snapshot.Rows {
+		return false
+	}
+	if current.ClientCount > 1 {
+		return false
 	}
 	if bootstrap.SnapshotCaptured.IsZero() {
 		return true
 	}
-	if fns.SessionLatestActivity != nil {
-		latestActivity, hasActivity, err := fns.SessionLatestActivity(sessionName, opts)
-		if err != nil {
-			return false
-		}
-		if !hasActivity {
-			return true
-		}
-		// tmux rounds window_activity down to whole seconds. Treat only a later
-		// reported second as definite post-snapshot activity; same-second updates
-		// may have happened before the snapshot started.
-		return !latestActivity.After(bootstrap.SnapshotCaptured)
-	}
-	elapsed := time.Since(bootstrap.SnapshotCaptured)
-	if elapsed <= 0 {
+	if current.LatestActivity == 0 {
 		return true
 	}
-	recentActivity, err := fns.SessionActiveWithin(sessionName, elapsed, opts)
-	return err == nil && !recentActivity
+	// tmux rounds window_activity down to whole seconds. Treat only a later
+	// reported second as definite post-snapshot activity; same-second updates
+	// may have happened before the snapshot started.
+	return !time.Unix(current.LatestActivity, 0).After(bootstrap.SnapshotCaptured)
 }
 
-func bootstrapGenerationMatchesSession(
-	sessionName string,
-	bootstrap SessionBootstrapCapture,
-	opts tmux.Options,
-	fns SessionBootstrapFns,
-) bool {
+// bootstrapGenerationMatches reports whether a probe describes the same session
+// incarnation the bootstrap was captured from.
+func bootstrapGenerationMatches(bootstrap SessionBootstrapCapture, current tmux.SessionProbe) bool {
 	if bootstrap.SessionCreatedAt <= 0 || bootstrap.PaneID == "" {
 		return false
 	}
-	sessionCreatedAt, paneID, ok := SessionBootstrapGeneration(sessionName, opts, fns)
-	if !ok {
-		return false
-	}
-	return sessionCreatedAt == bootstrap.SessionCreatedAt && paneID == bootstrap.PaneID
+	return current.CreatedAt == bootstrap.SessionCreatedAt && current.PaneID == bootstrap.PaneID
 }
 
+// RollbackExistingSessionBootstrap restores the pane size the bootstrap resized
+// away from. It is skipped once anything else has taken an interest in the
+// session — a client attached, or the session was recreated — because resizing
+// then would disrupt a pane amux no longer exclusively controls.
 func RollbackExistingSessionBootstrap(sessionName string, bootstrap SessionBootstrapCapture, opts tmux.Options, fns SessionBootstrapFns) {
 	if !bootstrap.NeedsRollback || bootstrap.RollbackCols <= 0 || bootstrap.RollbackRows <= 0 {
 		return
 	}
-	if !bootstrapGenerationMatchesSession(sessionName, bootstrap, opts, fns) {
-		return
-	}
-	hasClients, err := fns.SessionHasClients(sessionName, opts)
-	if err != nil || hasClients {
+	current := probe(sessionName, opts, fns)
+	if !bootstrapGenerationMatches(bootstrap, current) || current.HasClients() {
 		return
 	}
 	_ = fns.ResizePaneToSize(sessionName, bootstrap.RollbackCols, bootstrap.RollbackRows, opts)
 }
 
+// SessionHistoryCaptureSize resolves the dimensions a history capture should be
+// interpreted at, preferring the live pane size over the caller's fallback.
 func SessionHistoryCaptureSize(sessionName string, fallbackCols, fallbackRows int, opts tmux.Options, fns SessionBootstrapFns) (int, int) {
-	cols, rows, hasSize, err := fns.SessionPaneSize(sessionName, opts)
-	if err == nil && hasSize && cols > 0 && rows > 0 {
-		return cols, rows
+	current := probe(sessionName, opts, fns)
+	if current.HasPaneSize && current.PaneCols > 0 && current.PaneRows > 0 {
+		return current.PaneCols, current.PaneRows
 	}
 	return fallbackCols, fallbackRows
 }
 
+// CaptureSessionHistory captures a session's scrollback plus the dimensions it
+// should be replayed at, in a single probe and a single capture.
 func CaptureSessionHistory(
 	sessionName string,
 	fallbackCols, fallbackRows int,
 	opts tmux.Options,
 	fns SessionBootstrapFns,
-	capturePane func(string, tmux.Options) ([]byte, error),
 ) ([]byte, int, int) {
-	cols, rows := SessionHistoryCaptureSize(sessionName, fallbackCols, fallbackRows, opts, fns)
-	scrollback, _ := capturePane(sessionName, opts)
+	current := probe(sessionName, opts, fns)
+	cols, rows := fallbackCols, fallbackRows
+	if current.HasPaneSize && current.PaneCols > 0 && current.PaneRows > 0 {
+		cols, rows = current.PaneCols, current.PaneRows
+	}
+	if current.PaneID == "" {
+		return nil, cols, rows
+	}
+	// A capture error is not fatal: replaying whatever bytes came back (possibly
+	// none) is always preferable to failing the reattach.
+	scrollback, _ := fns.CapturePaneHistoryData(current.PaneID, opts)
 	return scrollback, cols, rows
 }
 

--- a/internal/ui/ptyio/session_bootstrap_test.go
+++ b/internal/ui/ptyio/session_bootstrap_test.go
@@ -1,134 +1,314 @@
 package ptyio
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestCaptureExistingSessionBootstrap_SkipsRollbackWhenClientsAppearAfterResize(t *testing.T) {
-	calls := make([]string, 0, 12)
-	hasClientsCalls := 0
+// eligibleProbe is a session probe that passes every bootstrap gate: detached,
+// quiet, single live pane, complete metadata. Tests start from it and change the
+// one fact under test.
+func eligibleProbe() tmux.SessionProbe {
+	return tmux.SessionProbe{
+		Exists:           true,
+		CreatedAt:        123,
+		ClientCount:      0,
+		PaneID:           "%1",
+		PaneCols:         91,
+		PaneRows:         27,
+		HasPaneSize:      true,
+		HasLivePane:      true,
+		SinglePaneWindow: true,
+		PaneMeta: tmux.PaneSnapshotMeta{
+			Cols:      91,
+			Rows:      27,
+			HasSize:   true,
+			ModeState: tmux.PaneModeState{HasState: true},
+		},
+	}
+}
+
+// probeScript returns a ProbeSession fn that hands out the given probes in
+// order, repeating the last one once exhausted, and records each call in calls.
+// The bootstrap's guards are a sequence of point-in-time reads, so scripting the
+// probes is how a test says "the session changed at step N".
+func probeScript(calls *[]string, probes ...tmux.SessionProbe) func(string, tmux.Options) (tmux.SessionProbe, error) {
+	i := 0
+	return func(string, tmux.Options) (tmux.SessionProbe, error) {
+		*calls = append(*calls, "probe")
+		p := probes[i]
+		if i < len(probes)-1 {
+			i++
+		}
+		return p, nil
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_CapturesQuietDetachedSession(t *testing.T) {
+	var calls []string
+	var resizedCols, resizedRows int
 	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			calls = append(calls, "clients")
-			hasClientsCalls++
-			return hasClientsCalls >= 3, nil
-		},
-		SessionActiveWithin: func(sessionName string, quietWindow time.Duration, opts tmux.Options) (bool, error) {
-			calls = append(calls, "activity")
-			return false, nil
-		},
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSnapshotInfo: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "info")
-			return 91, 27, true, nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			return 0, 0, false, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
+		ProbeSession: probeScript(&calls, eligibleProbe()),
+		ResizePaneToSize: func(_ string, cols, rows int, _ tmux.Options) error {
 			calls = append(calls, "resize")
+			resizedCols, resizedRows = cols, rows
 			return nil
 		},
-		CapturePaneSnapshot: func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-			t.Fatal("did not expect snapshot capture after exclusivity was lost")
-			return tmux.PaneSnapshot{}, nil
+		CapturePaneFullData: func(paneID string, _ tmux.Options) ([]byte, error) {
+			calls = append(calls, "capture")
+			if paneID != "%1" {
+				t.Fatalf("capture targeted pane %q, want the probed pane %q", paneID, "%1")
+			}
+			return []byte("frame"), nil
+		},
+	})
+
+	if !bootstrap.CaptureFullPane {
+		t.Fatalf("expected a quiet detached session to yield a full-pane bootstrap, got %+v", bootstrap)
+	}
+	if string(bootstrap.Snapshot.Data) != "frame" {
+		t.Fatalf("snapshot data = %q, want %q", bootstrap.Snapshot.Data, "frame")
+	}
+	if resizedCols != 80 || resizedRows != 24 {
+		t.Fatalf("resized to (%d, %d), want the attaching client's size (80, 24)", resizedCols, resizedRows)
+	}
+	// The pane size read before the resize is what a rollback must restore.
+	if bootstrap.RollbackCols != 91 || bootstrap.RollbackRows != 27 {
+		t.Fatalf("rollback size = (%d, %d), want the pre-resize size (91, 27)", bootstrap.RollbackCols, bootstrap.RollbackRows)
+	}
+	if !bootstrap.NeedsRollback {
+		t.Fatal("expected a resized pane to be marked as needing rollback")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsRollbackWhenClientsAppearAfterResize(t *testing.T) {
+	var calls []string
+	attached := eligibleProbe()
+	attached.ClientCount = 1
+
+	resizes := 0
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		// Quiet at the first checkpoint, a client attached by the post-resize one.
+		ProbeSession: probeScript(&calls, eligibleProbe(), attached),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			calls = append(calls, "resize")
+			resizes++
+			return nil
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture after exclusivity was lost")
+			return nil, nil
 		},
 	})
 
 	if bootstrap.CaptureFullPane {
 		t.Fatal("expected full-pane bootstrap to abort once another client attached")
 	}
-	resizeCalls := 0
-	for _, call := range calls {
-		if call == "resize" {
-			resizeCalls++
-		}
-	}
-	if resizeCalls != 1 {
-		t.Fatalf("expected exactly one resize without rollback after client attach, got %d calls: %v", resizeCalls, calls)
+	// Exactly one resize: the rollback must not fire, because resizing a pane a
+	// live client is now rendering would disrupt that client.
+	if resizes != 1 {
+		t.Fatalf("expected exactly one resize and no rollback, got %d resizes (calls %v)", resizes, calls)
 	}
 }
 
 func TestCaptureExistingSessionBootstrap_IgnoresResizeInducedActivity(t *testing.T) {
-	calls := make([]string, 0, 12)
-	activityCalls := 0
+	var calls []string
+	// The resize itself bumps window_activity, so every post-resize probe reports
+	// activity inside the quiet window. That must not abort the capture.
+	noisy := eligibleProbe()
+	noisy.LatestActivity = time.Now().Unix()
+
 	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			calls = append(calls, "clients")
-			return false, nil
-		},
-		SessionActiveWithin: func(sessionName string, quietWindow time.Duration, opts tmux.Options) (bool, error) {
-			calls = append(calls, "activity")
-			activityCalls++
-			return activityCalls >= 3, nil
-		},
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSnapshotInfo: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "info")
-			return 91, 27, true, nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			return 0, 0, false, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
-			calls = append(calls, "resize")
-			return nil
-		},
-		CapturePaneSnapshot: func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-			calls = append(calls, "snapshot")
-			return tmux.PaneSnapshot{Data: []byte("frame"), Cols: 80, Rows: 24}, nil
+		ProbeSession:     probeScript(&calls, eligibleProbe(), noisy),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error { return nil },
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			return []byte("frame"), nil
 		},
 	})
 
 	if !bootstrap.CaptureFullPane {
-		t.Fatalf("expected bootstrap snapshot to survive resize-induced activity, got %+v (calls=%v)", bootstrap, calls)
+		t.Fatalf("expected bootstrap snapshot to survive resize-induced activity, got %+v (calls %v)", bootstrap, calls)
 	}
 	if len(bootstrap.Snapshot.Data) == 0 {
 		t.Fatalf("expected snapshot data to be preserved, got %+v", bootstrap)
 	}
 }
 
-func TestCaptureExistingSessionBootstrap_StartsFreshnessWindowBeforeSnapshotReturns(t *testing.T) {
-	captureDelay := 25 * time.Millisecond
+func TestCaptureExistingSessionBootstrap_SkipsActiveSession(t *testing.T) {
+	var calls []string
+	active := eligibleProbe()
+	active.LatestActivity = time.Now().Unix()
+
 	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			return false, nil
-		},
-		SessionActiveWithin: func(sessionName string, quietWindow time.Duration, opts tmux.Options) (bool, error) {
-			return false, nil
-		},
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionPaneSnapshotInfo: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			return 91, 27, true, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
+		ProbeSession: probeScript(&calls, active),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect a resize on a session with recent activity")
 			return nil
 		},
-		CapturePaneSnapshot: func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture on a session with recent activity")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected recent activity to skip the pre-attach full-pane bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsAttachedSession(t *testing.T) {
+	var calls []string
+	attached := eligibleProbe()
+	attached.ClientCount = 1
+
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, FullPaneCaptureQuietWindow, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, attached),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect a resize while another client is attached")
+			return nil
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture while another client is attached")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected an attached session to skip the pre-attach full-pane bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsSplitWindow(t *testing.T) {
+	var calls []string
+	// A split (or zoomed-split) window shares the resize with hidden siblings,
+	// so it is never eligible for the pre-attach resize-and-snapshot.
+	split := eligibleProbe()
+	split.SinglePaneWindow = false
+
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, split),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect a resize for a split window")
+			return nil
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture for a split window")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected a split window to skip the pre-attach full-pane bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsMissingModeState(t *testing.T) {
+	var calls []string
+	// Without VT mode state there is no way to replay alt-screen/scroll-region
+	// state, so the snapshot would seed a subtly wrong screen.
+	noMode := eligibleProbe()
+	noMode.PaneMeta.ModeState = tmux.PaneModeState{}
+
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, noMode),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect a resize without pane mode metadata")
+			return nil
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture without pane mode metadata")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected missing mode metadata to skip the full-pane bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_DiscardsSnapshotWhenSessionRecreated(t *testing.T) {
+	var calls []string
+	// Same name, new incarnation: different creation stamp and pane ID.
+	replacement := eligibleProbe()
+	replacement.CreatedAt = 456
+	replacement.PaneID = "%9"
+
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession:     probeScript(&calls, eligibleProbe(), replacement),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error { return nil },
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture from a replacement session")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected a recreated session to invalidate the bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_DiscardsSnapshotOnMetadataDrift(t *testing.T) {
+	var calls []string
+	// The pane moved between the pre-capture and post-capture checkpoints, so the
+	// captured bytes describe no single coherent screen.
+	drifted := eligibleProbe()
+	drifted.PaneMeta.CursorY = 7
+
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession:     probeScript(&calls, eligibleProbe(), eligibleProbe(), drifted),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error { return nil },
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			return []byte("torn frame"), nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected pane metadata drift across the capture to discard the snapshot")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsWhenResizeFails(t *testing.T) {
+	var calls []string
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, eligibleProbe()),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			return errors.New("resize failed")
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture after the resize failed")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected a failed resize to skip the full-pane bootstrap")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_SkipsWhenProbeFails(t *testing.T) {
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: func(string, tmux.Options) (tmux.SessionProbe, error) {
+			return tmux.SessionProbe{}, errors.New("no server")
+		},
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect a resize when the session could not be probed")
+			return nil
+		},
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture when the session could not be probed")
+			return nil, nil
+		},
+	})
+	if bootstrap.CaptureFullPane {
+		t.Fatal("expected an unreadable session to fall back to history replay")
+	}
+}
+
+func TestCaptureExistingSessionBootstrap_StartsFreshnessWindowBeforeSnapshotReturns(t *testing.T) {
+	var calls []string
+	captureDelay := 25 * time.Millisecond
+	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession:     probeScript(&calls, eligibleProbe()),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error { return nil },
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
 			time.Sleep(captureDelay)
-			return tmux.PaneSnapshot{Data: []byte("frame"), Cols: 80, Rows: 24}, nil
+			return []byte("frame"), nil
 		},
 	})
 
@@ -142,35 +322,12 @@ func TestCaptureExistingSessionBootstrap_StartsFreshnessWindowBeforeSnapshotRetu
 }
 
 func TestCaptureExistingSessionBootstrap_SkipsUnknownViewportSize(t *testing.T) {
-	calls := make([]string, 0, 4)
+	var calls []string
 	bootstrap := CaptureExistingSessionBootstrap("session-race", 0, 0, 2*time.Second, tmux.Options{}, SessionBootstrapFns{
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			calls = append(calls, "clients")
-			return false, nil
-		},
-		SessionActiveWithin: func(sessionName string, quietWindow time.Duration, opts tmux.Options) (bool, error) {
-			calls = append(calls, "activity")
-			return false, nil
-		},
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSnapshotInfo: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "info")
-			return 91, 27, true, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
-			calls = append(calls, "resize")
-			return nil
-		},
-		CapturePaneSnapshot: func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-			calls = append(calls, "snapshot")
-			return tmux.PaneSnapshot{Data: []byte("frame")}, nil
+		ProbeSession:     probeScript(&calls, eligibleProbe()),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error { return nil },
+		CapturePaneFullData: func(string, tmux.Options) ([]byte, error) {
+			return []byte("frame"), nil
 		},
 	})
 
@@ -179,299 +336,5 @@ func TestCaptureExistingSessionBootstrap_SkipsUnknownViewportSize(t *testing.T) 
 	}
 	if len(calls) != 0 {
 		t.Fatalf("expected unknown viewport size to avoid tmux bootstrap work, got %v", calls)
-	}
-}
-
-func TestRollbackExistingSessionBootstrap_SkipsReplacementSession(t *testing.T) {
-	calls := make([]string, 0, 4)
-	RollbackExistingSessionBootstrap("session-race", SessionBootstrapCapture{
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-		RollbackCols:     91,
-		RollbackRows:     27,
-		NeedsRollback:    true,
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 456, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%9", nil
-		},
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			t.Fatal("did not expect client check after generation mismatch")
-			return false, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
-			t.Fatal("did not expect rollback resize for a replacement session")
-			return nil
-		},
-	})
-	if len(calls) != 2 {
-		t.Fatalf("expected only generation check before skipping rollback, got %v", calls)
-	}
-}
-
-func TestRollbackExistingSessionBootstrap_SkipsLiveSharedSession(t *testing.T) {
-	calls := make([]string, 0, 4)
-	RollbackExistingSessionBootstrap("session-race", SessionBootstrapCapture{
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-		RollbackCols:     91,
-		RollbackRows:     27,
-		NeedsRollback:    true,
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			calls = append(calls, "clients")
-			return true, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
-			t.Fatal("did not expect rollback resize for a shared session")
-			return nil
-		},
-	})
-	if len(calls) != 3 {
-		t.Fatalf("expected generation and client checks before skipping rollback, got %v", calls)
-	}
-}
-
-func TestBootstrapSnapshotStillMatchesSession_RejectsRecentActivitySinceCapture(t *testing.T) {
-	calls := make([]string, 0, 4)
-	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
-		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
-		CaptureFullPane:  true,
-		SnapshotCaptured: time.Now().Add(-5 * time.Second),
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "size")
-			return 91, 27, true, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			calls = append(calls, "activity")
-			if window < 4*time.Second {
-				t.Fatalf("expected activity recheck window to cover time since snapshot, got %s", window)
-			}
-			return true, nil
-		},
-	})
-	if ok {
-		t.Fatal("expected snapshot to be rejected once the pane became active after capture")
-	}
-	if len(calls) != 4 {
-		t.Fatalf("expected generation, size, and activity recheck, got %v", calls)
-	}
-}
-
-func TestBootstrapSnapshotStillMatchesSession_IgnoresSameSecondActivityBeforeSnapshot(t *testing.T) {
-	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
-		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
-		CaptureFullPane:  true,
-		SnapshotCaptured: time.Unix(12, 900_000_000),
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			return 91, 27, true, nil
-		},
-		SessionClientCount: func(sessionName string, opts tmux.Options) (int, error) {
-			return 1, nil
-		},
-		SessionLatestActivity: func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-			return time.Unix(12, 0), true, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			t.Fatal("did not expect padded activity-window check when raw activity timestamp is available")
-			return false, nil
-		},
-	})
-	if !ok {
-		t.Fatal("expected same-second activity before snapshot to keep the snapshot valid")
-	}
-}
-
-func TestBootstrapSnapshotStillMatchesSession_RejectsLaterSecondActivitySinceCapture(t *testing.T) {
-	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
-		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
-		CaptureFullPane:  true,
-		SnapshotCaptured: time.Unix(12, 100_000_000),
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			return 91, 27, true, nil
-		},
-		SessionClientCount: func(sessionName string, opts tmux.Options) (int, error) {
-			return 1, nil
-		},
-		SessionLatestActivity: func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-			return time.Unix(13, 0), true, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			t.Fatal("did not expect padded activity-window check when raw activity timestamp is available")
-			return false, nil
-		},
-	})
-	if ok {
-		t.Fatal("expected later-second activity after capture to invalidate the snapshot")
-	}
-}
-
-func TestBootstrapSnapshotStillMatchesSession_RejectsSharedSessionAfterCapture(t *testing.T) {
-	calls := make([]string, 0, 4)
-	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
-		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
-		CaptureFullPane:  true,
-		SnapshotCaptured: time.Now().Add(-5 * time.Second),
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "size")
-			return 91, 27, true, nil
-		},
-		SessionClientCount: func(sessionName string, opts tmux.Options) (int, error) {
-			calls = append(calls, "clients")
-			return 2, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			t.Fatal("did not expect activity check after session became shared")
-			return false, nil
-		},
-	})
-	if ok {
-		t.Fatal("expected snapshot to be rejected once another tmux client attached")
-	}
-	if len(calls) != 4 {
-		t.Fatalf("expected generation, size, and shared-session recheck, got %v", calls)
-	}
-}
-
-func TestBootstrapSnapshotStillMatchesSession_RejectsPaneSizeChangeAfterCapture(t *testing.T) {
-	calls := make([]string, 0, 3)
-	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
-		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
-		CaptureFullPane:  true,
-		SnapshotCaptured: time.Now().Add(-5 * time.Second),
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSize: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "size")
-			return 120, 40, true, nil
-		},
-		SessionClientCount: func(sessionName string, opts tmux.Options) (int, error) {
-			t.Fatal("did not expect shared-session check after size drift")
-			return 0, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			t.Fatal("did not expect activity check after size drift")
-			return false, nil
-		},
-	})
-	if ok {
-		t.Fatal("expected snapshot to be rejected once pane size changed after capture")
-	}
-	if len(calls) != 3 {
-		t.Fatalf("expected generation and size recheck, got %v", calls)
-	}
-}
-
-func TestCaptureExistingSessionBootstrap_RechecksExclusivityBeforeResize(t *testing.T) {
-	calls := make([]string, 0, 8)
-	hasClientsCalls := 0
-	bootstrap := CaptureExistingSessionBootstrap("session-race", 80, 24, FullPaneCaptureQuietWindow, tmux.Options{}, SessionBootstrapFns{
-		SessionHasClients: func(sessionName string, opts tmux.Options) (bool, error) {
-			calls = append(calls, "clients")
-			hasClientsCalls++
-			return hasClientsCalls >= 2, nil
-		},
-		SessionActiveWithin: func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-			calls = append(calls, "activity")
-			return false, nil
-		},
-		SessionCreatedAt: func(sessionName string, opts tmux.Options) (int64, error) {
-			calls = append(calls, "created")
-			return 123, nil
-		},
-		SessionPaneID: func(sessionName string, opts tmux.Options) (string, error) {
-			calls = append(calls, "pane")
-			return "%1", nil
-		},
-		SessionPaneSnapshotInfo: func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-			calls = append(calls, "info")
-			return 91, 27, true, nil
-		},
-		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
-			calls = append(calls, "resize")
-			return nil
-		},
-		CapturePaneSnapshot: func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-			calls = append(calls, "snapshot")
-			return tmux.PaneSnapshot{Data: []byte("frame")}, nil
-		},
-	})
-	if bootstrap.CaptureFullPane {
-		t.Fatal("expected shared-on-recheck session to skip pre-attach full-pane bootstrap")
-	}
-	for _, call := range calls {
-		if call == "resize" || call == "snapshot" {
-			t.Fatalf("expected exclusivity recheck to prevent resize/snapshot, got %v", calls)
-		}
-	}
-	want := []string{"clients", "activity", "created", "pane", "info", "clients", "activity"}
-	if len(calls) != len(want) {
-		t.Fatalf("call order = %v, want %v", calls, want)
-	}
-	for i := range want {
-		if calls[i] != want[i] {
-			t.Fatalf("call order = %v, want %v", calls, want)
-		}
 	}
 }

--- a/internal/ui/ptyio/session_bootstrap_validate_test.go
+++ b/internal/ui/ptyio/session_bootstrap_validate_test.go
@@ -1,0 +1,204 @@
+package ptyio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/tmux"
+)
+
+// These cover the two guards that run after the pre-attach snapshot has already
+// been taken: the rollback that undoes the bootstrap resize, and the
+// post-attach validation deciding whether the snapshot is still an accurate
+// picture of the session. Shared fixtures (eligibleProbe, probeScript) live in
+// session_bootstrap_test.go.
+
+func TestRollbackExistingSessionBootstrap_SkipsReplacementSession(t *testing.T) {
+	var calls []string
+	replacement := eligibleProbe()
+	replacement.CreatedAt = 456
+	replacement.PaneID = "%9"
+
+	RollbackExistingSessionBootstrap("session-race", SessionBootstrapCapture{
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+		RollbackCols:     91,
+		RollbackRows:     27,
+		NeedsRollback:    true,
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, replacement),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect rollback resize for a replacement session")
+			return nil
+		},
+	})
+	if len(calls) != 1 {
+		t.Fatalf("expected a single probe before skipping rollback, got %v", calls)
+	}
+}
+
+func TestRollbackExistingSessionBootstrap_SkipsLiveSharedSession(t *testing.T) {
+	var calls []string
+	attached := eligibleProbe()
+	attached.ClientCount = 1
+
+	RollbackExistingSessionBootstrap("session-race", SessionBootstrapCapture{
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+		RollbackCols:     91,
+		RollbackRows:     27,
+		NeedsRollback:    true,
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, attached),
+		ResizePaneToSize: func(string, int, int, tmux.Options) error {
+			t.Fatal("did not expect rollback resize for a shared session")
+			return nil
+		},
+	})
+	if len(calls) != 1 {
+		t.Fatalf("expected a single probe before skipping rollback, got %v", calls)
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_AcceptsUnchangedSession(t *testing.T) {
+	var calls []string
+	// One client is the attaching client itself, which is expected.
+	attached := eligibleProbe()
+	attached.ClientCount = 1
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Now(),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, attached),
+	})
+	if !ok {
+		t.Fatal("expected an unchanged session with only the attaching client to keep the snapshot")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_RejectsRecentActivitySinceCapture(t *testing.T) {
+	var calls []string
+	active := eligibleProbe()
+	active.ClientCount = 1
+	active.LatestActivity = time.Now().Unix()
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Now().Add(-5 * time.Second),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, active),
+	})
+	if ok {
+		t.Fatal("expected snapshot to be rejected once the pane became active after capture")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_IgnoresSameSecondActivityBeforeSnapshot(t *testing.T) {
+	var calls []string
+	sameSecond := eligibleProbe()
+	sameSecond.ClientCount = 1
+	sameSecond.LatestActivity = 12
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Unix(12, 900_000_000),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, sameSecond),
+	})
+	if !ok {
+		t.Fatal("expected same-second activity before snapshot to keep the snapshot valid")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_RejectsLaterSecondActivitySinceCapture(t *testing.T) {
+	var calls []string
+	laterSecond := eligibleProbe()
+	laterSecond.ClientCount = 1
+	laterSecond.LatestActivity = 13
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Unix(12, 100_000_000),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, laterSecond),
+	})
+	if ok {
+		t.Fatal("expected later-second activity after capture to invalidate the snapshot")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_RejectsSharedSessionAfterCapture(t *testing.T) {
+	var calls []string
+	// Two clients: one is the attaching client, the other is something else
+	// driving the session.
+	shared := eligibleProbe()
+	shared.ClientCount = 2
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Now().Add(-5 * time.Second),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, shared),
+	})
+	if ok {
+		t.Fatal("expected snapshot to be rejected once another tmux client attached")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_RejectsPaneSizeChangeAfterCapture(t *testing.T) {
+	var calls []string
+	resized := eligibleProbe()
+	resized.ClientCount = 1
+	resized.PaneMeta.Cols, resized.PaneMeta.Rows = 120, 40
+	resized.PaneCols, resized.PaneRows = 120, 40
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Now().Add(-5 * time.Second),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, resized),
+	})
+	if ok {
+		t.Fatal("expected snapshot to be rejected once pane size changed after capture")
+	}
+}
+
+func TestBootstrapSnapshotStillMatchesSession_RejectsReplacementSession(t *testing.T) {
+	var calls []string
+	replacement := eligibleProbe()
+	replacement.ClientCount = 1
+	replacement.CreatedAt = 456
+	replacement.PaneID = "%9"
+
+	ok := BootstrapSnapshotStillMatchesSession("session-race", SessionBootstrapCapture{
+		Snapshot:         tmux.PaneSnapshot{Cols: 91, Rows: 27},
+		CaptureFullPane:  true,
+		SnapshotCaptured: time.Now(),
+		SessionCreatedAt: 123,
+		PaneID:           "%1",
+	}, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: probeScript(&calls, replacement),
+	})
+	if ok {
+		t.Fatal("expected a recreated session to invalidate the snapshot")
+	}
+}

--- a/internal/ui/ptyio/session_history_test.go
+++ b/internal/ui/ptyio/session_history_test.go
@@ -7,12 +7,28 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
+// sizedProbe returns a probe reporting the given live pane size. A zero size
+// stands for "tmux could not tell us", which is what makes the caller's fallback
+// dimensions apply.
+func sizedProbe(cols, rows int) tmux.SessionProbe {
+	p := tmux.SessionProbe{Exists: true, CreatedAt: 1, PaneID: "%1", HasLivePane: true}
+	if cols > 0 && rows > 0 {
+		p.PaneCols, p.PaneRows, p.HasPaneSize = cols, rows, true
+		p.PaneMeta = tmux.PaneSnapshotMeta{Cols: cols, Rows: rows, HasSize: true}
+	}
+	return p
+}
+
+func staticProbe(p tmux.SessionProbe) func(string, tmux.Options) (tmux.SessionProbe, error) {
+	return func(string, tmux.Options) (tmux.SessionProbe, error) { return p, nil }
+}
+
 func TestSessionHistoryCaptureSize(t *testing.T) {
 	tests := []struct {
 		name         string
 		fallbackCols int
 		fallbackRows int
-		paneSize     func(string, tmux.Options) (int, int, bool, error)
+		probe        func(string, tmux.Options) (tmux.SessionProbe, error)
 		wantCols     int
 		wantRows     int
 	}{
@@ -20,28 +36,24 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			name:         "live pane size overrides fallback",
 			fallbackCols: 80,
 			fallbackRows: 24,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 120, 40, true, nil
-			},
-			wantCols: 120,
-			wantRows: 40,
+			probe:        staticProbe(sizedProbe(120, 40)),
+			wantCols:     120,
+			wantRows:     40,
 		},
 		{
 			name:         "missing pane size falls back",
 			fallbackCols: 80,
 			fallbackRows: 24,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 0, 0, false, nil
-			},
-			wantCols: 80,
-			wantRows: 24,
+			probe:        staticProbe(sizedProbe(0, 0)),
+			wantCols:     80,
+			wantRows:     24,
 		},
 		{
-			name:         "pane size error falls back",
+			name:         "probe error falls back",
 			fallbackCols: 100,
 			fallbackRows: 30,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 120, 40, true, errors.New("boom")
+			probe: func(string, tmux.Options) (tmux.SessionProbe, error) {
+				return sizedProbe(120, 40), errors.New("boom")
 			},
 			wantCols: 100,
 			wantRows: 30,
@@ -50,9 +62,9 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			name:         "non-positive cols falls back",
 			fallbackCols: 100,
 			fallbackRows: 30,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 0, 40, true, nil
-			},
+			probe: staticProbe(tmux.SessionProbe{
+				Exists: true, PaneID: "%1", HasPaneSize: true, PaneCols: 0, PaneRows: 40,
+			}),
 			wantCols: 100,
 			wantRows: 30,
 		},
@@ -60,9 +72,9 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			name:         "non-positive rows falls back",
 			fallbackCols: 100,
 			fallbackRows: 30,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 120, 0, true, nil
-			},
+			probe: staticProbe(tmux.SessionProbe{
+				Exists: true, PaneID: "%1", HasPaneSize: true, PaneCols: 120, PaneRows: 0,
+			}),
 			wantCols: 100,
 			wantRows: 30,
 		},
@@ -70,9 +82,9 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			name:         "negative live size falls back",
 			fallbackCols: 64,
 			fallbackRows: 16,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return -1, -1, true, nil
-			},
+			probe: staticProbe(tmux.SessionProbe{
+				Exists: true, PaneID: "%1", HasPaneSize: true, PaneCols: -1, PaneRows: -1,
+			}),
 			wantCols: 64,
 			wantRows: 16,
 		},
@@ -80,18 +92,16 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			name:         "zero fallback preserved when pane size unavailable",
 			fallbackCols: 0,
 			fallbackRows: 0,
-			paneSize: func(string, tmux.Options) (int, int, bool, error) {
-				return 0, 0, false, nil
-			},
-			wantCols: 0,
-			wantRows: 0,
+			probe:        staticProbe(sizedProbe(0, 0)),
+			wantCols:     0,
+			wantRows:     0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCols, gotRows := SessionHistoryCaptureSize("session-history", tt.fallbackCols, tt.fallbackRows, tmux.Options{}, SessionBootstrapFns{
-				SessionPaneSize: tt.paneSize,
+				ProbeSession: tt.probe,
 			})
 			if gotCols != tt.wantCols || gotRows != tt.wantRows {
 				t.Fatalf("SessionHistoryCaptureSize = (%d, %d), want (%d, %d)", gotCols, gotRows, tt.wantCols, tt.wantRows)
@@ -101,19 +111,20 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 }
 
 func TestCaptureSessionHistory_UsesLivePaneSize(t *testing.T) {
-	var capturedSession string
+	var capturedPane string
 	wantData := []byte("scrollback frame")
 	data, cols, rows := CaptureSessionHistory("session-history", 80, 24, tmux.Options{}, SessionBootstrapFns{
-		SessionPaneSize: func(string, tmux.Options) (int, int, bool, error) {
-			return 120, 40, true, nil
+		ProbeSession: staticProbe(sizedProbe(120, 40)),
+		CapturePaneHistoryData: func(paneID string, opts tmux.Options) ([]byte, error) {
+			capturedPane = paneID
+			return wantData, nil
 		},
-	}, func(sessionName string, opts tmux.Options) ([]byte, error) {
-		capturedSession = sessionName
-		return wantData, nil
 	})
 
-	if capturedSession != "session-history" {
-		t.Fatalf("capturePane received session %q, want %q", capturedSession, "session-history")
+	// The capture targets the pane the same probe resolved, so it cannot land on
+	// a different pane than the size it is interpreted at.
+	if capturedPane != "%1" {
+		t.Fatalf("capture targeted pane %q, want the probed pane %q", capturedPane, "%1")
 	}
 	if string(data) != string(wantData) {
 		t.Fatalf("CaptureSessionHistory data = %q, want %q", data, wantData)
@@ -125,11 +136,10 @@ func TestCaptureSessionHistory_UsesLivePaneSize(t *testing.T) {
 
 func TestCaptureSessionHistory_FallsBackToProvidedSize(t *testing.T) {
 	data, cols, rows := CaptureSessionHistory("session-history", 90, 28, tmux.Options{}, SessionBootstrapFns{
-		SessionPaneSize: func(string, tmux.Options) (int, int, bool, error) {
-			return 0, 0, false, nil
+		ProbeSession: staticProbe(sizedProbe(0, 0)),
+		CapturePaneHistoryData: func(string, tmux.Options) ([]byte, error) {
+			return []byte("frame"), nil
 		},
-	}, func(string, tmux.Options) ([]byte, error) {
-		return []byte("frame"), nil
 	})
 
 	if cols != 90 || rows != 28 {
@@ -142,11 +152,10 @@ func TestCaptureSessionHistory_FallsBackToProvidedSize(t *testing.T) {
 
 func TestCaptureSessionHistory_SwallowsCaptureErrorAndReturnsPartialData(t *testing.T) {
 	data, cols, rows := CaptureSessionHistory("session-history", 80, 24, tmux.Options{}, SessionBootstrapFns{
-		SessionPaneSize: func(string, tmux.Options) (int, int, bool, error) {
-			return 100, 30, true, nil
+		ProbeSession: staticProbe(sizedProbe(100, 30)),
+		CapturePaneHistoryData: func(string, tmux.Options) ([]byte, error) {
+			return []byte("partial"), errors.New("capture failed")
 		},
-	}, func(string, tmux.Options) ([]byte, error) {
-		return []byte("partial"), errors.New("capture failed")
 	})
 
 	// The capture error is intentionally swallowed; whatever bytes the callback
@@ -161,15 +170,31 @@ func TestCaptureSessionHistory_SwallowsCaptureErrorAndReturnsPartialData(t *test
 
 func TestCaptureSessionHistory_NilScrollbackOnEmptyCapture(t *testing.T) {
 	data, cols, rows := CaptureSessionHistory("session-history", 70, 20, tmux.Options{}, SessionBootstrapFns{
-		SessionPaneSize: func(string, tmux.Options) (int, int, bool, error) {
-			return 0, 0, false, nil
+		ProbeSession: staticProbe(sizedProbe(0, 0)),
+		CapturePaneHistoryData: func(string, tmux.Options) ([]byte, error) {
+			return nil, nil
 		},
-	}, func(string, tmux.Options) ([]byte, error) {
-		return nil, nil
 	})
 
 	if data != nil {
 		t.Fatalf("CaptureSessionHistory data = %q, want nil for empty capture", data)
+	}
+	if cols != 70 || rows != 20 {
+		t.Fatalf("CaptureSessionHistory size = (%d, %d), want fallback (70, 20)", cols, rows)
+	}
+}
+
+func TestCaptureSessionHistory_SkipsCaptureWhenNoPaneResolved(t *testing.T) {
+	data, cols, rows := CaptureSessionHistory("session-history", 70, 20, tmux.Options{}, SessionBootstrapFns{
+		ProbeSession: staticProbe(tmux.SessionProbe{}),
+		CapturePaneHistoryData: func(string, tmux.Options) ([]byte, error) {
+			t.Fatal("did not expect a capture when the probe resolved no pane")
+			return nil, nil
+		},
+	})
+
+	if data != nil {
+		t.Fatalf("CaptureSessionHistory data = %q, want nil when no pane was resolved", data)
 	}
 	if cols != 70 || rows != 20 {
 		t.Fatalf("CaptureSessionHistory size = (%d, %d), want fallback (70, 20)", cols, rows)
@@ -181,6 +206,9 @@ func TestRollbackSessionBootstrap_RestoresOriginalSizeWhenSessionUnchanged(t *te
 		resizeCols, resizeRows int
 		resizeCalled           bool
 	)
+	unchanged := sizedProbe(80, 24)
+	unchanged.CreatedAt = 123
+
 	rollbackSessionBootstrap("session-history", SessionBootstrapCapture{
 		SessionCreatedAt: 123,
 		PaneID:           "%1",
@@ -188,15 +216,7 @@ func TestRollbackSessionBootstrap_RestoresOriginalSizeWhenSessionUnchanged(t *te
 		RollbackRows:     27,
 		NeedsRollback:    true,
 	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(string, tmux.Options) (int64, error) {
-			return 123, nil
-		},
-		SessionPaneID: func(string, tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionHasClients: func(string, tmux.Options) (bool, error) {
-			return false, nil
-		},
+		ProbeSession: staticProbe(unchanged),
 		ResizePaneToSize: func(sessionName string, cols, rows int, opts tmux.Options) error {
 			resizeCalled = true
 			resizeCols, resizeRows = cols, rows
@@ -252,9 +272,9 @@ func TestRollbackSessionBootstrap_SkipsWhenRollbackNotNeeded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rollbackSessionBootstrap("session-history", tt.bootstrap, tmux.Options{}, SessionBootstrapFns{
-				SessionCreatedAt: func(string, tmux.Options) (int64, error) {
-					t.Fatal("did not expect a generation check when rollback is unnecessary")
-					return 0, nil
+				ProbeSession: func(string, tmux.Options) (tmux.SessionProbe, error) {
+					t.Fatal("did not expect a probe when rollback is unnecessary")
+					return tmux.SessionProbe{}, nil
 				},
 				ResizePaneToSize: func(string, int, int, tmux.Options) error {
 					t.Fatal("did not expect a resize when rollback is unnecessary")
@@ -265,7 +285,7 @@ func TestRollbackSessionBootstrap_SkipsWhenRollbackNotNeeded(t *testing.T) {
 	}
 }
 
-func TestRollbackSessionBootstrap_SkipsWhenGenerationLookupFails(t *testing.T) {
+func TestRollbackSessionBootstrap_SkipsWhenProbeFails(t *testing.T) {
 	rollbackSessionBootstrap("session-history", SessionBootstrapCapture{
 		SessionCreatedAt: 123,
 		PaneID:           "%1",
@@ -273,42 +293,11 @@ func TestRollbackSessionBootstrap_SkipsWhenGenerationLookupFails(t *testing.T) {
 		RollbackRows:     27,
 		NeedsRollback:    true,
 	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(string, tmux.Options) (int64, error) {
-			return 0, errors.New("session gone")
-		},
-		SessionPaneID: func(string, tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionHasClients: func(string, tmux.Options) (bool, error) {
-			t.Fatal("did not expect a client check after generation lookup failed")
-			return false, nil
+		ProbeSession: func(string, tmux.Options) (tmux.SessionProbe, error) {
+			return tmux.SessionProbe{}, errors.New("session gone")
 		},
 		ResizePaneToSize: func(string, int, int, tmux.Options) error {
-			t.Fatal("did not expect a resize after generation lookup failed")
-			return nil
-		},
-	})
-}
-
-func TestRollbackSessionBootstrap_SkipsWhenClientCheckErrors(t *testing.T) {
-	rollbackSessionBootstrap("session-history", SessionBootstrapCapture{
-		SessionCreatedAt: 123,
-		PaneID:           "%1",
-		RollbackCols:     91,
-		RollbackRows:     27,
-		NeedsRollback:    true,
-	}, tmux.Options{}, SessionBootstrapFns{
-		SessionCreatedAt: func(string, tmux.Options) (int64, error) {
-			return 123, nil
-		},
-		SessionPaneID: func(string, tmux.Options) (string, error) {
-			return "%1", nil
-		},
-		SessionHasClients: func(string, tmux.Options) (bool, error) {
-			return false, errors.New("query failed")
-		},
-		ResizePaneToSize: func(string, int, int, tmux.Options) error {
-			t.Fatal("did not expect a resize when the client check errored")
+			t.Fatal("did not expect a resize after the probe failed")
 			return nil
 		},
 	})

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -19,17 +19,11 @@ import (
 var (
 	ensureTmuxAvailableFn       = tmux.EnsureAvailable
 	sessionStateForFn           = tmux.SessionStateFor
-	sessionHasClientsFn         = tmux.SessionHasClients
-	sessionClientCountFn        = tmux.SessionClientCount
-	sessionActiveWithinFn       = tmux.SessionActiveWithin
-	sessionLatestActivityFn     = tmux.SessionLatestActivity
-	sessionCreatedAtFn          = tmux.SessionCreatedAt
-	sessionPaneIDFn             = tmux.SessionPaneID
-	sessionPaneSnapshotInfoFn   = tmux.SessionPaneSnapshotInfo
-	sessionPaneSizeFn           = tmux.SessionPaneSize
+	probeSessionFn              = tmux.ProbeSession
 	newPTYWithSizeFn            = pty.NewWithSize
 	resizePaneToSizeFn          = tmux.ResizePaneToSize
-	capturePaneSnapshotFn       = tmux.CapturePaneSnapshot
+	capturePaneFullDataFn       = tmux.CapturePaneFullData
+	capturePaneHistoryDataFn    = tmux.CapturePaneHistoryData
 	capturePaneFn               = tmux.CapturePane
 	verifyTerminalSessionTagsFn = verifyTerminalSessionTags
 )
@@ -42,18 +36,11 @@ type sessionBootstrapCapture = ptyio.SessionBootstrapCapture
 func sessionBootstrap() ptyio.SessionBootstrap {
 	return ptyio.SessionBootstrap{
 		Fns: ptyio.SessionBootstrapFns{
-			SessionHasClients:       sessionHasClientsFn,
-			SessionClientCount:      sessionClientCountFn,
-			SessionActiveWithin:     sessionActiveWithinFn,
-			SessionLatestActivity:   sessionLatestActivityFn,
-			SessionCreatedAt:        sessionCreatedAtFn,
-			SessionPaneID:           sessionPaneIDFn,
-			SessionPaneSnapshotInfo: sessionPaneSnapshotInfoFn,
-			SessionPaneSize:         sessionPaneSizeFn,
-			ResizePaneToSize:        resizePaneToSizeFn,
-			CapturePaneSnapshot:     capturePaneSnapshotFn,
+			ProbeSession:           probeSessionFn,
+			ResizePaneToSize:       resizePaneToSizeFn,
+			CapturePaneFullData:    capturePaneFullDataFn,
+			CapturePaneHistoryData: capturePaneHistoryDataFn,
 		},
-		CapturePane: capturePaneFn,
 	}
 }
 

--- a/internal/ui/sidebar/terminal_pty_attach_ops_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_ops_test.go
@@ -3,7 +3,6 @@ package sidebar
 import (
 	"errors"
 	"testing"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -28,7 +27,7 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 		paneCols     int
 		paneRows     int
 		paneHasSize  bool
-		paneErr      error
+		probeErr     error
 		fallbackCols int
 		fallbackRows int
 		wantCols     int
@@ -45,11 +44,11 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 			wantRows:     45,
 		},
 		{
-			name:         "falls back when pane size query errors",
+			name:         "falls back when the session probe errors",
 			paneCols:     123,
 			paneRows:     45,
 			paneHasSize:  true,
-			paneErr:      errors.New("no such session"),
+			probeErr:     errors.New("no such session"),
 			fallbackCols: 80,
 			fallbackRows: 24,
 			wantCols:     80,
@@ -97,17 +96,22 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 		},
 	}
 
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	defer func() { sessionPaneSizeFn = oldSessionPaneSizeFn }()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			restoreAttachSeams(t)
+
 			var gotSession string
 			var gotOpts tmux.Options
-			sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
+			probeSessionFn = func(sessionName string, opts tmux.Options) (tmux.SessionProbe, error) {
 				gotSession = sessionName
 				gotOpts = opts
-				return tt.paneCols, tt.paneRows, tt.paneHasSize, tt.paneErr
+				return tmux.SessionProbe{
+					Exists:      true,
+					PaneID:      "%1",
+					PaneCols:    tt.paneCols,
+					PaneRows:    tt.paneRows,
+					HasPaneSize: tt.paneHasSize,
+				}, tt.probeErr
 			}
 
 			opts := tmux.DefaultOptions()
@@ -116,10 +120,10 @@ func TestSessionHistoryCaptureSize(t *testing.T) {
 				t.Fatalf("expected %dx%d, got %dx%d", tt.wantCols, tt.wantRows, cols, rows)
 			}
 			if gotSession != "session-xyz" {
-				t.Fatalf("expected pane size query for session %q, got %q", "session-xyz", gotSession)
+				t.Fatalf("expected the probe to target session %q, got %q", "session-xyz", gotSession)
 			}
 			if gotOpts != opts {
-				t.Fatalf("expected pane size query to forward tmux options, got %+v", gotOpts)
+				t.Fatalf("expected the probe to forward tmux options, got %+v", gotOpts)
 			}
 		})
 	}
@@ -345,63 +349,34 @@ func TestRestartActiveTab_RunningEmitsToastWithoutKillingSession(t *testing.T) {
 
 // withReattachSeams installs no-op/successful tmux seams sufficient for a
 // "reattach" attachToSession command to run without touching real processes,
-// returning the given scrollback as the pane history. Every tmux seam reached
-// on the bootstrap/history-only path is stubbed (including the activity,
-// creation-time, and pane-id probes that fire whenever a live session is
-// present), so the command never shells out to a real tmux. Originals are
-// restored on test cleanup.
+// returning the given scrollback as the pane history. The session probe reports
+// a pane with no VT mode metadata, which makes the pre-attach snapshot
+// ineligible and puts the command on the history-only path: no resize and no
+// full-pane capture, just the history read. Originals are restored on cleanup.
 func withReattachSeams(t *testing.T, scrollback string) {
 	t.Helper()
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	t.Cleanup(func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	})
+	restoreAttachSeams(t)
+
+	ineligible := eligibleAttachProbe()
+	ineligible.PaneID = "%0"
+	ineligible.PaneCols, ineligible.PaneRows = 80, 24
+	ineligible.PaneMeta = tmux.PaneSnapshotMeta{Cols: 80, Rows: 24, HasSize: true}
 
 	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(string, tmux.Options) (tmux.SessionState, error) {
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(string, tmux.Options) (bool, error) { return false, nil }
-	// Stub the live-session probes (activity window, creation time, pane id)
-	// so the bootstrap path stays entirely off real tmux even when a session
-	// is reported present.
-	sessionActiveWithinFn = func(string, time.Duration, tmux.Options) (bool, error) {
-		return false, nil
+	probeSeq(nil, ineligible)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		t.Fatal("did not expect a resize on the history-only path")
+		return nil
 	}
-	sessionCreatedAtFn = func(string, tmux.Options) (int64, error) { return 0, nil }
-	sessionPaneIDFn = func(string, tmux.Options) (string, error) { return "%0", nil }
-	// Make the pre-attach snapshot ineligible so the command takes the
-	// history-only path (no resize/snapshot exec, just capturePane).
-	sessionPaneSnapshotInfoFn = func(string, tmux.Options) (int, int, bool, error) {
-		return 0, 0, false, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		t.Fatal("did not expect a full-pane capture on the history-only path")
+		return nil, nil
 	}
-	sessionPaneSizeFn = func(string, tmux.Options) (int, int, bool, error) {
-		return 80, 24, true, nil
-	}
-	capturePaneSnapshotFn = func(string, tmux.Options) (tmux.PaneSnapshot, error) {
-		return tmux.PaneSnapshot{}, errors.New("not whole window")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		return []byte(scrollback), nil
 	}
 	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
 		return []byte(scrollback), nil

--- a/internal/ui/sidebar/terminal_pty_attach_safety_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_safety_test.go
@@ -3,93 +3,67 @@ package sidebar
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestAttachToSession_SharedClientFallsBackToHistoryOnly(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+// installSidebarHistoryFallbackSeams wires a live session whose probe reports
+// the given ineligibility, so the bootstrap must fall back to replaying history
+// without ever resizing or snapshotting the pane.
+func installSidebarHistoryFallbackSeams(t *testing.T, calls *[]string, probe tmux.SessionProbe) {
+	t.Helper()
+	restoreAttachSeams(t)
 
-	calls := make([]string, 0, 5)
-	ensureTmuxAvailableFn = func() error {
-		return nil
-	}
+	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return true, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 0, 0, false, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	probeSeq(calls, probe)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("should not use"), nil
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("history only"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("history only"), nil
 	}
 	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
+		*calls = append(*calls, "attach")
 		return &pty.Terminal{}, nil
 	}
 	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
+		*calls = append(*calls, "verify")
 		return nil
 	}
+}
+
+// assertNoPreAttachMutation asserts the fallback path never resized or
+// snapshotted the pane.
+func assertNoPreAttachMutation(t *testing.T, calls []string) {
+	t.Helper()
+	for _, call := range calls {
+		if call == "resize" || call == "snapshot" {
+			t.Fatalf("expected an ineligible session to avoid pre-attach resize/snapshot, got %v", calls)
+		}
+	}
+}
+
+func TestAttachToSession_SharedClientFallsBackToHistoryOnly(t *testing.T) {
+	var calls []string
+	shared := eligibleAttachProbe()
+	shared.ClientCount = 1
+	installSidebarHistoryFallbackSeams(t, &calls, shared)
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -110,13 +84,15 @@ func TestAttachToSession_SharedClientFallsBackToHistoryOnly(t *testing.T) {
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", reattach.CaptureCols, reattach.CaptureRows)
 	}
-	attachIdx := -1
-	scrollbackIdx := -1
+
+	// The history capture has to happen after the attach: it is what reconciles
+	// anything the session emitted while the client was connecting.
+	attachIdx, scrollbackIdx := -1, -1
 	for i, call := range calls {
-		if call == "attach" {
+		switch call {
+		case "attach":
 			attachIdx = i
-		}
-		if call == "scrollback" {
+		case "scrollback":
 			scrollbackIdx = i
 		}
 	}
@@ -126,91 +102,15 @@ func TestAttachToSession_SharedClientFallsBackToHistoryOnly(t *testing.T) {
 	if scrollbackIdx < attachIdx {
 		t.Fatalf("expected shared-client fallback scrollback capture after attach, got call order %v", calls)
 	}
-	for _, call := range calls {
-		if call == "resize" || call == "snapshot" {
-			t.Fatalf("expected shared-client reattach to avoid pre-attach resize/snapshot, got %v", calls)
-		}
-	}
+	assertNoPreAttachMutation(t, calls)
 }
 
 func TestCreateTerminalTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
-
-	calls := make([]string, 0, 6)
-	ensureTmuxAvailableFn = func() error { return nil }
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 0, 0, false, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{}, errors.New("not whole window")
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history only"), nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
+	var calls []string
+	// A pane with no VT mode metadata cannot anchor an authoritative snapshot.
+	ineligible := eligibleAttachProbe()
+	ineligible.PaneMeta.ModeState = tmux.PaneModeState{}
+	installSidebarHistoryFallbackSeams(t, &calls, ineligible)
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -231,91 +131,14 @@ func TestCreateTerminalTab_SnapshotIneligibleFallsBackWithoutResize(t *testing.T
 	if created.CaptureCols != 123 || created.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", created.CaptureCols, created.CaptureRows)
 	}
-	for _, call := range calls {
-		if call == "resize" || call == "snapshot" {
-			t.Fatalf("expected snapshot ineligibility to skip pre-attach resize, got %v", calls)
-		}
-	}
+	assertNoPreAttachMutation(t, calls)
 }
 
 func TestAttachToSession_SnapshotIneligibleFallsBackWithoutResize(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
-
-	calls := make([]string, 0, 6)
-	ensureTmuxAvailableFn = func() error { return nil }
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 0, 0, false, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{}, errors.New("not whole window")
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history only"), nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
+	var calls []string
+	ineligible := eligibleAttachProbe()
+	ineligible.PaneMeta.ModeState = tmux.PaneModeState{}
+	installSidebarHistoryFallbackSeams(t, &calls, ineligible)
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -336,76 +159,28 @@ func TestAttachToSession_SnapshotIneligibleFallsBackWithoutResize(t *testing.T) 
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", reattach.CaptureCols, reattach.CaptureRows)
 	}
-	for _, call := range calls {
-		if call == "resize" || call == "snapshot" {
-			t.Fatalf("expected snapshot ineligibility to skip pre-attach resize, got %v", calls)
-		}
-	}
+	assertNoPreAttachMutation(t, calls)
 }
 
 func TestAttachToSession_AttachFailureRollsBackBootstrapResize(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+	var calls []string
+	restoreAttachSeams(t)
 
-	calls := make([]string, 0, 8)
 	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
 		calls = append(calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 91, 27, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
+	// Still unattached and unchanged at the rollback probe, so the rollback is
+	// safe to perform.
+	probeSeq(&calls, eligibleAttachProbe())
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
 		calls = append(calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
 		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("resized"), Cols: 77, Rows: 19}, nil
+		return []byte("resized"), nil
 	}
 	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
 		calls = append(calls, "attach")
@@ -429,7 +204,9 @@ func TestAttachToSession_AttachFailureRollsBackBootstrapResize(t *testing.T) {
 	if failed.Err == nil || failed.Err.Error() != "attach failed" {
 		t.Fatalf("expected attach failure, got %+v", failed)
 	}
-	assertSidebarCallOrder(t, calls, "clients", "activity", "info", "resize", "snapshot", "attach", "resize")
+	// The trailing resize is the rollback: a failed attach must not leave the
+	// pane at the size the aborted bootstrap set.
+	assertSidebarCallOrder(t, calls, "probe", "resize", "snapshot", "attach", "resize")
 }
 
 func assertSidebarCallOrder(t *testing.T, calls []string, expected ...string) {

--- a/internal/ui/sidebar/terminal_pty_attach_seams_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_seams_test.go
@@ -1,4 +1,4 @@
-package center
+package sidebar
 
 import (
 	"testing"
@@ -6,41 +6,38 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func setKnownViewport(m *Model) {
-	m.width = 120
-	m.height = 40
-}
-
-// restoreReattachSeams snapshots every reattach/bootstrap seam var and restores
-// it when the test ends. Tests then assign only the seams they care about
-// instead of hand-rolling a save/restore block per seam. Because the seams are
+// restoreAttachSeams snapshots every attach/bootstrap seam var and restores it
+// when the test ends. Tests then assign only the seams they care about instead
+// of hand-rolling a save/restore block per seam. Because the seams are
 // package-level, tests using this must not call t.Parallel.
-func restoreReattachSeams(t *testing.T) {
+func restoreAttachSeams(t *testing.T) {
 	t.Helper()
+	oldEnsureTmuxAvailable := ensureTmuxAvailableFn
 	oldSessionStateFor := sessionStateForFn
 	oldProbeSession := probeSessionFn
-	oldKillSession := killSessionFn
+	oldNewPTYWithSize := newPTYWithSizeFn
 	oldResizePaneToSize := resizePaneToSizeFn
 	oldCapturePaneFullData := capturePaneFullDataFn
 	oldCapturePaneHistoryData := capturePaneHistoryDataFn
 	oldCapturePane := capturePaneFn
-	oldCreateAgentWithTags := createAgentWithTagsFn
+	oldVerifyTerminalSessionTags := verifyTerminalSessionTagsFn
 	t.Cleanup(func() {
+		ensureTmuxAvailableFn = oldEnsureTmuxAvailable
 		sessionStateForFn = oldSessionStateFor
 		probeSessionFn = oldProbeSession
-		killSessionFn = oldKillSession
+		newPTYWithSizeFn = oldNewPTYWithSize
 		resizePaneToSizeFn = oldResizePaneToSize
 		capturePaneFullDataFn = oldCapturePaneFullData
 		capturePaneHistoryDataFn = oldCapturePaneHistoryData
 		capturePaneFn = oldCapturePane
-		createAgentWithTagsFn = oldCreateAgentWithTags
+		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTags
 	})
 }
 
-// eligibleReattachProbe is a session probe that passes every bootstrap gate:
+// eligibleAttachProbe is a session probe that passes every bootstrap gate:
 // detached, quiet, a single live pane, complete metadata. Tests start from it
 // and change the one fact under test.
-func eligibleReattachProbe() tmux.SessionProbe {
+func eligibleAttachProbe() tmux.SessionProbe {
 	return tmux.SessionProbe{
 		Exists:           true,
 		CreatedAt:        111,
@@ -66,7 +63,9 @@ func eligibleReattachProbe() tmux.SessionProbe {
 func probeSeq(calls *[]string, probes ...tmux.SessionProbe) {
 	i := 0
 	probeSessionFn = func(string, tmux.Options) (tmux.SessionProbe, error) {
-		*calls = append(*calls, "probe")
+		if calls != nil {
+			*calls = append(*calls, "probe")
+		}
 		p := probes[i]
 		if i < len(probes)-1 {
 			i++

--- a/internal/ui/sidebar/terminal_pty_attach_snapshot_race_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_snapshot_race_test.go
@@ -9,454 +9,184 @@ import (
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestCreateTerminalTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+// installSidebarDemotionSeams wires a session that looks eligible right up to
+// the moment the client attaches, then reports postAttach on every later probe.
+// That is the shape of every race the pre-attach snapshot has to survive: the
+// snapshot is taken in good faith and only the post-attach validation can tell
+// it went stale.
+func installSidebarDemotionSeams(t *testing.T, calls *[]string, postAttach tmux.SessionProbe) {
+	t.Helper()
+	restoreAttachSeams(t)
 
-	calls := make([]string, 0, 8)
 	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	createdAtCalls := 0
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		createdAtCalls++
-		return 111, nil
-	}
-	paneIDCalls := 0
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		paneIDCalls++
-		if paneIDCalls <= 4 {
-			return "%old", nil
-		}
-		return "%new", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	// Three probes bracket the capture (eligibility, post-resize, post-capture);
+	// everything after them is the post-attach world.
+	probeSeq(calls, eligibleAttachProbe(), eligibleAttachProbe(), eligibleAttachProbe(), postAttach)
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("stale frame"), nil
 	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("post history"), nil
 	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("post history"), nil
+	}
+	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
+		*calls = append(*calls, "attach")
+		return &pty.Terminal{}, nil
+	}
 	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
+		*calls = append(*calls, "verify")
 		return nil
 	}
+}
 
+// sidebarRestore is the subset of a create/reattach result the demotion
+// assertions care about, so both message types share one assertion.
+type sidebarRestore struct {
+	captureFullPane bool
+	scrollback      []byte
+	postAttach      []byte
+	captureCols     int
+	captureRows     int
+	snapshotCols    int
+	snapshotRows    int
+	checkSizes      bool
+}
+
+func assertSidebarSnapshotDemoted(t *testing.T, r sidebarRestore, calls []string) {
+	t.Helper()
+	if r.captureFullPane {
+		t.Fatal("expected a stale pre-attach snapshot to be discarded")
+	}
+	if got := string(r.scrollback); got != "post history" {
+		t.Fatalf("expected post-attach history recapture, got %q", got)
+	}
+	if len(r.postAttach) != 0 {
+		t.Fatalf("expected no reconciliation delta after demotion, got %q", string(r.postAttach))
+	}
+	if r.checkSizes {
+		if r.captureCols != 123 || r.captureRows != 45 {
+			t.Fatalf("expected history-only capture size 123x45, got %dx%d", r.captureCols, r.captureRows)
+		}
+		if r.snapshotCols != 0 || r.snapshotRows != 0 {
+			t.Fatalf("expected stale snapshot metadata to be cleared, got %dx%d", r.snapshotCols, r.snapshotRows)
+		}
+	}
+	assertSidebarCallOrder(t, calls, "state", "probe", "resize", "snapshot", "attach", "probe", "scrollback")
+}
+
+// recreatedSidebarProbe is the same session name running a different
+// incarnation: new creation stamp and new pane ID.
+func recreatedSidebarProbe() tmux.SessionProbe {
+	p := eligibleAttachProbe()
+	p.ClientCount = 1
+	p.CreatedAt = 999
+	p.PaneID = "%new"
+	return p
+}
+
+func newSidebarTestModel() (*TerminalModel, *data.Workspace) {
 	m := NewTerminalModel()
 	m.width = 20
 	m.height = 5
-	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
+	return m, data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
+}
 
+func TestCreateTerminalTab_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
+	var calls []string
+	installSidebarDemotionSeams(t, &calls, recreatedSidebarProbe())
+
+	m, ws := newSidebarTestModel()
 	msg := m.createTerminalTab(ws)()
 	created, ok := msg.(SidebarTerminalCreated)
 	if !ok {
 		t.Fatalf("expected SidebarTerminalCreated, got %T", msg)
 	}
-	if created.CaptureFullPane {
-		t.Fatal("expected recreated session to discard the pre-attach snapshot")
-	}
-	if got := string(created.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
-	}
-	if len(created.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(created.PostAttachScrollbackCapture))
-	}
-	if created.CaptureCols != 123 || created.CaptureRows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", created.CaptureCols, created.CaptureRows)
-	}
-	if created.SnapshotCols != 0 || created.SnapshotRows != 0 {
-		t.Fatalf("expected stale snapshot metadata to be cleared, got %dx%d", created.SnapshotCols, created.SnapshotRows)
-	}
-	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSidebarSnapshotDemoted(t, sidebarRestore{
+		captureFullPane: created.CaptureFullPane,
+		scrollback:      created.ScrollbackCapture,
+		postAttach:      created.PostAttachScrollbackCapture,
+		captureCols:     created.CaptureCols,
+		captureRows:     created.CaptureRows,
+		snapshotCols:    created.SnapshotCols,
+		snapshotRows:    created.SnapshotRows,
+		checkSizes:      true,
+	}, calls)
 }
 
 func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionRecreated(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+	var calls []string
+	installSidebarDemotionSeams(t, &calls, recreatedSidebarProbe())
 
-	calls := make([]string, 0, 8)
-	ensureTmuxAvailableFn = func() error { return nil }
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	createdAtCalls := 0
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		createdAtCalls++
-		return 111, nil
-	}
-	paneIDCalls := 0
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		paneIDCalls++
-		if paneIDCalls <= 4 {
-			return "%old", nil
-		}
-		return "%new", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("post history"), nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
-
-	m := NewTerminalModel()
-	m.width = 20
-	m.height = 5
-	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
-
+	m, ws := newSidebarTestModel()
 	msg := m.attachToSession(ws, TerminalTabID("term-tab-race"), "session-race", true, "reattach")()
 	reattach, ok := msg.(SidebarTerminalReattachResult)
 	if !ok {
 		t.Fatalf("expected SidebarTerminalReattachResult, got %T", msg)
 	}
-	if reattach.CaptureFullPane {
-		t.Fatal("expected recreated session to discard the pre-attach snapshot")
-	}
-	if got := string(reattach.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
-	}
-	if len(reattach.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation capture after demoting to history-only restore, got %q", string(reattach.PostAttachScrollbackCapture))
-	}
-	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
-		t.Fatalf("expected history-only capture size 123x45, got %dx%d", reattach.CaptureCols, reattach.CaptureRows)
-	}
-	if reattach.SnapshotCols != 0 || reattach.SnapshotRows != 0 {
-		t.Fatalf("expected stale snapshot metadata to be cleared, got %dx%d", reattach.SnapshotCols, reattach.SnapshotRows)
-	}
-	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSidebarSnapshotDemoted(t, sidebarRestore{
+		captureFullPane: reattach.CaptureFullPane,
+		scrollback:      reattach.ScrollbackCapture,
+		postAttach:      reattach.PostAttachScrollbackCapture,
+		captureCols:     reattach.CaptureCols,
+		captureRows:     reattach.CaptureRows,
+		snapshotCols:    reattach.SnapshotCols,
+		snapshotRows:    reattach.SnapshotRows,
+		checkSizes:      true,
+	}, calls)
 }
 
 func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionBecomesActive(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+	var calls []string
+	// The pane produced output after the snapshot was taken, so the snapshot no
+	// longer describes the current screen.
+	active := eligibleAttachProbe()
+	active.ClientCount = 1
+	active.LatestActivity = time.Now().Add(time.Hour).Unix()
+	installSidebarDemotionSeams(t, &calls, active)
 
-	calls := make([]string, 0, 12)
-	ensureTmuxAvailableFn = func() error { return nil }
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	activityCalls := 0
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		activityCalls++
-		return activityCalls >= 3, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 111, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%same", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("post history"), nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
-
-	m := NewTerminalModel()
-	m.width = 20
-	m.height = 5
-	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
-
+	m, ws := newSidebarTestModel()
 	msg := m.attachToSession(ws, TerminalTabID("term-tab-active-race"), "session-race", true, "reattach")()
 	reattach, ok := msg.(SidebarTerminalReattachResult)
 	if !ok {
 		t.Fatalf("expected SidebarTerminalReattachResult, got %T", msg)
 	}
-	if reattach.CaptureFullPane {
-		t.Fatal("expected activity after snapshot capture to demote sidebar restore back to history-only")
-	}
-	if got := string(reattach.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after stale snapshot demotion, got %q", got)
-	}
-	if len(reattach.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation delta after stale snapshot demotion, got %q", string(reattach.PostAttachScrollbackCapture))
-	}
-	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSidebarSnapshotDemoted(t, sidebarRestore{
+		captureFullPane: reattach.CaptureFullPane,
+		scrollback:      reattach.ScrollbackCapture,
+		postAttach:      reattach.PostAttachScrollbackCapture,
+	}, calls)
 }
 
 func TestAttachToSession_DiscardsPreAttachSnapshotWhenSessionBecomesShared(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+	var calls []string
+	// Two clients: one is the client amux just attached, the other is something
+	// else driving the session, so the snapshot cannot be trusted.
+	shared := eligibleAttachProbe()
+	shared.ClientCount = 2
+	installSidebarDemotionSeams(t, &calls, shared)
 
-	calls := make([]string, 0, 12)
-	ensureTmuxAvailableFn = func() error { return nil }
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 2, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 111, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%same", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("stale frame"), Cols: 77, Rows: 19}, nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("post history"), nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
-
-	m := NewTerminalModel()
-	m.width = 20
-	m.height = 5
-	ws := data.NewWorkspace("ws", "main", "main", "/repo/ws", "/repo/ws")
-
+	m, ws := newSidebarTestModel()
 	msg := m.attachToSession(ws, TerminalTabID("term-tab-shared-race"), "session-race", true, "reattach")()
 	reattach, ok := msg.(SidebarTerminalReattachResult)
 	if !ok {
 		t.Fatalf("expected SidebarTerminalReattachResult, got %T", msg)
 	}
-	if reattach.CaptureFullPane {
-		t.Fatal("expected shared sidebar session after snapshot capture to demote back to history-only")
-	}
-	if got := string(reattach.ScrollbackCapture); got != "post history" {
-		t.Fatalf("expected post-attach history recapture after shared-session demotion, got %q", got)
-	}
-	if len(reattach.PostAttachScrollbackCapture) != 0 {
-		t.Fatalf("expected no reconciliation delta after shared-session demotion, got %q", string(reattach.PostAttachScrollbackCapture))
-	}
-	assertSidebarCallOrder(t, calls, "state", "clients", "activity", "info", "resize", "snapshot", "attach", "size", "scrollback")
+	assertSidebarSnapshotDemoted(t, sidebarRestore{
+		captureFullPane: reattach.CaptureFullPane,
+		scrollback:      reattach.ScrollbackCapture,
+		postAttach:      reattach.PostAttachScrollbackCapture,
+	}, calls)
 }

--- a/internal/ui/sidebar/terminal_pty_attach_snapshot_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_snapshot_test.go
@@ -3,103 +3,137 @@ package sidebar
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 )
 
-func TestCreateTerminalTab_CapturesReusedSessionBeforeAttachAfterResize(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionLatestActivityFn := sessionLatestActivityFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionLatestActivityFn = oldSessionLatestActivityFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+// installSidebarSnapshotSeams wires an eligible session: the pre-attach resize
+// and full-pane capture both succeed, and the post-attach probe reports the
+// single attaching client so the snapshot survives validation. Resize and attach
+// calls record their dimensions so a test can pin what size each ran at.
+func installSidebarSnapshotSeams(t *testing.T, calls *[]string, snapshotData string) {
+	t.Helper()
+	restoreAttachSeams(t)
 
-	calls := make([]string, 0, 4)
-	ensureTmuxAvailableFn = func() error {
-		return nil
+	attached := eligibleAttachProbe()
+	attached.ClientCount = 1
+	// The pane ends up at the size the bootstrap resized it to, which is what the
+	// snapshot metadata must report.
+	sized := func(p tmux.SessionProbe) tmux.SessionProbe {
+		p.PaneCols, p.PaneRows = 77, 19
+		p.PaneMeta.Cols, p.PaneMeta.Rows = 77, 19
+		return p
 	}
+
+	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionLatestActivityFn = func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-		return time.Time{}, false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 77, 19, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, fmt.Sprintf("resize:%dx%d", cols, rows))
+	probeSeq(calls,
+		eligibleAttachProbe(),
+		sized(eligibleAttachProbe()),
+		sized(eligibleAttachProbe()),
+		sized(attached),
+	)
+	resizePaneToSizeFn = func(_ string, cols, rows int, _ tmux.Options) error {
+		*calls = append(*calls, fmt.Sprintf("resize:%dx%d", cols, rows))
 		return nil
 	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, fmt.Sprintf("attach:%dx%d", cols, rows))
-		return &pty.Terminal{}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte(snapshotData), nil
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("resized frame"), Cols: 77, Rows: 19}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("fallback"), nil
 	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("fallback"), nil
+	}
+	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
+		*calls = append(*calls, fmt.Sprintf("attach:%dx%d", cols, rows))
+		return &pty.Terminal{}, nil
+	}
 	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
+		*calls = append(*calls, "verify")
 		return nil
 	}
+}
+
+// assertSidebarSnapshotOrder pins the ordering the pre-attach snapshot depends
+// on: probe, then resize to the client's size, then snapshot, then attach, then
+// exactly one reconciliation history capture.
+func assertSidebarSnapshotOrder(t *testing.T, calls []string, termWidth, termHeight int) {
+	t.Helper()
+	expectedAttach := fmt.Sprintf("attach:%dx%d", termWidth, termHeight)
+	expectedResize := fmt.Sprintf("resize:%dx%d", termWidth, termHeight)
+
+	probeIdx, resizeIdx, snapshotIdx, attachIdx := -1, -1, -1, -1
+	scrollbackIdx, verifyIdx := -1, -1
+	snapshotCount, scrollbackCount := 0, 0
+	for i, call := range calls {
+		switch call {
+		case "probe":
+			if probeIdx == -1 {
+				probeIdx = i
+			}
+		case expectedResize:
+			if resizeIdx == -1 {
+				resizeIdx = i
+			}
+		case "snapshot":
+			snapshotCount++
+			if snapshotIdx == -1 {
+				snapshotIdx = i
+			}
+		case expectedAttach:
+			attachIdx = i
+		case "scrollback":
+			scrollbackCount++
+			if scrollbackIdx == -1 {
+				scrollbackIdx = i
+			}
+		case "verify":
+			verifyIdx = i
+		}
+	}
+
+	if probeIdx == -1 {
+		t.Fatalf("expected a bootstrap probe before the resize, got %v", calls)
+	}
+	if resizeIdx == -1 {
+		t.Fatalf("expected resize call %q, got %v", expectedResize, calls)
+	}
+	if attachIdx == -1 {
+		t.Fatalf("expected attach call %q, got %v", expectedAttach, calls)
+	}
+	if snapshotCount != 1 {
+		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
+	}
+	if probeIdx > resizeIdx || resizeIdx > snapshotIdx {
+		t.Fatalf("expected probe before resize and snapshot after resize, got call order %v", calls)
+	}
+	if snapshotIdx > attachIdx {
+		t.Fatalf("expected the snapshot before the live attach, got call order %v", calls)
+	}
+	if scrollbackCount != 1 {
+		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
+	}
+	if scrollbackIdx < attachIdx {
+		t.Fatalf("expected reconciliation history capture after attach, got %v", calls)
+	}
+	if verifyIdx != -1 && scrollbackIdx > verifyIdx {
+		t.Fatalf("expected history reconciliation before session tag verification, got %v", calls)
+	}
+}
+
+func TestCreateTerminalTab_CapturesReusedSessionBeforeAttachAfterResize(t *testing.T) {
+	var calls []string
+	installSidebarSnapshotSeams(t, &calls, "resized frame")
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -124,178 +158,12 @@ func TestCreateTerminalTab_CapturesReusedSessionBeforeAttachAfterResize(t *testi
 	if created.SnapshotCols != 77 || created.SnapshotRows != 19 {
 		t.Fatalf("expected actual snapshot size 77x19, got %dx%d", created.SnapshotCols, created.SnapshotRows)
 	}
-
-	expectedAttach := fmt.Sprintf("attach:%dx%d", termWidth, termHeight)
-	expectedResize := fmt.Sprintf("resize:%dx%d", termWidth, termHeight)
-	clientsIdx := -1
-	activityIdx := -1
-	attachIdx := -1
-	resizeIdx := -1
-	for i, call := range calls {
-		if call == "clients" {
-			clientsIdx = i
-		}
-		if call == "activity" {
-			activityIdx = i
-		}
-		if call == expectedResize {
-			resizeIdx = i
-		}
-		if call == expectedAttach {
-			attachIdx = i
-		}
-	}
-	if attachIdx == -1 {
-		t.Fatalf("expected attach call %q, got %v", expectedAttach, calls)
-	}
-	if clientsIdx == -1 || activityIdx == -1 {
-		t.Fatalf("expected safety checks before snapshot, got %v", calls)
-	}
-	if resizeIdx == -1 {
-		t.Fatalf("expected resize call %q, got %v", expectedResize, calls)
-	}
-	snapshotCount := 0
-	infoIdx := -1
-	snapshotIdx := -1
-	for i, call := range calls {
-		if call == "info" {
-			infoIdx = i
-		}
-		if call != "snapshot" {
-			continue
-		}
-		snapshotCount++
-		if snapshotIdx == -1 {
-			snapshotIdx = i
-		}
-	}
-	if infoIdx == -1 {
-		t.Fatalf("expected bootstrap pane metadata lookup, got %v", calls)
-	}
-	if snapshotCount != 1 {
-		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
-	}
-	if infoIdx > resizeIdx || resizeIdx > snapshotIdx {
-		t.Fatalf("expected metadata lookup before resize and final snapshot after resize, got call order %v", calls)
-	}
-	if snapshotIdx > attachIdx {
-		t.Fatalf("expected reused-session snapshot before attach, got call order %v", calls)
-	}
-	scrollbackIdx := -1
-	scrollbackCount := 0
-	verifyIdx := -1
-	for i, call := range calls {
-		if call == "scrollback" {
-			scrollbackCount++
-			if scrollbackIdx == -1 {
-				scrollbackIdx = i
-			}
-		}
-		if call == "verify" {
-			verifyIdx = i
-		}
-	}
-	if scrollbackCount != 1 {
-		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected reconciliation history capture after attach, got %v", calls)
-	}
-	if verifyIdx != -1 && scrollbackIdx > verifyIdx {
-		t.Fatalf("expected history reconciliation before session tag verification, got %v", calls)
-	}
+	assertSidebarSnapshotOrder(t, calls, termWidth, termHeight)
 }
 
 func TestAttachToSession_CapturesReattachSnapshotBeforeAttach(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionClientCountFn := sessionClientCountFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionLatestActivityFn := sessionLatestActivityFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionClientCountFn = oldSessionClientCountFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionLatestActivityFn = oldSessionLatestActivityFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
-
-	calls := make([]string, 0, 4)
-	ensureTmuxAvailableFn = func() error {
-		return nil
-	}
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionClientCountFn = func(sessionName string, opts tmux.Options) (int, error) {
-		return 1, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionLatestActivityFn = func(sessionName string, opts tmux.Options) (time.Time, bool, error) {
-		return time.Time{}, false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 77, 19, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, fmt.Sprintf("resize:%dx%d", cols, rows))
-		return nil
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("pre-attach frame"), Cols: 77, Rows: 19}, nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, fmt.Sprintf("attach:%dx%d", cols, rows))
-		return &pty.Terminal{}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("fallback"), nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
+	var calls []string
+	installSidebarSnapshotSeams(t, &calls, "pre-attach frame")
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -320,84 +188,5 @@ func TestAttachToSession_CapturesReattachSnapshotBeforeAttach(t *testing.T) {
 	if reattach.SnapshotCols != 77 || reattach.SnapshotRows != 19 {
 		t.Fatalf("expected actual snapshot size 77x19, got %dx%d", reattach.SnapshotCols, reattach.SnapshotRows)
 	}
-
-	expectedAttach := fmt.Sprintf("attach:%dx%d", termWidth, termHeight)
-	expectedResize := fmt.Sprintf("resize:%dx%d", termWidth, termHeight)
-	clientsIdx := -1
-	activityIdx := -1
-	attachIdx := -1
-	resizeIdx := -1
-	for i, call := range calls {
-		if call == "clients" {
-			clientsIdx = i
-		}
-		if call == "activity" {
-			activityIdx = i
-		}
-		if call == expectedAttach {
-			attachIdx = i
-		}
-		if call == expectedResize {
-			resizeIdx = i
-		}
-	}
-	if resizeIdx == -1 {
-		t.Fatalf("expected reattach resize call %q, got %v", expectedResize, calls)
-	}
-	if clientsIdx == -1 || activityIdx == -1 {
-		t.Fatalf("expected safety checks before pre-attach snapshot, got %v", calls)
-	}
-	if attachIdx == -1 {
-		t.Fatalf("expected attach call %q, got %v", expectedAttach, calls)
-	}
-	snapshotCount := 0
-	infoIdx := -1
-	snapshotIdx := -1
-	for i, call := range calls {
-		if call == "info" {
-			infoIdx = i
-		}
-		if call != "snapshot" {
-			continue
-		}
-		snapshotCount++
-		if snapshotIdx == -1 {
-			snapshotIdx = i
-		}
-	}
-	if infoIdx == -1 {
-		t.Fatalf("expected bootstrap pane metadata lookup, got %v", calls)
-	}
-	if snapshotCount != 1 {
-		t.Fatalf("expected a single resized snapshot capture, got %v", calls)
-	}
-	if infoIdx > resizeIdx || resizeIdx > snapshotIdx {
-		t.Fatalf("expected metadata lookup before resize and final snapshot after resize, got call order %v", calls)
-	}
-	if snapshotIdx > attachIdx {
-		t.Fatalf("expected reattach snapshot before live attach, got call order %v", calls)
-	}
-	scrollbackIdx := -1
-	scrollbackCount := 0
-	verifyIdx := -1
-	for i, call := range calls {
-		if call == "scrollback" {
-			scrollbackCount++
-			if scrollbackIdx == -1 {
-				scrollbackIdx = i
-			}
-		}
-		if call == "verify" {
-			verifyIdx = i
-		}
-	}
-	if scrollbackCount != 1 {
-		t.Fatalf("expected a single post-attach delta capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected reconciliation history capture after attach, got %v", calls)
-	}
-	if verifyIdx != -1 && scrollbackIdx > verifyIdx {
-		t.Fatalf("expected history reconciliation before session tag verification, got %v", calls)
-	}
+	assertSidebarSnapshotOrder(t, calls, termWidth, termHeight)
 }

--- a/internal/ui/sidebar/terminal_pty_attach_test.go
+++ b/internal/ui/sidebar/terminal_pty_attach_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/andyrewlee/amux/internal/data"
 	"github.com/andyrewlee/amux/internal/pty"
@@ -61,86 +60,75 @@ func TestAttachToSessionRejectsInvalidShell(t *testing.T) {
 	}
 }
 
-func TestCreateTerminalTab_FallsBackToHistoryWhenPreAttachResizeFails(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
+// installResizeFailureSeams wires an otherwise-eligible session whose pre-attach
+// resize fails. The bootstrap must abandon the snapshot at that point: it never
+// got the pane to the client's size, so a capture would describe the wrong
+// geometry.
+func installResizeFailureSeams(t *testing.T, calls *[]string) {
+	t.Helper()
+	restoreAttachSeams(t)
 
-	calls := make([]string, 0, 5)
-	ensureTmuxAvailableFn = func() error {
-		return nil
-	}
+	ensureTmuxAvailableFn = func() error { return nil }
 	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
+		*calls = append(*calls, "state")
 		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
 	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
+	probeSeq(calls, eligibleAttachProbe())
+	resizePaneToSizeFn = func(string, int, int, tmux.Options) error {
+		*calls = append(*calls, "resize")
 		return errors.New("resize failed")
 	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
+	capturePaneFullDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "snapshot")
+		return []byte("should not use"), nil
 	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
+	capturePaneHistoryDataFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
+		return []byte("history only"), nil
+	}
+	capturePaneFn = func(string, tmux.Options) ([]byte, error) {
+		*calls = append(*calls, "scrollback")
 		return []byte("history only"), nil
 	}
 	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
+		*calls = append(*calls, "attach")
 		return &pty.Terminal{}, nil
 	}
 	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
+		*calls = append(*calls, "verify")
 		return nil
 	}
+}
+
+// assertResizeFailureFallback asserts the history fallback ran after the attach
+// and that no full-pane capture was attempted.
+func assertResizeFailureFallback(t *testing.T, calls []string) {
+	t.Helper()
+	attachIdx, scrollbackIdx, snapshotCount := -1, -1, 0
+	for i, call := range calls {
+		switch call {
+		case "attach":
+			attachIdx = i
+		case "scrollback":
+			scrollbackIdx = i
+		case "snapshot":
+			snapshotCount++
+		}
+	}
+	if attachIdx == -1 || scrollbackIdx == -1 {
+		t.Fatalf("expected attach and post-attach scrollback capture, got %v", calls)
+	}
+	if scrollbackIdx < attachIdx {
+		t.Fatalf("expected fallback scrollback capture after attach, got call order %v", calls)
+	}
+	if snapshotCount != 0 {
+		t.Fatalf("expected resize failure to prevent any full snapshot capture, got %v", calls)
+	}
+}
+
+func TestCreateTerminalTab_FallsBackToHistoryWhenPreAttachResizeFails(t *testing.T) {
+	var calls []string
+	installResizeFailureSeams(t, &calls)
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -161,113 +149,12 @@ func TestCreateTerminalTab_FallsBackToHistoryWhenPreAttachResizeFails(t *testing
 	if created.CaptureCols != 123 || created.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", created.CaptureCols, created.CaptureRows)
 	}
-	attachIdx := -1
-	scrollbackIdx := -1
-	for i, call := range calls {
-		if call == "attach" {
-			attachIdx = i
-		}
-		if call == "scrollback" {
-			scrollbackIdx = i
-		}
-	}
-	if attachIdx == -1 || scrollbackIdx == -1 {
-		t.Fatalf("expected attach and post-attach scrollback capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected fallback scrollback capture after attach, got call order %v", calls)
-	}
-	snapshotCount := 0
-	for _, call := range calls {
-		if call == "snapshot" {
-			snapshotCount++
-		}
-	}
-	if snapshotCount != 0 {
-		t.Fatalf("expected resize failure to prevent any full snapshot capture, got %v", calls)
-	}
+	assertResizeFailureFallback(t, calls)
 }
 
 func TestAttachToSession_FallsBackToHistoryWhenPreAttachResizeFails(t *testing.T) {
-	oldEnsureTmuxAvailableFn := ensureTmuxAvailableFn
-	oldSessionStateForFn := sessionStateForFn
-	oldSessionHasClientsFn := sessionHasClientsFn
-	oldSessionActiveWithinFn := sessionActiveWithinFn
-	oldSessionCreatedAtFn := sessionCreatedAtFn
-	oldSessionPaneIDFn := sessionPaneIDFn
-	oldSessionPaneSnapshotInfoFn := sessionPaneSnapshotInfoFn
-	oldSessionPaneSizeFn := sessionPaneSizeFn
-	oldNewPTYWithSizeFn := newPTYWithSizeFn
-	oldResizePaneToSizeFn := resizePaneToSizeFn
-	oldCapturePaneSnapshotFn := capturePaneSnapshotFn
-	oldCapturePaneFn := capturePaneFn
-	oldVerifyTerminalSessionTagsFn := verifyTerminalSessionTagsFn
-	defer func() {
-		ensureTmuxAvailableFn = oldEnsureTmuxAvailableFn
-		sessionStateForFn = oldSessionStateForFn
-		sessionHasClientsFn = oldSessionHasClientsFn
-		sessionActiveWithinFn = oldSessionActiveWithinFn
-		sessionCreatedAtFn = oldSessionCreatedAtFn
-		sessionPaneIDFn = oldSessionPaneIDFn
-		sessionPaneSnapshotInfoFn = oldSessionPaneSnapshotInfoFn
-		sessionPaneSizeFn = oldSessionPaneSizeFn
-		newPTYWithSizeFn = oldNewPTYWithSizeFn
-		resizePaneToSizeFn = oldResizePaneToSizeFn
-		capturePaneSnapshotFn = oldCapturePaneSnapshotFn
-		capturePaneFn = oldCapturePaneFn
-		verifyTerminalSessionTagsFn = oldVerifyTerminalSessionTagsFn
-	}()
-
-	calls := make([]string, 0, 5)
-	ensureTmuxAvailableFn = func() error {
-		return nil
-	}
-	sessionStateForFn = func(sessionName string, opts tmux.Options) (tmux.SessionState, error) {
-		calls = append(calls, "state")
-		return tmux.SessionState{Exists: true, HasLivePane: true}, nil
-	}
-	sessionHasClientsFn = func(sessionName string, opts tmux.Options) (bool, error) {
-		calls = append(calls, "clients")
-		return false, nil
-	}
-	sessionActiveWithinFn = func(sessionName string, window time.Duration, opts tmux.Options) (bool, error) {
-		calls = append(calls, "activity")
-		return false, nil
-	}
-	sessionCreatedAtFn = func(sessionName string, opts tmux.Options) (int64, error) {
-		return 123, nil
-	}
-	sessionPaneIDFn = func(sessionName string, opts tmux.Options) (string, error) {
-		return "%1", nil
-	}
-	sessionPaneSnapshotInfoFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "info")
-		return 91, 27, true, nil
-	}
-	sessionPaneSizeFn = func(sessionName string, opts tmux.Options) (int, int, bool, error) {
-		calls = append(calls, "size")
-		return 123, 45, true, nil
-	}
-	resizePaneToSizeFn = func(sessionName string, cols, rows int, opts tmux.Options) error {
-		calls = append(calls, "resize")
-		return errors.New("resize failed")
-	}
-	capturePaneSnapshotFn = func(sessionName string, opts tmux.Options) (tmux.PaneSnapshot, error) {
-		calls = append(calls, "snapshot")
-		return tmux.PaneSnapshot{Data: []byte("should not use")}, nil
-	}
-	capturePaneFn = func(sessionName string, opts tmux.Options) ([]byte, error) {
-		calls = append(calls, "scrollback")
-		return []byte("history only"), nil
-	}
-	newPTYWithSizeFn = func(command, dir string, env []string, rows, cols uint16) (*pty.Terminal, error) {
-		calls = append(calls, "attach")
-		return &pty.Terminal{}, nil
-	}
-	verifyTerminalSessionTagsFn = func(sessionName string, tags tmux.SessionTags, opts tmux.Options) error {
-		calls = append(calls, "verify")
-		return nil
-	}
+	var calls []string
+	installResizeFailureSeams(t, &calls)
 
 	m := NewTerminalModel()
 	m.width = 20
@@ -288,29 +175,5 @@ func TestAttachToSession_FallsBackToHistoryWhenPreAttachResizeFails(t *testing.T
 	if reattach.CaptureCols != 123 || reattach.CaptureRows != 45 {
 		t.Fatalf("expected history-only capture size 123x45, got %dx%d", reattach.CaptureCols, reattach.CaptureRows)
 	}
-	attachIdx := -1
-	scrollbackIdx := -1
-	for i, call := range calls {
-		if call == "attach" {
-			attachIdx = i
-		}
-		if call == "scrollback" {
-			scrollbackIdx = i
-		}
-	}
-	if attachIdx == -1 || scrollbackIdx == -1 {
-		t.Fatalf("expected attach and post-attach scrollback capture, got %v", calls)
-	}
-	if scrollbackIdx < attachIdx {
-		t.Fatalf("expected fallback scrollback capture after attach, got call order %v", calls)
-	}
-	snapshotCount := 0
-	for _, call := range calls {
-		if call == "snapshot" {
-			snapshotCount++
-		}
-	}
-	if snapshotCount != 0 {
-		t.Fatalf("expected resize failure to prevent any full snapshot capture, got %v", calls)
-	}
+	assertResizeFailureFallback(t, calls)
 }


### PR DESCRIPTION
## Why

Reattaching a detached tab could visibly hang for seconds — the tab sat on `DETACHED` and eventually came back.

The cause was round-trip count, not any single slow call. A reattach fired **~60 serialized tmux process spawns**, and amux talks to one shared, single-threaded tmux server that is also pumping pane output for every attached agent. Measured against a live server, one command costs ~13ms idle but **50–230ms under load**, so the same reattach ran anywhere from 0.8s to 13s. That variance is the "sometimes".

Where the 60 went:

| stage | tmux execs |
|---|---|
| `SessionStateFor` | 2 |
| bootstrap snapshot guards | ~28 |
| attach shell (`sh -c` string) | 20 |
| post-attach re-verify + capture | ~10 |

The guard ladder was the worst offender — it re-read the same handful of facts at every checkpoint (`SessionCreatedAt` ×5, `SessionPaneID` ×5, `SessionHasClients` ×4 per reattach), and several helpers paid a throwaway `has-session` before their real query.

## What changed

**`tmux.SessionProbe` — one round-trip replaces the ladder.** A single `list-panes -s -F …` returns every fact the guards need: creation stamp, client count, pane id, geometry, liveness, single-pane-ness, window activity, and the full VT mode metadata. The bootstrap is rewritten around probes taken at the three points that actually matter — eligibility, after the resize, after the capture.

This is also *more* correct than before: a probe is a single point-in-time view, so a guard can no longer straddle a change and reach a conclusion true of no single moment. The pre-resize gate is tighter too — the last clients/activity read is now one probe before the mutation instead of three tmux calls before it.

**Attach shell batched, 20 execs → 1**, chained via tmux's own `;` separator. tmux aborts a chain at the first failure, so a `||` fallback re-runs the options one at a time, preserving the per-option best-effort behavior the `2>/dev/null` suppression implies. The settings are braced so a failed `ensureSession` can't fall through into that fallback.

**Redundant `has-session` pre-checks dropped** from `SessionClientCount`, `SessionCreatedAt`, `sessionPaneID`, `ResizePaneToSize`, and `hasLivePane`. tmux exits 1 for a missing target, which `listTmux`/`runTmux` already map to the same answer.

**`REATTACHING` replaces `DETACHED`** while a reattach is in flight, so the remaining wait reads as progress rather than as a hang.

## Result

**~60 round-trips → ~6.** Measured against a live tmux server, the equivalent command sequence went **634ms → 75ms**.

Separately worth knowing: the default `AMUX_MAX_ATTACHED_AGENT_TABS=6` makes this path run constantly — logs showed the LRU evictor firing every few seconds, so every tab switch past 6 re-paid the full cost. Raising it reduces how often the cost is paid at all.

## Verification

- `make devcheck`, `make verify-loop`, full `go test ./...` — green
- **Cross-checked against the real thing**: `TestProbeSession_MatchesDedicatedHelpers` runs the probe *and* every original single-purpose helper against a live tmux server and asserts they agree, comparing the whole `PaneMeta` struct — so the round-trip savings can't silently change what the bootstrap sees.
- **Mutation-tested**: all 9 field-order transpositions in the 19-field probe format (cursor x/y, scroll-region upper/lower, alt-saved x/y, alternate_on/cursor_flag, session_created/window_activity, …) are caught by the suite. Several were not, before review — the live tests now deliberately drive the pane into alt-screen with distinct cursor/saved/scroll-region coordinates, and wait for `window_activity` to diverge from `session_created`, so no two compared fields hold the same value.
- Race/demotion tests rewritten against scripted probe sequences, preserving each original's intent (recreated session, activity after capture, second client, metadata drift, rollback on attach failure).
- Coverage: `internal/tmux` 86.9%, `internal/ui/ptyio` 85.3%.

## Review findings folded in

Two review passes ran over this; both findings are fixed with regression tests:

1. **`chooseProbePane` reached past the active window.** `ProbeSession` reads `list-panes -s` (all windows) but the `sessionPaneID` it mirrors reads `list-panes -t <session>`, which tmux scopes to the **active window only**. Since `ResizePaneToSize` also resolves to the active window, a dead active window plus a live pane elsewhere meant the resize landed on one window while the snapshot described another — at the wrong dimensions, and the guards couldn't catch it because the described pane never changes. Reproduced on tmux 3.6a (resize hit `@1` at 100x30 while the probe picked a pane in `@0` at 80x24). Pane choice and `HasLivePane` are now both scoped to the active window.

2. **Field-order mutations passed silently** (see above), and the two new capture helpers had 0% coverage — `CapturePane` now delegates to `CapturePaneHistoryData` so the shared flags can't drift, with a live test pinning history-vs-full behavior.

Also documented in code: the one activity sample before the resize is an accepted tradeoff — activity can't be rechecked afterwards because the resize itself bumps `window_activity`, and the consequence is bounded (the post-attach validation discards the snapshot; what survives is a brief resize of a pane that just woke up, which tmux re-lays-out on attach anyway).

## Note on `make perf-check`

It reports 2 presets over threshold on my machine, and **I could not clear it**. Stashing this change and re-running as a control measured *worse* on all three presets (CENTER 3.00ms vs 1.36ms with the change; SIDEBAR 11.23ms vs 1.72ms) — load average was ~43. SIDEBAR and MONITOR don't touch any code this PR changes. It reads as machine noise, but it is unverified on a quiet host and worth a re-run.

One `internal/e2e` workspace test failed once during a heavily-parallel full-suite run; 3/3 clean in isolation on this branch and 3/3 clean on unmodified `main`, so it's the known load-related flake, not this change.