### PR TITLE
fix: keep agent chrome out of synthesized alt-screen history

### DIFF
--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -151,6 +151,22 @@ Invariant (pinned by `TestChatTab_DragUpAutoScroll_AnchorStableWhileStreaming`):
 while an agent repaints and scrollback churns through capture/dedup, an
 anchored chat view must not move except by explicit scroll steps.
 
+### Chrome is not transcript
+
+A captured frame carries the agent's prompt box and footer as well as its
+transcript, so storing frames verbatim bakes a stale prompt box into history
+every time one is captured — scrolling back then reads as prose interrupted by
+`❯` rows and full-width rules in the left gutter. `vterm/chrome_filter.go`
+drops everything from the frame's last horizontal rule downward before it
+reaches scrollback. A rule is the anchor because it is unambiguous: no line of
+prose is one glyph repeated across most of the terminal.
+
+Both synthesized-history entry points trim: `captureScreenToScrollback` (the
+`2J` path) and `scrollUp` (tmux renders a chat agent's scroll as a bulk
+client-side scroll, so the displaced block is itself a frame). Trimming is
+gated on `AltScreen && AllowAltScreenScrollback` — a real scrollback-backed
+program keeps every scrolled line, rules included.
+
 ## Gestures: one implementation per gesture
 
 All selection/scroll gestures are implemented once, as tab-actor handlers

--- a/internal/vterm/alt_screen_capture.go
+++ b/internal/vterm/alt_screen_capture.go
@@ -11,6 +11,11 @@ import "github.com/andyrewlee/amux/internal/logging"
 // preserving, even if that frame was already present in scrollback.
 func (v *VTerm) captureScreenToScrollback() bool {
 	lines := v.visibleCaptureFrame()
+	if v.AltScreen && v.AllowAltScreenScrollback {
+		// Synthesized history only: a repainting chat agent's frame carries its
+		// prompt box and footer, which are not transcript. See chrome_filter.go.
+		lines = trimCapturedChrome(lines, v.Width)
+	}
 	if len(lines) == 0 {
 		v.clearPendingRestoredAltScreenCapture()
 		return false

--- a/internal/vterm/chrome_filter.go
+++ b/internal/vterm/chrome_filter.go
@@ -1,0 +1,130 @@
+package vterm
+
+import "unicode"
+
+// Synthesized alt-screen history and the chrome problem.
+//
+// A chat agent that lives on the alternate screen (Claude Code) never scrolls
+// and never clears its transcript: it repaints the whole screen in place. It
+// therefore leaves no real scrollback, so amux synthesizes history from whole
+// captured frames (see SCROLLING.md and captureScreenToScrollback).
+//
+// Every one of those frames carries the agent's chrome — the prompt box, its
+// horizontal rules, and the mode/status footer beneath them. Capturing frames
+// verbatim bakes a copy of that chrome into the transcript each time, so
+// scrolling back reads as prose interrupted by stale prompt boxes and
+// full-width rules starting in the left gutter.
+//
+// A prompt box is anchored by a full-width horizontal rule, and a rule is
+// unambiguous: no line of prose is one box-drawing glyph repeated across most
+// of the terminal. Everything from the last such rule to the end of the frame
+// is chrome, and dropping it leaves the transcript. An agent that draws no rule
+// keeps its frame captured verbatim, exactly as before.
+
+const (
+	// chromeRuleMinCoverage is the fraction of the terminal width a single
+	// repeated glyph must span to count as a rule. Claude Code's rules span the
+	// full width; the margin absorbs agents that inset theirs.
+	chromeRuleMinCoverage = 0.6
+
+	// chromeSearchDepth bounds how far above the last content row a rule may
+	// sit and still anchor the trailing chrome. A prompt box plus its footer is
+	// a handful of rows; searching further risks cutting real transcript.
+	chromeSearchDepth = 8
+)
+
+// trimCapturedChrome returns the prefix of a captured frame that is transcript,
+// dropping the agent's trailing chrome block and any blank padding beneath it.
+// Frames with no trailing rule are returned unchanged.
+func trimCapturedChrome(lines [][]Cell, width int) [][]Cell {
+	last := lastNonBlankRow(lines)
+	if last < 0 {
+		return lines
+	}
+	start := last - chromeSearchDepth + 1
+	if start < 0 {
+		start = 0
+	}
+	// The lowest rule anchors the chrome: a prompt box draws one above and one
+	// below its input row, and the footer sits under the lower one.
+	for i := last; i >= start; i-- {
+		if isRuleRow(lines[i], width) {
+			return lines[:i]
+		}
+	}
+	return lines
+}
+
+// isRuleRow reports whether a row is a horizontal rule: a single punctuation
+// or box-drawing glyph repeated across most of the terminal width.
+//
+// The glyph must not be alphanumeric. Prose and program output do produce long
+// runs of one character — a row of "xxxxxxxx" or a bare "========" separator —
+// and treating those as chrome would drop every line beneath them.
+func isRuleRow(line []Cell, width int) bool {
+	if width <= 0 || len(line) == 0 {
+		return false
+	}
+	var glyph string
+	count := 0
+	for _, c := range line {
+		content := c.GraphemeCluster
+		if content == "" {
+			if c.Rune == 0 || c.Rune == ' ' {
+				continue
+			}
+			content = string(c.Rune)
+		} else if content == " " {
+			continue
+		}
+		if !isRuleGlyph(content) {
+			return false
+		}
+		if glyph == "" {
+			glyph = content
+		} else if content != glyph {
+			return false
+		}
+		count++
+	}
+	if glyph == "" {
+		return false
+	}
+	return float64(count) >= chromeRuleMinCoverage*float64(width)
+}
+
+// isRuleGlyph reports whether a grapheme may form a horizontal rule. Letters
+// and digits are excluded; everything else (box drawing, dashes, punctuation)
+// qualifies.
+func isRuleGlyph(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// lastNonBlankRow returns the index of the last row holding visible content, or
+// -1 when every row is blank.
+func lastNonBlankRow(screen [][]Cell) int {
+	for i := len(screen) - 1; i >= 0; i-- {
+		if !lineIsBlank(screen[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// lineIsBlank reports whether a line holds no visible content.
+func lineIsBlank(line []Cell) bool {
+	for _, c := range line {
+		if c.Rune != 0 && c.Rune != ' ' {
+			return false
+		}
+		if c.GraphemeCluster != "" && c.GraphemeCluster != " " {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/vterm/chrome_filter_test.go
+++ b/internal/vterm/chrome_filter_test.go
@@ -1,0 +1,176 @@
+package vterm
+
+import (
+	"strings"
+	"testing"
+)
+
+// chromeLine builds a width-sized row from text, blank-padded on the right.
+func chromeLine(text string, width int) []Cell {
+	line := MakeBlankLine(width)
+	i := 0
+	for _, r := range text {
+		if i >= width {
+			break
+		}
+		line[i] = Cell{Rune: r, Width: 1}
+		i++
+	}
+	return line
+}
+
+func chromeFrameText(frame [][]Cell) []string {
+	out := make([]string, 0, len(frame))
+	for _, row := range frame {
+		var b strings.Builder
+		for _, c := range row {
+			if c.Rune == 0 {
+				b.WriteRune(' ')
+				continue
+			}
+			b.WriteRune(c.Rune)
+		}
+		out = append(out, strings.TrimRight(b.String(), " "))
+	}
+	return out
+}
+
+func TestIsRuleRow(t *testing.T) {
+	const width = 20
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"full width rule", strings.Repeat("─", width), true},
+		{"inset rule", strings.Repeat("─", 14), true},
+		{"rule too short", strings.Repeat("─", 5), false},
+		{"prose", "The medieval period", false},
+		{"blank", "", false},
+		{"mixed glyphs", strings.Repeat("─", 10) + strings.Repeat("━", 8), false},
+		{"repeated letter is not a rule", strings.Repeat("x", width), false},
+		{"repeated digit is not a rule", strings.Repeat("1", width), false},
+		{"ascii dashes are a rule", strings.Repeat("-", width), true},
+		{"equals separator is a rule", strings.Repeat("=", width), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRuleRow(chromeLine(tc.text, width), width); got != tc.want {
+				t.Fatalf("isRuleRow(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrimCapturedChromeDropsPromptBox(t *testing.T) {
+	const width = 20
+	rule := strings.Repeat("─", width)
+	frame := [][]Cell{
+		chromeLine("first paragraph", width),
+		chromeLine("second line", width),
+		chromeLine("", width),
+		chromeLine(rule, width),
+		chromeLine("❯ ", width),
+		chromeLine(rule, width),
+		chromeLine("  plan mode on", width),
+		chromeLine("", width),
+	}
+	got := chromeFrameText(trimCapturedChrome(frame, width))
+	want := []string{"first paragraph", "second line", "", rule, "❯"}
+	if len(got) != len(want) {
+		t.Fatalf("trimCapturedChrome returned %d rows (%q), want %d (%q)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTrimCapturedChromeKeepsFrameWithoutRule(t *testing.T) {
+	const width = 20
+	frame := [][]Cell{
+		chromeLine("only prose here", width),
+		chromeLine("and more prose", width),
+	}
+	if got := trimCapturedChrome(frame, width); len(got) != len(frame) {
+		t.Fatalf("frame without a rule was trimmed to %d rows, want %d", len(got), len(frame))
+	}
+}
+
+func TestTrimCapturedChromeIgnoresDistantRule(t *testing.T) {
+	const width = 20
+	frame := [][]Cell{chromeLine(strings.Repeat("─", width), width)}
+	for i := 0; i < chromeSearchDepth+2; i++ {
+		frame = append(frame, chromeLine("prose line", width))
+	}
+	if got := trimCapturedChrome(frame, width); len(got) != len(frame) {
+		t.Fatalf("rule above the search depth trimmed the frame to %d rows, want %d", len(got), len(frame))
+	}
+}
+
+// A normal scrollback-backed program must keep every scrolled line, rules
+// included: the trim is only for synthesized alt-screen history.
+func TestScrollUpKeepsRulesOnNormalScreen(t *testing.T) {
+	const width = 20
+	vt := New(width, 3)
+	rule := strings.Repeat("─", width) + "\r\n"
+	vt.Write([]byte("prose\r\n" + rule + "❯ prompt\r\nmore\r\n"))
+
+	var sawRule bool
+	for _, row := range vt.Scrollback {
+		if isRuleRow(row, width) {
+			sawRule = true
+		}
+	}
+	if !sawRule {
+		t.Fatalf("normal-screen scrollback dropped a rule row; scrollback=%q", chromeFrameText(vt.Scrollback))
+	}
+}
+
+// Synthesized alt-screen history drops the trailing prompt box.
+func TestScrollUpTrimsChromeInSynthesizedHistory(t *testing.T) {
+	const width = 20
+	vt := New(width, 6)
+	vt.AllowAltScreenScrollback = true
+	vt.Write([]byte("\x1b[?1049h"))
+	if !vt.AltScreen {
+		t.Fatal("expected alt screen")
+	}
+	rule := strings.Repeat("─", width)
+	vt.Write([]byte("prose one\r\nprose two\r\n" + rule + "\r\n❯ \r\n" + rule + "\r\n"))
+	// Force a scroll so the frame is displaced into synthesized history.
+	vt.Write([]byte("\r\n\r\n"))
+
+	for _, row := range vt.Scrollback {
+		if isRuleRow(row, width) {
+			t.Fatalf("synthesized history kept a rule row; scrollback=%q", chromeFrameText(vt.Scrollback))
+		}
+	}
+}
+
+// A partial scroll displaces rows from the middle of the transcript, where a
+// trailing rule is content. Only a whole-region scroll may be trimmed.
+func TestScrollUpPartialScrollKeepsEverything(t *testing.T) {
+	const width = 20
+	vt := New(width, 6)
+	vt.AllowAltScreenScrollback = true
+	vt.Write([]byte("\x1b[?1049h"))
+	rule := strings.Repeat("\u2500", width)
+	// Fill the screen so the rule is mid-transcript, then push it off the top
+	// one line at a time — each write scrolls a single row, never the region.
+	vt.Write([]byte("a\r\nb\r\nc\r\n" + rule + "\r\nd\r\ne\r\n"))
+	for _, line := range []string{"f", "g", "h", "i", "j"} {
+		vt.Write([]byte(line + "\r\n"))
+	}
+
+	var sawRule bool
+	for _, row := range vt.Scrollback {
+		if isRuleRow(row, width) {
+			sawRule = true
+		}
+	}
+	if !sawRule {
+		t.Fatalf("a one-line scroll dropped a rule that was transcript; scrollback=%q", chromeFrameText(vt.Scrollback))
+	}
+}

--- a/internal/vterm/scroll.go
+++ b/internal/vterm/scroll.go
@@ -24,17 +24,28 @@ func (v *VTerm) scrollUp(n int) {
 		if bottom > v.ScrollBottom {
 			bottom = v.ScrollBottom
 		}
+		if bottom > len(v.Screen) {
+			bottom = len(v.Screen)
+		}
+		// Move (not copy) the rows: the shift and blank-fill loops below
+		// reassign every Screen slot in [ScrollTop, ScrollBottom), so after
+		// this append the appended slice is the sole live reference
+		// (snapshot/render paths copy cell contents, never retain Screen row
+		// headers).
+		displaced := v.Screen[top:bottom]
+		// Synthesized history only, and only for a scroll that displaces the
+		// whole region at once: that is how tmux renders a repainting chat
+		// agent's scroll, and it is the only case where the displaced block is
+		// a frame whose tail is the agent's prompt box (see chrome_filter.go).
+		// A smaller scroll displaces rows from the middle of the transcript,
+		// where a trailing rule is content rather than chrome.
+		if v.AltScreen && v.AllowAltScreenScrollback && n >= regionHeight-1 {
+			displaced = trimCapturedChrome(displaced, v.Width)
+		}
 		added := 0
-		for i := top; i < bottom; i++ {
-			if i < len(v.Screen) {
-				// Move (not copy) the row: the shift and blank-fill loops
-				// below reassign every Screen slot in [ScrollTop, ScrollBottom),
-				// so after this append the appended slice is the sole live
-				// reference (snapshot/render paths copy cell contents, never
-				// retain Screen row headers).
-				v.Scrollback = append(v.Scrollback, v.Screen[i])
-				added++
-			}
+		for _, line := range displaced {
+			v.Scrollback = append(v.Scrollback, line)
+			added++
 		}
 		if added > 0 {
 			if v.altCapture.tracked && v.altCapture.frameLen > 0 &&


### PR DESCRIPTION
## Problem

A chat agent that lives on the alternate screen (Claude Code) never scrolls and never clears — it repaints the whole screen in place. Measured on a live pane: `alternate_on=1, history_size=0`, and in 370 KB of its output there are **zero** line feeds and **zero** `ESC[2J`. So it leaves no real scrollback, and amux synthesizes history from the frames that pass through the viewport.

Every one of those frames carries the agent's chrome as well as its transcript. Scrolling back looked like this:

```
  1961, now surrounded by more measurement than the coffee industry has…
✻ Churned for 1m 22s
※ recap: You asked for a series of long-form history write-ups…
──────────────────────────────────────────────────────────────────────
❯
──────────────────────────────────────────────────────────────────────
  ⏸ plan mode on (shift+tab to cycle) · ← 1 agent
                        (18 blank rows)
```

Prose indented two columns, interrupted by a stale prompt box, full-width rules and a footer all starting at column 0, then a run off the end of scrollback into blanks.

## Change

Trim from a captured frame's last horizontal rule downward. A rule anchors the chrome because it's unambiguous — no line of prose is one glyph repeated across most of the terminal. Two guards keep it from eating content:

- the glyph must be **non-alphanumeric**, so a row of `xxxxxxxx` or a bare `========` separator in real output isn't mistaken for chrome
- the search is bounded to the rows just above the frame's last content, so a rule further up can't cut the transcript

Both synthesized-history entry points trim. `captureScreenToScrollback` takes a whole frame, whose tail is the prompt box. `scrollUp` trims **only** when the scroll displaces the whole region at once — that's how tmux renders a repainting agent's scroll, and the only case where the displaced block is a frame. A smaller scroll displaces rows from mid-transcript, where a trailing rule is content.

Both gated on `AltScreen && AllowAltScreenScrollback`, so a real scrollback-backed program keeps every scrolled line, rules included (pinned by `TestScrollUpKeepsRulesOnNormalScreen`).

## Verification

Replaying a captured Claude Code session, scrollback goes 103 → 86 rows and the scrolled window becomes continuous prose with no prompt box, rules, or blank tail.

Six new tests; full suite green; `make lint` reports 0 issues.

## One thing I can't explain

Replayed through the real binary, this also cuts torn rows during heavy repaints from ~10.4 to ~3.2 per run across matched 8-run samples. I don't know why — the trim changes only what enters scrollback and shouldn't reach the live screen at `ViewOffset 0`. **The repaint tearing is a separate open bug and this is not a fix for it**; the reduction is recorded here so the next person has the thread.