### PR TITLE
fix: stop a lost reattach outcome from pinning a tab in REATTACHING

### DIFF
--- a/internal/app/app_input_pty.go
+++ b/internal/app/app_input_pty.go
@@ -121,11 +121,20 @@ func (a *App) handlePTYWatchdogTick() []tea.Cmd {
 		if cmd := a.center.StartPTYReaders(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		// A tab whose reattach outcome never arrived holds its reattach lock
+		// forever and refuses every retry, so the same tick that keeps readers
+		// alive also frees tabs stuck mid-reattach.
+		if cmd := a.center.SweepStalledReattaches(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 	if a.sidebarTerminal != nil {
 		if cmd := a.sidebarTerminal.StartPTYReaders(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		// Same hazard as the center pane: a terminal holding a stale reattach
+		// lock is refused by the attach gate forever.
+		a.sidebarTerminal.SweepStalledReattaches()
 	}
 	// Keep dashboard "working" state accurate even when agents go idle.
 	a.syncActiveWorkspacesToDashboard()

--- a/internal/ui/center/model_input_lifecycle.go
+++ b/internal/ui/center/model_input_lifecycle.go
@@ -75,17 +75,40 @@ func (m *Model) sessionRestoreLiveSize(captureFullPane bool, captureCols, captur
 
 // updatePtyTabReattachResult handles ptyTabReattachResult.
 func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, tea.Cmd) {
-	tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
+	tab, wsID := m.resolveTabForResult(msg.WorkspaceID, msg.TabID, "reattach result")
 	if tab == nil {
 		// The tab was closed (or its workspace deleted) while the reattach was
 		// in flight: release the freshly created agent/PTY so it does not leak.
+		// Logged because this also silently discards a successful attach, which
+		// is indistinguishable from a hang if it ever happens to a live tab.
+		logging.Info("Discarding reattach result for unknown tab %s (workspace %s)", msg.TabID, msg.WorkspaceID)
+		if msg.Agent != nil {
+			_ = m.agentManager.CloseAgent(msg.Agent)
+		}
+		return m, nil
+	}
+	if superseded, _ := m.reattachSuperseded(tab, msg.Epoch); superseded {
+		// A newer reattach has started since this one was dispatched — possible
+		// once the stall sweep releases a lock. Applying this result would
+		// overwrite the newer attempt's agent with a stale one and leak the tmux
+		// client it replaced, so drop it and release what it created.
+		logging.Warn("Dropping superseded reattach result for tab %s (epoch %d)", msg.TabID, msg.Epoch)
 		if msg.Agent != nil {
 			_ = m.agentManager.CloseAgent(msg.Agent)
 		}
 		return m, nil
 	}
 	if msg.Agent == nil {
-		return m, nil
+		// A result with no agent cannot attach anything, but the reattach lock
+		// is still held: release it so the tab reads as detached and the user
+		// can retry instead of being stuck in REATTACHING forever.
+		tab.mu.Lock()
+		tab.markReattachFailedLocked(false)
+		tab.mu.Unlock()
+		logging.Warn("Reattach for tab %s returned no agent; releasing reattach lock", msg.TabID)
+		return m, func() tea.Msg {
+			return messages.TabStateChanged{WorkspaceID: wsID, TabID: string(msg.TabID)}
+		}
 	}
 	// Reject a result for a tab that was explicitly detached while this reattach
 	// was in flight: detachTab clears reattachInFlight and sets Detached, so a
@@ -140,7 +163,7 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 
 	if tab.Terminal != nil && msg.Agent.Terminal != nil {
 		agentTerm := msg.Agent.Terminal
-		workspaceID := msg.WorkspaceID
+		workspaceID := wsID
 		tabID := tab.ID
 		tab.Terminal.SetResponseWriter(func(data []byte) {
 			if len(data) == 0 || agentTerm == nil {
@@ -157,16 +180,21 @@ func (m *Model) updatePtyTabReattachResult(msg ptyTabReattachResult) (*Model, te
 
 	m.resizePTY(tab, rows, cols)
 
-	cmd := m.startPTYReader(msg.WorkspaceID, tab)
+	cmd := m.startPTYReader(wsID, tab)
 	return m, common.SafeBatch(cmd, func() tea.Msg {
-		return messages.TabReattached{WorkspaceID: msg.WorkspaceID, TabID: string(msg.TabID)}
+		return messages.TabReattached{WorkspaceID: wsID, TabID: string(msg.TabID)}
 	})
 }
 
 // updatePtyTabReattachFailed handles ptyTabReattachFailed.
 func (m *Model) updatePtyTabReattachFailed(msg ptyTabReattachFailed) (*Model, tea.Cmd) {
-	tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
+	tab, wsID := m.resolveTabForResult(msg.WorkspaceID, msg.TabID, "reattach failure")
 	if tab == nil {
+		return m, nil
+	}
+	if superseded, _ := m.reattachSuperseded(tab, msg.Epoch); superseded {
+		// A newer attempt owns the tab now; this one's failure says nothing
+		// about it and must not release its lock or toast over it.
 		return m, nil
 	}
 	tab.mu.Lock()
@@ -186,13 +214,90 @@ func (m *Model) updatePtyTabReattachFailed(msg ptyTabReattachFailed) (*Model, te
 		label = "Reattach"
 	}
 	return m, common.SafeBatch(func() tea.Msg {
-		return messages.TabStateChanged{WorkspaceID: msg.WorkspaceID, TabID: string(msg.TabID)}
+		return messages.TabStateChanged{WorkspaceID: wsID, TabID: string(msg.TabID)}
 	}, func() tea.Msg {
 		return messages.Toast{
 			Message: fmt.Sprintf("%s failed: %v", label, msg.Err),
 			Level:   messages.ToastWarning,
 		}
 	})
+}
+
+// reattachSuperseded reports whether a reattach outcome belongs to an attempt
+// that a newer one has already replaced, along with the tab's current epoch.
+//
+// Epoch 0 means the outcome predates epoch tracking (or came from a tab that
+// never took the lock through beginReattachLocked); such an outcome is applied
+// as before rather than dropped, so the guard can only ever reject a message it
+// can positively identify as stale.
+func (m *Model) reattachSuperseded(tab *Tab, epoch uint64) (bool, uint64) {
+	tab.mu.Lock()
+	current := tab.reattachEpochLocked()
+	tab.mu.Unlock()
+	if epoch == 0 {
+		return false, current
+	}
+	return epoch != current, current
+}
+
+// SweepStalledReattaches releases reattach locks whose outcome never arrived.
+//
+// The reattach lock is normally released by ptyTabReattachResult or
+// ptyTabReattachFailed. If such a message is dropped, misrouted, or never
+// produced, the tab is pinned in the reattaching state forever: the badge never
+// changes and every retry — keypress or automatic — no-ops behind the lock it
+// is waiting on. This sweep is the backstop for all of those causes at once,
+// including ones added later, which is why it is a periodic scan of state
+// rather than a timer armed by each reattach path.
+//
+// It is not a cancellation: the reattach goroutine is untouched and a late
+// outcome still applies normally. All the sweep does is stop the tab from
+// claiming to be reattaching, so the user can act on it.
+func (m *Model) SweepStalledReattaches() tea.Cmd {
+	now := time.Now()
+	var cmds []tea.Cmd
+	var stalled int
+	for wsID, tabs := range m.tabs.ByWorkspace {
+		for _, tab := range tabs {
+			if tab == nil || tab.isClosed() {
+				continue
+			}
+			tab.mu.Lock()
+			// A running tab holds no meaningful lock even if the flag lingers,
+			// and a zero stamp means the flag was set outside beginReattachLocked
+			// — stamp it now rather than releasing something never timed.
+			stuck := false
+			switch {
+			case !tab.reattachInFlight || tab.Running:
+			case tab.reattachStartedAt.IsZero():
+				tab.reattachStartedAt = now
+			case now.Sub(tab.reattachStartedAt) > ptyio.ReattachStallTimeout:
+				tab.markReattachFailedLocked(false)
+				stuck = true
+			}
+			tabID := tab.ID
+			tab.mu.Unlock()
+			if !stuck {
+				continue
+			}
+			stalled++
+			logging.Warn("Reattach for tab %s produced no outcome within %s; releasing reattach lock", tabID, ptyio.ReattachStallTimeout)
+			cmds = append(cmds, func() tea.Msg {
+				return messages.TabStateChanged{WorkspaceID: wsID, TabID: string(tabID)}
+			})
+		}
+	}
+	if stalled == 0 {
+		return nil
+	}
+	cmds = append(cmds, func() tea.Msg {
+		return messages.Toast{
+			// Same spelling the help bar uses for this binding.
+			Message: "Reattach timed out; press C-Spc t r to retry",
+			Level:   messages.ToastWarning,
+		}
+	})
+	return common.SafeBatch(cmds...)
 }
 
 // updateTabSessionStatus handles messages.TabSessionStatus.

--- a/internal/ui/center/model_reattach_stall_test.go
+++ b/internal/ui/center/model_reattach_stall_test.go
@@ -1,0 +1,282 @@
+package center
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	appPty "github.com/andyrewlee/amux/internal/pty"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+)
+
+// drainMsgs runs a command and flattens any batch it produces into messages.
+func drainMsgs(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{msg}
+	}
+	out := make([]tea.Msg, 0, len(batch))
+	for _, c := range batch {
+		out = append(out, drainMsgs(t, c)...)
+	}
+	return out
+}
+
+func inFlightTab(id TabID, sessionName string) *Tab {
+	return &Tab{
+		ID:               id,
+		Assistant:        "claude",
+		SessionName:      sessionName,
+		Running:          false,
+		Detached:         true,
+		reattachInFlight: true,
+	}
+}
+
+// A reattach outcome stamped with a workspace ID the tab is no longer filed
+// under must still reach the tab. Routing it by workspace alone used to drop
+// the result, leaving the tab pinned in the reattaching state permanently.
+func TestReattachFailedResolvesTabAcrossWorkspaceDrift(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := inFlightTab(TabID("tab-drift"), "sess-drift")
+	tab.Workspace = ws
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	_, cmd := m.updatePtyTabReattachFailed(ptyTabReattachFailed{
+		WorkspaceID: "some-other-workspace-id",
+		TabID:       tab.ID,
+		Err:         errors.New("boom"),
+		Action:      "reattach",
+	})
+
+	tab.mu.Lock()
+	inFlight := tab.reattachInFlight
+	tab.mu.Unlock()
+	if inFlight {
+		t.Fatalf("expected the reattach lock to be released despite the workspace mismatch")
+	}
+
+	var sawStateChange bool
+	for _, msg := range drainMsgs(t, cmd) {
+		if changed, ok := msg.(messages.TabStateChanged); ok {
+			sawStateChange = true
+			// Follow-ups must carry the key the tab is actually filed under,
+			// not the stale one the result arrived with.
+			if changed.WorkspaceID != string(ws.ID()) {
+				t.Fatalf("state change carried workspace %q, want %q", changed.WorkspaceID, string(ws.ID()))
+			}
+		}
+	}
+	if !sawStateChange {
+		t.Fatal("expected a TabStateChanged follow-up")
+	}
+}
+
+// A success message that carries no agent cannot attach anything; it must still
+// release the lock so the tab reads as detached and can be retried.
+func TestReattachResultWithoutAgentReleasesLock(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := inFlightTab(TabID("tab-noagent"), "sess-noagent")
+	tab.Workspace = ws
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	m.updatePtyTabReattachResult(ptyTabReattachResult{
+		WorkspaceID: string(ws.ID()),
+		TabID:       tab.ID,
+	})
+
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if tab.reattachInFlight {
+		t.Fatal("expected the reattach lock to be released when the result carries no agent")
+	}
+	if !tab.Detached {
+		t.Fatal("expected the tab to read as detached so the user can retry")
+	}
+}
+
+func TestSweepStalledReattachesReleasesOnlyStaleLocks(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	stalled := inFlightTab(TabID("tab-stalled"), "sess-stalled")
+	stalled.reattachStartedAt = time.Now().Add(-2 * ptyio.ReattachStallTimeout)
+
+	fresh := inFlightTab(TabID("tab-fresh"), "sess-fresh")
+	fresh.reattachStartedAt = time.Now()
+
+	// Running tabs hold no meaningful lock even if the flag lingers.
+	running := inFlightTab(TabID("tab-running"), "sess-running")
+	running.reattachStartedAt = time.Now().Add(-2 * ptyio.ReattachStallTimeout)
+	running.Running = true
+	running.Detached = false
+
+	for _, tab := range []*Tab{stalled, fresh, running} {
+		tab.Workspace = ws
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{stalled, fresh, running}
+
+	cmd := m.SweepStalledReattaches()
+	if cmd == nil {
+		t.Fatal("expected the sweep to report the stalled tab")
+	}
+
+	stalled.mu.Lock()
+	stalledInFlight := stalled.reattachInFlight
+	stalled.mu.Unlock()
+	if stalledInFlight {
+		t.Fatal("expected the stalled reattach lock to be released")
+	}
+
+	fresh.mu.Lock()
+	freshInFlight := fresh.reattachInFlight
+	fresh.mu.Unlock()
+	if !freshInFlight {
+		t.Fatal("expected a reattach still within the timeout to be left alone")
+	}
+
+	running.mu.Lock()
+	runningInFlight := running.reattachInFlight
+	running.mu.Unlock()
+	if !runningInFlight {
+		t.Fatal("expected a running tab to be skipped by the sweep")
+	}
+
+	var sawToast bool
+	for _, msg := range drainMsgs(t, cmd) {
+		if _, ok := msg.(messages.Toast); ok {
+			sawToast = true
+		}
+	}
+	if !sawToast {
+		t.Fatal("expected the user to be told the reattach timed out")
+	}
+}
+
+// An unstamped lock is timed from the first sweep rather than released
+// immediately, so a reattach in progress is never cut short.
+func TestSweepStalledReattachesStampsUntimedLock(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := inFlightTab(TabID("tab-unstamped"), "sess-unstamped")
+	tab.Workspace = ws
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	if cmd := m.SweepStalledReattaches(); cmd != nil {
+		t.Fatal("expected an unstamped lock to be timed, not released")
+	}
+
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if !tab.reattachInFlight {
+		t.Fatal("expected the lock to survive the stamping sweep")
+	}
+	if tab.reattachStartedAt.IsZero() {
+		t.Fatal("expected the sweep to stamp the lock so a later sweep can time it")
+	}
+}
+
+// The stall sweep makes retries possible while an earlier attempt may still be
+// running, so a result from the superseded attempt must not install its agent
+// over the newer one's.
+func TestSupersededReattachResultIsDropped(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{ID: TabID("tab-superseded"), Assistant: "claude", Workspace: ws, Detached: true}
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	// Attempt 1 stalls and is swept; attempt 2 starts.
+	tab.mu.Lock()
+	_ = tab.beginReattachLocked()
+	staleEpoch := tab.reattachEpochLocked()
+	tab.markReattachFailedLocked(false)
+	_ = tab.beginReattachLocked()
+	liveEpoch := tab.reattachEpochLocked()
+	tab.mu.Unlock()
+	if staleEpoch == liveEpoch {
+		t.Fatal("expected each acquisition to get its own epoch")
+	}
+
+	// Attempt 1 finally returns.
+	m.updatePtyTabReattachResult(ptyTabReattachResult{
+		WorkspaceID: string(ws.ID()),
+		TabID:       tab.ID,
+		Epoch:       staleEpoch,
+		Agent:       &appPty.Agent{},
+	})
+
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if tab.Agent != nil {
+		t.Fatal("expected the superseded result's agent to be dropped, not installed")
+	}
+	if !tab.reattachInFlight {
+		t.Fatal("expected the live attempt to keep its reattach lock")
+	}
+}
+
+// A failure from a superseded attempt must not release the live attempt's lock.
+func TestSupersededReattachFailureIsIgnored(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := &Tab{ID: TabID("tab-superseded-fail"), Assistant: "claude", Workspace: ws, Detached: true}
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	tab.mu.Lock()
+	_ = tab.beginReattachLocked()
+	staleEpoch := tab.reattachEpochLocked()
+	tab.markReattachFailedLocked(false)
+	_ = tab.beginReattachLocked()
+	tab.mu.Unlock()
+
+	_, cmd := m.updatePtyTabReattachFailed(ptyTabReattachFailed{
+		WorkspaceID: string(ws.ID()),
+		TabID:       tab.ID,
+		Epoch:       staleEpoch,
+		Err:         errors.New("stale boom"),
+	})
+	if cmd != nil {
+		t.Fatal("expected a superseded failure to be ignored entirely")
+	}
+
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if !tab.reattachInFlight {
+		t.Fatal("expected the live attempt to keep its reattach lock")
+	}
+}
+
+// Outcomes that predate epoch tracking carry epoch 0 and must still apply, so
+// the guard can only reject a message it can positively identify as stale.
+func TestZeroEpochResultStillApplies(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	tab := inFlightTab(TabID("tab-zero-epoch"), "sess-zero")
+	tab.Workspace = ws
+	m.tabs.ByWorkspace[string(ws.ID())] = []*Tab{tab}
+
+	if superseded, _ := m.reattachSuperseded(tab, 0); superseded {
+		t.Fatal("expected a zero epoch to be treated as untracked, not stale")
+	}
+}
+
+func TestBeginReattachStampsAcquisition(t *testing.T) {
+	tab := &Tab{ID: TabID("tab-stamp")}
+	if !tab.beginReattachLocked() {
+		t.Fatal("expected to acquire the reattach lock")
+	}
+	if tab.reattachStartedAt.IsZero() {
+		t.Fatal("expected the acquisition to be stamped")
+	}
+}

--- a/internal/ui/center/model_tab.go
+++ b/internal/ui/center/model_tab.go
@@ -55,12 +55,18 @@ type Tab struct {
 	Detached    bool
 	// reattachInFlight prevents overlapping reattach attempts for the same tab.
 	reattachInFlight bool
-	Terminal         *vterm.VTerm // Virtual terminal emulator with scrollback
-	DiffViewer       *diff.Model  // Native diff viewer (replaces PTY-based viewer)
-	mu               sync.Mutex   // Protects Terminal, Agent, Running, Detached, Workspace, DiffViewer and the embedded state groups
-	closed           uint32
-	closing          uint32
-	Running          bool // Whether the agent is actively running
+	// reattachStartedAt is when reattachInFlight was last acquired, used by the
+	// stalled-reattach sweep to release a lock whose outcome never arrived.
+	reattachStartedAt time.Time
+	// reattachEpoch increments on every acquisition so a result can be matched
+	// to the attempt that produced it; see beginReattachLocked.
+	reattachEpoch uint64
+	Terminal      *vterm.VTerm // Virtual terminal emulator with scrollback
+	DiffViewer    *diff.Model  // Native diff viewer (replaces PTY-based viewer)
+	mu            sync.Mutex   // Protects Terminal, Agent, Running, Detached, Workspace, DiffViewer and the embedded state groups
+	closed        uint32
+	closing       uint32
+	Running       bool // Whether the agent is actively running
 
 	// ptyio.State holds the shared PTY buffering/reader/restart/snapshot
 	// bookkeeping (locking owned by mu, as documented on the type).

--- a/internal/ui/center/model_tab_lookup.go
+++ b/internal/ui/center/model_tab_lookup.go
@@ -1,0 +1,46 @@
+package center
+
+import "github.com/andyrewlee/amux/internal/logging"
+
+// findTabByIDAnyWorkspace returns the tab with the given ID regardless of which
+// workspace key it is filed under, plus that key.
+//
+// TabIDs are process-unique (generateTabID is a per-instance counter), so the
+// ID alone is enough to identify a tab. The workspace key is only a routing
+// hint, and it can go stale: a tab's Workspace pointer is what stamps the
+// WorkspaceID on an async result, so any rebind or identity change between
+// dispatch and delivery makes the pair (wsID, tabID) miss while the tab is
+// still very much alive. Losing an async result that way used to strand the
+// tab, so lookups that must not miss fall back to this scan.
+func (m *Model) findTabByIDAnyWorkspace(tabID TabID) (*Tab, string) {
+	for wsID, tabs := range m.tabs.ByWorkspace {
+		for _, tab := range tabs {
+			if tab == nil || tab.isClosed() {
+				continue
+			}
+			if tab.ID == tabID {
+				return tab, wsID
+			}
+		}
+	}
+	return nil, ""
+}
+
+// resolveTabForResult finds the tab an async PTY result belongs to, preferring
+// the workspace the result was stamped with and falling back to an ID-only
+// scan. The returned workspace ID is the key the tab is actually filed under,
+// which is the one follow-up messages must use.
+func (m *Model) resolveTabForResult(wsID string, tabID TabID, context string) (*Tab, string) {
+	if tab := m.getTabByID(wsID, tabID); tab != nil {
+		return tab, wsID
+	}
+	tab, actualWsID := m.findTabByIDAnyWorkspace(tabID)
+	if tab == nil {
+		return nil, ""
+	}
+	// Worth a warning: the result was routed with a workspace ID the tab is no
+	// longer filed under. The fallback keeps the user unblocked, but the drift
+	// itself is a bug worth seeing in the log.
+	logging.Warn("%s: tab %s routed with workspace %s but filed under %s", context, tabID, wsID, actualWsID)
+	return tab, actualWsID
+}

--- a/internal/ui/center/model_tab_phase.go
+++ b/internal/ui/center/model_tab_phase.go
@@ -1,5 +1,7 @@
 package center
 
+import "time"
+
 // A Tab's PTY lifecycle is held as the underlying flags
 // (Running/Detached/reattachInFlight) rather than a derived phase value:
 // Running and Detached are exported package API (the app, harness and
@@ -69,12 +71,33 @@ func (t *Tab) markReattachFailedLocked(stopped bool) {
 
 // beginReattachLocked acquires the reattach transition lock, reporting false
 // when a reattach is already in flight.
+//
+// The acquisition is stamped because the lock is only released by the reattach
+// outcome coming back. An outcome that is dropped, misrouted, or never produced
+// would otherwise pin the tab in the reattaching state for the rest of the
+// process lifetime — with every retry silently no-oping behind this same lock.
+// The stamp is what lets the periodic sweep tell a slow reattach from a lost
+// one; see SweepStalledReattaches.
+//
+// The epoch bump exists because that sweep makes retries possible while an
+// earlier attempt may still be running: without it, a slow attempt returning
+// after the retry would overwrite the newer attempt's agent with its own —
+// leaking a tmux client and pointing the tab at a PTY the retry already
+// superseded. Results carry the epoch they were dispatched under and are
+// dropped if a newer attempt has since started.
 func (t *Tab) beginReattachLocked() bool {
 	if t.reattachInFlight {
 		return false
 	}
 	t.reattachInFlight = true
+	t.reattachStartedAt = time.Now()
+	t.reattachEpoch++
 	return true
+}
+
+// reattachEpochLocked reports the current reattach generation.
+func (t *Tab) reattachEpochLocked() uint64 {
+	return t.reattachEpoch
 }
 
 // endReattachLocked releases the reattach transition lock without changing

--- a/internal/ui/center/model_tabs.go
+++ b/internal/ui/center/model_tabs.go
@@ -63,15 +63,19 @@ type ptyTabCreateResult struct {
 type ptyTabReattachResult struct {
 	WorkspaceID string
 	TabID       TabID
-	Agent       *appPty.Agent
-	Rows        int
-	Cols        int
+	// Epoch is the reattach generation this result was dispatched under; a
+	// result from a superseded attempt is dropped. See beginReattachLocked.
+	Epoch uint64
+	Agent *appPty.Agent
+	Rows  int
+	Cols  int
 	ptyio.SessionRestoreCapture
 }
 
 type ptyTabReattachFailed struct {
 	WorkspaceID string
 	TabID       TabID
+	Epoch       uint64
 	Err         error
 	Stopped     bool
 	Action      string

--- a/internal/ui/center/model_tabs_restore.go
+++ b/internal/ui/center/model_tabs_restore.go
@@ -61,7 +61,7 @@ func (m *Model) addDetachedTab(ws *data.Workspace, info data.TabInfo) {
 // addPlaceholderTab synchronously creates a placeholder tab in the correct slice
 // position. The tab starts detached and non-running; an async reattach upgrades
 // it in-place (by TabID) without changing slice order.
-func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID, string) {
+func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID, string, uint64) {
 	tm := m.terminalMetrics()
 	termWidth := tm.Width
 	termHeight := tm.Height
@@ -90,19 +90,21 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 		ca = time.Now().Unix()
 	}
 	tab := &Tab{
-		ID:          tabID,
-		Name:        displayName,
-		Assistant:   info.Assistant,
-		Workspace:   ws,
-		SessionName: sessionName,
-		Detached:    true,
-		Running:     false,
-		// Placeholder tabs are immediately queued for async reattach.
-		reattachInFlight: true,
-		Terminal:         term,
-		createdAt:        ca,
-		lastFocusedAt:    time.Unix(ca, 0),
+		ID:            tabID,
+		Name:          displayName,
+		Assistant:     info.Assistant,
+		Workspace:     ws,
+		SessionName:   sessionName,
+		Detached:      true,
+		Running:       false,
+		Terminal:      term,
+		createdAt:     ca,
+		lastFocusedAt: time.Unix(ca, 0),
 	}
+	// Placeholder tabs are immediately queued for async reattach, so they are
+	// born holding the reattach lock. Take it the same way every other path
+	// does, so it is stamped and versioned rather than a bare flag.
+	_ = tab.beginReattachLocked()
 	isChat := m.isChatTab(tab)
 	term.IgnoreCursorVisibilityControls = false
 	term.TreatLFAsCRLF = isChat
@@ -110,13 +112,13 @@ func (m *Model) addPlaceholderTab(ws *data.Workspace, info data.TabInfo) (TabID,
 	wsID := string(ws.ID())
 	m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
 	m.markHelpDirty()
-	return tabID, sessionName
+	return tabID, sessionName, tab.reattachEpochLocked()
 }
 
 // reattachToSession returns a tea.Cmd that asynchronously connects a placeholder
 // tab to its tmux session. On success it produces ptyTabReattachResult which
 // updates the tab in-place (by TabID). On failure it produces ptyTabReattachFailed.
-func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, sessionName string) tea.Cmd {
+func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, sessionName string, epoch uint64) tea.Cmd {
 	termWidth, termHeight := m.sessionBootstrapViewportSize()
 	tm := m.terminalMetrics()
 	attachWidth := tm.Width
@@ -128,6 +130,7 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         err,
 				Action:      "reattach",
 			}
@@ -136,6 +139,7 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         errors.New("tmux session ended"),
 				Stopped:     true,
 				Action:      "reattach",
@@ -172,6 +176,7 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         err,
 				Action:      "reattach",
 			}
@@ -189,6 +194,7 @@ func (m *Model) reattachToSession(ws *data.Workspace, tabID TabID, assistant, se
 		return ptyTabReattachResult{
 			WorkspaceID: string(ws.ID()),
 			TabID:       tabID,
+			Epoch:       epoch,
 			Agent:       agent,
 			Rows:        captureRows,
 			Cols:        captureCols,

--- a/internal/ui/center/model_tabs_restore_test.go
+++ b/internal/ui/center/model_tabs_restore_test.go
@@ -41,7 +41,7 @@ func TestAddPlaceholderTab_SetsLastFocusedFromCreatedAt(t *testing.T) {
 	wsID := string(ws.ID())
 	createdAt := time.Now().Add(-2 * time.Hour).Unix()
 
-	_, _ = m.addPlaceholderTab(ws, data.TabInfo{
+	_, _, _ = m.addPlaceholderTab(ws, data.TabInfo{
 		Assistant: "claude",
 		Name:      "Claude",
 		CreatedAt: createdAt,

--- a/internal/ui/center/model_tabs_session.go
+++ b/internal/ui/center/model_tabs_session.go
@@ -155,8 +155,12 @@ func (m *Model) autoReattachActiveTabOnSelection() tea.Cmd {
 	}
 	tab.mu.Lock()
 	detached := tab.Detached
+	reattachInFlight := tab.reattachInFlight
 	tab.mu.Unlock()
-	if !detached {
+	// Automatic flows stay silent: ReattachActiveTab reports an in-flight
+	// reattach to the user, which is right for a keypress and noise for a tab
+	// switch.
+	if !detached || reattachInFlight {
 		return nil
 	}
 	return m.ReattachActiveTab()
@@ -200,8 +204,8 @@ func (m *Model) RestoreTabsFromWorkspace(ws *data.Workspace) tea.Cmd {
 			continue
 		}
 		restoreCount++
-		tabID, sessionName := m.addPlaceholderTab(ws, tab)
-		cmds = append(cmds, m.reattachToSession(ws, tabID, tab.Assistant, sessionName))
+		tabID, sessionName, epoch := m.addPlaceholderTab(ws, tab)
+		cmds = append(cmds, m.reattachToSession(ws, tabID, tab.Assistant, sessionName, epoch))
 	}
 	if restoreCount > 0 {
 		desired := lastBeforeActive
@@ -262,8 +266,8 @@ func (m *Model) AddTabsFromWorkspace(ws *data.Workspace, tabs []data.TabInfo) te
 			m.addDetachedTab(ws, tab)
 			continue
 		}
-		tabID, sn := m.addPlaceholderTab(ws, tab)
-		cmds = append(cmds, m.reattachToSession(ws, tabID, tab.Assistant, sn))
+		tabID, sn, epoch := m.addPlaceholderTab(ws, tab)
+		cmds = append(cmds, m.reattachToSession(ws, tabID, tab.Assistant, sn, epoch))
 	}
 	return common.SafeBatch(cmds...)
 }

--- a/internal/ui/center/model_tabs_session_auto_reattach_test.go
+++ b/internal/ui/center/model_tabs_session_auto_reattach_test.go
@@ -100,8 +100,48 @@ func TestReattachActiveTab_DeduplicatesInFlight(t *testing.T) {
 	m.workspace = ws
 
 	cmd := m.ReattachActiveTab()
-	if cmd != nil {
-		t.Fatalf("expected nil cmd when reattachInFlight is already true")
+	if cmd == nil {
+		t.Fatalf("expected a toast cmd when reattachInFlight is already true")
+	}
+	// The dedup must not start a second reattach, but it must still say
+	// something: a silent keybinding makes a stuck tab look like a broken one.
+	toast, ok := cmd().(messages.Toast)
+	if !ok {
+		t.Fatalf("expected messages.Toast, got %T", cmd())
+	}
+	if toast.Message != "Reattach already in progress" {
+		t.Fatalf("unexpected toast message: %q", toast.Message)
+	}
+	tab.mu.Lock()
+	stillInFlight := tab.reattachInFlight
+	tab.mu.Unlock()
+	if !stillInFlight {
+		t.Fatalf("expected the in-flight reattach lock to be left untouched")
+	}
+}
+
+func TestAutoReattachOnSelection_SilentWhileReattachInFlight(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	tab := &Tab{
+		ID:               TabID("tab-inflight"),
+		Assistant:        "claude",
+		Workspace:        ws,
+		Running:          false,
+		Detached:         true,
+		reattachInFlight: true,
+		SessionName:      "sess-inflight",
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	// Automatic flows must not toast: selecting a reattaching tab is not a
+	// request for a second reattach.
+	if cmd := m.autoReattachActiveTabOnSelection(); cmd != nil {
+		t.Fatalf("expected nil cmd from the automatic path, got %T", cmd())
 	}
 }
 

--- a/internal/ui/center/model_tabs_session_reattach.go
+++ b/internal/ui/center/model_tabs_session_reattach.go
@@ -98,12 +98,21 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 	if canReattach && !reattachInFlight {
 		_ = tab.beginReattachLocked()
 	}
+	epoch := tab.reattachEpochLocked()
 	tab.mu.Unlock()
 	if !canReattach {
 		return nil
 	}
 	if reattachInFlight {
-		return nil
+		// Say so rather than no-op. A reattach that is genuinely in flight
+		// resolves on its own or is released by SweepStalledReattaches, but a
+		// silent keybinding makes a stuck tab look like a broken one.
+		return func() tea.Msg {
+			return messages.Toast{
+				Message: "Reattach already in progress",
+				Level:   messages.ToastInfo,
+			}
+		}
 	}
 	if m.config == nil || m.config.Assistants == nil {
 		tab.mu.Lock()
@@ -144,6 +153,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         err,
 				Action:      "reattach",
 			}
@@ -176,6 +186,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 				return ptyTabReattachFailed{
 					WorkspaceID: string(ws.ID()),
 					TabID:       tabID,
+					Epoch:       epoch,
 					Err:         err,
 					Stopped:     true,
 					Action:      "reattach",
@@ -186,6 +197,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 			return ptyTabReattachResult{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Agent:       agent,
 				Rows:        captureRows,
 				Cols:        captureCols,
@@ -228,6 +240,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         err,
 				Action:      "reattach",
 			}
@@ -245,6 +258,7 @@ func (m *Model) ReattachActiveTab() tea.Cmd {
 		return ptyTabReattachResult{
 			WorkspaceID: string(ws.ID()),
 			TabID:       tabID,
+			Epoch:       epoch,
 			Agent:       agent,
 			Rows:        captureRows,
 			Cols:        captureCols,
@@ -290,6 +304,7 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 	if !running && !reattachInFlight {
 		_ = tab.beginReattachLocked()
 	}
+	epoch := tab.reattachEpochLocked()
 	tab.mu.Unlock()
 	if running {
 		return func() tea.Msg {
@@ -356,6 +371,7 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 			return ptyTabReattachFailed{
 				WorkspaceID: string(ws.ID()),
 				TabID:       tabID,
+				Epoch:       epoch,
 				Err:         err,
 				Stopped:     true,
 				Action:      "restart",
@@ -368,6 +384,7 @@ func (m *Model) RestartActiveTab() tea.Cmd {
 		return ptyTabReattachResult{
 			WorkspaceID: string(ws.ID()),
 			TabID:       tabID,
+			Epoch:       epoch,
 			Agent:       agent,
 			Rows:        captureRows,
 			Cols:        captureCols,

--- a/internal/ui/center/model_tabs_session_reattach_history_size_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_history_size_test.go
@@ -140,7 +140,7 @@ func TestReattachToSession_BusySessionCapturesHistoryAfterAttach(t *testing.T) {
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
 
-	msg := m.reattachToSession(ws, TabID("tab-restore-busy"), "codex", "session-busy")()
+	msg := m.reattachToSession(ws, TabID("tab-restore-busy"), "codex", "session-busy", 1)()
 	result, ok := msg.(ptyTabReattachResult)
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)

--- a/internal/ui/center/model_tabs_session_reattach_order_test.go
+++ b/internal/ui/center/model_tabs_session_reattach_order_test.go
@@ -137,7 +137,7 @@ func TestReattachToSession_CapturesSnapshotBeforeAttach(t *testing.T) {
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
 
-	result, ok := m.reattachToSession(ws, TabID("tab-restore"), "codex", "session-restore")().(ptyTabReattachResult)
+	result, ok := m.reattachToSession(ws, TabID("tab-restore"), "codex", "session-restore", 1)().(ptyTabReattachResult)
 	if !ok {
 		t.Fatal("expected ptyTabReattachResult")
 	}

--- a/internal/ui/center/model_tabs_session_snapshot_race_test.go
+++ b/internal/ui/center/model_tabs_session_snapshot_race_test.go
@@ -126,7 +126,7 @@ func TestReattachToSession_DiscardsPreAttachSnapshotWhenSessionRecreated(t *test
 	setKnownViewport(m)
 	ws := newTestWorkspace("ws", "/repo/ws")
 
-	msg := m.reattachToSession(ws, TabID("tab-restore-race"), "codex", "session-race")()
+	msg := m.reattachToSession(ws, TabID("tab-restore-race"), "codex", "session-race", 1)()
 	result, ok := msg.(ptyTabReattachResult)
 	if !ok {
 		t.Fatalf("expected ptyTabReattachResult, got %T", msg)

--- a/internal/ui/ptyio/tuning.go
+++ b/internal/ui/ptyio/tuning.go
@@ -24,4 +24,13 @@ const (
 	PtyRestartMax = 5
 	// PtyRestartWindow is the sliding window for counting reader restarts.
 	PtyRestartWindow = time.Minute
+	// ReattachStallTimeout bounds how long a tab or terminal may hold its
+	// reattach lock. Both panes release that lock only when the reattach
+	// outcome comes back, so an outcome that is dropped, misrouted, or never
+	// produced pins the tab in the reattaching state and makes every retry
+	// no-op behind the same lock. A reattach is a handful of tmux round-trips
+	// against a shared, single-threaded server, so a loaded server can take
+	// seconds; this sits well past any real reattach so a sweep only ever
+	// releases a lost one, never a slow one.
+	ReattachStallTimeout = 45 * time.Second
 )

--- a/internal/ui/sidebar/terminal.go
+++ b/internal/ui/sidebar/terminal.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/logging"
 	"github.com/andyrewlee/amux/internal/pty"
 	"github.com/andyrewlee/amux/internal/tmux"
 	"github.com/andyrewlee/amux/internal/ui/common"
@@ -43,8 +44,11 @@ type TerminalState struct {
 	Detached         bool
 	UserDetached     bool
 	reattachInFlight bool
-	SessionName      string
-	mu               sync.Mutex
+	// reattachStartedAt is when reattachInFlight was last acquired, used by the
+	// stalled-reattach sweep to release a lock whose outcome never arrived.
+	reattachStartedAt time.Time
+	SessionName       string
+	mu                sync.Mutex
 
 	// ptyio.State holds the shared PTY buffering/reader/restart/snapshot
 	// bookkeeping (locking owned by mu, as documented on the type).
@@ -215,6 +219,32 @@ func (m *TerminalModel) getTabByID(wsID string, tabID TerminalTabID) *TerminalTa
 		}
 	}
 	return nil
+}
+
+// resolveTabForResult finds the tab an async attach result belongs to,
+// preferring the workspace the result was stamped with and falling back to an
+// ID-only scan. It returns the key the tab is actually filed under, which is
+// the one follow-up work must use.
+//
+// TerminalTabIDs are process-unique, so the ID alone identifies a tab; the
+// workspace key is only a routing hint and can go stale between dispatch and
+// delivery. Missing on the pair used to drop the result, and because the
+// attach gate refuses to retry while reattachInFlight is set, a dropped result
+// left the terminal permanently unable to reattach.
+func (m *TerminalModel) resolveTabForResult(wsID string, tabID TerminalTabID, context string) (*TerminalTab, string) {
+	if tab := m.getTabByID(wsID, tabID); tab != nil {
+		return tab, wsID
+	}
+	for actualWsID, tabs := range m.tabs.ByWorkspace {
+		for _, tab := range tabs {
+			if tab == nil || tab.ID != tabID {
+				continue
+			}
+			logging.Warn("%s: terminal tab %s routed with workspace %s but filed under %s", context, tabID, wsID, actualWsID)
+			return tab, actualWsID
+		}
+	}
+	return nil, ""
 }
 
 // nextTerminalName returns the next available terminal name

--- a/internal/ui/sidebar/terminal_reattach_stall.go
+++ b/internal/ui/sidebar/terminal_reattach_stall.go
@@ -1,0 +1,57 @@
+package sidebar
+
+import (
+	"time"
+
+	"github.com/andyrewlee/amux/internal/logging"
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+)
+
+// beginReattachLocked acquires the reattach lock and stamps the acquisition.
+// The caller must hold ts.mu.
+//
+// The stamp exists because the lock is released only when the attach outcome
+// comes back. An outcome that is dropped, misrouted, or never produced would
+// otherwise leave the terminal unable to reattach for the rest of the process
+// lifetime: shouldAttachExistingTerminalTab refuses every retry while this
+// flag is set. The stamp is what lets the sweep tell a slow attach from a lost
+// one; see SweepStalledReattaches.
+func (ts *TerminalState) beginReattachLocked() {
+	ts.reattachInFlight = true
+	ts.reattachStartedAt = time.Now()
+}
+
+// SweepStalledReattaches releases reattach locks whose outcome never arrived.
+//
+// It is a periodic scan of state rather than a timer armed by each attach path
+// so that any cause — and any path added later — is covered without having to
+// opt in. It is not a cancellation: the attach goroutine is untouched, and
+// releasing the lock simply lets the next attach sweep retry the terminal,
+// which is how a sidebar terminal recovers on its own.
+func (m *TerminalModel) SweepStalledReattaches() {
+	now := time.Now()
+	for _, tabs := range m.tabs.ByWorkspace {
+		for _, tab := range tabs {
+			if tab == nil || tab.State == nil {
+				continue
+			}
+			ts := tab.State
+			ts.mu.Lock()
+			stalled := false
+			switch {
+			case !ts.reattachInFlight || ts.Running:
+			case ts.reattachStartedAt.IsZero():
+				// Never timed (set outside beginReattachLocked): start its clock
+				// now rather than releasing an attach that may be in progress.
+				ts.reattachStartedAt = now
+			case now.Sub(ts.reattachStartedAt) > ptyio.ReattachStallTimeout:
+				ts.reattachInFlight = false
+				stalled = true
+			}
+			ts.mu.Unlock()
+			if stalled {
+				logging.Warn("Sidebar terminal attach for tab %s produced no outcome within %s; releasing reattach lock", tab.ID, ptyio.ReattachStallTimeout)
+			}
+		}
+	}
+}

--- a/internal/ui/sidebar/terminal_reattach_stall_test.go
+++ b/internal/ui/sidebar/terminal_reattach_stall_test.go
@@ -1,0 +1,109 @@
+package sidebar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/ui/ptyio"
+)
+
+func inFlightTerminalTab(id TerminalTabID, sessionName string) *TerminalTab {
+	tab := &TerminalTab{
+		ID:   id,
+		Name: "Terminal 1",
+		State: &TerminalState{
+			SessionName: sessionName,
+			Detached:    true,
+		},
+	}
+	tab.State.beginReattachLocked()
+	return tab
+}
+
+// An attach outcome stamped with a workspace ID the tab is no longer filed
+// under must still reach the tab. Routing by workspace alone dropped it, and
+// because shouldAttachExistingTerminalTab refuses to retry while the reattach
+// lock is held, the terminal could never attach again.
+func TestSidebarResolveTabForResultFallsBackToTabID(t *testing.T) {
+	m := &TerminalModel{}
+	m.tabs.ByWorkspace = map[string][]*TerminalTab{}
+	tab := inFlightTerminalTab(TerminalTabID("term-tab-drift"), "sess-drift")
+	m.tabs.ByWorkspace["real-ws"] = []*TerminalTab{tab}
+
+	found, wsID := m.resolveTabForResult("stale-ws", tab.ID, "test")
+	if found != tab {
+		t.Fatalf("expected the tab to be found despite the workspace mismatch, got %v", found)
+	}
+	if wsID != "real-ws" {
+		t.Fatalf("expected the key the tab is filed under, got %q", wsID)
+	}
+
+	if missing, _ := m.resolveTabForResult("stale-ws", TerminalTabID("term-tab-missing"), "test"); missing != nil {
+		t.Fatal("expected a genuinely absent tab to resolve to nil")
+	}
+}
+
+func TestSidebarSweepStalledReattachesReleasesOnlyStaleLocks(t *testing.T) {
+	m := &TerminalModel{}
+	m.tabs.ByWorkspace = map[string][]*TerminalTab{}
+
+	stalled := inFlightTerminalTab(TerminalTabID("term-tab-stalled"), "sess-stalled")
+	stalled.State.reattachStartedAt = time.Now().Add(-2 * ptyio.ReattachStallTimeout)
+
+	fresh := inFlightTerminalTab(TerminalTabID("term-tab-fresh"), "sess-fresh")
+
+	running := inFlightTerminalTab(TerminalTabID("term-tab-running"), "sess-running")
+	running.State.reattachStartedAt = time.Now().Add(-2 * ptyio.ReattachStallTimeout)
+	running.State.Running = true
+
+	m.tabs.ByWorkspace["ws"] = []*TerminalTab{stalled, fresh, running}
+
+	m.SweepStalledReattaches()
+
+	for _, tc := range []struct {
+		name         string
+		tab          *TerminalTab
+		wantInFlight bool
+	}{
+		{"stalled", stalled, false},
+		{"fresh", fresh, true},
+		{"running", running, true},
+	} {
+		tc.tab.State.mu.Lock()
+		got := tc.tab.State.reattachInFlight
+		tc.tab.State.mu.Unlock()
+		if got != tc.wantInFlight {
+			t.Fatalf("%s: reattachInFlight = %v, want %v", tc.name, got, tc.wantInFlight)
+		}
+	}
+
+	// A released terminal must become eligible for the next attach sweep,
+	// which is how it recovers without the user doing anything.
+	if !shouldAttachExistingTerminalTab(stalled) {
+		t.Fatal("expected the swept terminal to be eligible for reattach")
+	}
+	if shouldAttachExistingTerminalTab(fresh) {
+		t.Fatal("expected a terminal still within the timeout to stay locked")
+	}
+}
+
+// An unstamped lock is timed from the first sweep rather than released
+// immediately, so an attach in progress is never cut short.
+func TestSidebarSweepStampsUntimedLock(t *testing.T) {
+	m := &TerminalModel{}
+	m.tabs.ByWorkspace = map[string][]*TerminalTab{}
+	tab := inFlightTerminalTab(TerminalTabID("term-tab-unstamped"), "sess-unstamped")
+	tab.State.reattachStartedAt = time.Time{}
+	m.tabs.ByWorkspace["ws"] = []*TerminalTab{tab}
+
+	m.SweepStalledReattaches()
+
+	tab.State.mu.Lock()
+	defer tab.State.mu.Unlock()
+	if !tab.State.reattachInFlight {
+		t.Fatal("expected the lock to survive the stamping sweep")
+	}
+	if tab.State.reattachStartedAt.IsZero() {
+		t.Fatal("expected the sweep to stamp the lock so a later sweep can time it")
+	}
+}

--- a/internal/ui/sidebar/terminal_sessions.go
+++ b/internal/ui/sidebar/terminal_sessions.go
@@ -40,7 +40,7 @@ func shouldAttachExistingTerminalTab(tab *TerminalTab) bool {
 	if ts.Running && ts.Terminal != nil && ts.VTerm != nil && !ts.Detached {
 		return false
 	}
-	ts.reattachInFlight = true
+	ts.beginReattachLocked()
 	return true
 }
 
@@ -64,12 +64,12 @@ func (m *TerminalModel) AddTabsFromSessions(ws *data.Workspace, sessions []strin
 			ID:   tabID,
 			Name: nextTerminalName(m.tabs.ByWorkspace[wsID]),
 			State: &TerminalState{
-				SessionName:      sessionName,
-				Running:          false,
-				Detached:         true,
-				reattachInFlight: true,
+				SessionName: sessionName,
+				Running:     false,
+				Detached:    true,
 			},
 		}
+		tab.State.beginReattachLocked()
 		m.tabs.ByWorkspace[wsID] = append(m.tabs.ByWorkspace[wsID], tab)
 		if len(m.tabs.ByWorkspace[wsID]) == 1 {
 			m.tabs.ActiveByWorkspace[wsID] = 0
@@ -115,7 +115,7 @@ func (m *TerminalModel) AddTabsFromSessionInfos(ws *data.Workspace, sessions []S
 		if session.Attach {
 			if tab.State != nil {
 				tab.State.mu.Lock()
-				tab.State.reattachInFlight = true
+				tab.State.beginReattachLocked()
 				tab.State.mu.Unlock()
 			}
 			cmds = append(cmds, m.attachToSession(ws, tabID, session.Name, session.DetachExisting, "reattach"))

--- a/internal/ui/sidebar/terminal_update_session.go
+++ b/internal/ui/sidebar/terminal_update_session.go
@@ -67,7 +67,7 @@ func (m *TerminalModel) handleTerminalCreated(msg SidebarTerminalCreated) tea.Cm
 
 // handleReattachResult applies the result of a terminal reattach operation.
 func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) tea.Cmd {
-	tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
+	tab, wsID := m.resolveTabForResult(msg.WorkspaceID, msg.TabID, "sidebar attach result")
 	if tab == nil || tab.State == nil {
 		// The tab was closed or its workspace deleted while the attach was in
 		// flight; close the orphaned PTY or its tmux client leaks for the
@@ -125,12 +125,12 @@ func (m *TerminalModel) handleReattachResult(msg SidebarTerminalReattachResult) 
 			_ = setTerminalSizeFn(msg.Terminal, ptyRows, ptyCols)
 		}
 	}
-	return m.startPTYReader(msg.WorkspaceID, tab.ID)
+	return m.startPTYReader(wsID, tab.ID)
 }
 
 // handleReattachFailed handles a failed reattach attempt.
 func (m *TerminalModel) handleReattachFailed(msg SidebarTerminalReattachFailed) tea.Cmd {
-	tab := m.getTabByID(msg.WorkspaceID, msg.TabID)
+	tab, _ := m.resolveTabForResult(msg.WorkspaceID, msg.TabID, "sidebar attach failure")
 	if tab != nil && tab.State != nil {
 		ts := tab.State
 		ts.mu.Lock()


### PR DESCRIPTION
## The bug

A tab could sit on the `REATTACHING` badge indefinitely, with `C-Spc t r` doing nothing at all. Two checkfu workspaces were found wedged that way against live, healthy tmux sessions — panes alive, agents running, zero clients attached — that amux simply refused to reconnect to.

The reattach lock (`reattachInFlight`) is released only by the result or failure message coming back, and `updatePtyTabReattachResult` routed those by the pair `(WorkspaceID, TabID)`. When that lookup missed, it closed the freshly created agent and returned — leaving the lock held and logging nothing. From then on the tab was stuck for the life of the process: every retry, keypress or automatic, no-opped behind the very lock it was waiting on.

The miss is real, not theoretical. A reattach agent was created with its tab's `Workspace` pointer naming one workspace while its session belonged to another:

```
agent closed: session=amux-fcfc88256be17433-tab-812431c2-k workspace=fed3629352feda00
```

The result was stamped with the wrong key, missed, and the attached client was torn down — which is exactly the state the wedged sessions were found in.

## The fix

Rather than chase the one way a workspace key can drift, make a lost outcome survivable:

- **Route by tab ID when the workspace key misses.** Tab IDs are process-unique, so the workspace key is only a routing hint. When the fallback fires it logs a warning, which turns a silent wedge into a named bug the next time the drift happens.
- **Sweep stalled locks.** Acquisitions are stamped, and the existing 5s PTY watchdog releases any lock older than `ptyio.ReattachStallTimeout` (45s). A periodic scan rather than a timer armed per call site, so paths added later are covered without opting in. It is not a cancellation — a late outcome still applies normally.
- **Guard outcomes with a reattach epoch.** The sweep makes a retry possible while an earlier attempt is still running; without this, a slow attempt returning after the retry would overwrite the newer agent and leak its tmux client. Epoch 0 (untracked) still applies, so the guard only rejects what it can positively identify as stale.
- **Stop failing silently.** A result with no agent releases the lock; the keybinding reports an in-flight reattach instead of ignoring the keypress; a swept tab says so. Automatic flows stay quiet.

## Sidebar

The sidebar had the same bug: `handleReattachResult` dropped on the same lookup, and `shouldAttachExistingTerminalTab` refuses to retry while the lock is held — so a dropped result left a terminal permanently unable to reattach, and sidebar terminals are auto-detached by the attached limit every few minutes. It gets the same three fixes; releasing its lock is enough for it to recover on its own via the next attach sweep.

## Verification

`make lint` clean, `go test ./...` and `go test -race` on the touched packages pass. New tests cover: routing across workspace drift, the agent-less result, the sweep's release/skip/stamp behavior, superseded result and failure handling, zero-epoch compatibility, the dedup toast, and the sidebar equivalents.