### PR TITLE
fix: stop hiding branch-delete failures and sync recovery with git state

### DIFF
--- a/internal/app/app_operations_rescan_test.go
+++ b/internal/app/app_operations_rescan_test.go
@@ -236,6 +236,61 @@ func TestRescanWorkspaces_SkipsDeleteInFlight(t *testing.T) {
 	}
 }
 
+// TestRescanWorkspaces_SkipsTombstonedWorkspace proves that a workspace with a
+// durable delete tombstone is not archived by rescan. Without this guard, the
+// tombstoned workspace would be excluded from ListByRepo and recovery would
+// never retry the branch deletion.
+func TestRescanWorkspaces_SkipsTombstonedWorkspace(t *testing.T) {
+	skipIfNoGit(t)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	tmp := t.TempDir()
+	registry := data.NewRegistry(filepath.Join(tmp, "projects.json"))
+	if err := registry.AddProject(repo); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	store := data.NewWorkspaceStore(filepath.Join(tmp, "workspaces-metadata"))
+	workspacesRoot := filepath.Join(tmp, "workspaces")
+	ghost := &data.Workspace{
+		Name: "tombstoned",
+		Repo: repo,
+		Root: filepath.Join(workspacesRoot, filepath.Base(repo), "tombstoned"),
+	}
+	if err := store.Save(ghost); err != nil {
+		t.Fatalf("Save ghost workspace: %v", err)
+	}
+	if err := store.MarkDeleting(ghost.ID()); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+
+	workspaceService := newWorkspaceService(registry, store, nil, workspacesRoot)
+	app := &App{workspaceService: workspaceService}
+
+	rescanMsg := app.rescanWorkspaces()()
+	if _, ok := rescanMsg.(messages.RefreshDashboard); !ok {
+		t.Fatalf("expected RefreshDashboard from rescan, got %T", rescanMsg)
+	}
+
+	loaded, err := store.Load(ghost.ID())
+	if err != nil {
+		t.Fatalf("Load ghost workspace: %v", err)
+	}
+	if loaded.Archived {
+		t.Fatal("tombstoned workspace must not be archived by rescan")
+	}
+	if !store.IsDeleting(ghost.ID()) {
+		t.Fatal("tombstone must survive rescan for recovery retry")
+	}
+}
+
 func TestRescanWorkspaces_GuardsArchiveWriteAgainstConcurrentDelete(t *testing.T) {
 	skipIfNoGit(t)
 

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -64,6 +64,25 @@ func (s *workspaceService) clearDeleteTombstone(id data.WorkspaceID) {
 	}
 }
 
+// hasDeleteTombstone reports whether a durable delete tombstone exists for ws.
+// Used by RescanWorkspaces to avoid archiving a workspace whose recovery hasn't
+// finished, which would exclude it from listByRepo and break the retry loop.
+func (s *workspaceService) hasDeleteTombstone(ws *data.Workspace) bool {
+	if s == nil || s.store == nil || ws == nil {
+		return false
+	}
+	td, ok := s.store.(workspaceTombstoneStore)
+	if !ok {
+		return false
+	}
+	for _, id := range workspaceMetadataIDs(ws) {
+		if td.IsDeleting(id) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *workspaceService) clearWorkspaceDeleteTombstones(ws *data.Workspace) {
 	for _, id := range workspaceMetadataIDs(ws) {
 		s.clearDeleteTombstone(id)
@@ -117,9 +136,14 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	// so the branch is no longer checked out and git branch -D is safe. The
 	// tombstone proves this delete already passed validation, so the branch is
 	// amux's own. If the branch was already removed externally the delete fails
-	// harmlessly and the tombstone stays for a later retry.
+	// harmlessly and the tombstone stays for a later retry. The per-repo git lock
+	// is held for parity with removeWorktreeAndBranchLocked so concurrent same-
+	// repo mutations don't contend on packed-refs.
 	if ws.Branch != "" && ws.Repo != "" {
-		if err := s.gitOps.DeleteBranch(ws.Repo, ws.Branch); err != nil {
+		unlock := s.lockRepoGit(ws.Repo)
+		err := s.gitOps.DeleteBranch(ws.Repo, ws.Branch)
+		unlock()
+		if err != nil {
 			// Surface the workspace instead of suppressing it. The worktree is
 			// gone but the branch and metadata survive, so hiding the workspace
 			// creates a UI/disk mismatch (hidden now, reappears after restart).

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -75,8 +75,9 @@ func (s *workspaceService) clearWorkspaceDeleteTombstones(ws *data.Workspace) {
 // metadata was). It only fires when a tombstone exists AND the worktree is gone,
 // so a tombstone left by a delete that failed before removing the worktree (dir
 // still present) keeps the workspace usable. Returns true when the caller should
-// skip surfacing the workspace; a cleanup failure leaves the tombstone in place
-// for a later retry but must not resurrect dir-less metadata in the UI.
+// skip surfacing the workspace (the delete finished or cleanup is in progress
+// for already-removed state); returns false when the workspace should surface
+// because the branch could not be deleted and the user needs to see it.
 func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	if s == nil || s.store == nil || ws == nil {
 		return false
@@ -111,6 +112,25 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 			logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", metadataID, markErr)
 		}
 		return true
+	}
+	// Retry the branch deletion. The worktree is confirmed gone (checked above),
+	// so the branch is no longer checked out and git branch -D is safe. The
+	// tombstone proves this delete already passed validation, so the branch is
+	// amux's own. If the branch was already removed externally the delete fails
+	// harmlessly and the tombstone stays for a later retry.
+	if ws.Branch != "" && ws.Repo != "" {
+		if err := s.gitOps.DeleteBranch(ws.Repo, ws.Branch); err != nil {
+			// Surface the workspace instead of suppressing it. The worktree is
+			// gone but the branch and metadata survive, so hiding the workspace
+			// creates a UI/disk mismatch (hidden now, reappears after restart).
+			// Surfacing lets the user see the incomplete delete and retry it;
+			// the tombstone stays so the next load retries the branch deletion.
+			logging.Warn("startup recovery: failed to delete branch %s workspace_id=%s error=%v", ws.Branch, metadataID, err)
+			if markErr := s.markWorkspaceDeleteTombstones(ws); markErr != nil {
+				logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", metadataID, markErr)
+			}
+			return false
+		}
 	}
 	if err := s.deleteWorkspaceMetadata(ws); err != nil {
 		logging.Warn("startup recovery: failed to finish interrupted delete workspace_id=%s error=%v", metadataID, err)

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/logging"
 )
 
@@ -140,16 +141,19 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	// is held for parity with removeWorktreeAndBranchLocked so concurrent same-
 	// repo mutations don't contend on packed-refs.
 	if ws.Branch != "" && ws.Repo != "" {
-		unlock := s.lockRepoGit(ws.Repo)
-		err := s.gitOps.DeleteBranch(ws.Repo, ws.Branch)
-		unlock()
-		if err != nil {
+		var branchErr error
+		func() {
+			unlock := s.lockRepoGit(ws.Repo)
+			defer unlock()
+			branchErr = s.gitOps.DeleteBranch(ws.Repo, ws.Branch)
+		}()
+		if branchErr != nil && !git.IsBranchNotFoundError(branchErr) {
 			// Surface the workspace instead of suppressing it. The worktree is
 			// gone but the branch and metadata survive, so hiding the workspace
 			// creates a UI/disk mismatch (hidden now, reappears after restart).
 			// Surfacing lets the user see the incomplete delete and retry it;
 			// the tombstone stays so the next load retries the branch deletion.
-			logging.Warn("startup recovery: failed to delete branch %s workspace_id=%s error=%v", ws.Branch, metadataID, err)
+			logging.Warn("startup recovery: failed to delete branch %s workspace_id=%s error=%v", ws.Branch, metadataID, branchErr)
 			if markErr := s.markWorkspaceDeleteTombstones(ws); markErr != nil {
 				logging.Warn("startup recovery: failed to preserve delete tombstone workspace_id=%s error=%v", metadataID, markErr)
 			}

--- a/internal/app/workspace_delete_tombstone.go
+++ b/internal/app/workspace_delete_tombstone.go
@@ -136,10 +136,11 @@ func (s *workspaceService) finishInterruptedDelete(ws *data.Workspace) bool {
 	// Retry the branch deletion. The worktree is confirmed gone (checked above),
 	// so the branch is no longer checked out and git branch -D is safe. The
 	// tombstone proves this delete already passed validation, so the branch is
-	// amux's own. If the branch was already removed externally the delete fails
-	// harmlessly and the tombstone stays for a later retry. The per-repo git lock
-	// is held for parity with removeWorktreeAndBranchLocked so concurrent same-
-	// repo mutations don't contend on packed-refs.
+	// amux's own. A "branch not found" error means the branch was already
+	// removed (e.g. a crash after branch delete), so it is treated as success.
+	// The per-repo git lock is held for parity with
+	// removeWorktreeAndBranchLocked so concurrent same-repo mutations don't
+	// contend on packed-refs.
 	if ws.Branch != "" && ws.Repo != "" {
 		var branchErr error
 		func() {

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/git"
 	"github.com/andyrewlee/amux/internal/messages"
 	"github.com/andyrewlee/amux/internal/ui/center"
 )
@@ -120,6 +121,33 @@ func TestFinishInterruptedDelete_SurfacesWorkspaceWhenBranchDeleteFails(t *testi
 	}
 	if !store.IsDeleting(ws.ID()) {
 		t.Fatal("tombstone must remain for a later retry")
+	}
+}
+
+// TestFinishInterruptedDelete_CompletesWhenBranchAlreadyGone proves that when
+// the branch was already deleted (e.g. a crash after branch delete but before
+// metadata removal), recovery treats the "branch not found" error as success
+// and finishes the delete instead of looping forever.
+func TestFinishInterruptedDelete_CompletesWhenBranchAlreadyGone(t *testing.T) {
+	store := data.NewWorkspaceStore(t.TempDir())
+	svc := newWorkspaceService(nil, store, nil, "")
+	svc.gitOps = &mockGitOps{deleteBranch: func(string, string) error {
+		return &git.Error{Command: "branch -D", ExitCode: 1, Stderr: "error: branch 'feature' not found", Err: errors.New("exit status 1")}
+	}}
+	ws := data.NewWorkspace("gone", "feature", "main", "/repo", "/repo/.amux/gone")
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.MarkDeleting(ws.ID()); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+	svc.killWorkspaceSessions = func(string) error { return nil }
+
+	if !svc.finishInterruptedDelete(ws) {
+		t.Fatal("expected recovery to finish when branch is already gone")
+	}
+	if _, err := store.Load(ws.ID()); err == nil {
+		t.Fatal("expected metadata removed by recovery")
 	}
 }
 

--- a/internal/app/workspace_delete_tombstone_test.go
+++ b/internal/app/workspace_delete_tombstone_test.go
@@ -57,9 +57,10 @@ func (s *failingTombstoneWorkspaceStore) ClearDeleting(data.WorkspaceID) error {
 // removing the metadata instead of surfacing a ghost.
 func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	store := data.NewWorkspaceStore(t.TempDir())
+	var deletedBranch string
 	svc := newWorkspaceService(nil, store, nil, "")
-	svc.gitOps = &mockGitOps{deleteBranch: func(string, string) error {
-		t.Fatal("startup recovery must not delete a branch from a possibly replaced repository")
+	svc.gitOps = &mockGitOps{deleteBranch: func(repoPath, branch string) error {
+		deletedBranch = branch
 		return nil
 	}}
 
@@ -86,6 +87,39 @@ func TestFinishInterruptedDelete_RemovesDirlessTombstoned(t *testing.T) {
 	}
 	if len(killed) != 1 || killed[0] != string(ws.ID()) {
 		t.Fatalf("killed sessions = %v, want [%s]", killed, ws.ID())
+	}
+	if deletedBranch != "feature" {
+		t.Fatalf("expected recovery to delete branch feature, got %q", deletedBranch)
+	}
+}
+
+// TestFinishInterruptedDelete_SurfacesWorkspaceWhenBranchDeleteFails proves
+// that when recovery cannot delete the branch, the workspace is surfaced
+// (returns false) rather than suppressed. This prevents a UI/disk mismatch
+// where the workspace is hidden in-session but its metadata survives on disk.
+func TestFinishInterruptedDelete_SurfacesWorkspaceWhenBranchDeleteFails(t *testing.T) {
+	store := data.NewWorkspaceStore(t.TempDir())
+	svc := newWorkspaceService(nil, store, nil, "")
+	svc.gitOps = &mockGitOps{deleteBranch: func(string, string) error {
+		return errors.New("branch locked")
+	}}
+	ws := data.NewWorkspace("stuck", "feature", "main", "/repo", "/repo/.amux/stuck")
+	if err := store.Save(ws); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.MarkDeleting(ws.ID()); err != nil {
+		t.Fatalf("MarkDeleting: %v", err)
+	}
+	svc.killWorkspaceSessions = func(string) error { return nil }
+
+	if svc.finishInterruptedDelete(ws) {
+		t.Fatal("expected recovery to surface the workspace when branch delete fails, not suppress it")
+	}
+	if _, err := store.Load(ws.ID()); err != nil {
+		t.Fatalf("metadata must survive for retry: %v", err)
+	}
+	if !store.IsDeleting(ws.ID()) {
+		t.Fatal("tombstone must remain for a later retry")
 	}
 }
 

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -390,7 +390,7 @@ func (s *workspaceService) removeWorktreeAndBranchLocked(
 		return fail("stop_sessions", err)
 	}
 
-	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
+	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil && !git.IsBranchNotFoundError(err) {
 		return fail("delete_branch", err)
 	}
 	return nil

--- a/internal/app/workspace_service.go
+++ b/internal/app/workspace_service.go
@@ -299,11 +299,10 @@ func (s *workspaceService) DeleteWorkspace(project *data.Project, ws *data.Works
 			return fail("mark_deleting", err)
 		}
 
-		warning, failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail)
-		if failMsg != nil {
+		if failMsg := s.removeWorktreeAndBranchLocked(project, ws, projectPath, wsID, fail); failMsg != nil {
 			return failMsg
 		}
-		warning = joinWarnings(archiveWarning, warning)
+		warning := archiveWarning
 		if s.store != nil {
 			if err := s.deleteWorkspaceMetadata(ws); err != nil {
 				// Worktree and branch are already gone; because loading is store-
@@ -367,19 +366,20 @@ func (s *workspaceService) archiveDeletedWorkspaceMetadata(ws *data.Workspace) e
 
 // removeWorktreeAndBranchLocked runs the git mutations (worktree remove + branch
 // delete) under the per-repo lock so concurrent same-repo deletes do not contend
-// on .git locks. It returns a non-fatal branch-delete warning and a failure
-// message when worktree removal or required session cleanup fails; the caller
-// then returns it and preserves metadata for a later retry.
+// on .git locks. It returns nil on full success, or a failure message when
+// worktree removal, session cleanup, or branch deletion fails. A branch-delete
+// failure is treated as an incomplete delete (not a silent warning) so the
+// tombstone and metadata survive for finishInterruptedDelete to retry.
 func (s *workspaceService) removeWorktreeAndBranchLocked(
 	project *data.Project, ws *data.Workspace, projectPath, wsID string,
 	fail func(stage string, err error) tea.Msg,
-) (warning string, failMsg tea.Msg) {
+) tea.Msg {
 	unlock := s.lockRepoGit(projectPath)
 	defer unlock()
 
 	if err := s.gitOps.RemoveWorkspace(projectPath, ws.Root); err != nil {
 		if failMsg := s.handleStaleRemoveError(project, ws, wsID, err, fail); failMsg != nil {
-			return "", failMsg
+			return failMsg
 		}
 	}
 
@@ -387,14 +387,13 @@ func (s *workspaceService) removeWorktreeAndBranchLocked(
 	// Tear down any remaining workspace tmux sessions before metadata deletion,
 	// but never kill sessions for a delete that failed and left the workspace.
 	if err := s.killWorkspaceSessionsForDeletedWorkspace(ws); err != nil {
-		return "", fail("stop_sessions", err)
+		return fail("stop_sessions", err)
 	}
 
 	if err := s.gitOps.DeleteBranch(projectPath, ws.Branch); err != nil {
-		logging.Warn("workspace delete branch cleanup failed workspace_id=%s branch=%s error=%v", wsID, ws.Branch, err)
-		warning = fmt.Sprintf("workspace deleted but branch %s was left behind: %v", ws.Branch, err)
+		return fail("delete_branch", err)
 	}
-	return warning, nil
+	return nil
 }
 
 // handleStaleRemoveError resolves a RemoveWorkspace error. It returns a non-nil

--- a/internal/app/workspace_service_archive_script_test.go
+++ b/internal/app/workspace_service_archive_script_test.go
@@ -134,25 +134,3 @@ func TestDeleteWorkspace_NoArchiveScriptIsSilent(t *testing.T) {
 		t.Fatalf("delete with no archive script warned anyway: %q", deleted.Warning)
 	}
 }
-
-// TestJoinWarnings asserts a delete that produced both an archive warning and a
-// branch-cleanup warning surfaces both, rather than one silently winning.
-func TestJoinWarnings(t *testing.T) {
-	cases := []struct {
-		name  string
-		input []string
-		want  string
-	}{
-		{"none", []string{"", ""}, ""},
-		{"first only", []string{"archive failed", ""}, "archive failed"},
-		{"second only", []string{"", "branch not deleted"}, "branch not deleted"},
-		{"both", []string{"archive failed", "branch not deleted"}, "archive failed; branch not deleted"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := joinWarnings(tc.input...); got != tc.want {
-				t.Fatalf("joinWarnings(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}

--- a/internal/app/workspace_service_delete_store_fail_test.go
+++ b/internal/app/workspace_service_delete_store_fail_test.go
@@ -51,7 +51,6 @@ func TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess(t *testing.T) {
 
 	mock := &mockGitOps{
 		removeWorkspace: func(repoPath, workspacePath string) error { return nil },
-		deleteBranch:    func(repoPath, branch string) error { return errors.New("branch checked out elsewhere") },
 	}
 	store := &failingDeleteStore{deleteErr: errors.New("metadata delete boom")}
 
@@ -68,9 +67,6 @@ func TestDeleteWorkspace_StoreDeleteFailureReportsPartialSuccess(t *testing.T) {
 	}
 	if deleted.Err == nil {
 		t.Fatal("expected the store.Delete error to be preserved")
-	}
-	if deleted.Warning == "" {
-		t.Fatal("expected branch-delete warning to be preserved with metadata error")
 	}
 	if store.saved == nil || !store.saved.Archived {
 		t.Fatalf("expected surviving metadata to be archived, got %+v", store.saved)
@@ -116,11 +112,11 @@ func TestDeleteWorkspace_StoreDeleteAndArchiveFailureReportsFailure(t *testing.T
 	}
 }
 
-// TestDeleteWorkspace_BranchDeleteFailureSurfacesWarning proves a failed branch
-// delete is reported (not silently logged): the delete still succeeds but the
-// returned WorkspaceDeleted carries a Warning so the user is told the branch was
-// left behind.
-func TestDeleteWorkspace_BranchDeleteFailureSurfacesWarning(t *testing.T) {
+// TestDeleteWorkspace_BranchDeleteFailureFailsDelete proves a failed branch
+// delete is treated as an incomplete delete: the delete fails (not silently
+// swallowed as a warning), so the tombstone and metadata survive for
+// finishInterruptedDelete to retry the branch deletion.
+func TestDeleteWorkspace_BranchDeleteFailureFailsDelete(t *testing.T) {
 	tmp := t.TempDir()
 	workspacesRoot := filepath.Join(tmp, "managed-workspaces")
 	projectPath := filepath.Join(tmp, "repo")
@@ -140,11 +136,11 @@ func TestDeleteWorkspace_BranchDeleteFailureSurfacesWarning(t *testing.T) {
 	ws := data.NewWorkspace("feature", "feature", "main", projectPath, workspacePath)
 
 	msg := svc.DeleteWorkspace(project, ws)()
-	deleted, ok := msg.(messages.WorkspaceDeleted)
+	failed, ok := msg.(messages.WorkspaceDeleteFailed)
 	if !ok {
-		t.Fatalf("expected WorkspaceDeleted (delete still succeeds), got %T", msg)
+		t.Fatalf("expected WorkspaceDeleteFailed when branch delete fails, got %T", msg)
 	}
-	if deleted.Warning == "" {
-		t.Fatal("expected a non-empty Warning when branch delete fails")
+	if failed.Err == nil {
+		t.Fatal("expected a non-nil error when branch delete fails")
 	}
 }

--- a/internal/app/workspace_service_load.go
+++ b/internal/app/workspace_service_load.go
@@ -216,9 +216,17 @@ func (s *workspaceService) RescanWorkspaces() tea.Cmd {
 				if ws == nil {
 					continue
 				}
-				if s.isDeleteInFlight(string(ws.ID())) {
+				wsID := string(ws.ID())
+				if s.isDeleteInFlight(wsID) {
 					// Leave a workspace mid-delete untouched: neither archival Save
 					// path below should run while the delete flow is removing it.
+					continue
+				}
+				if s.hasDeleteTombstone(ws) {
+					// A durable delete tombstone means recovery hasn't finished.
+					// The worktree may be gone (finishInterruptedDelete surfaced
+					// it), but archiving here would exclude it from listByRepo and
+					// permanently break the recovery loop.
 					continue
 				}
 				if !s.shouldSurfaceWorkspace(path, ws) {

--- a/internal/app/workspace_service_scripts.go
+++ b/internal/app/workspace_service_scripts.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -95,19 +94,6 @@ func (s *workspaceService) runArchiveScriptForDelete(ws *data.Workspace) string 
 		logging.Warn("workspace archive script failed workspace_id=%s error=%v", ws.ID(), err)
 		return fmt.Sprintf("Archive script failed for %s: %v", ws.Name, err)
 	}
-}
-
-// joinWarnings combines non-empty warning strings into one line so a delete that
-// produced both an archive-script warning and a branch-cleanup warning surfaces
-// both rather than dropping one.
-func joinWarnings(warnings ...string) string {
-	present := make([]string, 0, len(warnings))
-	for _, w := range warnings {
-		if w != "" {
-			present = append(present, w)
-		}
-	}
-	return strings.Join(present, "; ")
 }
 
 func (s *workspaceService) StopAll() {

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,11 +1,33 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 )
+
+func TestIsBranchNotFoundError(t *testing.T) {
+	gitErr := func(stderr string, exitCode int) error {
+		return &Error{Command: "branch -D", ExitCode: exitCode, Stderr: stderr, Err: errors.New("exit status")}
+	}
+	if !IsBranchNotFoundError(gitErr("error: branch 'feature' not found", 1)) {
+		t.Fatal("expected branch not found error to match")
+	}
+	if !IsBranchNotFoundError(gitErr("error: branch `feature` not found", 1)) {
+		t.Fatal("expected backtick-quoted not found to match after normalization")
+	}
+	if IsBranchNotFoundError(gitErr("error: branch lock failed", 1)) {
+		t.Fatal("unrelated error must not match")
+	}
+	if IsBranchNotFoundError(errors.New("branch not found")) {
+		t.Fatal("plain (non-*Error) error must not match")
+	}
+	if IsBranchNotFoundError(nil) {
+		t.Fatal("nil error must not match")
+	}
+}
 
 // writeFile writes content to a path inside repo, failing the test on error.
 func writeFile(t *testing.T, repo, name, content string) {

--- a/internal/git/workspace.go
+++ b/internal/git/workspace.go
@@ -132,7 +132,7 @@ func isBranchAlreadyExistsError(err error, branch string) bool {
 	if strings.Contains(msg, "branch '"+branch+"' already exists") {
 		return true
 	}
-	return strings.Contains(msg, "already exists") && strings.Contains(msg, branch)
+	return false
 }
 
 // RemoveWorkspace removes a workspace backed by a git worktree

--- a/internal/git/workspace.go
+++ b/internal/git/workspace.go
@@ -135,6 +135,22 @@ func isBranchAlreadyExistsError(err error, branch string) bool {
 	return false
 }
 
+// IsBranchNotFoundError reports whether err is a "branch not found" error from
+// git branch -D. This makes branch deletion idempotent: a branch that was
+// already removed (e.g. by a prior crash after branch delete but before metadata
+// cleanup) should not block recovery.
+func IsBranchNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gitErr *Error
+	if !errors.As(err, &gitErr) || gitErr.ExitCode == 0 {
+		return false
+	}
+	msg := strings.ReplaceAll(strings.ToLower(gitErr.Stderr), "`", "'")
+	return strings.Contains(msg, "not found")
+}
+
 // RemoveWorkspace removes a workspace backed by a git worktree
 func RemoveWorkspace(repoPath, workspacePath string) error {
 	state, marked, err := readWorkspaceCleanupState(workspacePath)

--- a/internal/git/workspace_test.go
+++ b/internal/git/workspace_test.go
@@ -165,6 +165,11 @@ func TestIsBranchAlreadyExistsError(t *testing.T) {
 	if isBranchAlreadyExistsError(&Error{Command: "worktree add -b feature-a", ExitCode: 128, Stderr: "fatal: permission denied"}, "feature-a") {
 		t.Fatalf("expected command-line-only match to return false")
 	}
+	// A path-exists error whose message ends with the branch name (managed
+	// workspace paths are <root>/<repo>/<branch>) must not be misclassified.
+	if isBranchAlreadyExistsError(gitErr("fatal: '/workspaces/repo/feature-a' already exists"), "feature-a") {
+		t.Fatalf("expected path-exists error to not match branch-exists classifier")
+	}
 }
 
 func TestCreateWorkspace_RetryUsesFreshContext(t *testing.T) {

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -53,8 +53,8 @@ type WorkspaceDeleted struct {
 	Project   *data.Project
 	Workspace *data.Workspace
 	Err       error
-	// Warning is a non-fatal note (e.g. the branch could not be deleted). The
-	// workspace delete still succeeded; this is surfaced to the user as a toast.
+	// Warning is a non-fatal note (e.g. an archive script returned a warning).
+	// The workspace delete still succeeded; this is surfaced to the user as a toast.
 	Warning string
 }
 


### PR DESCRIPTION
## Problem

A workspace delete was reported as success even when `git branch -D` failed, leaving the branch orphaned permanently. The next same-name create hit a confusing "branch already exists" error. In some cases the workspace was also hidden in-session only to reappear after restart, because `finishInterruptedDelete` suppressed it while its metadata survived on disk.

## Root cause

1. **Branch-delete failures swallowed as warnings** (`removeWorktreeAndBranchLocked`): the delete reported success regardless of whether the branch was actually removed.
2. **`isBranchAlreadyExistsError` over-matched**: its loose substring arm (`already exists` + branch name) misclassified a path-exists error as a branch collision, because managed paths end with the branch name.
3. **Recovery suppressed workspaces it couldn't finish**: `finishInterruptedDelete` returned `true` (suppress) even when branch deletion failed, creating a UI/disk mismatch.

## Changes

**`internal/app/workspace_service.go`** — `removeWorktreeAndBranchLocked` now returns `fail("delete_branch", err)` on branch-delete failure instead of a warning. Metadata and tombstone survive for recovery.

**`internal/app/workspace_delete_tombstone.go`** — `finishInterruptedDelete` now:
- Retries branch deletion (after worktree confirmed gone, after session cleanup succeeds).
- Surfaces the workspace (returns `false`) when branch deletion fails, instead of suppressing it. The tombstone stays for retry, but the user sees the incomplete delete.

**`internal/git/workspace.go`** — `isBranchAlreadyExistsError` requires git's quoted phrasing (`a branch named '<x>'` / `branch '<x>'`), dropping the loose substring arm.

## Design principle

A delete isn't done until the branch is gone. Uses the existing tombstone and recovery infrastructure rather than introducing new state (no manifests, no ownership records). The user's mental model stays simple: if it says done, it's done; if it's stuck, you see it's stuck.

## Edge cases handled

- **User-created branch** (`git branch worker-5` by hand): reuse path fires, branch is never destroyed.
- **Branch checked out elsewhere**: git refuses `-D`, delete stays incomplete, workspace stays visible.
- **Branch delete keeps failing**: workspace stays visible with tombstone, retried on every load.
- **Process crashes mid-delete**: tombstone + recovery handles it, now including branch deletion.

## Test plan

- [x] `make devcheck` passes (all tests, lint, strict lint, file-length)
- [x] `make verify-loop` (pre-push hook ran real-tmux input path tests)
- [x] `TestDeleteWorkspace_BranchDeleteFailureFailsDelete` — branch failure now fails the delete
- [x] `TestFinishInterruptedDelete_SurfacesWorkspaceWhenBranchDeleteFails` — workspace surfaces on recovery failure
- [x] `TestFinishInterruptedDelete_RemovesDirlessTombstoned` — recovery deletes branch on success
