### PR TITLE
perf: cache the composed frame across render-neutral PTY messages

### DIFF
--- a/internal/app/ARCHITECTURE.md
+++ b/internal/app/ARCHITECTURE.md
@@ -20,6 +20,15 @@ keep Bubble Tea, tmux, and PTY state consistent.
 3. Render
 - `App.View` composes dashboard + center + sidebar layers using layout
   measurements and compositor caches.
+- `App.View` reuses the complete prior frame for render-neutral PTY buffering
+  messages. The frame key covers everything those messages can change behind
+  `App.Update`'s back: the active center/sidebar vterm content versions, the
+  active tab's OSC title version (title updates never move the content version),
+  and center tab activity - the tab bar's working highlights, which the actor
+  sets for background tabs too, plus the active chat tab's cursor-trust window.
+  Inactive terminal *content* deliberately does not participate.
+- Anything else that a render-neutral message mutates must join that key or the
+  screen will hold a stale frame until an unrelated message arrives.
 - Render is derived from state only; no side effects.
 
 4. Shutdown

--- a/internal/app/app_cache.go
+++ b/internal/app/app_cache.go
@@ -1,9 +1,63 @@
 package app
 
 import (
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/andyrewlee/amux/internal/ui/common"
 	"github.com/andyrewlee/amux/internal/ui/compositor"
 )
+
+// visibleFrameVersion is the small render-time key for visible state that can
+// mutate outside App.Update. All other visible app state invalidates the frame
+// cache synchronously in App.Update; the active center/sidebar vterm versions
+// cover actor writes and the synchronous PTY fallback without forcing inactive
+// terminal output to rebuild the full canvas.
+//
+// The two non-content fields exist because the center pane renders more than the
+// active terminal's cells: the window title comes from the active tab's OSC title
+// (which never moves the content version), and tab activity drives both the tab
+// bar's working highlight - including for background tabs the actor updates - and
+// the active chat tab's cursor-trust window.
+type visibleFrameVersion struct {
+	centerTerminal      uint64
+	centerTerminalTitle uint64
+	centerActivity      uint64
+	sidebarTerminal     uint64
+}
+
+// fullFrameCache sits at the App.View seam. Bubble Tea calls View after every
+// message, including raw PTY buffering messages that did not alter the visible
+// screen. Pane caches avoid rebuilding some strings, but still leave Canvas
+// clear/compose/render work. This cache makes a clean View an O(1) copy.
+//
+// valid is explicitly invalidated by visible App.Update messages. key catches
+// active vterm mutations performed by the tab actor or synchronous PTY paths.
+type fullFrameCache struct {
+	valid  bool
+	key    visibleFrameVersion
+	view   tea.View
+	builds uint64 // test/perf instrumentation
+	hits   uint64 // test/perf instrumentation
+}
+
+func (c *fullFrameCache) get(key visibleFrameVersion) (tea.View, bool) {
+	if !c.valid || c.key != key {
+		return tea.View{}, false
+	}
+	c.hits++
+	return c.view, true
+}
+
+func (c *fullFrameCache) store(key visibleFrameVersion, view tea.View) {
+	c.valid = true
+	c.key = key
+	c.view = view
+	c.builds++
+}
+
+func (c *fullFrameCache) invalidate() {
+	c.valid = false
+}
 
 type drawableCache struct {
 	content  string
@@ -90,6 +144,7 @@ func (g *paneGate) record(version uint64, geom [4]int, rendered bool) {
 // rendering. Each cache is keyed on the inputs that produced it and reused
 // across frames until those inputs change.
 type renderCacheState struct {
+	frame                fullFrameCache
 	dashboardChrome      *compositor.ChromeCache
 	centerChrome         *compositor.ChromeCache
 	sidebarChrome        *compositor.ChromeCache

--- a/internal/app/app_input.go
+++ b/internal/app/app_input.go
@@ -16,15 +16,34 @@ import (
 
 // Update handles all messages with panic recovery.
 func (a *App) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
+	if frameInvalidatedBy(msg) {
+		a.renderCache.frame.invalidate()
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			logging.Error("panic in app.Update: %v\n%s", r, debug.Stack())
 			a.err = fmt.Errorf("internal error: %v", r)
+			a.renderCache.frame.invalidate()
 			model = a
 			cmd = nil
 		}
 	}()
 	return a.update(msg)
+}
+
+// frameInvalidatedBy identifies messages whose Update work may change the
+// composed frame directly. Raw PTY output only buffers bytes, and PTY flushes
+// are covered by the active vterm versions in the full-frame cache key. Keeping
+// these high-frequency messages render-neutral prevents inactive tabs and
+// flush scheduling from rebuilding an unchanged screen.
+func frameInvalidatedBy(msg tea.Msg) bool {
+	switch msg.(type) {
+	case center.PTYOutput, center.PTYFlush,
+		messages.SidebarPTYOutput, messages.SidebarPTYFlush:
+		return false
+	default:
+		return true
+	}
 }
 
 func (a *App) update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/app/app_view.go
+++ b/internal/app/app_view.go
@@ -29,6 +29,10 @@ func (a *App) View() (view tea.View) {
 		if r := recover(); r != nil {
 			logging.Error("panic in app.View: %v\n%s", r, debug.Stack())
 			a.err = fmt.Errorf("render error: %v", r)
+			// A half-built frame must not leave the last good frame reachable:
+			// the error view would otherwise be replaced by stale content on the
+			// next unchanged-key View.
+			a.renderCache.frame.invalidate()
 			view = a.fallbackView()
 		}
 	}()
@@ -37,6 +41,12 @@ func (a *App) View() (view tea.View) {
 
 func (a *App) view() tea.View {
 	defer perf.Time("view")()
+	frameVersion := a.visibleFrameVersion()
+	if cached, ok := a.renderCache.frame.get(frameVersion); ok {
+		perf.Count("full_frame_cache_hit", 1)
+		return a.finalizeView(cached)
+	}
+	perf.Count("full_frame_cache_miss", 1)
 
 	baseView := func() tea.View {
 		var view tea.View
@@ -52,17 +62,34 @@ func (a *App) view() tea.View {
 	if a.quitting {
 		view := baseView()
 		view.SetContent("Goodbye!\n")
-		return a.finalizeView(view)
+		return a.storeFrame(frameVersion, view)
 	}
 
 	if !a.ready {
 		view := baseView()
 		view.SetContent("Loading...")
-		return a.finalizeView(view)
+		return a.storeFrame(frameVersion, view)
 	}
 
 	// Use layer-based rendering
-	return a.finalizeView(a.viewLayerBased())
+	return a.storeFrame(frameVersion, a.viewLayerBased())
+}
+
+func (a *App) visibleFrameVersion() visibleFrameVersion {
+	var version visibleFrameVersion
+	if a.center != nil && a.layout != nil && a.layout.ShowCenter() {
+		version.centerTerminal, version.centerTerminalTitle = a.center.VisibleTerminalVersions()
+		version.centerActivity = a.center.ActivityVersion()
+	}
+	if a.sidebarTerminal != nil && a.layout != nil && a.layout.ShowSidebar() {
+		version.sidebarTerminal = a.sidebarTerminal.VisibleTerminalVersion()
+	}
+	return version
+}
+
+func (a *App) storeFrame(version visibleFrameVersion, view tea.View) tea.View {
+	a.renderCache.frame.store(version, view)
+	return a.finalizeView(view)
 }
 
 func (a *App) canvasFor(width, height int) *lipgloss.Canvas {

--- a/internal/app/app_view_frame_cache_test.go
+++ b/internal/app/app_view_frame_cache_test.go
@@ -1,0 +1,152 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/ui/center"
+)
+
+func newFrameCacheHarness(t *testing.T, tabs int) *Harness {
+	t.Helper()
+	h, err := NewHarness(HarnessOptions{
+		Mode:   HarnessCenter,
+		Tabs:   tabs,
+		Width:  160,
+		Height: 48,
+	})
+	if err != nil {
+		t.Fatalf("frame-cache harness init: %v", err)
+	}
+	h.app.ready = true
+	h.app.syncPaneFocusFlags()
+	return h
+}
+
+func TestFullFrameCache_ReusesFrameForRenderNeutralPTYMessages(t *testing.T) {
+	h := newFrameCacheHarness(t, 1)
+
+	first := h.app.view()
+	builds := h.app.renderCache.frame.builds
+	if builds == 0 {
+		t.Fatal("first view did not populate the full-frame cache")
+	}
+
+	_, _ = h.app.Update(center.PTYOutput{
+		WorkspaceID: "missing-workspace",
+		TabID:       center.TabID("missing-tab"),
+		Data:        []byte("buffered output"),
+	})
+	second := h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds {
+		t.Fatalf("render-neutral PTY output rebuilt full frame: builds %d -> %d", builds, got)
+	}
+	if h.app.renderCache.frame.hits == 0 {
+		t.Fatal("render-neutral PTY output did not hit the full-frame cache")
+	}
+	if second.Content != first.Content {
+		t.Fatal("cached frame content changed after render-neutral PTY output")
+	}
+}
+
+func TestFullFrameCache_ActiveTerminalVersionForcesRebuild(t *testing.T) {
+	h := newFrameCacheHarness(t, 1)
+
+	first := h.app.view()
+	builds := h.app.renderCache.frame.builds
+	h.tabs[0].WriteToTerminal([]byte("active mutation"))
+	second := h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds+1 {
+		t.Fatalf("active terminal mutation did not rebuild full frame: builds %d -> %d", builds, got)
+	}
+	if second.Content == first.Content {
+		t.Fatal("active terminal mutation reused stale frame content")
+	}
+}
+
+func TestFullFrameCache_ActiveTerminalTitleForcesRebuild(t *testing.T) {
+	h := newFrameCacheHarness(t, 1)
+
+	_ = h.app.view()
+	builds := h.app.renderCache.frame.builds
+	// OSC title only: no cell changes, so the content version stays put while the
+	// window title the frame carries does not.
+	h.tabs[0].WriteToTerminal([]byte("\x1b]0;agent working\x07"))
+	_ = h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds+1 {
+		t.Fatalf("terminal title change did not rebuild full frame: builds %d -> %d", builds, got)
+	}
+}
+
+func TestFullFrameCache_InactiveTerminalVersionReusesFrame(t *testing.T) {
+	h := newFrameCacheHarness(t, 2)
+	_ = h.app.center.SelectTab(0)
+
+	first := h.app.view()
+	builds := h.app.renderCache.frame.builds
+	h.tabs[1].WriteToTerminal([]byte("inactive mutation"))
+	second := h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds {
+		t.Fatalf("inactive terminal mutation rebuilt full frame: builds %d -> %d", builds, got)
+	}
+	if second.Content != first.Content {
+		t.Fatal("inactive terminal mutation changed the visible frame")
+	}
+}
+
+// TestFullFrameCache_BackgroundTabActivityForcesRebuild is the regression the
+// activity key exists for: the tab bar highlights a background chat tab that is
+// working, and nothing about that reaches the active terminal's content.
+func TestFullFrameCache_BackgroundTabActivityForcesRebuild(t *testing.T) {
+	h := newFrameCacheHarness(t, 2)
+	_ = h.app.center.SelectTab(0)
+
+	first := h.app.view()
+	builds := h.app.renderCache.frame.builds
+	h.tabs[1].NoteVisibleOutput(time.Now())
+	second := h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds+1 {
+		t.Fatalf("background tab activity did not rebuild full frame: builds %d -> %d", builds, got)
+	}
+	if second.Content == first.Content {
+		t.Fatal("background tab activity left the tab bar unchanged")
+	}
+}
+
+func TestFullFrameCache_OrdinaryMessageInvalidatesFrame(t *testing.T) {
+	h := newFrameCacheHarness(t, 1)
+
+	_ = h.app.view()
+	builds := h.app.renderCache.frame.builds
+	_, _ = h.app.Update(tea.WindowSizeMsg{Width: 161, Height: 48})
+	_ = h.app.view()
+
+	if got := h.app.renderCache.frame.builds; got != builds+1 {
+		t.Fatalf("ordinary visible message did not rebuild full frame: builds %d -> %d", builds, got)
+	}
+}
+
+func TestFrameInvalidatedBy_HighFrequencyPTYMessagesAreNeutral(t *testing.T) {
+	neutral := []tea.Msg{
+		center.PTYOutput{},
+		center.PTYFlush{},
+		messages.SidebarPTYOutput{},
+		messages.SidebarPTYFlush{},
+	}
+	for _, msg := range neutral {
+		if frameInvalidatedBy(msg) {
+			t.Fatalf("expected %T to be render-neutral", msg)
+		}
+	}
+	if !frameInvalidatedBy(center.PTYStopped{}) {
+		t.Fatal("PTYStopped must invalidate the frame")
+	}
+}

--- a/internal/ui/center/harness.go
+++ b/internal/ui/center/harness.go
@@ -1,5 +1,7 @@
 package center
 
+import "time"
+
 // AddTab appends a tab to the model. Used by harness/test code that builds tabs manually.
 func (m *Model) AddTab(tab *Tab) {
 	if m == nil || tab == nil || tab.Workspace == nil {
@@ -29,5 +31,18 @@ func (t *Tab) WriteToTerminal(data []byte) {
 	}
 	t.mu.Lock()
 	t.Terminal.Write(data)
+	t.mu.Unlock()
+}
+
+// NoteVisibleOutput stamps the visible-activity clock the way the tab actor does
+// after applying a flush chunk. Harness/test code uses it to reproduce activity
+// on tabs it is not driving through the real PTY pipeline.
+func (t *Tab) NoteVisibleOutput(at time.Time) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.lastVisibleOutput = at
+	t.LastOutputAt = at
 	t.mu.Unlock()
 }

--- a/internal/ui/center/model_frame_activity_test.go
+++ b/internal/ui/center/model_frame_activity_test.go
@@ -1,0 +1,111 @@
+package center
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// TestActivityVersion_TracksBackgroundTabs pins the contract App's full-frame
+// cache depends on: a background chat tab that starts or stops working changes
+// the fingerprint, because the tab bar highlights it.
+func TestActivityVersion_TracksBackgroundTabs(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	active := &Tab{ID: TabID("tab-0"), Assistant: "claude", Workspace: ws, Running: true}
+	background := &Tab{ID: TabID("tab-1"), Assistant: "claude", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{active, background}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	idle := m.ActivityVersion()
+	if idle != 0 {
+		t.Fatalf("expected no activity bits with no output, got %#x", idle)
+	}
+
+	background.mu.Lock()
+	background.lastVisibleOutput = time.Now()
+	background.mu.Unlock()
+
+	working := m.ActivityVersion()
+	if working == idle {
+		t.Fatalf("background tab activity did not change the fingerprint (still %#x)", working)
+	}
+
+	background.mu.Lock()
+	background.lastVisibleOutput = time.Now().Add(-2 * tabActiveWindow)
+	background.mu.Unlock()
+
+	if got := m.ActivityVersion(); got != idle {
+		t.Fatalf("expired background activity = %#x, want %#x", got, idle)
+	}
+}
+
+// TestActivityVersion_TracksActiveTabCursorWindow covers the other half: PTY
+// bytes that change no cell at all still open the active chat tab's cursor-trust
+// window, which moves where the cursor is drawn.
+func TestActivityVersion_TracksActiveTabCursorWindow(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	tab := &Tab{ID: TabID("tab-0"), Assistant: "claude", Workspace: ws, Running: true}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	idle := m.ActivityVersion()
+
+	// LastOutputAt without lastVisibleOutput is exactly the invisible-output case:
+	// no cell changed, so no vterm version moved either.
+	tab.mu.Lock()
+	tab.LastOutputAt = time.Now()
+	tab.mu.Unlock()
+
+	if got := m.ActivityVersion(); got == idle {
+		t.Fatalf("invisible output did not change the fingerprint (still %#x)", got)
+	}
+
+	tab.mu.Lock()
+	tab.LastOutputAt = time.Now().Add(-2 * tabActiveWindow)
+	tab.mu.Unlock()
+
+	if got := m.ActivityVersion(); got != idle {
+		t.Fatalf("expired cursor window = %#x, want %#x", got, idle)
+	}
+}
+
+// TestVisibleTerminalVersions_SplitsContentAndTitle covers the reason the title
+// is keyed separately: an OSC title update repaints the window title without
+// touching a single cell.
+func TestVisibleTerminalVersions_SplitsContentAndTitle(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	tab := &Tab{
+		ID:        TabID("tab-0"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		Terminal:  vterm.New(80, 24),
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	content, title := m.VisibleTerminalVersions()
+
+	tab.WriteToTerminal([]byte("\x1b]0;agent working\x07"))
+
+	gotContent, gotTitle := m.VisibleTerminalVersions()
+	if gotContent != content {
+		t.Fatalf("title-only output moved the content version: %d -> %d", content, gotContent)
+	}
+	if gotTitle == title {
+		t.Fatalf("title-only output did not move the title version (still %d)", gotTitle)
+	}
+}

--- a/internal/ui/center/model_pty_status.go
+++ b/internal/ui/center/model_pty_status.go
@@ -50,19 +50,37 @@ func (m *Model) HasActiveAgents() bool {
 // IsTabActive returns whether a specific tab has emitted output recently.
 // This is used for the tab bar spinner animation (shows activity, not just running state).
 func (m *Model) IsTabActive(tab *Tab) bool {
-	if tab == nil {
-		return false
-	}
-	if tab.isClosed() {
-		return false
-	}
-	if !m.isChatTab(tab) {
+	return m.isTabActiveAt(tab, time.Now())
+}
+
+// isTabActiveAt evaluates the whole predicate under one lock: ActivityVersion
+// calls it for every tab on every frame, so a second acquisition per tab is
+// pure overhead, and it needs one shared "now" across the tabs it compares.
+func (m *Model) isTabActiveAt(tab *Tab, now time.Time) bool {
+	if tab == nil || tab.isClosed() {
 		return false
 	}
 	tab.mu.Lock()
-	active := isTabVisiblyActiveLocked(tab, time.Now())
-	tab.mu.Unlock()
-	return active
+	defer tab.mu.Unlock()
+	if !m.isChatTabLocked(tab) {
+		return false
+	}
+	return isTabVisiblyActiveLocked(tab, now)
+}
+
+// isTabCursorOutputActiveAt is the chat-cursor half of the same question: it
+// reports the window TerminalLayerWithCursorOwner consults when deciding whether
+// to trust the live cursor. See isTabCursorOutputActiveLocked.
+func (m *Model) isTabCursorOutputActiveAt(tab *Tab, now time.Time) bool {
+	if tab == nil || tab.isClosed() {
+		return false
+	}
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if !m.isChatTabLocked(tab) {
+		return false
+	}
+	return isTabCursorOutputActiveLocked(tab, now)
 }
 
 func isTabVisiblyActiveLocked(tab *Tab, now time.Time) bool {
@@ -205,6 +223,56 @@ func (m *Model) StartPTYReaders() tea.Cmd {
 // It snapshots terminal state under lock and reuses cached snapshots when valid.
 func (m *Model) TerminalLayer() *compositor.VTermLayer {
 	return m.TerminalLayerWithCursorOwner(true)
+}
+
+// VisibleTerminalVersions returns the active terminal's visible-content version
+// and its OSC title version. App's full-frame cache uses this small interface to
+// observe actor writes without treating output from inactive tabs as a reason to
+// rebuild the canvas. The title is reported separately because App renders it as
+// the window title while the content version deliberately ignores title updates.
+func (m *Model) VisibleTerminalVersions() (content, title uint64) {
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if activeIdx < 0 || activeIdx >= len(tabs) {
+		return 0, 0
+	}
+	tab := tabs[activeIdx]
+	if tab == nil {
+		return 0, 0
+	}
+	tab.mu.Lock()
+	defer tab.mu.Unlock()
+	if tab.Terminal == nil {
+		return 0, 0
+	}
+	return tab.Terminal.Version(), tab.Terminal.TitleVersion()
+}
+
+// ActivityVersion fingerprints the frame inputs the center derives from tab
+// activity rather than from terminal content: the tab bar's per-tab working
+// highlight (bits 0..62, current workspace order) and the active chat tab's
+// cursor-trust window (bit 63). Both are time-based, and the PTY paths that move
+// them - buffered output, actor writes - never touch a vterm version, so App's
+// full-frame cache keys on this to avoid holding a stale frame. Tabs past the
+// 63rd get no bit; the tab bar cannot show that many at once anyway.
+func (m *Model) ActivityVersion() uint64 {
+	tabs := m.getTabs()
+	now := time.Now()
+	var fingerprint uint64
+	for i, tab := range tabs {
+		if i >= 63 {
+			break
+		}
+		if m.isTabActiveAt(tab, now) {
+			fingerprint |= 1 << uint(i)
+		}
+	}
+	if activeIdx := m.getActiveTabIdx(); activeIdx >= 0 && activeIdx < len(tabs) {
+		if m.isTabCursorOutputActiveAt(tabs[activeIdx], now) {
+			fingerprint |= 1 << 63
+		}
+	}
+	return fingerprint
 }
 
 // TerminalLayerWithCursorOwner returns a VTermLayer for the active terminal while

--- a/internal/ui/center/model_tabs_session.go
+++ b/internal/ui/center/model_tabs_session.go
@@ -2,6 +2,7 @@ package center
 
 import (
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -110,7 +111,29 @@ func (m *Model) tabSelectionChangedCmd(changed bool) tea.Cmd {
 		},
 		m.flushActiveTabBacklogCmd(),
 		m.autoReattachActiveTabOnSelection(),
+		m.scheduleActiveChatCursorRefreshCmd(),
 	)
+}
+
+// scheduleActiveChatCursorRefreshCmd arms the timed chat-cursor refresh for the
+// tab that just became visible. Background tabs get no post-write redraw, so a
+// tab that was producing output while hidden arrives with a cursor policy that
+// only elapsed time can change and nothing scheduled to repaint it.
+func (m *Model) scheduleActiveChatCursorRefreshCmd() tea.Cmd {
+	wsID := m.workspaceID()
+	if wsID == "" {
+		return nil
+	}
+	tabs := m.getTabs()
+	activeIdx := m.getActiveTabIdx()
+	if activeIdx < 0 || activeIdx >= len(tabs) {
+		return nil
+	}
+	tab := tabs[activeIdx]
+	if tab == nil || tab.isClosed() {
+		return nil
+	}
+	return m.scheduleChatCursorRefresh(tab, wsID, time.Now())
 }
 
 func (m *Model) flushActiveTabBacklogCmd() tea.Cmd {

--- a/internal/ui/center/model_tabs_session_selection_cursor_test.go
+++ b/internal/ui/center/model_tabs_session_selection_cursor_test.go
@@ -1,0 +1,43 @@
+package center
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andyrewlee/amux/internal/vterm"
+)
+
+// TestTabSelectionChangedCmd_ArmsChatCursorRefresh covers the hand-off for a
+// chat tab that was working while hidden: background tabs get no post-write
+// redraw, so selection is what arms the timer that repaints the cursor when the
+// activity window expires.
+func TestTabSelectionChangedCmd_ArmsChatCursorRefresh(t *testing.T) {
+	m := newTestModel()
+	ws := newTestWorkspace("ws", "/repo/ws")
+	wsID := string(ws.ID())
+
+	tab := &Tab{
+		ID:        TabID("tab-chat"),
+		Assistant: "claude",
+		Workspace: ws,
+		Running:   true,
+		Terminal:  vterm.New(80, 24),
+		tabActivityState: tabActivityState{
+			lastVisibleOutput: time.Now(),
+		},
+	}
+	m.tabs.ByWorkspace[wsID] = []*Tab{tab}
+	m.tabs.ActiveByWorkspace[wsID] = 0
+	m.workspace = ws
+
+	if cmd := m.tabSelectionChangedCmd(true); cmd == nil {
+		t.Fatalf("expected non-nil cmd")
+	}
+
+	tab.mu.Lock()
+	pending := tab.cursorRefreshPending
+	tab.mu.Unlock()
+	if !pending {
+		t.Fatalf("expected tab selection to arm the chat cursor refresh")
+	}
+}

--- a/internal/ui/center/tab_actor.go
+++ b/internal/ui/center/tab_actor.go
@@ -101,7 +101,7 @@ type TabInputFailed struct {
 }
 
 func (m *Model) shouldPostWriteRedraw(tab *Tab) bool {
-	return tab != nil && (m.isChatTab(tab) || tab.postWriteVisible())
+	return tab != nil && tab.postWriteVisible()
 }
 
 func (m *Model) sendTabEvent(ev tabEvent) bool {

--- a/internal/ui/center/tab_actor_input_test.go
+++ b/internal/ui/center/tab_actor_input_test.go
@@ -57,14 +57,15 @@ func TestSendToTerminal_EmitsCursorRefreshOnlyForChatTabs(t *testing.T) {
 	}
 }
 
-func TestHandleTabEvent_WriteOutputEmitsPostWriteRedrawForChatAndActiveTabs(t *testing.T) {
+func TestHandleTabEvent_WriteOutputEmitsPostWriteRedrawOnlyForVisibleTab(t *testing.T) {
 	tests := []struct {
 		name          string
 		assistant     string
 		visible       bool
 		wantRefreshes int
 	}{
-		{name: "chat background", assistant: "codex", wantRefreshes: 1},
+		{name: "chat background", assistant: "codex", wantRefreshes: 0},
+		{name: "chat visible", assistant: "codex", visible: true, wantRefreshes: 1},
 		{name: "non-chat visible", assistant: "bash", visible: true, wantRefreshes: 1},
 		{name: "non-chat background", assistant: "bash", wantRefreshes: 0},
 	}
@@ -158,6 +159,7 @@ func TestHandleTabEvent_WriteOutputSuppressesRedrawUntilCatchUpTarget(t *testing
 		catchUpTargetBytes:   2,
 		ptyBytesReceived:     2,
 	}
+	tab.setPostWriteVisible(true)
 
 	refreshes := 0
 	m.msgSink = func(msg tea.Msg) {
@@ -207,7 +209,8 @@ func TestShouldPostWriteRedraw(t *testing.T) {
 		visible   bool
 		want      bool
 	}{
-		{name: "chat background", assistant: "codex", want: true},
+		{name: "chat background", assistant: "codex", want: false},
+		{name: "chat visible", assistant: "codex", visible: true, want: true},
 		{name: "non-chat visible", assistant: "bash", visible: true, want: true},
 		{name: "non-chat background", assistant: "bash", want: false},
 	}

--- a/internal/ui/center/tab_actor_write.go
+++ b/internal/ui/center/tab_actor_write.go
@@ -56,7 +56,9 @@ func (m *Model) handleWriteOutput(ev tabEvent) {
 		m.msgSink(PTYFlush{WorkspaceID: ev.workspaceID, TabID: ev.tabID, CatchUp: ev.catchUp})
 	}
 	if !suppressRedraw && m.msgSink != nil && m.shouldPostWriteRedraw(tab) {
-		// Visible tabs need one redraw after actor-applied terminal writes.
+		// Only the visible tab needs a redraw after actor-applied terminal writes.
+		// Inactive tabs retain their vterm state and activity bookkeeping, but a
+		// redraw would rebuild an identical app frame.
 		m.msgSink(PTYCursorRefresh{WorkspaceID: ev.workspaceID, TabID: ev.tabID})
 	}
 }

--- a/internal/ui/sidebar/terminal_render.go
+++ b/internal/ui/sidebar/terminal_render.go
@@ -146,6 +146,21 @@ func (m *TerminalModel) TerminalLayer() *compositor.VTermLayer {
 	return m.TerminalLayerWithCursorOwner(true)
 }
 
+// VisibleTerminalVersion returns the active sidebar terminal's visible-content
+// version for App's full-frame cache key.
+func (m *TerminalModel) VisibleTerminalVersion() uint64 {
+	ts := m.getTerminal()
+	if ts == nil {
+		return 0
+	}
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.VTerm == nil {
+		return 0
+	}
+	return ts.VTerm.Version()
+}
+
 // TerminalLayerWithCursorOwner returns a VTermLayer for the active workspace
 // terminal while enforcing whether this pane currently owns cursor rendering.
 func (m *TerminalModel) TerminalLayerWithCursorOwner(cursorOwner bool) *compositor.VTermLayer {

--- a/internal/vterm/osc_test.go
+++ b/internal/vterm/osc_test.go
@@ -208,3 +208,30 @@ func TestOSCOversizedMetadataIgnored(t *testing.T) {
 		}
 	})
 }
+
+// TestOSCTitleVersion pins the split between the content version and the title
+// version: render caches key the window title on TitleVersion precisely because
+// a title update leaves every cell untouched.
+func TestOSCTitleVersion(t *testing.T) {
+	t.Parallel()
+
+	v := New(80, 24)
+	v.Write([]byte("hello"))
+	contentBefore := v.Version()
+	titleBefore := v.TitleVersion()
+
+	v.Write([]byte("\x1b]0;working\x07"))
+
+	if got := v.Version(); got != contentBefore {
+		t.Fatalf("title-only write moved the content version: %d -> %d", contentBefore, got)
+	}
+	if got := v.TitleVersion(); got == titleBefore {
+		t.Fatalf("title-only write did not move the title version (still %d)", got)
+	}
+
+	titleAfter := v.TitleVersion()
+	v.Write([]byte("\x1b]0;working\x07"))
+	if got := v.TitleVersion(); got != titleAfter {
+		t.Fatalf("repeated identical title moved the title version: %d -> %d", titleAfter, got)
+	}
+}

--- a/internal/vterm/vterm.go
+++ b/internal/vterm/vterm.go
@@ -88,6 +88,7 @@ type VTerm struct {
 
 	// OSC-captured state (set by the parser; consumed by the owning UI layer).
 	oscTitle         string
+	titleVersion     uint64
 	oscWorkingDir    string
 	pendingClipboard []byte
 
@@ -354,6 +355,11 @@ func (v *VTerm) respond(data []byte) {
 // Title returns the most recent window/tab title reported via OSC 0/1/2.
 func (v *VTerm) Title() string { return v.oscTitle }
 
+// TitleVersion returns a counter that increments whenever the OSC title changes.
+// A title update leaves every cell alone, so Version() deliberately ignores it;
+// render caches that surface the title separately key on this instead.
+func (v *VTerm) TitleVersion() uint64 { return v.titleVersion }
+
 // WorkingDir returns the most recent working directory reported via OSC 7
 // (raw payload, e.g. "file://host/path").
 func (v *VTerm) WorkingDir() string { return v.oscWorkingDir }
@@ -366,7 +372,14 @@ func (v *VTerm) TakePendingClipboard() []byte {
 	return b
 }
 
-func (v *VTerm) setOSCTitle(s string)         { v.oscTitle = s }
+func (v *VTerm) setOSCTitle(s string) {
+	if v.oscTitle == s {
+		return
+	}
+	v.oscTitle = s
+	v.titleVersion++
+}
+
 func (v *VTerm) setOSCWorkingDir(s string)    { v.oscWorkingDir = s }
 func (v *VTerm) setPendingClipboard(b []byte) { v.pendingClipboard = b }
 


### PR DESCRIPTION
## What

Bubble Tea calls `View` after every message, including the raw PTY output/flush messages that only buffer bytes. Those frames rebuilt the whole canvas for a screen that had not changed.

`App.View` now reuses the previous `tea.View` when nothing visible moved. Invalidation is explicit for every message except PTY buffering, and the frame key covers what those messages can still change behind `Update`'s back:

- active center/sidebar vterm **content** versions (actor writes, synchronous flush fallback)
- the active tab's **OSC title** version — `Version()` deliberately ignores title updates, but the frame carries the title
- center **tab activity** — the tab bar's per-tab working highlight (the actor sets it for background tabs too) and the active chat tab's cursor-trust window, both time-based and both moved by PTY paths that touch no cell

Inactive terminal *content* deliberately stays out of the key: that is the whole point.

## Supporting changes

- `VTerm` tracks a `titleVersion`, so the content version keeps its "cells only" contract.
- The tab actor stops emitting a post-write redraw for background chat tabs — that redraw is what made every background write rebuild the frame. Tab selection now arms the chat cursor refresh instead, so a tab that was working while hidden still repaints its cursor when the activity window expires.
- `IsTabActive` evaluates under a single lock (the frame key calls it per tab per frame).
- `App.View`'s panic recovery invalidates the cache, so the error view is not replaced by the last good frame on the next unchanged-key render.

## Testing

- `go test` + `go test -race` over the full CI package set
- new coverage: frame reuse for neutral messages, rebuild on active-terminal content / title / background-tab activity, reuse on inactive-tab writes, the content-vs-title version split, and cursor-refresh arming on selection
- `make lint` and strict lint (`--new-from-rev=origin/main`) clean; harness presets (center/sidebar/monitor) pass their visible-cell assertions