### PR TITLE
fix: support background color erase (BCE) in vterm and augment agent PATH

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/andyrewlee/amux
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1

--- a/internal/pty/agent.go
+++ b/internal/pty/agent.go
@@ -95,6 +95,9 @@ func (m *AgentManager) CreateAgentWithTags(ws *data.Workspace, agentType AgentTy
 		"COLUMNS=", // Unset to force ioctl usage
 		"COLORTERM=truecolor",
 	}
+	if path := AugmentedPath(); path != "" {
+		env = append(env, "PATH="+path)
+	}
 
 	// Create terminal with agent command, falling back to shell on exit
 	loginShellCommand, err := LoginShellCommandFromEnv()
@@ -157,6 +160,9 @@ func (m *AgentManager) CreateViewerWithTags(ws *data.Workspace, command, session
 		"WORKSPACE_NAME=" + ws.Name,
 		"TERM=xterm-256color",
 		"COLORTERM=truecolor",
+	}
+	if path := AugmentedPath(); path != "" {
+		env = append(env, "PATH="+path)
 	}
 
 	termCommand := tmux.NewClientCommand(sessionName, tmux.ClientCommandParams{

--- a/internal/pty/shell.go
+++ b/internal/pty/shell.go
@@ -31,3 +31,66 @@ func LoginShellCommand(shell string) (string, error) {
 	}
 	return "exec " + shellutil.ShellQuote(shell) + " -l", nil
 }
+
+// AugmentedPath returns the current PATH environment variable, augmented with
+// common CLI tool directories (such as ~/.opencode/bin, ~/.local/bin, /opt/homebrew/bin)
+// if they exist on disk and are not already present in PATH.
+func AugmentedPath() string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		home = os.Getenv("HOME")
+	}
+	return AugmentPath(os.Getenv("PATH"), home)
+}
+
+// AugmentPath augments the given path string with common tool binary locations
+// that exist on disk, avoiding duplicates.
+func AugmentPath(currentPath, homeDir string) string {
+	sep := string(os.PathListSeparator)
+	rawParts := filepath.SplitList(currentPath)
+	parts := make([]string, 0, len(rawParts)+13)
+	seen := make(map[string]struct{}, len(rawParts)+13)
+	for _, p := range rawParts {
+		if p != "" {
+			clean := filepath.Clean(p)
+			if _, exists := seen[clean]; !exists {
+				seen[clean] = struct{}{}
+				parts = append(parts, p)
+			}
+		}
+	}
+
+	var candidates []string
+	if homeDir != "" {
+		candidates = append(candidates,
+			filepath.Join(homeDir, ".opencode", "bin"),
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, ".cargo", "bin"),
+			filepath.Join(homeDir, ".npm-global", "bin"),
+			filepath.Join(homeDir, "go", "bin"),
+		)
+	}
+	candidates = append(candidates,
+		"/opt/homebrew/bin",
+		"/opt/homebrew/sbin",
+		"/usr/local/bin",
+		"/usr/local/sbin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	)
+
+	for _, cand := range candidates {
+		candClean := filepath.Clean(cand)
+		if _, exists := seen[candClean]; exists {
+			continue
+		}
+		if info, err := os.Stat(cand); err == nil && info.IsDir() {
+			parts = append(parts, cand)
+			seen[candClean] = struct{}{}
+		}
+	}
+
+	return strings.Join(parts, sep)
+}

--- a/internal/pty/shell_test.go
+++ b/internal/pty/shell_test.go
@@ -1,6 +1,10 @@
 package pty
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestLoginShellCommand(t *testing.T) {
 	tests := []struct {
@@ -65,5 +69,28 @@ func TestLoginShellCommandFromEnvDefault(t *testing.T) {
 	want := "exec '" + defaultLoginShell + "' -l"
 	if got != want {
 		t.Fatalf("LoginShellCommandFromEnv() = %q, want %q", got, want)
+	}
+}
+
+func TestAugmentPath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	opencodeBin := tmpDir + "/.opencode/bin"
+	if err := os.MkdirAll(opencodeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initialPath := "/usr/bin:/bin"
+	got := AugmentPath(initialPath, tmpDir)
+
+	if !strings.Contains(got, opencodeBin) {
+		t.Fatalf("AugmentPath(%q, %q) = %q, want it to contain %q", initialPath, tmpDir, got, opencodeBin)
+	}
+
+	// Calling again on the augmented path shouldn't duplicate the entry
+	second := AugmentPath(got, tmpDir)
+	if strings.Count(second, opencodeBin) != 1 {
+		t.Fatalf("AugmentPath duplicated entry: %q", second)
 	}
 }

--- a/internal/ui/sidebar/terminal_pty_attach.go
+++ b/internal/ui/sidebar/terminal_pty_attach.go
@@ -99,6 +99,9 @@ func (m *TerminalModel) createTerminalTab(ws *data.Workspace) tea.Cmd {
 		captureRows := attachHeight
 		reuseExistingSession := false
 		env := []string{"COLORTERM=truecolor"}
+		if path := pty.AugmentedPath(); path != "" {
+			env = append(env, "PATH="+path)
+		}
 		sessionName := tmux.SessionName("amux", wsID, string(tabID))
 		// Reuse scrollback if a prior tmux session with the same name exists
 		// (e.g., app restart with persisted tmux session).
@@ -241,7 +244,6 @@ func (m *TerminalModel) attachToSession(ws *data.Workspace, tabID TerminalTabID,
 	termWidth, termHeight := m.sessionBootstrapViewportSize()
 	attachWidth, attachHeight := m.terminalContentSize()
 	loginShellCommand, shellErr := pty.LoginShellCommandFromEnv()
-	env := []string{"COLORTERM=truecolor"}
 	wsID := string(ws.ID())
 	root := ws.Root
 	instanceID := m.instanceID
@@ -306,6 +308,10 @@ func (m *TerminalModel) attachToSession(ws *data.Workspace, tabID TerminalTabID,
 			bootstrap = captureExistingSessionBootstrap(sessionName, termWidth, termHeight, opts)
 			snapshot = bootstrap.Snapshot
 			captureFullPane = bootstrap.CaptureFullPane
+		}
+		env := []string{"COLORTERM=truecolor"}
+		if path := pty.AugmentedPath(); path != "" {
+			env = append(env, "PATH="+path)
 		}
 		command := tmux.NewClientCommand(sessionName, tmux.ClientCommandParams{
 			WorkDir:        root,

--- a/internal/vterm/bce_test.go
+++ b/internal/vterm/bce_test.go
@@ -1,0 +1,126 @@
+package vterm
+
+import (
+	"testing"
+)
+
+func TestBCE_EraseLine(t *testing.T) {
+	t.Parallel()
+
+	vt := New(10, 2)
+	// Write with black truecolor background: \x1b[48;2;10;10;10m
+	vt.Write([]byte("\x1b[48;2;10;10;10mHello\x1b[K"))
+
+	// Row 0 columns 0..4 have "Hello" with bg 10,10,10
+	// Row 0 columns 5..9 are erased via \x1b[K and should have bg 10,10,10
+	wantBg := Color{Type: ColorRGB, Value: 0x0a0a0a}
+	for x := 0; x < 10; x++ {
+		cell := vt.Screen[0][x]
+		if cell.Style.Bg != wantBg {
+			t.Errorf("cell (x=%d, y=0) bg = %+v, want %+v", x, cell.Style.Bg, wantBg)
+		}
+	}
+}
+
+func TestBCE_EraseDisplay(t *testing.T) {
+	t.Parallel()
+
+	vt := New(10, 3)
+	// Set background to indexed color 4 (blue) and clear screen
+	vt.Write([]byte("\x1b[44m\x1b[2J"))
+
+	wantBg := Color{Type: ColorIndexed, Value: 4}
+	for y := 0; y < 3; y++ {
+		for x := 0; x < 10; x++ {
+			cell := vt.Screen[y][x]
+			if cell.Style.Bg != wantBg {
+				t.Errorf("cell (x=%d, y=%d) bg = %+v, want %+v", x, y, cell.Style.Bg, wantBg)
+			}
+		}
+	}
+}
+
+func TestBCE_ScrollUp(t *testing.T) {
+	t.Parallel()
+
+	vt := New(5, 2)
+	vt.Write([]byte("\x1b[48;2;20;30;40mLine1\nLine2\n"))
+
+	wantBg := Color{Type: ColorRGB, Value: 0x141e28}
+	for x := 0; x < 5; x++ {
+		cell := vt.Screen[1][x]
+		if cell.Style.Bg != wantBg {
+			t.Errorf("scrolled cell (x=%d, y=1) bg = %+v, want %+v", x, cell.Style.Bg, wantBg)
+		}
+	}
+}
+
+func TestBCE_EraseChars(t *testing.T) {
+	t.Parallel()
+
+	vt := New(5, 1)
+	vt.Write([]byte("ABCDE\x1b[1;2H\x1b[42m\x1b[2X"))
+
+	// Cursor at (1, 0), erase 2 chars ('B' and 'C') with green background (indexed 2)
+	wantBg := Color{Type: ColorIndexed, Value: 2}
+	if vt.Screen[0][1].Style.Bg != wantBg || vt.Screen[0][1].Rune != ' ' {
+		t.Errorf("cell 1 = %+v, want space with green bg", vt.Screen[0][1])
+	}
+	if vt.Screen[0][2].Style.Bg != wantBg || vt.Screen[0][2].Rune != ' ' {
+		t.Errorf("cell 2 = %+v, want space with green bg", vt.Screen[0][2])
+	}
+	// 'A' and 'D' should retain their original style
+	if vt.Screen[0][0].Rune != 'A' || vt.Screen[0][0].Style.Bg.Type != ColorDefault {
+		t.Errorf("cell 0 = %+v, want 'A' with default bg", vt.Screen[0][0])
+	}
+}
+
+func TestBCE_ResetRestoresDefault(t *testing.T) {
+	t.Parallel()
+
+	vt := New(5, 1)
+	vt.Write([]byte("\x1b[41m\x1b[K\x1b[0m\x1b[1;1H\x1b[K"))
+
+	// After \x1b[0m, eraseLine should use default bg
+	for x := 0; x < 5; x++ {
+		if vt.Screen[0][x].Style.Bg.Type != ColorDefault {
+			t.Errorf("cell %d bg = %+v, want default", x, vt.Screen[0][x].Style.Bg)
+		}
+	}
+}
+
+func TestBCE_InsertDeleteLines(t *testing.T) {
+	t.Parallel()
+
+	vt := New(4, 3)
+	vt.Write([]byte("\x1b[45m\x1b[1;1H\x1b[1L")) // IL with magenta bg
+
+	wantBg := Color{Type: ColorIndexed, Value: 5}
+	for x := 0; x < 4; x++ {
+		if vt.Screen[0][x].Style.Bg != wantBg {
+			t.Errorf("inserted line cell %d bg = %+v, want %+v", x, vt.Screen[0][x].Style.Bg, wantBg)
+		}
+	}
+
+	vt.Write([]byte("\x1b[46m\x1b[1;1H\x1b[1M")) // DL with cyan bg
+	wantBg2 := Color{Type: ColorIndexed, Value: 6}
+	for x := 0; x < 4; x++ {
+		if vt.Screen[2][x].Style.Bg != wantBg2 {
+			t.Errorf("bottom line after delete cell %d bg = %+v, want %+v", x, vt.Screen[2][x].Style.Bg, wantBg2)
+		}
+	}
+}
+
+func TestBCE_ScrollDown(t *testing.T) {
+	t.Parallel()
+
+	vt := New(4, 2)
+	vt.Write([]byte("\x1b[43m\x1b[1;1H\x1b[1T")) // SD with yellow bg
+
+	wantBg := Color{Type: ColorIndexed, Value: 3}
+	for x := 0; x < 4; x++ {
+		if vt.Screen[0][x].Style.Bg != wantBg {
+			t.Errorf("top line after scrollDown cell %d bg = %+v, want %+v", x, vt.Screen[0][x].Style.Bg, wantBg)
+		}
+	}
+}

--- a/internal/vterm/lineedit.go
+++ b/internal/vterm/lineedit.go
@@ -22,7 +22,7 @@ func (v *VTerm) insertLines(n int) {
 	// Insert blank lines
 	for i := v.CursorY; i < v.CursorY+n && i < v.ScrollBottom; i++ {
 		if i < len(v.Screen) {
-			v.Screen[i] = MakeBlankLine(v.Width)
+			v.Screen[i] = v.makeEraseLine(v.Width)
 		}
 	}
 	v.markDirtyRange(v.ScrollTop, v.ScrollBottom-1)
@@ -50,7 +50,7 @@ func (v *VTerm) deleteLines(n int) {
 	// Fill bottom with blank lines
 	for i := v.ScrollBottom - n; i < v.ScrollBottom; i++ {
 		if i >= 0 && i < len(v.Screen) {
-			v.Screen[i] = MakeBlankLine(v.Width)
+			v.Screen[i] = v.makeEraseLine(v.Width)
 		}
 	}
 	v.markDirtyRange(v.ScrollTop, v.ScrollBottom-1)
@@ -72,9 +72,10 @@ func (v *VTerm) insertChars(n int) {
 	}
 
 	// Insert blanks
+	eraseC := v.eraseCell()
 	for i := v.CursorX; i < v.CursorX+n && i < v.Width; i++ {
 		if i < len(line) {
-			line[i] = DefaultCell()
+			line[i] = eraseC
 		}
 	}
 	normalizeLine(line)
@@ -105,9 +106,10 @@ func (v *VTerm) deleteChars(n int) {
 	}
 
 	// Fill end with blanks
+	eraseC := v.eraseCell()
 	for i := v.Width - n; i < v.Width; i++ {
 		if i >= 0 && i < len(line) {
-			line[i] = DefaultCell()
+			line[i] = eraseC
 		}
 	}
 	normalizeLine(line)
@@ -120,10 +122,11 @@ func (v *VTerm) eraseChars(n int) {
 		return
 	}
 	line := v.Screen[v.CursorY]
+	eraseC := v.eraseCell()
 
 	for i := v.CursorX; i < v.CursorX+n && i < v.Width; i++ {
 		if i < len(line) {
-			line[i] = DefaultCell()
+			line[i] = eraseC
 		}
 	}
 	normalizeLine(line)
@@ -138,12 +141,12 @@ func normalizeLine(line []Cell) {
 		case 0:
 			// Continuation without a leading wide cell is invalid.
 			if !IsWideContinuation(line, i) {
-				line[i] = DefaultCell()
+				line[i] = Cell{Rune: ' ', Width: 1, Style: line[i].Style}
 			}
 		case 2:
 			// If the continuation cell is missing, drop the wide glyph.
 			if !HasWideContinuation(line, i, len(line)) {
-				line[i] = DefaultCell()
+				line[i] = Cell{Rune: ' ', Width: 1, Style: line[i].Style}
 			}
 		}
 	}

--- a/internal/vterm/ops.go
+++ b/internal/vterm/ops.go
@@ -187,8 +187,26 @@ func (v *VTerm) backspace() {
 	v.bumpVersionIfCursorMoved(prevX, prevY)
 }
 
+func (v *VTerm) eraseCell() Cell {
+	return Cell{
+		Rune:  ' ',
+		Width: 1,
+		Style: Style{Bg: v.CurrentStyle.Bg},
+	}
+}
+
+func (v *VTerm) makeEraseLine(width int) []Cell {
+	line := make([]Cell, width)
+	c := v.eraseCell()
+	for i := range line {
+		line[i] = c
+	}
+	return line
+}
+
 // eraseDisplay clears parts of the display
 func (v *VTerm) eraseDisplay(mode int) {
+	eraseC := v.eraseCell()
 	switch mode {
 	case 0: // Cursor to end
 		if v.CursorX == 0 && v.CursorY == 0 && v.shouldCaptureScreenOnClear() {
@@ -199,7 +217,7 @@ func (v *VTerm) eraseDisplay(mode int) {
 		if v.CursorY < len(v.Screen) {
 			for x := v.CursorX; x < v.Width; x++ {
 				if x < len(v.Screen[v.CursorY]) {
-					v.Screen[v.CursorY][x] = DefaultCell()
+					v.Screen[v.CursorY][x] = eraseC
 				}
 			}
 			normalizeLine(v.Screen[v.CursorY])
@@ -207,7 +225,7 @@ func (v *VTerm) eraseDisplay(mode int) {
 		// Clear all lines below
 		for y := v.CursorY + 1; y < v.Height; y++ {
 			if y < len(v.Screen) {
-				v.Screen[y] = MakeBlankLine(v.Width)
+				v.Screen[y] = v.makeEraseLine(v.Width)
 			}
 		}
 		v.markDirtyRange(v.CursorY, v.Height-1)
@@ -215,14 +233,14 @@ func (v *VTerm) eraseDisplay(mode int) {
 		// Clear all lines above
 		for y := 0; y < v.CursorY; y++ {
 			if y < len(v.Screen) {
-				v.Screen[y] = MakeBlankLine(v.Width)
+				v.Screen[y] = v.makeEraseLine(v.Width)
 			}
 		}
 		// Clear from start of line to cursor
 		if v.CursorY < len(v.Screen) {
 			for x := 0; x <= v.CursorX && x < v.Width; x++ {
 				if x < len(v.Screen[v.CursorY]) {
-					v.Screen[v.CursorY][x] = DefaultCell()
+					v.Screen[v.CursorY][x] = eraseC
 				}
 			}
 			normalizeLine(v.Screen[v.CursorY])
@@ -238,7 +256,7 @@ func (v *VTerm) eraseDisplay(mode int) {
 		}
 		for y := 0; y < v.Height; y++ {
 			if y < len(v.Screen) {
-				v.Screen[y] = MakeBlankLine(v.Width)
+				v.Screen[y] = v.makeEraseLine(v.Width)
 			}
 		}
 		if mode == 3 {
@@ -267,6 +285,7 @@ func (v *VTerm) eraseLine(mode int) {
 		return
 	}
 
+	eraseC := v.eraseCell()
 	// A partial erase can cut a wide glyph in half; normalizeLine drops the
 	// leftover half so the line keeps exactly one cell per column. Mode 2
 	// replaces the whole line with blanks, so it needs no normalization.
@@ -274,19 +293,19 @@ func (v *VTerm) eraseLine(mode int) {
 	case 0: // Cursor to end
 		for x := v.CursorX; x < v.Width; x++ {
 			if x < len(v.Screen[v.CursorY]) {
-				v.Screen[v.CursorY][x] = DefaultCell()
+				v.Screen[v.CursorY][x] = eraseC
 			}
 		}
 		normalizeLine(v.Screen[v.CursorY])
 	case 1: // Start to cursor
 		for x := 0; x <= v.CursorX && x < v.Width; x++ {
 			if x < len(v.Screen[v.CursorY]) {
-				v.Screen[v.CursorY][x] = DefaultCell()
+				v.Screen[v.CursorY][x] = eraseC
 			}
 		}
 		normalizeLine(v.Screen[v.CursorY])
 	case 2: // Entire line
-		v.Screen[v.CursorY] = MakeBlankLine(v.Width)
+		v.Screen[v.CursorY] = v.makeEraseLine(v.Width)
 	}
 	v.markDirtyLine(v.CursorY)
 }

--- a/internal/vterm/scroll.go
+++ b/internal/vterm/scroll.go
@@ -69,7 +69,7 @@ func (v *VTerm) scrollUp(n int) {
 	// Fill bottom with blank lines
 	for i := v.ScrollBottom - n; i < v.ScrollBottom; i++ {
 		if i >= 0 && i < len(v.Screen) {
-			v.Screen[i] = MakeBlankLine(v.Width)
+			v.Screen[i] = v.makeEraseLine(v.Width)
 		}
 	}
 	v.markDirtyRange(v.ScrollTop, v.ScrollBottom-1)
@@ -97,7 +97,7 @@ func (v *VTerm) scrollDown(n int) {
 	// Fill top with blank lines
 	for i := v.ScrollTop; i < v.ScrollTop+n; i++ {
 		if i >= 0 && i < len(v.Screen) {
-			v.Screen[i] = MakeBlankLine(v.Width)
+			v.Screen[i] = v.makeEraseLine(v.Width)
 		}
 	}
 	v.markDirtyRange(v.ScrollTop, v.ScrollBottom-1)


### PR DESCRIPTION
### Summary

1. **Background Color Erase (BCE) Support in `vterm`**
   - Implemented standard BCE across `eraseDisplay`, `eraseLine`, `eraseChars`, `insertLines`, `deleteLines`, `insertChars`, `deleteChars`, `scrollUp`, and `scrollDown`.
   - Cleared and erased cells now retain `Style{Bg: v.CurrentStyle.Bg}` instead of being overwritten with unstyled `DefaultCell()` (default/transparent background).
   - Preserves cell styles during `normalizeLine` when wide character continuations are truncated.
   - Fixes splotchy rendering and transparent background holes in OpenCode / OpenTUI and other TUIs with colored backgrounds.

2. **Agent PATH Environment Augmentation**
   - Added `AugmentPath()` and `AugmentedPath()` to safely include common CLI agent and tool locations (`~/.opencode/bin`, `~/.local/bin`, `~/.cargo/bin`, `~/.npm-global/bin`, `~/go/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) when present on disk, without duplicates and respecting existing user PATH precedence.
   - Exported `PATH` into the tmux client environment for agent tabs, viewers, and sidebar terminals.
   - Fixes the immediate exit (`Agent exited. Dropping to shell...`) when launching OpenCode from newly created workspaces.

### Verification
- Added `internal/vterm/bce_test.go` with comprehensive tests for truecolor/indexed line erasures, display clears, character erasures, line scrolling, insert/delete lines, and SGR reset.
- Added `internal/pty/shell_test.go` tests for `AugmentPath` deduplication and candidate paths.
- `go test ./...` passed across all packages.
- `make verify-loop` (PTY keystroke & raw agent end-to-end delivery) passed.
- `make harness-presets` passed.