### PR TITLE
fix: stop workspace deletes from corrupting sibling workspaces

### DIFF
--- a/internal/app/app_input_messages_workspace.go
+++ b/internal/app/app_input_messages_workspace.go
@@ -56,7 +56,7 @@ func (a *App) handleProjectsLoaded(msg messages.ProjectsLoaded) []tea.Cmd {
 func (a *App) filterDeletedWorkspacesFromProjectLoad(projects []data.Project, loadToken projectsLoadToken) []data.Project {
 	for i := range projects {
 		project := &projects[i]
-		filtered := project.Workspaces[:0]
+		filtered := make([]data.Workspace, 0, len(project.Workspaces))
 		for j := range project.Workspaces {
 			ws := project.Workspaces[j]
 			if a.lifecycle.shouldFilterDeletedWorkspace(string(ws.ID()), ws.Root, loadToken) {

--- a/internal/app/app_input_workspace.go
+++ b/internal/app/app_input_workspace.go
@@ -21,6 +21,7 @@ func (a *App) handleDeleteWorkspace(msg messages.DeleteWorkspace) []tea.Cmd {
 		logging.Warn("DeleteWorkspace received with nil project or workspace")
 		return nil
 	}
+	msg.Workspace = snapshotWorkspaceForSave(msg.Workspace)
 	if !a.markWorkspaceDeleteInFlight(msg.Workspace, true) {
 		logging.Warn("DeleteWorkspace rejected while workspace %s is in another lifecycle phase", msg.Workspace.ID())
 		return nil
@@ -339,7 +340,7 @@ func (a *App) removeWorkspaceFromLoadedProjects(ws *data.Workspace) {
 	wsID := string(ws.ID())
 	for i := range a.projects {
 		workspaces := a.projects[i].Workspaces
-		filtered := workspaces[:0]
+		filtered := make([]data.Workspace, 0, len(workspaces))
 		for j := range workspaces {
 			candidate := &workspaces[j]
 			if string(candidate.ID()) == wsID || candidate.Root == ws.Root {

--- a/internal/app/workspace_delete_pointer_aliasing_test.go
+++ b/internal/app/workspace_delete_pointer_aliasing_test.go
@@ -1,0 +1,118 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andyrewlee/amux/internal/data"
+	"github.com/andyrewlee/amux/internal/messages"
+	"github.com/andyrewlee/amux/internal/tmux"
+	"github.com/andyrewlee/amux/internal/ui/center"
+	"github.com/andyrewlee/amux/internal/ui/dashboard"
+	"github.com/andyrewlee/amux/internal/ui/sidebar"
+)
+
+// aliasingTestProject builds a project whose Workspaces backing array models
+// the shared slices dashboard rows and long-running commands point into.
+func aliasingTestProject() *data.Project {
+	project := data.NewProject("/tmp/repo")
+	project.Workspaces = []data.Workspace{
+		*data.NewWorkspace("a", "a", "main", "/tmp/repo", "/tmp/workspaces/repo/a"),
+		*data.NewWorkspace("b", "b", "main", "/tmp/repo", "/tmp/workspaces/repo/b"),
+		*data.NewWorkspace("c", "c", "main", "/tmp/repo", "/tmp/workspaces/repo/c"),
+	}
+	return project
+}
+
+// TestRemoveWorkspaceFromLoadedProjects_DoesNotShiftOutstandingPointers proves
+// removing a workspace never compacts the slice in place. Dashboard rows and an
+// async delete command hold &Workspaces[j]; an in-place shift would re-point
+// those pointers at a different workspace, which made deleting one workspace
+// tear down another workspace's tabs and agents.
+func TestRemoveWorkspaceFromLoadedProjects_DoesNotShiftOutstandingPointers(t *testing.T) {
+	app := &App{projects: []data.Project{*aliasingTestProject()}}
+	outstandingB := &app.projects[0].Workspaces[1]
+	outstandingC := &app.projects[0].Workspaces[2]
+
+	app.removeWorkspaceFromLoadedProjects(&app.projects[0].Workspaces[0])
+
+	if outstandingB.Root != "/tmp/workspaces/repo/b" || outstandingB.Branch != "b" {
+		t.Fatalf("pointer to workspace b drifted to %s (%s): in-place compaction re-pointed it at another workspace", outstandingB.Root, outstandingB.Branch)
+	}
+	if outstandingC.Root != "/tmp/workspaces/repo/c" || outstandingC.Branch != "c" {
+		t.Fatalf("pointer to workspace c drifted to %s (%s): in-place compaction re-pointed it at another workspace", outstandingC.Root, outstandingC.Branch)
+	}
+	remaining := app.projects[0].Workspaces
+	if len(remaining) != 2 || remaining[0].Root != "/tmp/workspaces/repo/b" || remaining[1].Root != "/tmp/workspaces/repo/c" {
+		t.Fatalf("unexpected remaining workspaces: %+v", remaining)
+	}
+}
+
+// TestFilterDeletedWorkspacesFromProjectLoad_DoesNotMutateBackingArray pins the
+// same no-in-place-mutation rule on the projects-load filter path.
+func TestFilterDeletedWorkspacesFromProjectLoad_DoesNotMutateBackingArray(t *testing.T) {
+	app := &App{}
+	project := aliasingTestProject()
+	outstandingB := &project.Workspaces[1]
+
+	wsA := &project.Workspaces[0]
+	if !app.lifecycle.markDeletingWorkspace(string(wsA.ID()), wsA.Root, true) {
+		t.Fatal("failed to mark workspace a as deleting")
+	}
+
+	filtered := app.filterDeletedWorkspacesFromProjectLoad([]data.Project{*project}, 0)
+
+	if outstandingB.Root != "/tmp/workspaces/repo/b" || outstandingB.Branch != "b" {
+		t.Fatalf("pointer to workspace b drifted to %s (%s): load filtering mutated the shared backing array", outstandingB.Root, outstandingB.Branch)
+	}
+	got := filtered[0].Workspaces
+	if len(got) != 2 || got[0].Root != "/tmp/workspaces/repo/b" || got[1].Root != "/tmp/workspaces/repo/c" {
+		t.Fatalf("unexpected filtered workspaces: %+v", got)
+	}
+}
+
+// TestHandleDeleteWorkspace_FreezeIdentityAgainstAliasedMutation proves the
+// delete pipeline reads a frozen snapshot: even if the element the caller
+// handed over is overwritten mid-delete (the aliasing drift observed in the
+// logs, where a delete of "cleanup" ended up running git branch -D pickup), the
+// async cmd and the resulting WorkspaceDeleted keep the original identity.
+func TestHandleDeleteWorkspace_FreezesIdentityAgainstAliasedMutation(t *testing.T) {
+	project := aliasingTestProject()
+	handedOver := &project.Workspaces[0]
+	victimID := string(handedOver.ID())
+	victimRoot := handedOver.Root
+
+	svc := newWorkspaceService(nil, nil, nil, "/tmp/workspaces")
+	svc.gitOps = &mockGitOps{}
+	app := &App{
+		dashboard:        dashboard.New(),
+		center:           center.New(nil),
+		sidebar:          sidebar.NewTabbedSidebar(),
+		sidebarTerminal:  sidebar.NewTerminalModel(),
+		tmuxService:      &killRecordingTmuxOps{},
+		tmuxOptions:      tmux.Options{},
+		workspaceService: svc,
+	}
+
+	cmds := app.handleDeleteWorkspace(messages.DeleteWorkspace{Project: project, Workspace: handedOver})
+
+	project.Workspaces[0] = *data.NewWorkspace("c", "c", "main", "/tmp/repo", "/tmp/workspaces/repo/c")
+
+	var deleted *messages.WorkspaceDeleted
+	for _, cmd := range cmds {
+		if cmd == nil {
+			continue
+		}
+		if msg := cmd(); msg != nil {
+			if d, ok := msg.(messages.WorkspaceDeleted); ok {
+				deleted = &d
+			}
+		}
+	}
+	if deleted == nil {
+		t.Fatal("expected a messages.WorkspaceDeleted from the delete cmd")
+	}
+	if string(deleted.Workspace.ID()) != victimID || deleted.Workspace.Root != victimRoot {
+		t.Fatalf("delete result drifted: got id=%s root=%s, want id=%s root=%s",
+			deleted.Workspace.ID(), deleted.Workspace.Root, victimID, victimRoot)
+	}
+}


### PR DESCRIPTION
## Problem

Every workspace delete risked corrupting *other* workspaces: tabs from other workspaces started showing, agents of live workspaces were closed, and one delete even ran `git branch -D pickup` against a different workspace's branch.

Log evidence (2026-08-21, `~/.amux/logs`):
- `delete start id=b25991b0… name=cleanup` → later `delete failed id=b25991b0… stage=delete_branch name=pickup error=git branch -D -- pickup …`
- `delete start id=55fb2641… name=free` → `delete succeeded id=55fb2641… name=clawpatch`
- Right after deleting cma-handoff: `closing 1 agents for workspace 20634b0994f362f9` — a different, still-live workspace
- Repeated `reattach result: tab … routed with workspace X but filed under Y`

## Root cause

Dashboard rows hold `*data.Workspace` pointers directly into `Project.Workspaces` backing arrays (which the App shares with UI models), and the delete dialog hands that exact pointer into the async `DeleteWorkspace` cmd, which holds it across a 40–97s git operation.

While it ran, another delete's `handleWorkspaceDeleted` → `removeWorkspaceFromLoadedProjects` filtered with `workspaces[:0]`, compacting the shared backing array **in place** and shifting later workspaces into the slot the in-flight delete was still reading. The drifted struct then reported a different ID/Name/Root/Branch, so cleanup (`center.CleanupWorkspace`, agent close, tmux kill) targeted the wrong workspace while the actually-deleted workspace's orphaned tmux sessions got re-filed under surviving workspaces.

## Fix

1. `handleDeleteWorkspace` freezes identity via `snapshotWorkspaceForSave` before anything downstream runs — every stage, log line, tombstone, session kill, and `WorkspaceDeleted`/`Failed` message now reads immutable values. (Also fixes the delete-in-flight phase leaking when entry/exit IDs disagreed.)
2. Both filter sites — `removeWorkspaceFromLoadedProjects` and `filterDeletedWorkspacesFromProjectLoad` — now copy-on-filter instead of mutating shared backing arrays.

## Testing

- New regressions in `internal/app/workspace_delete_pointer_aliasing_test.go`; verified they fail on the old code with exactly the production symptom (`delete of "a" reported root ".../c"`) and pass with the fix.
- Full `make devcheck` green; `make lint-strict-new` 0 issues.