### PR TITLE
feat: add shift+wheel force-local scrollback override

### DIFF
--- a/internal/e2e/closeloop_test.go
+++ b/internal/e2e/closeloop_test.go
@@ -128,4 +128,32 @@ func TestCloseLoopKeystrokeDeliveryToRawAgent(t *testing.T) {
 		t.Fatalf("agent did not receive forwarded wheel input via amux\n got: % x\nwant: % x\nouter: % x\n\nscreen:\n%s",
 			got, []byte(wheelInput.forwarded), []byte(wheelInput.outer), session.ScreenASCII())
 	}
+
+	// Shift+wheel is the force-local override: amux must scroll its own
+	// scrollback instead of forwarding the event to the agent. Send it first,
+	// then a plain wheel at different coordinates: its forwarded bytes are
+	// unique in the agent log, so their arrival proves the shift event was
+	// already processed (PTY input is ordered), making the absence check
+	// race-free.
+	// amux throttles wheel events arriving within 15ms of each other
+	// (mouseEventFilter in cmd/amux), so pace both wheels past it — otherwise
+	// the shift+wheel could be dropped before reaching the guard.
+	time.Sleep(50 * time.Millisecond)
+	if err := session.SendString(centerPaneShiftWheelUpInput(120, 30, 2, 3)); err != nil {
+		t.Fatalf("send shift+wheel: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	secondWheel := centerPaneWheelUpInput(120, 30, 5, 7)
+	if err := session.SendString(secondWheel.outer); err != nil {
+		t.Fatalf("send second wheel: %v", err)
+	}
+	got, ok = waitForFileBytes(logPath, []byte(secondWheel.forwarded), closeLoopTimeout)
+	if !ok {
+		t.Fatalf("agent did not receive second forwarded wheel via amux\n got: % x\nwant: % x\nouter: % x\n\nscreen:\n%s",
+			got, []byte(secondWheel.forwarded), []byte(secondWheel.outer), session.ScreenASCII())
+	}
+	if bytes.Contains(got, []byte("\x1b[<68;")) {
+		t.Fatalf("shift+wheel was forwarded to the agent; want force-local scroll only\n got: % x\n\nscreen:\n%s",
+			got, session.ScreenASCII())
+	}
 }

--- a/internal/e2e/mouse_helpers_test.go
+++ b/internal/e2e/mouse_helpers_test.go
@@ -41,3 +41,14 @@ func centerPaneWheelUpInput(width, height, termX, termY int) wheelInput {
 		forwarded: fmt.Sprintf("\x1b[<64;%d;%dM", termX+1, termY+1),
 	}
 }
+
+// centerPaneShiftWheelUpInput encodes shift+wheel-up (button 64 | shift bit 4)
+// in SGR mode at the given pane-local terminal coordinates.
+func centerPaneShiftWheelUpInput(width, height, termX, termY int) string {
+	l := layout.NewManager()
+	l.Resize(width, height)
+	centerStartX := l.LeftGutter() + l.DashboardWidth() + l.GapX()
+	screenX := centerStartX + 2 + termX
+	screenY := l.TopGutter() + 2 + termY
+	return fmt.Sprintf("\x1b[<68;%d;%dM", screenX+1, screenY+1)
+}

--- a/internal/ui/center/SCROLLING.md
+++ b/internal/ui/center/SCROLLING.md
@@ -169,6 +169,17 @@ program keeps every scrolled line, rules included.
 
 ## Gestures: one implementation per gesture
 
+### Shift+wheel forces local scrollback
+
+When the hosted app enables mouse reporting (DECSET 1000/1002/1003), plain
+wheel events are forwarded to it as SGR/X10 sequences and amux's own scrollback
+does not move. **Shift+wheel bypasses that forwarding** and always scrolls
+`ViewOffset` locally (`updateMouseWheel` in `model_input_mouse.go`) — the same
+force-local convention as iTerm2, kitty, and xterm, so there is always a way
+to scroll regardless of what the embedded app does with the wheel. The diff
+viewer still sees shift+wheel first: it is amux's own UI and never forwards
+anything to the agent.
+
 All selection/scroll gestures are implemented once, as tab-actor handlers
 (`tab_actor_selection.go`, `tab_actor.go`), and every entry point routes
 through `dispatchOrHandleTabEvent`: actor queue when available, synchronous

--- a/internal/ui/center/model_input_mouse.go
+++ b/internal/ui/center/model_input_mouse.go
@@ -119,8 +119,13 @@ func (m *Model) updateMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 	if handled, cmd := m.dispatchDiffInput(tab, msg); handled {
 		return m, cmd
 	}
-	if m.forwardMouseWheelToTerminal(msg, tab) {
-		return m, nil
+	// Shift+wheel is the standard force-local-scroll override (iTerm2, kitty,
+	// xterm): it bypasses mouse-reporting forwarding so the user can always
+	// scroll amux's own scrollback, even when the hosted app wants the wheel.
+	if !msg.Mod.Contains(tea.ModShift) {
+		if m.forwardMouseWheelToTerminal(msg, tab) {
+			return m, nil
+		}
 	}
 
 	delta := 0

--- a/internal/ui/center/model_input_mouse_test.go
+++ b/internal/ui/center/model_input_mouse_test.go
@@ -78,6 +78,38 @@ func TestMouseWheelForwardsToMouseReportingTerminalInsteadOfLocalScroll(t *testi
 	}
 }
 
+func TestMouseWheelWithShiftScrollsLocallyDespiteMouseReporting(t *testing.T) {
+	// No tab actor: gestures run through the synchronous fallback, like the
+	// chat-history scroll tests below.
+	m, tab := setupSelectionModel(t)
+
+	tab.mu.Lock()
+	for i := 0; i < 40; i++ {
+		tab.Terminal.Write([]byte("line\n"))
+	}
+	tab.Terminal.Write([]byte("\x1b[?1000h\x1b[?1006h"))
+	tab.mu.Unlock()
+
+	tm := m.terminalMetrics()
+	_, _ = m.Update(tea.MouseWheelMsg{
+		Button: tea.MouseWheelUp,
+		X:      tm.ContentStartX + 2,
+		Y:      tm.ContentStartY + 3,
+		Mod:    tea.ModShift,
+	})
+
+	// With mouse reporting on and the pointer in bounds, an unguarded wheel
+	// would be forwarded and return before local scrolling (see the forwarding
+	// test above), leaving the offset at 0. Offset > 0 therefore proves the
+	// shift guard skipped forwarding.
+	tab.mu.Lock()
+	offset, _ := tab.Terminal.GetScrollInfo()
+	tab.mu.Unlock()
+	if offset == 0 {
+		t.Fatal("expected shift+wheel to scroll local scrollback despite mouse reporting")
+	}
+}
+
 func TestCanConsumeWheelWhenTerminalRequestedMouseReporting(t *testing.T) {
 	m, tab := setupSelectionModel(t)
 


### PR DESCRIPTION
## Problem

Wheel behavior was inconsistent across CLIs. When a hosted app enables mouse reporting (DECSET 1000/1002/1003 — vim, htop, fzf, `less --mouse`, many TUIs), every wheel event is forwarded to the app as SGR/X10 sequences and amux's own scrollback never moves. If the app ignores wheels or the user wants amux scrollback, the wheel is simply dead.

tmux can't fix this: panes in alternate-screen mode discard scrolled lines per xterm semantics, so for full-screen repainters there is no history anywhere to scroll back through.

## Change

Shift+wheel now bypasses mouse-reporting forwarding and always scrolls amux's own scrollback (`ViewOffset`), matching the force-local convention in iTerm2, kitty, and xterm:

- Plain-wheel behavior is unchanged — apps that handle wheels natively keep working exactly as before
- The diff viewer still sees shift+wheel first (it's amux UI; it never forwards anything)
- X10-mode agents get the same override (modifier bit survives the shared decoder)

## Verification

- Unit test: shift+wheel on a mouse-reporting terminal scrolls locally and forwards nothing (synchronous fallback path)
- E2E close-loop against a real tmux + real raw-mode agent: plain wheel still arrives at the agent; shift+wheel never does. Wheels are paced past the 15ms `mouseEventFilter` throttle so both events deterministically reach the guard; ordered PTY input + unique forwarded bytes make the absence check race-free
- `make devcheck`, `make lint-strict-new` (0 issues), `make verify-loop` all green

Documented in `internal/ui/center/SCROLLING.md`.

Note: this is an input-contract change — embedded apps no longer receive shift+wheel (button code 68). This matches standard terminal behavior and is intentional.